### PR TITLE
hle(#3054): publish caller chains from sceKernelAllocateDirectMemory, not only the Main variant

### DIFF
--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -155,10 +155,10 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
   a byte it owns. With both entry points sharing one attribution helper the writer is named
   immediately: `eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing 8x16 B per iteration to
   offsets computed in `%ymm10`.
-  **Reproduction needs code that is NOT on master.** `attribute_dmem_allocation` is not in this PR
-  and not in `origin/master`; it is tracked in **#3054**. Until it lands, the recipe below reports
-  `caller-chain=0` for this title and the trace refuses to arm — which is the very failure the row
-  retires, so do not read a failed arm as contradicting it. (#2998, #3054)
+  **Reproduction needs #3054**, which made `sceKernelAllocateDirectMemory` publish a caller chain.
+  Before it, this title produced no `[dmem-caller]` records at all and the trace refused to arm for
+  any configuration — which is the very failure this row retires, so on an older tree do not read a
+  failed arm as contradicting it. (#2998, #3054)
 
 - **Nothing maps into the atlas per-slice, and no host/kernel write streams into it** — both with
   controls, both new instruments. `PROSPER_MAPWATCH` sees one 1 GiB `map_dmem` covering the atlas,

--- a/prosper/src/hle/memory/dmem_caller_chain.hpp
+++ b/prosper/src/hle/memory/dmem_caller_chain.hpp
@@ -44,9 +44,13 @@ inline void append_dmem_caller_chain_number(std::string& line, uint64_t value, i
 // sceKernelAllocateDirectMemory publishes them too, a hardcoded label makes the record state the
 // wrong source for its own allocation -- and a diagnostic that misreports where it came from is
 // worse than one that says nothing.
+//
+// Deliberately NOT defaulted. A default is the same silent borrowing the empty-string guard below
+// exists to prevent, just moved to the call site: a third allocator that omitted the argument
+// would mislabel every record it produced, and nothing would say so.
 inline std::string format_dmem_caller_chain_definition(
         uint32_t id, uint64_t len, const DmemCallerChainFrame* frames, size_t frame_count,
-        int scanned_slots, int requested_slots, const char* api = "alloc_main_dmem") {
+        int scanned_slots, int requested_slots, const char* api) {
     std::string line;
     line.reserve(256);
     line += "[dmem-caller] caller-chain=";
@@ -85,8 +89,7 @@ inline void write_dmem_caller_chain_line(FILE* stream, std::string_view line) {
 
 inline void write_dmem_caller_chain_definition(
         FILE* stream, uint32_t id, uint64_t len, const DmemCallerChainFrame* frames,
-        size_t frame_count, int scanned_slots, int requested_slots,
-        const char* api = "alloc_main_dmem") {
+        size_t frame_count, int scanned_slots, int requested_slots, const char* api) {
     const std::string line = format_dmem_caller_chain_definition(
         id, len, frames, frame_count, scanned_slots, requested_slots, api);
     write_dmem_caller_chain_line(stream, line);

--- a/prosper/src/hle/memory/dmem_caller_chain.hpp
+++ b/prosper/src/hle/memory/dmem_caller_chain.hpp
@@ -39,14 +39,21 @@ inline void append_dmem_caller_chain_number(std::string& line, uint64_t value, i
 
 // Build the whole definition before taking the output lock. Besides keeping the lock hold short,
 // this makes it impossible for another first-seen chain to splice its ID or frames into this line.
+// `api` names the allocator this chain was interned for. It used to be the literal
+// "alloc_main_dmem", which was true while only that entry point published chains; once
+// sceKernelAllocateDirectMemory publishes them too, a hardcoded label makes the record state the
+// wrong source for its own allocation -- and a diagnostic that misreports where it came from is
+// worse than one that says nothing.
 inline std::string format_dmem_caller_chain_definition(
         uint32_t id, uint64_t len, const DmemCallerChainFrame* frames, size_t frame_count,
-        int scanned_slots, int requested_slots) {
+        int scanned_slots, int requested_slots, const char* api = "alloc_main_dmem") {
     std::string line;
     line.reserve(256);
     line += "[dmem-caller] caller-chain=";
     append_dmem_caller_chain_number(line, id, 10);
-    line += " alloc_main_dmem len=0x";
+    line += ' ';
+    line += (api && *api) ? api : "<unknown-allocator>";
+    line += " len=0x";
     append_dmem_caller_chain_number(line, len, 16);
     line += " from";
     for (size_t i = 0; i < frame_count; ++i) {
@@ -78,9 +85,10 @@ inline void write_dmem_caller_chain_line(FILE* stream, std::string_view line) {
 
 inline void write_dmem_caller_chain_definition(
         FILE* stream, uint32_t id, uint64_t len, const DmemCallerChainFrame* frames,
-        size_t frame_count, int scanned_slots, int requested_slots) {
+        size_t frame_count, int scanned_slots, int requested_slots,
+        const char* api = "alloc_main_dmem") {
     const std::string line = format_dmem_caller_chain_definition(
-        id, len, frames, frame_count, scanned_slots, requested_slots);
+        id, len, frames, frame_count, scanned_slots, requested_slots, api);
     write_dmem_caller_chain_line(stream, line);
 }
 

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -745,15 +745,22 @@ namespace {
         const uintptr_t slots = (hi - base) / sizeof(uint64_t);
         return slots < (uintptr_t)want ? (int)slots : want;
     }
-    void log_main_dmem_allocation(uint64_t len, uint64_t phys,
-                                  const volatile uint64_t* frame) {
-        // Preserve the unarmed path: no stack query, interner construction, or extra formatting unless
-        // PROSPER_DMEM_CALLER was explicitly requested. MEMLOG alone keeps its historical line byte-for-byte.
-        if (!dmem_caller_log()) {
-            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
-                 (unsigned long long)len, (unsigned long long)phys);
-            return;
-        }
+    // #2998: allocation attribution, shared by every direct-memory entry point.
+    //
+    // Only sceKernelAllocateMainDirectMemory used to build a caller chain. A title that allocates
+    // through sceKernelAllocateDirectMemory instead therefore produced no chain id at all, which
+    // made PROSPER_DMEM_WRITE_TRACE structurally unable to name a single byte it owns -- the
+    // selector is keyed on caller-chain plus allocation size, and neither was ever published for
+    // that API. Tomb Raider I-III takes exactly this path (two 1 GiB allocations), so the trace
+    // could not be pointed at its texture atlas however it was configured. That read as "the
+    // instrument cannot target a sub-allocation" when the truth was "this allocator never reports".
+    //
+    // The interner is one shared static on purpose: a second interner would issue ids from its own
+    // sequence, so one id would mean two different call sites depending on which API allocated, and
+    // a configured trace would silently arm on the wrong memory rather than fail to arm.
+    DmemCallerChainResult attribute_dmem_allocation(uint64_t len, uint64_t phys,
+                                                    const volatile uint64_t* frame,
+                                                    const char* api) {
         constexpr int kWant = 6;          // return addresses to report
         constexpr int kScan = 160;        // stack slots to walk
         // Never read past the mapped end of this stack (#1755).
@@ -775,8 +782,45 @@ namespace {
             phys, len,
             correlation.state == DmemCallerChainState::Known ? correlation.id : 0);
 
+        if (!correlation.first) return correlation;
+        if (correlation.state == DmemCallerChainState::Overflow) {
+            // The cap is a state, not a population: every later MEMLOG record says `overflow`.
+            fprintf(stderr, "[dmem-caller] caller-chain=overflow: chain limit %zu reached;"
+                            " further distinct call chains are NOT retained\n",
+                    DmemCallerChainInterner<>::capacity());
+            return correlation;
+        }
+        if (correlation.state == DmemCallerChainState::Unknown) {
+            fprintf(stderr,
+                    "[dmem-caller] caller-chain=unknown %s len=0x%llx"
+                    " from <no guest return addresses>\n",
+                    api, (unsigned long long)len);
+            return correlation;
+        }
+        DmemCallerChainFrame frames[kWant] = {};
+        for (int i = 0; i < n; ++i) {
+            frames[i].module = guest_module_name(ra[i]);
+            frames[i].offset = guest_module_offset(ra[i]);
+        }
+        write_dmem_caller_chain_definition(
+            stderr, correlation.id, len, frames, static_cast<size_t>(n), scan, kScan, api);
+        return correlation;
+    }
+
+    void log_main_dmem_allocation(uint64_t len, uint64_t phys,
+                                  const volatile uint64_t* frame) {
+        // Preserve the unarmed path: no stack query, interner construction, or extra formatting unless
+        // PROSPER_DMEM_CALLER was explicitly requested. MEMLOG alone keeps its historical line byte-for-byte.
+        if (!dmem_caller_log()) {
+            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
+                 (unsigned long long)len, (unsigned long long)phys);
+            return;
+        }
+        const DmemCallerChainResult correlation =
+            attribute_dmem_allocation(len, phys, frame, "alloc_main_dmem");
+
         // MEMLOG is the per-allocation census. Give every one of its allocation records a correlation
-        // token; the full stack remains one line per distinct bounded ID below.
+        // token; the full stack remains one line per distinct bounded ID, printed by the helper above.
         if (!dmem_caller_chain_correlates_allocation(correlation)) {
             MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
                  (unsigned long long)len, (unsigned long long)phys);
@@ -798,29 +842,6 @@ namespace {
                 break;
             }
         }
-
-        if (!correlation.first) return;
-        if (correlation.state == DmemCallerChainState::Overflow) {
-            // The cap is a state, not a population: every later MEMLOG record says `overflow`.
-            fprintf(stderr, "[dmem-caller] caller-chain=overflow: chain limit %zu reached;"
-                            " further distinct call chains are NOT retained\n",
-                    DmemCallerChainInterner<>::capacity());
-            return;
-        }
-        if (correlation.state == DmemCallerChainState::Unknown) {
-            fprintf(stderr,
-                    "[dmem-caller] caller-chain=unknown alloc_main_dmem len=0x%llx"
-                    " from <no guest return addresses>\n",
-                    (unsigned long long)len);
-            return;
-        }
-        DmemCallerChainFrame frames[kWant] = {};
-        for (int i = 0; i < n; ++i) {
-            frames[i].module = guest_module_name(ra[i]);
-            frames[i].offset = guest_module_offset(ra[i]);
-        }
-        write_dmem_caller_chain_definition(
-            stderr, correlation.id, len, frames, static_cast<size_t>(n), scan, kScan);
     }
 
     constexpr uint32_t kVirtualQueryFlexible = 0x01;
@@ -1645,6 +1666,12 @@ HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, ph
     MLOG("alloc_dmem range=[0x%llx,0x%llx) len=0x%llx align=0x%llx type=0x%llx -> phys=0x%llx\n",
          (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
          (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)off);
+    // #2998: publish the caller chain for THIS allocator too. Without it PROSPER_DMEM_WRITE_TRACE
+    // can never select memory obtained here, because its selector is keyed on a chain id that was
+    // only ever minted for sceKernelAllocateMainDirectMemory.
+    if (dmem_caller_log())
+        attribute_dmem_allocation(sz, off, (const volatile uint64_t*)__builtin_frame_address(0),
+                                  "alloc_dmem");
     return 0;
 }
 
@@ -3687,15 +3714,22 @@ namespace {
         const uintptr_t slots = (hi - base) / sizeof(uint64_t);
         return slots < (uintptr_t)want ? (int)slots : want;
     }
-    void log_main_dmem_allocation(uint64_t len, uint64_t phys,
-                                  const volatile uint64_t* frame) {
-        // Preserve the unarmed path: no stack query, interner construction, or extra formatting unless
-        // PROSPER_DMEM_CALLER was explicitly requested. MEMLOG alone keeps its historical line byte-for-byte.
-        if (!dmem_caller_log()) {
-            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
-                 (unsigned long long)len, (unsigned long long)phys);
-            return;
-        }
+    // #2998: allocation attribution, shared by every direct-memory entry point.
+    //
+    // Only sceKernelAllocateMainDirectMemory used to build a caller chain. A title that allocates
+    // through sceKernelAllocateDirectMemory instead therefore produced no chain id at all, which
+    // made PROSPER_DMEM_WRITE_TRACE structurally unable to name a single byte it owns -- the
+    // selector is keyed on caller-chain plus allocation size, and neither was ever published for
+    // that API. Tomb Raider I-III takes exactly this path (two 1 GiB allocations), so the trace
+    // could not be pointed at its texture atlas however it was configured. That read as "the
+    // instrument cannot target a sub-allocation" when the truth was "this allocator never reports".
+    //
+    // The interner is one shared static on purpose: a second interner would issue ids from its own
+    // sequence, so one id would mean two different call sites depending on which API allocated, and
+    // a configured trace would silently arm on the wrong memory rather than fail to arm.
+    DmemCallerChainResult attribute_dmem_allocation(uint64_t len, uint64_t phys,
+                                                    const volatile uint64_t* frame,
+                                                    const char* api) {
         constexpr int kWant = 6;          // return addresses to report
         constexpr int kScan = 160;        // stack slots to walk
         // Never read past the mapped end of this stack (#1755).
@@ -3717,8 +3751,45 @@ namespace {
             phys, len,
             correlation.state == DmemCallerChainState::Known ? correlation.id : 0);
 
+        if (!correlation.first) return correlation;
+        if (correlation.state == DmemCallerChainState::Overflow) {
+            // The cap is a state, not a population: every later MEMLOG record says `overflow`.
+            fprintf(stderr, "[dmem-caller] caller-chain=overflow: chain limit %zu reached;"
+                            " further distinct call chains are NOT retained\n",
+                    DmemCallerChainInterner<>::capacity());
+            return correlation;
+        }
+        if (correlation.state == DmemCallerChainState::Unknown) {
+            fprintf(stderr,
+                    "[dmem-caller] caller-chain=unknown %s len=0x%llx"
+                    " from <no guest return addresses>\n",
+                    api, (unsigned long long)len);
+            return correlation;
+        }
+        DmemCallerChainFrame frames[kWant] = {};
+        for (int i = 0; i < n; ++i) {
+            frames[i].module = guest_module_name(ra[i]);
+            frames[i].offset = guest_module_offset(ra[i]);
+        }
+        write_dmem_caller_chain_definition(
+            stderr, correlation.id, len, frames, static_cast<size_t>(n), scan, kScan, api);
+        return correlation;
+    }
+
+    void log_main_dmem_allocation(uint64_t len, uint64_t phys,
+                                  const volatile uint64_t* frame) {
+        // Preserve the unarmed path: no stack query, interner construction, or extra formatting unless
+        // PROSPER_DMEM_CALLER was explicitly requested. MEMLOG alone keeps its historical line byte-for-byte.
+        if (!dmem_caller_log()) {
+            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
+                 (unsigned long long)len, (unsigned long long)phys);
+            return;
+        }
+        const DmemCallerChainResult correlation =
+            attribute_dmem_allocation(len, phys, frame, "alloc_main_dmem");
+
         // MEMLOG is the per-allocation census. Give every one of its allocation records a correlation
-        // token; the full stack remains one line per distinct bounded ID below.
+        // token; the full stack remains one line per distinct bounded ID, printed by the helper above.
         if (!dmem_caller_chain_correlates_allocation(correlation)) {
             MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
                  (unsigned long long)len, (unsigned long long)phys);
@@ -3740,29 +3811,6 @@ namespace {
                 break;
             }
         }
-
-        if (!correlation.first) return;
-        if (correlation.state == DmemCallerChainState::Overflow) {
-            // The cap is a state, not a population: every later MEMLOG record says `overflow`.
-            fprintf(stderr, "[dmem-caller] caller-chain=overflow: chain limit %zu reached;"
-                            " further distinct call chains are NOT retained\n",
-                    DmemCallerChainInterner<>::capacity());
-            return;
-        }
-        if (correlation.state == DmemCallerChainState::Unknown) {
-            fprintf(stderr,
-                    "[dmem-caller] caller-chain=unknown alloc_main_dmem len=0x%llx"
-                    " from <no guest return addresses>\n",
-                    (unsigned long long)len);
-            return;
-        }
-        DmemCallerChainFrame frames[kWant] = {};
-        for (int i = 0; i < n; ++i) {
-            frames[i].module = guest_module_name(ra[i]);
-            frames[i].offset = guest_module_offset(ra[i]);
-        }
-        write_dmem_caller_chain_definition(
-            stderr, correlation.id, len, frames, static_cast<size_t>(n), scan, kScan);
     }
 
     // --- VA tracker + direct-memory pool: PURE logic, copied verbatim from the Linux path -----
@@ -6324,6 +6372,10 @@ HLE(k_alloc_dmem) {
     dmem_prepare_allocation(off, sz);
     *(uint64_t*)a5 = off;
     MLOG("alloc_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a2, (unsigned long long)off);
+    // #2998: publish the caller chain for THIS allocator too -- see the Linux path.
+    if (dmem_caller_log())
+        attribute_dmem_allocation(sz, off, (const volatile uint64_t*)__builtin_frame_address(0),
+                                  "alloc_dmem");
     return 0;
 }
 // sceKernelAllocateMainDirectMemory(len, align, memType, off_t* physOut) — physOut at arg3.

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -794,7 +794,7 @@ namespace {
             fprintf(stderr,
                     "[dmem-caller] caller-chain=unknown %s len=0x%llx"
                     " from <no guest return addresses>\n",
-                    api, (unsigned long long)len);
+                    (api && *api) ? api : "<unknown-allocator>", (unsigned long long)len);
             return correlation;
         }
         DmemCallerChainFrame frames[kWant] = {};
@@ -3763,7 +3763,7 @@ namespace {
             fprintf(stderr,
                     "[dmem-caller] caller-chain=unknown %s len=0x%llx"
                     " from <no guest return addresses>\n",
-                    api, (unsigned long long)len);
+                    (api && *api) ? api : "<unknown-allocator>", (unsigned long long)len);
             return correlation;
         }
         DmemCallerChainFrame frames[kWant] = {};

--- a/prosper/tests/hle/memory/test_dmem_caller_chain.cpp
+++ b/prosper/tests/hle/memory/test_dmem_caller_chain.cpp
@@ -78,7 +78,8 @@ int main() {
         {"eboot", 0x1b2454f}, {"libSceFoo", 0x7d0a00},
     };
     check(format_dmem_caller_chain_definition(
-              17, 0x1000000, format_frames, std::size(format_frames), 23, 160) ==
+              17, 0x1000000, format_frames, std::size(format_frames), 23, 160,
+              "alloc_main_dmem") ==
               "[dmem-caller] caller-chain=17 alloc_main_dmem len=0x1000000 from"
               " eboot+0x1b2454f libSceFoo+0x7d0a00"
               " [scan clamped to 23/160 slots by stack top]\n",
@@ -124,7 +125,8 @@ int main() {
             }
             expected_lines[chain] = format_dmem_caller_chain_definition(
                 static_cast<uint32_t>(chain + 1), 0x1000000 + chain,
-                frame_sets[chain].data(), frame_sets[chain].size(), 160, 160);
+                frame_sets[chain].data(), frame_sets[chain].size(), 160, 160,
+                "alloc_main_dmem");
         }
 
         std::atomic<size_t> ready{0};
@@ -136,7 +138,8 @@ int main() {
                 while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
                 write_dmem_caller_chain_definition(
                     definitions, static_cast<uint32_t>(chain + 1), 0x1000000 + chain,
-                    frame_sets[chain].data(), frame_sets[chain].size(), 160, 160);
+                    frame_sets[chain].data(), frame_sets[chain].size(), 160, 160,
+                    "alloc_main_dmem");
             });
         }
         while (ready.load(std::memory_order_acquire) != kDistinctChains)

--- a/prosper/tests/hle/memory/test_dmem_caller_chain.cpp
+++ b/prosper/tests/hle/memory/test_dmem_caller_chain.cpp
@@ -84,6 +84,23 @@ int main() {
               " [scan clamped to 23/160 slots by stack top]\n",
           "a full-chain definition has one exact parseable line format");
 
+    // The allocator label is DATA, not a constant. It was the literal "alloc_main_dmem" while that
+    // was the only entry point publishing chains; sceKernelAllocateDirectMemory now publishes them
+    // too, so a hardcoded label would make every record from that path name the wrong allocator.
+    // This arm fails if the label is ever pinned back to a literal.
+    check(format_dmem_caller_chain_definition(
+              18, 0x40000000, format_frames, std::size(format_frames), 23, 160, "alloc_dmem") ==
+              "[dmem-caller] caller-chain=18 alloc_dmem len=0x40000000 from"
+              " eboot+0x1b2454f libSceFoo+0x7d0a00"
+              " [scan clamped to 23/160 slots by stack top]\n",
+          "the allocator label is carried from the caller, not hardcoded");
+    // An absent label must be visibly absent rather than silently borrowing the default, or a
+    // record would assert an allocator nobody supplied.
+    check(format_dmem_caller_chain_definition(
+              19, 0x10, format_frames, std::size(format_frames), 23, 160, "")
+              .find("<unknown-allocator>") != std::string::npos,
+          "an empty allocator label reports unknown instead of a plausible default");
+
     // Reproduce the reviewed failure shape: several guest threads discover DIFFERENT chains at
     // once. The old implementation emitted each definition through a sequence of fprintf calls,
     // so an ID prefix from one thread could be joined to frames from another. Exercise the exact

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -40,12 +40,18 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     / map with its size, which answers *how much* but never *who* — and the same guest allocator
     serves every subsystem, so a title whose heap grows without bound looks identical to one that is
     legitimately loading. Add **`PROSPER_DMEM_CALLER=1`** to print, once per distinct call chain, the
-    guest return addresses above each `sceKernelAllocateMainDirectMemory`. The first two return
+    guest return addresses above each `sceKernelAllocateMainDirectMemory` **and each
+    `sceKernelAllocateDirectMemory`** (#3054 — before that, only the Main variant published a chain,
+    so a title allocating through the other entry point produced no records at all and
+    `PROSPER_DMEM_WRITE_TRACE` could not name any byte it owned). The record names the allocator it
+    came from, so `alloc_dmem` and `alloc_main_dmem` lines are told apart. The first two return
     addresses are interned as a bounded run-local `caller-chain=N`; the full bounded chain prints
     once, while every allocation in the `PROSPER_MEMLOG=1` census carries the same correlation ID:
     ```text
     [memhle] alloc_main_dmem len=0x1000000 -> phys=0x21500000 caller-chain=1
     [dmem-caller] caller-chain=1 alloc_main_dmem len=0x1000000 from eboot+0x1b2454f eboot+0x7d0a00 eboot+0x22b1e80 …
+    [memhle] alloc_dmem range=[0x0,0x400000000) len=0x40000000 align=0x0 type=0xc -> phys=0x40010000
+    [dmem-caller] caller-chain=2 alloc_dmem len=0x40000000 from eboot+0xccb3 eboot+0x20c7c8 eboot+0x7677 …
     ```
     Feed the first address to `tools/re/edis.py` / `tools/re/xref.py` to name the caller. The walk is
     a heuristic stack scan (a stale spill slot looks exactly like a return address), so treat the


### PR DESCRIPTION
Fixes #3054. Investigation context: #2998.

## The defect

`PROSPER_DMEM_WRITE_TRACE` selects an allocation by **caller-chain + exact allocation size +
offset**. Only `sceKernelAllocateMainDirectMemory` ever minted a chain id, so a title that
allocates through `sceKernelAllocateDirectMemory` published **none** — and no selector could name
a single byte it owns. The trace was not merely weak for those titles; it was structurally
unreachable, and it failed by refusing to arm rather than by saying why.

## Failure scenario

*Tomb Raider I-III* (`PPSA16901`) makes two 1 GiB `alloc_dmem` allocations, and its 86 MiB texture
atlas lives inside the second. Before this change a run with `PROSPER_DMEM_CALLER=1` produced
**zero** `[dmem-caller]` records for that title, so every `PROSPER_DMEM_WRITE_TRACE` configuration
— any chain, any offset — failed to arm. There was no combination of inputs that worked.

## Why the original issue was wrong, and why this is not that fix

I opened #3054 asking for an absolute-address watchpoint, on the reasoning that the trace "cannot
arm on a fixed address" and the title sub-allocates inside its own 1 GiB block. **Both halves were
wrong:**

- the four-field selector's `offset` field already targets an arbitrary sub-range, which is exactly
  the case I claimed it could not express;
- the fixed-VA rejection in `guest_write_watch.hpp` is a **deliberate, correct** design decision —
  a guest VA is run-local, so the absolute mode I proposed would have silently armed on whatever
  occupied that address on a later run, the same failure the charter records for capture hashes and
  operation ordinals. Building it would have made the instrument *less* trustworthy.

The real gap was one allocator that never reported.

## Approach and invariants

Both entry points now share one `attribute_dmem_allocation` helper.

**The interner is a single static on purpose.** A second interner would issue ids from its own
sequence, so one id would mean two different call sites depending on which API allocated — and a
configured trace would then arm on the **wrong memory** instead of failing to arm, which is
strictly worse than the bug being fixed.

**The allocator label is now data, not a constant.** It was the literal `alloc_main_dmem`, true
while only that path published chains; left alone, every record from the new path would have named
the wrong allocator. An empty label reports `<unknown-allocator>` rather than borrowing the
default, so a record can never assert an allocator nobody supplied.

Applied to the **Linux and Windows** implementations alike, so the diagnostic is not silently dead
on one platform.

## Result

```
[memhle]      alloc_dmem len=0x40000000 -> phys=0x10000
[dmem-caller] caller-chain=1 alloc_dmem len=0x40000000 from eboot+0xcc58 eboot+0x20c7c8 ...
[memhle]      alloc_dmem len=0x40000000 -> phys=0x40010000
[dmem-caller] caller-chain=2 alloc_dmem len=0x40000000 from eboot+0xccb3 eboot+0x20c7c8 ...
```

With chain 2 nameable, `PROSPER_DMEM_WRITE_TRACE=2:0x40000000:0x51cc000:128` arms
(`target=0x20491cc000 target-phys=0x451dc000 pages=1`) and identifies the atlas writer:
`eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing 8x16 B per iteration to offsets computed
in `%ymm10`. That answers a question #2998 had been stuck on.

## Deliberately unaffected

Nothing changes with `PROSPER_DMEM_CALLER` unset: the attribution call sits behind the same
`dmem_caller_log()` gate the Main path already used, and MEMLOG's historical lines are
**byte-for-byte unchanged** on both paths. No production allocation behaviour is touched — the
helper runs after the allocation has succeeded and its result has been written to the guest.

## Risks

The helper walks the guest stack, as the Main path already did; it inherits the same `#1755`
mapped-end clamp and the `#2045` `guest_va_in_module_code` filter, unchanged. It runs only when the
diagnostic is enabled. The chain-id space is shared across two allocators now, so a run using both
will interleave ids — intended, and the reason for the single interner.

## Verification (exact head `f67d58be`)

- `cmake --build prosper/build-linux -j6` — clean
- `ctest --test-dir prosper/build-linux --no-tests=error -j4` — **311 of 311 passed**
- `check_diag_gates.py` — all checks passed
- `diff --check` — clean
- Live: `PPSA16901` with `PROSPER_DMEM_CALLER=1 PROSPER_MEMLOG=1` — output above; the same run
  before this change produced zero `[dmem-caller]` lines.

**Mutation-verified tests.** The two new arms in `test_dmem_caller_chain.cpp` are not merely
passing: restoring the hardcoded `alloc_main_dmem` literal makes both **FAIL** and the binary
report `FAILED`, and they pass again when reverted. Without that check the arms would have been
assertions that could not distinguish the fix from the bug.

No snapshots were run: this touches no rendering path.
