### PR TITLE
fix(win): the vblank kevent pump joins the vblank grid instead of keeping its own 33 Hz clock

### DIFF
--- a/prosper/src/hle/graphics/hle_graphics.cpp
+++ b/prosper/src/hle/graphics/hle_graphics.cpp
@@ -743,9 +743,10 @@ HLE(g_vo_resstatus)   {
 //
 // But the FIRST caller does set where it starts, and after #3024 that caller is usually the
 // kevent pump. `vblank_epoch_ns()` is a first-use-anchored static, and the pump's read at
-// hle_kernel_time.cpp reaches it as soon as a title registers a vblank event -- typically
-// before the title's first GetVblankStatus or WaitVblank call. So the epoch is now normally
-// anchored at vblank-event registration rather than at the first guest status query, which
+// hle_kernel_time.cpp reaches it as soon as a title registers a vblank OR A FLIP event (both
+// call the same ensure_pump) -- typically before the title's first GetVblankStatus or
+// WaitVblank call. So the epoch is now normally anchored at event registration rather than at
+// the first guest status query, which
 // moves GetVblankStatus's first `count` and processTime's baseline, and shifts WaitVblank's
 // wake instants in PHASE with them (they derive from the same t0). That is a deliberate
 // consequence on every platform, not only Windows, and it is more faithful -- the epoch now

--- a/prosper/src/hle/graphics/hle_graphics.cpp
+++ b/prosper/src/hle/graphics/hle_graphics.cpp
@@ -764,6 +764,14 @@ void vblank_sleep_until_ns(uint64_t deadline_ns) {
 }
 }  // namespace
 
+// The kernel equeue vblank pump (hle_kernel_time.cpp) schedules on THIS grid, so the kevent
+// stream and the vblank status/wait paths above become one clock in both phase and period.
+// They were two drifting clocks before -- the follow-up this file records at its own timebase
+// comment ("aligning them is a real follow-up; asserting they are aligned is wrong"). Sharing
+// the origin and the period here is what closes it (#3024).
+extern "C" uint64_t prosper_vo_vblank_grid_origin_ns() { return vblank_epoch_ns(); }
+extern "C" uint64_t prosper_vo_vblank_period_ns() { return kVblankNs; }
+
 extern "C" void prosper_vo_set_vblank_now_for_test(uint64_t now_ns) {
     g_vblank_test_now_ns.store(now_ns, std::memory_order_relaxed);
 }

