### PR TITLE
perf(compute): attribute the image-source snapshots — 89% are read/modify/write, and 0% are what I expected

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1151,6 +1151,20 @@ struct VulkanComputeContext {
     uint64_t storage_result_snapshot_bytes = 0;
     uint64_t image_result_snapshot_copies = 0;
     uint64_t image_result_snapshot_bytes = 0;
+    // WHY each snapshot was taken. The total above cannot be acted on: measured on GTA V gameplay
+    // it is 35 GB in one routed run and 48% of all CPU cycles land in the memmove underneath it,
+    // but the adaptive storage-result path already halves the rate (measured: disabling it doubles
+    // snapshots/pool-hit from 0.0715 to 0.1404), so the remaining traffic is whatever that path
+    // never sees. Two branches reach the copy without consulting it -- an early return for
+    // host-data sources, and read/modify/write or partial storage targets, which genuinely need an
+    // exact baseline. Which of those dominates decides whether there is anything left to win here,
+    // and no existing counter separates them. Same reasoning as the res_buffer_* leaves.
+    uint64_t snapshot_reason_host_data_copies = 0;
+    uint64_t snapshot_reason_host_data_bytes = 0;
+    uint64_t snapshot_reason_rmw_copies = 0;
+    uint64_t snapshot_reason_rmw_bytes = 0;
+    uint64_t snapshot_reason_changed_copies = 0;
+    uint64_t snapshot_reason_changed_bytes = 0;
     VkDescriptorSetLayout compare_descriptor_layout = VK_NULL_HANDLE;
     VkShaderModule compare_shader = VK_NULL_HANDLE;
     VkPipelineLayout compare_pipeline_layout = VK_NULL_HANDLE;
@@ -1677,9 +1691,12 @@ struct VulkanComputeContext {
                write_watch_promotion_budget.try_consume(source_bytes);
     }
 
+    enum class SnapshotReason { Unattributed, HostData, ReadModifyWrite, ContentChanged };
+
     void remember_image_source_snapshot(CachedComputeImage& cached,
                                         const uint8_t* source, size_t bytes,
-                                        bool storage_result = false) {
+                                        bool storage_result = false,
+                                        SnapshotReason reason = SnapshotReason::Unattributed) {
         if (!source) return;
         cached.source_snapshot.assign(source, source + bytes);
         ++image_source_snapshot_copies;
@@ -1687,6 +1704,15 @@ struct VulkanComputeContext {
         if (storage_result) {
             ++storage_result_snapshot_copies;
             storage_result_snapshot_bytes += bytes;
+        }
+        switch (reason) {
+        case SnapshotReason::HostData:
+            ++snapshot_reason_host_data_copies; snapshot_reason_host_data_bytes += bytes; break;
+        case SnapshotReason::ReadModifyWrite:
+            ++snapshot_reason_rmw_copies; snapshot_reason_rmw_bytes += bytes; break;
+        case SnapshotReason::ContentChanged:
+            ++snapshot_reason_changed_copies; snapshot_reason_changed_bytes += bytes; break;
+        case SnapshotReason::Unattributed: break;
         }
     }
 
@@ -2006,7 +2032,8 @@ struct VulkanComputeContext {
         } else if (!upload_skipped && source && source_snapshot_required) {
             cached.write_watch_stable_validations = 0;
             remember_image_source_snapshot(
-                cached, source, key.guest_bytes, key.storage);
+                cached, source, key.guest_bytes, key.storage,
+                SnapshotReason::ContentChanged);
             // Do not trust the new mirror until the corresponding transfer completes. A failed
             // submit leaves this false, so the next use refreshes instead of skipping stale pixels.
             cached.content_valid = false;
@@ -2369,7 +2396,8 @@ struct VulkanComputeContext {
         if (key.host_data) {
             if (current_source)
                 remember_image_source_snapshot(
-                    cached, current_source, key.guest_bytes, true);
+                    cached, current_source, key.guest_bytes, true,
+                    SnapshotReason::HostData);
             cached.write_watch.reset();
             return;
         }
@@ -2389,7 +2417,8 @@ struct VulkanComputeContext {
             // contract because their prior guest bytes are observable by the next dispatch.
             if (current_source)
                 remember_image_source_snapshot(
-                    cached, current_source, key.guest_bytes, true);
+                    cached, current_source, key.guest_bytes, true,
+                    SnapshotReason::ReadModifyWrite);
             if (cached.write_watch && cached.write_watch.rearm()) return;
             cached.write_watch.reset();
             return;
@@ -10457,6 +10486,27 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
                         (1024.0 * 1024.0),
                     (unsigned long long)g_compute_storage_transfer_seeds.load(
                         std::memory_order_relaxed));
+                // WHY those snapshots happened. `other` is the remainder and is printed SIGNED --
+                // a negative value means over-attribution, and clamping it would make a broken
+                // partition look like a complete one (the same rule the res_buffer leaves follow).
+                {
+                    const uint64_t attributed =
+                        context.snapshot_reason_host_data_bytes +
+                        context.snapshot_reason_rmw_bytes +
+                        context.snapshot_reason_changed_bytes;
+                    const double mib = 1024.0 * 1024.0;
+                    std::fprintf(stderr,
+                        "[render-timing] compute_snapshot_reason host_data=%llu %.1f MiB "
+                        "rmw=%llu %.1f MiB changed=%llu %.1f MiB other=%+.1f MiB\n",
+                        (unsigned long long)context.snapshot_reason_host_data_copies,
+                        static_cast<double>(context.snapshot_reason_host_data_bytes) / mib,
+                        (unsigned long long)context.snapshot_reason_rmw_copies,
+                        static_cast<double>(context.snapshot_reason_rmw_bytes) / mib,
+                        (unsigned long long)context.snapshot_reason_changed_copies,
+                        static_cast<double>(context.snapshot_reason_changed_bytes) / mib,
+                        (static_cast<double>(context.image_source_snapshot_bytes) -
+                         static_cast<double>(attributed)) / mib);
+                }
                 std::fprintf(stderr,
                     "[render-window] compute calls=%llu dispatches=%.1f avg_ms=%.2f\n",
                     (unsigned long long)window.calls,


### PR DESCRIPTION
## What this adds

Per-reason attribution for the compute image-source snapshots, so the existing volume counter can be
acted on:

```
[render-timing] compute_snapshot_reason host_data=0 0.0 MiB rmw=6572 71502.4 MiB
                changed=1744 8212.5 MiB other=+835.8 MiB
```

`remember_image_source_snapshot` has **ten call sites**; three are tagged here because they are the
ones that carry volume, five more are live on Linux but cold one-shot retentions (they land in
`other`), and two are inert in this configuration. The tagged three have **very different prospects**
— an early `if (key.host_data)` return that never consults the adaptive path, targets that require an
exact guest baseline, and the ordinary changed-content path. Nothing separated them, so choosing a
target meant guessing.

## What it establishes

- **`host_data` is exactly zero — on every platform, not just Linux.** `ShaderResource::host_data`
  is replay-only owned backing; production tables leave it zero, and every writer is in
  `gpu_capture.cpp` or `gpu_replay/`. So this branch cannot fire in a live run at all. It is the
  branch I expected to dominate, because it returns *before* the adaptive path is consulted; an
  optimisation aimed there would have been worth nothing.
- **88.8% required an exact guest baseline** — the branch guarded by `source_snapshot_required`,
  which the live caller supplies as `!seed_skip`. That is mostly read/modify/write and partial
  storage targets, whose prior bytes are observable by the next dispatch, but `!seed_skip` **also**
  catches coverage proving/re-proving, uncached-proof first sightings and thread-count failures, so
  the counter is a proxy for "needs a baseline" rather than a direct RMW test. The recurring member
  is bounded: `kSeedReproveInterval` defaults to 256, so proving frames are ~0.4%.
- `other` is **1.0%**, consistent with the five untagged live sites being cold one-shot retentions.
  It prints **signed** so an over-attribution shows as negative rather than being clamped into
  looking clean — the rule the `res_buffer_*` leaves already follow.

Split, recomputed: **88.77 / 10.20 / 1.04%**.

## Why guessing was not acceptable

Four attempts to name this frame's cost have now been wrong, which is the case for measuring rather
than reasoning:

| attempt | outcome |
| --- | --- |
| texture cost dominates | **stale** — a remembered 3.8 s figure the rendering series had obsoleted; it is ~384 ms now |
| the write-watch promotion budget blocks promotion | **falsified** — 16x raise moved snapshot volume 3%, and flips/s did not improve (1.19 → 1.05, an 11.8% drop; one run each, so treat as "no gain", not as a regression) |
| the adaptive storage-result path needs adding | **already there and working** — disabling it *doubles* snapshots per pool-hit, 0.0715 → 0.1404 |
| the `host_data` branch dominates | **zero**, per this PR's own counters |

The second and third required normalising per pool-hit: the raw counters are cumulative, so comparing
totals between runs of different progress measures run length, not the change.

## What this PR does NOT claim

An earlier version of this body opened with "48% of all CPU cycles in one `memmove`" and discussed
the snapshots as though that memmove were them. **That link was never established and the arithmetic
refutes it:** 65 core-seconds went to `memmove` in the perf window, while 69.8 GB of snapshots scales
to ~16.5 GB inside it — 1.0–2.1 core-seconds, i.e. **~2–3%**. Two large numbers placed side by side,
with the cause inferred. Retracted.

So: these snapshots are 69.8 GB of memory traffic, worth knowing and worth attributing, but on
current evidence they are **not** why GTA V runs at ~1.2 guest flips/s. The dominant `memmove` caller
is still **unidentified** — `perf` could not resolve it because the binary reported `(deleted)`.
Finding it is the next step and is not this PR.

## These are single runs

Every figure here is one run of one route on one host: the 48%/6% cycle shares, the 98.7 ms
`gpu-device`, the ~1.2 guest flips/s, and the 88.8/10.2/1.0 split. They are stated to show the shape
of the problem and to justify attributing it, not as characterisations of the title. The mean
snapshot is **10.88 MiB** (79 GB / 7452 copies at this reading); an earlier draft said "9.5 MiB",
which was a different run's mean and is not derivable from anything the tool prints.

## Scope

Instrumentation only. Three counters, one report line, and a `SnapshotReason` argument defaulted to
`Unattributed` so no existing call site changes behaviour. No policy, no allocation, no ordering, no
locking.

```
cmake --build prosper/build-linux -j6     # 0 errors
ctest --no-tests=error                    # 100% tests passed out of 306
```

`git diff --check` clean.

Refs #2863