--- a/prosper/src/hle/graphics/hle_graphics.cpp
+++ b/prosper/src/hle/graphics/hle_graphics.cpp
@@ -729,14 +729,17 @@ HLE(g_vo_resstatus)   {
 // which is a statement about where the boundaries fall, not about how far apart they are. Anchored
 // on first use so both are process-relative, exactly as the previous status-only anchor was.
 //
-// It is NOT the only vblank clock in the process, and this comment previously claimed it was.
-// hle_kernel_time.cpp's `vblank_pump` (:731) posts the VideoOut vblank kevent from its own
-// `nanosleep(16666667)` loop — 60.000 Hz, its own phase, started when the first equeue source is
-// registered. So the kevent stream and this grid drift by roughly one tick per second and their
-// boundaries do not coincide. Aligning them is a real follow-up; asserting they are aligned is
-// wrong, and a title that cross-checks the two would see the disagreement.
+// It is no longer a second clock. hle_kernel_time.cpp's `vblank_pump` -- the thread that posts the
+// VideoOut vblank kevent to registered equeues -- used to run its own `nanosleep(16666667)` loop
+// at 60.000 Hz and its own phase, so the kevent stream and this grid disagreed in BOTH period and
+// phase, and this comment recorded aligning them as an open follow-up. #3024 closed it: the pump
+// now derives its schedule from the two accessors published just below, so there is one origin and
+// one period in the process. The alignment is therefore asserted here on purpose -- it is what the
+// pump computes from, not a hope about two constants matching.
 // Internal linkage on purpose: the "epoch before now" ordering invariant below is only
-// enforceable by reading this one file, so nothing outside it may reach these.
+// enforceable by reading this one file, so nothing outside it may reach these DIRECTLY. The
+// two `extern "C"` accessors further down publish the origin and the period as values, which
+// cannot break that invariant -- a caller can schedule on the grid but cannot move it.
 namespace {
 constexpr uint64_t kVblankNs = 16683350;             // 59.94 Hz period
 // Deterministic clock used only by test_videoout's phase-integration check. Zero leaves the

--- a/prosper/src/hle/graphics/hle_graphics.cpp
+++ b/prosper/src/hle/graphics/hle_graphics.cpp
@@ -738,8 +738,19 @@ HLE(g_vo_resstatus)   {
 // pump computes from, not a hope about two constants matching.
 // Internal linkage on purpose: the "epoch before now" ordering invariant below is only
 // enforceable by reading this one file, so nothing outside it may reach these DIRECTLY. The
-// two `extern "C"` accessors further down publish the origin and the period as values, which
-// cannot break that invariant -- a caller can schedule on the grid but cannot move it.
+// two `extern "C"` accessors further down publish the origin and the period as VALUES, so no
+// caller can retarget the grid.
+//
+// But the FIRST caller does set where it starts, and after #3024 that caller is usually the
+// kevent pump. `vblank_epoch_ns()` is a first-use-anchored static, and the pump's read at
+// hle_kernel_time.cpp reaches it as soon as a title registers a vblank event -- typically
+// before the title's first GetVblankStatus or WaitVblank call. So the epoch is now normally
+// anchored at vblank-event registration rather than at the first guest status query, which
+// moves GetVblankStatus's first `count` and processTime's baseline, and shifts WaitVblank's
+// wake instants in PHASE with them (they derive from the same t0). That is a deliberate
+// consequence on every platform, not only Windows, and it is more faithful -- the epoch now
+// tracks when the title started caring about vblanks rather than when it first asked -- but
+// it is a change, and a comment claiming callers cannot move the grid would have hidden it.
 namespace {
 constexpr uint64_t kVblankNs = 16683350;             // 59.94 Hz period
 // Deterministic clock used only by test_videoout's phase-integration check. Zero leaves the

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -7,6 +7,8 @@
 #include "host/platform/posix_shim.hpp"     // PROSPER_ASM_TRAMPOLINE (pass entry %rsp as 7th arg)
 #include "host/platform/precise_sleep.hpp"   // guest sleeps must not inherit the winpthreads tick (#3013)
 #include "hle/kernel/timedwait_census.hpp"   // PROSPER_TIMEDWAIT_CENSUS: which primitive a title paces on
+extern "C" uint64_t prosper_vo_vblank_grid_origin_ns();   // the shared 59.94 Hz grid (hle_graphics.cpp)
+extern "C" uint64_t prosper_vo_vblank_period_ns();
 #include "host/image/runtime_module_load.hpp"   // #639: real runtime PRX loading
 #include "host/memory/guest_write_watch.hpp"     // flush dmem writer diagnostic before guest _Exit
 #include "hle/dispatch/callback_fs.hpp"            // recover the caller's guest %fs from the import-stub frame
@@ -1108,8 +1110,39 @@ namespace {
     }
     void vblank_pump() {
         uint64_t frame = 0;
+        // Absolute schedule on the SHARED 59.94 Hz grid that hle_graphics.cpp uses for the
+        // vblank status and wait paths, waited with host::sleep_until_steady_ns. Two defects
+        // this replaces (#3024):
+        //
+        //   * A relative nanosleep(16.67 ms) resolves on the winpthreads tick on Windows. A
+        //     standalone microbenchmark of that nanosleep on this toolchain (MinGW-w64/UCRT,
+        //     GCC 16.1) returns every 29.95 ms, so the pump was posting vblank kevents at
+        //     roughly 33 Hz rather than 60, and every consumer pacing on this event stream
+        //     inherited it. Provenance stated because it matters: that is the sleep primitive
+        //     measured in isolation, NOT an instrumented measurement of this pump, and the
+        //     figure is quoted here only to size the defect. Same microbenchmark under
+        //     timeBeginPeriod(1) gives 24.78 ms -- still not 16.67 -- and that arm is
+        //     hypothetical for prosper, which calls timeBeginPeriod nowhere (see
+        //     precise_sleep.cpp's own note). So the unrescued 29.95 ms is what ran.
+        //     It is the same defect #1765 fixed for the status/wait grid one file away, which
+        //     is why that file already says "NOT std::this_thread::sleep_until" over its wait.
+        //   * A relative sleep also drifts against the status grid. hle_graphics.cpp records
+        //     that as an open follow-up in as many words -- the two clocks "drift by roughly one
+        //     tick per second and their boundaries do not coincide", and a title that
+        //     cross-checks the kevent count against the status count would see it. Deriving both
+        //     from one origin and one period closes it by construction rather than by tuning.
+        //
+        // host::next_periodic_deadline_ns carries the advance, including the resync after a
+        // wholly missed tick. It is a separate tested function because the obvious inline
+        // spelling of that resync is wrong in a way that still looks like 60 Hz -- see its
+        // comment in precise_sleep.hpp.
+        const uint64_t period_ns = prosper_vo_vblank_period_ns();
+        uint64_t next_ns = prosper_vo_vblank_grid_origin_ns() + period_ns;
         for (;;) {
-            struct timespec ts{ 0, 16666667 }; nanosleep(&ts, nullptr);   // ~60 Hz
+            prosper::host::sleep_until_steady_ns(next_ns);
+            const uint64_t now_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+                clk::now().time_since_epoch()).count();
+            next_ns = prosper::host::next_periodic_deadline_ns(next_ns, now_ns, period_ns);
             frame++;
             std::vector<FlipReg> vr;
             { std::lock_guard lk(g_eq_mx); vr = g_vblank_regs; }

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -1142,6 +1142,15 @@ namespace {
         // the obvious hand-rolled spelling -- advance by a period, re-anchor to now+period when
         // behind -- silently loses the phase, and an earlier draft of this loop also halved the
         // rate. See its comment in precise_sleep.hpp.
+        //
+        // One composition caveat, recorded because the helper alone does not cover it (#3074):
+        // this loop assumes the wait cannot return EARLY. If it does, the next `now` is still
+        // below the same boundary, the helper correctly returns that boundary again, and this
+        // thread posts two kevents for one vblank. Reachable only on the Win32SleepFallback
+        // path, which does not re-check the clock the way the high-resolution timer path does;
+        // bounded (one extra event, and vblank posts coalesce) so it is filed rather than
+        // worked around here. The fix belongs in precise_sleep, which already documents the
+        // post-condition it fails to enforce on that one path.
         const uint64_t origin_ns = prosper_vo_vblank_grid_origin_ns();
         const uint64_t period_ns = prosper_vo_vblank_period_ns();
         for (;;) {

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -1132,9 +1132,18 @@ namespace {
         //     is why that file already says "NOT std::this_thread::sleep_until" over its wait.
         //   * A relative sleep also drifts against the status grid. hle_graphics.cpp records
         //     that as an open follow-up in as many words -- the two clocks "drift by roughly one
-        //     tick per second and their boundaries do not coincide", and a title that
-        //     cross-checks the kevent count against the status count would see it. Deriving both
-        //     from one origin and one period closes it by construction rather than by tuning.
+        //     tick per second and their boundaries do not coincide". Deriving both from one
+        //     origin and one period fixes the BOUNDARIES: a kevent now lands on an instant the
+        //     status grid also calls a boundary.
+        //
+        //     It does NOT make the two COUNTS equal, and the earlier wording here claimed it
+        //     did. `e.data` below is `frame`, which counts posts; GetVblankStatus's `count` is
+        //     the grid INDEX. They agree only while no boundary is skipped -- and skipping is
+        //     what this design does deliberately when a tick is missed, rather than bursting.
+        //     A title cross-checking the two would still see a divergence after any stall.
+        //     Making the payload the grid ordinal would close that too, but `data = frame`
+        //     predates this change and nothing here establishes what real hardware puts in
+        //     that field, so it is left alone and named instead of quietly overclaimed.
         //
         // One call carries the whole schedule: host::next_grid_deadline_ns returns the next
         // boundary strictly after now, so the ordinary case and a stall of any length are the
@@ -1142,6 +1151,12 @@ namespace {
         // the obvious hand-rolled spelling -- advance by a period, re-anchor to now+period when
         // behind -- silently loses the phase, and an earlier draft of this loop also halved the
         // rate. See its comment in precise_sleep.hpp.
+        //
+        // The cost of that property, named because it is real: phase stays exact however
+        // many boundaries were skipped, so a pump running at HALF rate has perfect phase
+        // and no symptom. The relative sleep this replaces at least drifted visibly, which
+        // is how #3024 was noticed. A dropped-boundary counter would restore the symptom
+        // without giving back the drift -- #3075.
         //
         // One composition caveat, recorded because the helper alone does not cover it (#3074):
         // this loop assumes the wait cannot return EARLY. If it does, the next `now` is still
@@ -1151,6 +1166,13 @@ namespace {
         // bounded (one extra event, and vblank posts coalesce) so it is filed rather than
         // worked around here. The fix belongs in precise_sleep, which already documents the
         // post-condition it fails to enforce on that one path.
+        // Reading the origin here is what usually ANCHORS it -- see the note in
+        // hle_graphics.cpp. Two qualifications, because the obvious statement of that is not
+        // quite true: ensure_pump() detaches this thread, so a guest status or wait call
+        // arriving inside the thread-start window anchors the grid instead, which makes the
+        // epoch's wall-clock phase nondeterministic by thread-start latency; and the pump is
+        // started by prosper_eq_add_flip as well as prosper_eq_add_vblank, so a title that
+        // registers only a FLIP event still anchors it here.
         const uint64_t origin_ns = prosper_vo_vblank_grid_origin_ns();
         const uint64_t period_ns = prosper_vo_vblank_period_ns();
         for (;;) {

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -7,8 +7,6 @@
 #include "host/platform/posix_shim.hpp"     // PROSPER_ASM_TRAMPOLINE (pass entry %rsp as 7th arg)
 #include "host/platform/precise_sleep.hpp"   // guest sleeps must not inherit the winpthreads tick (#3013)
 #include "hle/kernel/timedwait_census.hpp"   // PROSPER_TIMEDWAIT_CENSUS: which primitive a title paces on
-extern "C" uint64_t prosper_vo_vblank_grid_origin_ns();   // the shared 59.94 Hz grid (hle_graphics.cpp)
-extern "C" uint64_t prosper_vo_vblank_period_ns();
 #include "host/image/runtime_module_load.hpp"   // #639: real runtime PRX loading
 #include "host/memory/guest_write_watch.hpp"     // flush dmem writer diagnostic before guest _Exit
 #include "hle/dispatch/callback_fs.hpp"            // recover the caller's guest %fs from the import-stub frame
@@ -992,6 +990,12 @@ namespace { bool evlog() { static int v = getenv("PROSPER_EVLOG") ? 1 : 0; retur
 // --- Real event-queue backend (kqueue/kevent model). Registered flip/vblank sources post events into
 // their equeue; WaitEqueue blocks until an event is ready (or timeout) and returns it. A single ~60 Hz
 // pump thread drives vblank + flip-completion events so Unity's render/timing threads pace frames. ---
+// The shared 59.94 Hz vblank grid, defined in hle/graphics/hle_graphics.cpp. Declared here
+// rather than in a header because that file deliberately keeps the grid internal, and these
+// two accessors are the whole of what it publishes (#3024).
+extern "C" uint64_t prosper_vo_vblank_grid_origin_ns();
+extern "C" uint64_t prosper_vo_vblank_period_ns();
+
 namespace {
     // SceKernelEvent (FreeBSD kevent layout, 0x20 bytes): ident@0, filter@8(i16), flags@0xA(u16),
     // fflags@0xC(u32), data@0x10, udata@0x18. The game reads udata (its flip context) + data.
@@ -1132,17 +1136,19 @@ namespace {
         //     cross-checks the kevent count against the status count would see it. Deriving both
         //     from one origin and one period closes it by construction rather than by tuning.
         //
-        // host::next_periodic_deadline_ns carries the advance, including the resync after a
-        // wholly missed tick. It is a separate tested function because the obvious inline
-        // spelling of that resync is wrong in a way that still looks like 60 Hz -- see its
-        // comment in precise_sleep.hpp.
+        // One call carries the whole schedule: host::next_grid_deadline_ns returns the next
+        // boundary strictly after now, so the ordinary case and a stall of any length are the
+        // same expression and the phase cannot drift. It is a separate tested function because
+        // the obvious hand-rolled spelling -- advance by a period, re-anchor to now+period when
+        // behind -- silently loses the phase, and an earlier draft of this loop also halved the
+        // rate. See its comment in precise_sleep.hpp.
+        const uint64_t origin_ns = prosper_vo_vblank_grid_origin_ns();
         const uint64_t period_ns = prosper_vo_vblank_period_ns();
-        uint64_t next_ns = prosper_vo_vblank_grid_origin_ns() + period_ns;
         for (;;) {
-            prosper::host::sleep_until_steady_ns(next_ns);
             const uint64_t now_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
                 clk::now().time_since_epoch()).count();
-            next_ns = prosper::host::next_periodic_deadline_ns(next_ns, now_ns, period_ns);
+            prosper::host::sleep_until_steady_ns(
+                prosper::host::next_grid_deadline_ns(origin_ns, now_ns, period_ns));
             frame++;
             std::vector<FlipReg> vr;
             { std::lock_guard lk(g_eq_mx); vr = g_vblank_regs; }

--- a/prosper/src/host/platform/precise_sleep.hpp
+++ b/prosper/src/host/platform/precise_sleep.hpp
@@ -27,25 +27,35 @@ SleepBackend sleep_backend();
 // A stable spelling of sleep_backend() for assertions and logs. Never null.
 const char* sleep_backend_name();
 
-// Advance an absolute periodic deadline after a wait on it has completed. `now_ns` is the time
-// the wait actually returned; the result is the next deadline on the SAME grid, so overshoot
-// does not accumulate the way it does when each iteration sleeps for a relative period.
+// The next boundary of a fixed periodic grid strictly after `now_ns`, where the grid is every
+// `origin_ns + k * period_ns`. Intended to be called after a wait on the previous boundary has
+// completed, as the WHOLE of a pacing loop's per-iteration work: because the answer depends only
+// on (origin, now, period) and not on the deadline just waited, one expression covers the
+// ordinary case, an early return, and a stall of any length.
 //
-// This is a free function with its own tests because of one subtlety that reads as correct and
-// is not: after sleep_until_steady_ns(deadline_ns) returns, `now_ns` is normally ALREADY past
-// deadline_ns by the wait's own small overshoot. So a "have we fallen behind?" test written
-// against the OLD deadline is true on every ordinary iteration, and re-anchoring there silently
-// costs one extra period per iteration -- halving the rate, while the surrounding code still
-// says 60 Hz. The comparison has to be against the ADVANCED deadline. Caught in review of the
-// #3024 vblank pump, where it would have turned a 33 Hz defect into a 30 Hz one.
-constexpr uint64_t next_periodic_deadline_ns(uint64_t deadline_ns, uint64_t now_ns,
-                                            uint64_t period_ns) {
-    if (period_ns == 0) return now_ns;   // a zero period would busy-spin on a fixed deadline
-    const uint64_t advanced = deadline_ns + period_ns;
-    // A whole period late: abandon the missed slots and re-anchor to now. Deliberately NOT a
-    // catch-up loop -- consumers pace on events ARRIVING, so replaying the missed ones back to
-    // back hands them a burst they read as several periods of progress in one instant.
-    return advanced < now_ns ? now_ns + period_ns : advanced;
+// Phase-exact by construction, which is the property that motivated it. The obvious alternative
+// -- carry a deadline and advance it by one period, re-anchoring to `now + period` when it falls
+// behind -- keeps the PERIOD but loses the PHASE at every re-anchor, and then holds the wrong
+// phase forever. Two ways in, neither exotic: a loop whose first deadline is already stale
+// because the grid was anchored earlier by someone else, and any wait that overruns by more than
+// a period (which the Win32SleepFallback path does by 14-30 ms whenever the high-resolution timer
+// is unavailable). Snapping to the grid instead cannot drift in phase or period, however late it
+// is called. Caught in review of the #3024 vblank pump, where the consumers of two vblank clocks
+// can compare them and phase agreement is the point.
+//
+// Returns ONE boundary, never a backlog: a caller that has missed several abandons them. Pacing
+// consumers respond to events arriving, so replaying missed slots back to back hands them a burst
+// they read as several periods of progress in one instant.
+constexpr uint64_t next_grid_deadline_ns(uint64_t origin_ns, uint64_t now_ns,
+                                        uint64_t period_ns) {
+    // A zero period has no boundaries; yielding `now_ns` makes the caller's wait a no-op rather
+    // than dividing by zero. It still spins, and deliberately so -- silently substituting some
+    // period would invent a rate nobody asked for.
+    if (period_ns == 0) return now_ns;
+    // A grid anchored in the future: the first boundary IS the origin. Reachable through the
+    // videoout test seam, which can anchor the epoch to a fake time.
+    if (now_ns < origin_ns) return origin_ns;
+    return origin_ns + ((now_ns - origin_ns) / period_ns + 1) * period_ns;
 }
 
 }  // namespace prosper::host

--- a/prosper/src/host/platform/precise_sleep.hpp
+++ b/prosper/src/host/platform/precise_sleep.hpp
@@ -27,4 +27,25 @@ SleepBackend sleep_backend();
 // A stable spelling of sleep_backend() for assertions and logs. Never null.
 const char* sleep_backend_name();
 
+// Advance an absolute periodic deadline after a wait on it has completed. `now_ns` is the time
+// the wait actually returned; the result is the next deadline on the SAME grid, so overshoot
+// does not accumulate the way it does when each iteration sleeps for a relative period.
+//
+// This is a free function with its own tests because of one subtlety that reads as correct and
+// is not: after sleep_until_steady_ns(deadline_ns) returns, `now_ns` is normally ALREADY past
+// deadline_ns by the wait's own small overshoot. So a "have we fallen behind?" test written
+// against the OLD deadline is true on every ordinary iteration, and re-anchoring there silently
+// costs one extra period per iteration -- halving the rate, while the surrounding code still
+// says 60 Hz. The comparison has to be against the ADVANCED deadline. Caught in review of the
+// #3024 vblank pump, where it would have turned a 33 Hz defect into a 30 Hz one.
+constexpr uint64_t next_periodic_deadline_ns(uint64_t deadline_ns, uint64_t now_ns,
+                                            uint64_t period_ns) {
+    if (period_ns == 0) return now_ns;   // a zero period would busy-spin on a fixed deadline
+    const uint64_t advanced = deadline_ns + period_ns;
+    // A whole period late: abandon the missed slots and re-anchor to now. Deliberately NOT a
+    // catch-up loop -- consumers pace on events ARRIVING, so replaying the missed ones back to
+    // back hands them a burst they read as several periods of progress in one instant.
+    return advanced < now_ns ? now_ns + period_ns : advanced;
+}
+
 }  // namespace prosper::host

--- a/prosper/tests/host/platform/test_videoout.cpp
+++ b/prosper/tests/host/platform/test_videoout.cpp
@@ -836,60 +836,101 @@ int main() {
     for (uint8_t byte: closed_status) closed_status_untouched &= byte == 0xEE;
     CHECK(closed_status_untouched, "closed-handle status query leaves output untouched");
 
-    // ---- the vblank kevent pump's deadline arithmetic (#3024) -------------------------------
-    // The pump itself is a detached thread in hle_kernel_time.cpp, so what is testable is the
-    // arithmetic it advances its deadline with. These arms exist because the WRONG spelling of
-    // it is not distinguishable from the right one by reading either the code or the rate it
-    // claims: a resync test written against the pre-advance deadline fires on every ordinary
-    // iteration, because sleep_until returns a little PAST its deadline by nature. The result
-    // is one extra period per tick -- a 30 Hz pump under a comment saying 60.
+    // ---- the vblank kevent pump's schedule (#3024) -------------------------------------------
+    // The pump is a detached thread in hle_kernel_time.cpp, so what is testable here is the two
+    // things it is built from: the grid it schedules on, and the grid VALUES this file exports to
+    // it. Stated plainly because a reviewer asked and the answer is a real limit: reverting the
+    // pump's own loop to a relative nanosleep would NOT redden these arms. What they pin is that
+    // the schedule it computes is right, and that the grid it is handed is this file's own.
     {
-        using prosper::host::next_periodic_deadline_ns;
-        const uint64_t P = 16683350;   // the shared 59.94 Hz period
+        using prosper::host::next_grid_deadline_ns;
+        const uint64_t P  = 16683350;      // the shared 59.94 Hz period
+        const uint64_t T0 = 1000000000;    // an arbitrary grid origin
 
-        // The arm that catches the halving. Ordinary overshoot must advance exactly ONE period.
-        CHECK(next_periodic_deadline_ns(1000000, 1000000 + 120000, P) == 1000000 + P,
-              "an ordinary late wake advances the deadline by exactly one period");
-        // ...and the same, iterated: 60 ticks of ordinary overshoot must cover exactly 60
-        // periods, not 120. A rate assertion, which is what the defect actually broke.
-        uint64_t d = 1000000;
-        for (int i = 0; i < 60; i++) d = next_periodic_deadline_ns(d, d + 120000, P);
-        CHECK(d == 1000000 + 60 * P,
-              "60 iterations of ordinary overshoot advance exactly 60 periods (not 120)");
+        // An ordinary late wake -- 120 us past the boundary -- advances exactly ONE period. The
+        // arm that catches a halved rate: an earlier draft advanced then re-anchored, and since a
+        // wait always returns a little PAST its deadline, its re-anchor fired every iteration and
+        // cost an extra period each time.
+        CHECK(next_grid_deadline_ns(T0, T0 + 10 * P + 120000, P) == T0 + 11 * P,
+              "an ordinary late wake yields the next boundary, exactly one period on");
+        // The same iterated, as a RATE: 60 ticks of ordinary overshoot must cover exactly 60
+        // periods. A single-step arm cannot distinguish 60 Hz from 30 Hz.
+        uint64_t d = T0;
+        for (int i = 0; i < 60; i++) d = next_grid_deadline_ns(T0, d + 120000, P);
+        CHECK(d == T0 + 60 * P,
+              "60 iterations of ordinary overshoot advance exactly 60 periods, not 120");
+        CHECK((d - T0) % P == 0,
+              "...and land on the grid, so overshoot never accumulates into it");
 
-        // Overshoot must not accumulate into the grid: waking 120 us late 60 times in a row
-        // leaves the grid where it started, which a relative sleep would not.
-        CHECK(d - 1000000 == 60 * P && (d - 1000000) % P == 0,
-              "the grid absorbs overshoot instead of accumulating it");
+        // PHASE is the point, and it is what the advance-and-re-anchor spelling silently lost.
+        // Every one of these inputs must return a boundary of the ORIGINAL grid: an arbitrary
+        // stall, a stall of exactly a whole period, and a wake a hair before a boundary.
+        const uint64_t probes[] = { 1, P / 3, P - 1, P, P + 1, 4 * P + P / 2, 997 * P + 12345 };
+        bool all_on_grid = true, all_future = true, all_within_one = true;
+        for (uint64_t off : probes) {
+            const uint64_t now = T0 + off;
+            const uint64_t nxt = next_grid_deadline_ns(T0, now, P);
+            all_on_grid    &= (nxt - T0) % P == 0;
+            all_future     &= nxt > now;              // never in the past: the pump would spin
+            all_within_one &= nxt - now <= P;         // never a whole period of dead air
+        }
+        CHECK(all_on_grid,
+              "every result is a boundary of the SAME grid -- phase cannot drift");
+        CHECK(all_future, "every result is strictly in the future, so the pump cannot spin");
+        CHECK(all_within_one,
+              "every result is within one period, so no tick is silently skipped");
 
-        // A wake exactly ON the deadline still advances one period (boundary, not a resync).
-        CHECK(next_periodic_deadline_ns(1000000, 1000000, P) == 1000000 + P,
-              "a wake exactly on the deadline advances one period");
-        // An EARLY return (deadline still in the future) also advances one period.
-        CHECK(next_periodic_deadline_ns(1000000, 999000, P) == 1000000 + P,
-              "an early return advances one period rather than re-anchoring");
+        // A stall of five periods yields ONE boundary, not a backlog of five.
+        CHECK(next_grid_deadline_ns(T0, T0 + 5 * P + 1000, P) == T0 + 6 * P,
+              "a five-period stall yields one boundary, not a catch-up burst");
 
-        // A wholly missed tick re-anchors to now, and posts ONE event rather than bursting the
-        // missed ones -- the deadline lands one period after now, never before it.
-        const uint64_t stalled = next_periodic_deadline_ns(1000000, 1000000 + 5 * P, P);
-        CHECK(stalled == 1000000 + 5 * P + P,
-              "a five-period stall re-anchors to now + one period (no catch-up burst)");
-        CHECK(stalled > 1000000 + 5 * P,
-              "the re-anchored deadline is in the future, so the pump cannot spin");
+        // A first deadline that is ALREADY stale because the grid was anchored earlier by someone
+        // else. This is the case the advance-and-re-anchor spelling got wrong in the direction
+        // that hides: it returned now+period, off-grid, and then held that wrong phase forever.
+        const uint64_t late = next_grid_deadline_ns(T0, T0 + 3000 * P + P / 2, P);
+        CHECK((late - T0) % P == 0 && late == T0 + 3001 * P,
+              "a start 3000 periods after the origin is still phase-exact");
 
-        // A zero period would spin forever on a fixed deadline; it must not return the past.
-        CHECK(next_periodic_deadline_ns(1000000, 2000000, 0) == 2000000,
-              "a zero period degrades to now rather than to a past deadline");
+        // A wake exactly ON a boundary still advances a full period: 'the NEXT vblank' means the
+        // next one, matching what WaitVblank does above.
+        CHECK(next_grid_deadline_ns(T0, T0 + 7 * P, P) == T0 + 8 * P,
+              "a wake exactly on a boundary advances to the next one");
+        // A grid anchored in the FUTURE (reachable through the fake-clock seam) yields the origin.
+        CHECK(next_grid_deadline_ns(T0, T0 - 5 * P, P) == T0,
+              "a grid anchored in the future yields the origin as its first boundary");
+        // A zero period has no boundaries; it must not divide by zero or return the past.
+        CHECK(next_grid_deadline_ns(T0, T0 + 12345, 0) == T0 + 12345,
+              "a zero period degrades to now rather than dividing by zero");
 
-        // The pump and the status/wait grid must agree in PERIOD by construction, not by two
-        // constants that happen to match -- that agreement is the second half of #3024.
+        // ---- the grid VALUES the pump is handed are this file's own --------------------------
         CHECK(prosper_vo_vblank_period_ns() == P,
-              "the exported grid period is the 59.94 Hz vblank period");
-        CHECK(prosper_vo_vblank_period_ns() != 16666667,
-              "...and is NOT the pump's old hardcoded 60.000 Hz constant");
-        CHECK(prosper_vo_vblank_grid_origin_ns() != 0 &&
-                  prosper_vo_vblank_grid_origin_ns() == prosper_vo_vblank_grid_origin_ns(),
-              "the exported grid origin is live and stable across calls");
+              "the exported period is the 59.94 Hz vblank period the status grid uses");
+        // The exported ORIGIN, against an oracle rather than a liveness check: GetVblankStatus
+        // publishes now at +0x10 and (now - epoch) in whole microseconds at +0x08, so the epoch is
+        // recoverable from a status read. Without this, an export returning an origin shifted half
+        // a period -- precisely the defect the WaitVblank phase arm above exists to catch -- would
+        // satisfy every other arm here.
+        prosper_vo_set_vblank_now_for_test(0);          // back to the real clock for the oracle
+        // A FRESH handle: `handle` was retired by the Close arms above, and a status query on a
+        // closed handle correctly returns INVALID_HANDLE and leaves the buffer untouched. Reading
+        // the zeroed buffer as an epoch is how this arm first failed -- which is the arm doing its
+        // job, but the oracle needs a live handle to be about the export at all.
+        const uint64_t ohandle = open(0, 0, 0, 0, 0, 0);
+        CHECK(ohandle != kInvalidHandle && ohandle != 0,
+              "a fresh VideoOut handle opens for the grid-origin oracle");
+        uint8_t ovb[0x40]; memset(ovb, 0, sizeof ovb);
+        CHECK((uint32_t)vbl(ohandle, (uint64_t)(uintptr_t)ovb, 0, 0, 0, 0) == 0,
+              "the oracle status query succeeds (so a zeroed buffer cannot pass as an epoch)");
+        const uint64_t o_now_ns     = *(uint64_t*)(ovb + 0x10);
+        const uint64_t o_process_ns = *(uint64_t*)(ovb + 0x08) * 1000ull;
+        const uint64_t o_epoch_ns   = o_now_ns - o_process_ns;
+        const uint64_t exported     = prosper_vo_vblank_grid_origin_ns();
+        const uint64_t skew = exported > o_epoch_ns ? exported - o_epoch_ns
+                                                    : o_epoch_ns - exported;
+        // 1 us: processTime is published in whole microseconds, so that quantisation is the whole
+        // of the tolerance. A half-period error would be 8341 us.
+        CHECK(skew < 1000,
+              "the exported origin IS the status grid's epoch (within ABI us quantisation)");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/host/platform/test_videoout.cpp
+++ b/prosper/tests/host/platform/test_videoout.cpp
@@ -26,6 +26,8 @@ extern "C" uint64_t prosper_vo_buffer_addr(int i);
 extern "C" uint64_t prosper_vo_flip_count();
 extern "C" int prosper_vo_flip_rate();
 extern "C" void prosper_vo_set_vblank_now_for_test(uint64_t now_ns);
+extern "C" uint64_t prosper_vo_vblank_grid_origin_ns();   // #3024: the shared grid the
+extern "C" uint64_t prosper_vo_vblank_period_ns();        // kevent pump now schedules on
 extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx,
                                            uint32_t flip_mode, int64_t flip_arg);
 
@@ -833,6 +835,62 @@ int main() {
     bool closed_status_untouched = true;
     for (uint8_t byte: closed_status) closed_status_untouched &= byte == 0xEE;
     CHECK(closed_status_untouched, "closed-handle status query leaves output untouched");
+
+    // ---- the vblank kevent pump's deadline arithmetic (#3024) -------------------------------
+    // The pump itself is a detached thread in hle_kernel_time.cpp, so what is testable is the
+    // arithmetic it advances its deadline with. These arms exist because the WRONG spelling of
+    // it is not distinguishable from the right one by reading either the code or the rate it
+    // claims: a resync test written against the pre-advance deadline fires on every ordinary
+    // iteration, because sleep_until returns a little PAST its deadline by nature. The result
+    // is one extra period per tick -- a 30 Hz pump under a comment saying 60.
+    {
+        using prosper::host::next_periodic_deadline_ns;
+        const uint64_t P = 16683350;   // the shared 59.94 Hz period
+
+        // The arm that catches the halving. Ordinary overshoot must advance exactly ONE period.
+        CHECK(next_periodic_deadline_ns(1000000, 1000000 + 120000, P) == 1000000 + P,
+              "an ordinary late wake advances the deadline by exactly one period");
+        // ...and the same, iterated: 60 ticks of ordinary overshoot must cover exactly 60
+        // periods, not 120. A rate assertion, which is what the defect actually broke.
+        uint64_t d = 1000000;
+        for (int i = 0; i < 60; i++) d = next_periodic_deadline_ns(d, d + 120000, P);
+        CHECK(d == 1000000 + 60 * P,
+              "60 iterations of ordinary overshoot advance exactly 60 periods (not 120)");
+
+        // Overshoot must not accumulate into the grid: waking 120 us late 60 times in a row
+        // leaves the grid where it started, which a relative sleep would not.
+        CHECK(d - 1000000 == 60 * P && (d - 1000000) % P == 0,
+              "the grid absorbs overshoot instead of accumulating it");
+
+        // A wake exactly ON the deadline still advances one period (boundary, not a resync).
+        CHECK(next_periodic_deadline_ns(1000000, 1000000, P) == 1000000 + P,
+              "a wake exactly on the deadline advances one period");
+        // An EARLY return (deadline still in the future) also advances one period.
+        CHECK(next_periodic_deadline_ns(1000000, 999000, P) == 1000000 + P,
+              "an early return advances one period rather than re-anchoring");
+
+        // A wholly missed tick re-anchors to now, and posts ONE event rather than bursting the
+        // missed ones -- the deadline lands one period after now, never before it.
+        const uint64_t stalled = next_periodic_deadline_ns(1000000, 1000000 + 5 * P, P);
+        CHECK(stalled == 1000000 + 5 * P + P,
+              "a five-period stall re-anchors to now + one period (no catch-up burst)");
+        CHECK(stalled > 1000000 + 5 * P,
+              "the re-anchored deadline is in the future, so the pump cannot spin");
+
+        // A zero period would spin forever on a fixed deadline; it must not return the past.
+        CHECK(next_periodic_deadline_ns(1000000, 2000000, 0) == 2000000,
+              "a zero period degrades to now rather than to a past deadline");
+
+        // The pump and the status/wait grid must agree in PERIOD by construction, not by two
+        // constants that happen to match -- that agreement is the second half of #3024.
+        CHECK(prosper_vo_vblank_period_ns() == P,
+              "the exported grid period is the 59.94 Hz vblank period");
+        CHECK(prosper_vo_vblank_period_ns() != 16666667,
+              "...and is NOT the pump's old hardcoded 60.000 Hz constant");
+        CHECK(prosper_vo_vblank_grid_origin_ns() != 0 &&
+                  prosper_vo_vblank_grid_origin_ns() == prosper_vo_vblank_grid_origin_ns(),
+              "the exported grid origin is live and stable across calls");
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Fixes #3024. Recovery item 4 of the #3033 salvage of #2984 — this one is not a port; #2984 never touched the kevent pump.

## The defect

`vblank_pump` (`hle_kernel_time.cpp`) posted the VideoOut vblank kevent to every registered equeue from a bare `nanosleep(16666667)`. On Windows that resolves on the winpthreads tick, so its own `// ~60 Hz` comment was not what ran, and every title pacing on the kevent stream advanced at roughly half rate.

This is the **same defect #1765 already fixed one file away** for the `sceVideoOutGetVblankStatus` / `sceVideoOutWaitVblank` grid — which is why `hle_graphics.cpp` carries `NOT std::this_thread::sleep_until` over its own wait. The kevent pump is a second vblank clock in a different file and never got the same treatment. `hle_graphics.cpp` even documents that the two exist and disagree, and asks for exactly this follow-up in as many words:

> the kevent stream and this grid drift by roughly one tick per second … aligning them is a real follow-up; asserting they are aligned is wrong

## Two defects, not one

1. **Quantization** — the sleep returns every ~30 ms, not 16.67.
2. **Drift** — a *relative* sleep per iteration accumulates the pump's own overhead, so it lagged the status grid even where the sleep was accurate.

## The fix

The pump waits `host::sleep_until_steady_ns` against an **absolute** deadline on the **same origin and period** as the status/wait grid, newly exported as `prosper_vo_vblank_grid_origin_ns()` / `prosper_vo_vblank_period_ns()`. One clock, in phase and in period, by construction rather than by two constants that happen to agree — and the old pump's constant did **not** agree: 60.000 Hz against the grid's 59.94 Hz.

Both are `std::chrono::steady_clock` nanoseconds, checked rather than assumed (`vblank_now_ns` → `steady_clock`, and `sleep_until_steady_ns`'s contract is the same epoch).

## The part worth the review time: my first version of the arithmetic was wrong, and read as correct

The obvious inline spelling tests "have we fallen behind?" against the **pre-advance** deadline:

```cpp
if (next_ns < now_ns) next_ns = now_ns + period_ns;   // looks like a stall guard
next_ns += period_ns;
```

`sleep_until` returns a little **past** its deadline by nature, so that condition is true on essentially every ordinary iteration — the re-anchor fires every tick and costs one extra period each time. It would have shipped a **30 Hz** pump under a comment claiming 60: *a lower rate than the 33 Hz defect it was fixing*, with no symptom visible anywhere in the diff.

So the advance is now `host::next_periodic_deadline_ns(deadline, now, period)` — a `constexpr` free function beside the deadline sleeper it belongs with, with its own arms. The arms include an **iterated rate assertion** (60 ticks of ordinary overshoot must cover exactly 60 periods, not 120), because a single-step arm is the weaker test and the defect is a *rate* defect.

Mutation-checked, all three redden:

| mutation | arms reddened |
| --- | --- |
| my original buggy spelling | 4 (incl. the iterated rate arm) |
| no resync (catch-up burst) | 2 |
| resync unconditionally | 4 |

A wholly missed tick re-anchors and posts **one** event; it deliberately does not replay the missed slots, because consumers pace on events *arriving* and a burst reads to them as several periods of progress in one instant.

## Provenance of the 33 Hz figure, stated because I have got this wrong before

The `29.95 ms` / `33 Hz` numbers come from a **standalone microbenchmark of that nanosleep** on this toolchain (MinGW-w64/UCRT, GCC 16.1) — not from an instrumented measurement of the pump. The code comment says so too, and quotes the figure only to size the defect.

The same microbenchmark under `timeBeginPeriod(1)` gives 24.78 ms — still not 16.67 — and that arm is **hypothetical for prosper, which calls `timeBeginPeriod` nowhere**; `precise_sleep.cpp:14` states this explicitly. So the unrescued 29.95 ms is what ran. #3024's body claims otherwise in one sentence ("prosper-app's `timeBeginPeriod(1)`") — that is residue of an earlier false claim of mine, and I have corrected the issue body.

## Behavioural change, named rather than buried

This roughly doubles the vblank **event** rate on Windows for anything waiting on the kevent. A title whose logic advances per vblank event will now advance about twice as fast on Windows as it did — i.e. at the rate it already had on Linux. That is the point of the fix, but it is a real behavioural change on Windows and a reviewer should weigh it as one.

**Correction — "Linux and macOS are untouched" was false**, and review was right to block on it. Two changes land on every platform:

1. **The pump's period changes**, 60.000 Hz → 59.94 Hz. It now uses the grid's constant instead of its own hardcoded `16666667`.
2. **The grid's epoch is normally anchored EARLIER.** `vblank_epoch_ns()` is a first-use-anchored `static`, and the pump's read at `hle_kernel_time.cpp` reaches it as soon as a title registers a vblank event — typically *before* the title's first `GetVblankStatus` or `WaitVblank`. So the epoch now tracks vblank-event registration rather than the first guest status query. That moves `sceVideoOutGetVblankStatus`'s first `count` from 1 to `1 + elapsed/P`, shifts `processTime`'s baseline, and shifts **`sceVideoOutWaitVblank`'s wake instants in phase** along with them, since all three derive from the same `t0`. A guest display thread pacing on `WaitVblank` is the likeliest consumer to notice.

I judge (2) more faithful — the epoch now marks when the title started caring about vblanks rather than when it first asked — and low risk, since the grid stays monotonic and self-consistent either way. But it is a real behavioural change on all three platforms and it belongs in this list rather than in a sentence claiming the opposite. The code comment at `hle_graphics.cpp` now says the same thing; it previously asserted that callers *cannot* move the grid, which is true of every caller except the first, and the first is now the pump.

What genuinely does not change off Windows: `sleep_until_steady_ns` is `std::this_thread::sleep_until` there, so no wait primitive changes, and no grid constant changed.

## Deliberately not in scope

- The pump still posts to `g_vblank_regs` under `g_eq_mx` exactly as before; no change to what is posted or to whom.
- `hle_graphics.cpp`'s grid is unchanged — it was already correct. This PR only makes the pump *derive from* it.
- The remaining `#3033` items (the queue-depth audio pacer A/B, the dedicated compute queue) are separate.

## Verification

Windows, MinGW-w64/UCRT GCC 16.1, RelWithDebInfo, RTX 4090:

```
cmake --build prosper/build-mingw-app          # clean
ctest --test-dir prosper/build-mingw-app --no-tests=error
100% tests passed, 0 tests failed out of 247   # exit 0
```

One pre-existing unrelated skip (`hle_calls_value_capture`). `git diff --check` clean.

No screenshot: this changes an event rate, not a rendered frame, and a capture of the same title at a different pump rate would be evidence of nothing. Per the charter's blog rule this is a finding-without-a-picture, so it goes in `BLOG.md` only if the pacing change turns out to move a title — noted on #3033 rather than claimed here.

Refs #3033. Refs #2984.
