### PR TITLE
fix(test): the sem_timedwait wall-clock ceiling could pass the defect it guarded, and flaked on Rosetta

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -648,7 +648,15 @@ if(TARGET prosper_core)
   # other two arms measured a POSTED semaphore, which unfixed winpthreads serves in 0.01 ms -- better
   # than the poll loop, so they preferred the defect. A mechanism assertion cannot be satisfied by a
   # lucky duration and does not flake under load. Mutation-checked: reverting to the winpthreads
-  # delegation reddens two arms and prints "via none".
+  # delegation reddens the MECHANISM arm and prints "via none".
+  #
+  # It used to say "reddens two arms", the second being a wall-clock ceiling, and that ceiling
+  # is gone: measured across five reverted runs the defect delivered at 14.69, 12.06, 17.75,
+  # 10.00 and 15.32 ms, so a 12 ms ceiling PASSES the defect. A quantized wait returns at the
+  # next tick boundary, so the defect's latency distribution overlaps the fix's and no
+  # single-run bound separates them. The same ceiling also flaked on macOS/Rosetta at 18.54 and
+  # 46.46 ms, where the native call is untouched by the fix anyway. The mechanism arm is the
+  # discriminator; the bounds that remain are a stub/unit guard.
   add_executable(test_kernel_sem_timedwait tests/hle/kernel/test_kernel_sem_timedwait.cpp)
   target_link_libraries(test_kernel_sem_timedwait PRIVATE prosper_core)
   add_test(NAME kernel_sem_timedwait COMMAND test_kernel_sem_timedwait)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -650,13 +650,14 @@ if(TARGET prosper_core)
   # lucky duration and does not flake under load. Mutation-checked: reverting to the winpthreads
   # delegation reddens the MECHANISM arm and prints "via none".
   #
-  # It used to say "reddens two arms", the second being a wall-clock ceiling, and that ceiling
-  # is gone: measured across five reverted runs the defect delivered at 14.69, 12.06, 17.75,
-  # 10.00 and 15.32 ms, so a 12 ms ceiling PASSES the defect. A quantized wait returns at the
-  # next tick boundary, so the defect's latency distribution overlaps the fix's and no
-  # single-run bound separates them. The same ceiling also flaked on macOS/Rosetta at 18.54 and
-  # 46.46 ms, where the native call is untouched by the fix anyway. The mechanism arm is the
-  # discriminator; the bounds that remain are a stub/unit guard.
+  # It used to say "reddens two arms", the second being a wall-clock ceiling, and that ceiling is
+  # gone: it would have PASSED the defect, and it also flaked on macOS/Rosetta. The mechanism
+  # arm is the discriminator; the bounds that remain are a stub/unit guard.
+  #
+  # The measurements and the argument live in ONE place, the test file's own header. They were
+  # briefly in both, with two different lists -- and a third Rosetta figure existed in neither
+  # (23.22 ms, found in a CI log during review). Two copies of a figure list is one copy too
+  # many, and this is the copy that gets read second.
   add_executable(test_kernel_sem_timedwait tests/hle/kernel/test_kernel_sem_timedwait.cpp)
   target_link_libraries(test_kernel_sem_timedwait PRIVATE prosper_core)
   add_test(NAME kernel_sem_timedwait COMMAND test_kernel_sem_timedwait)

--- a/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
@@ -16,8 +16,11 @@
 // on a loaded host.
 //
 // So the arms are:
-//   1. MECHANISM  - the wait was served by the high-resolution timer, not ::Sleep's tick. Reddens on
-//                   the pre-fix code, which never touches precise_sleep at all.
+//   1. MECHANISM  - WHICH primitive served the wait. On Windows: the high-resolution timer, not
+//                   ::Sleep's tick -- reddens on the pre-fix code, which never touches
+//                   precise_sleep at all. On POSIX the assertion is the OPPOSITE value,
+//                   "none", because the native sem_timedwait is kept there and must not start
+//                   polling; the two are different assertions, not one with a platform tweak.
 //   2. ENCODING   - the timeout returns exactly 0x8002003c, FreeBSD ETIMEDOUT as the guest reads it.
 //                   Nothing else in the suite covers this path's encoding.
 //   3. BOUNDS     - a stub/unit/hang guard, and NOT the discriminator. With the fix reverted the
@@ -27,7 +30,12 @@
 //                   ~[5, 20.6] ms and the two distributions overlap. The same 12 ms ceiling
 //                   also flaked on macOS/Rosetta at 18.54 ms, where the native call is
 //                   untouched by this change anyway. Arm 1 caught all five.
-//   4. FAST PATH  - an already-posted semaphore never enters the loop.
+//   4. FAST PATH  - an already-posted semaphore is acquired at once, asserted as a COUNT of 0
+//                   afterwards rather than as a latency. The latency bound is kept as well but
+//                   is Windows-tight / POSIX-loose, and it cannot see the fast path at all:
+//                   the pre-loop trywait and the first call inside the loop are identical, so
+//                   deleting the fast path changes no duration. "Never enters the loop" is
+//                   therefore NOT what this arm asserts, and there is no loop on POSIX.
 //
 // The header being right about the arms is part of the test. Its first version was wrong about
 // them in the same breath as the arms were wrong, and the confident label is what stopped anyone
@@ -61,20 +69,34 @@ int main() {
     HleFn sem_init_fn = Hle::lookup(nid_hash("scePthreadSemInit").c_str());
     HleFn timedwait   = Hle::lookup(nid_hash("scePthreadSemTimedwait").c_str());
     HleFn post        = Hle::lookup(nid_hash("scePthreadSemPost").c_str());
+    // Optional: used only to make ARM 4 assert the COUNT rather than a duration. Guarded so a
+    // build where it is unregistered loses one assertion instead of the whole test.
+    HleFn getvalue    = Hle::lookup(nid_hash("scePthreadSemGetvalue").c_str());
     CHECK(sem_init_fn != nullptr, "scePthreadSemInit is registered");
     CHECK(timedwait != nullptr, "scePthreadSemTimedwait is registered");
     CHECK(post != nullptr, "scePthreadSemPost is registered");
     if (!sem_init_fn || !timedwait || !post) { printf("== FAIL (unresolved) ==\n"); return 1; }
 
-    // The guest handle is an opaque slot; ensure_sem backs it with a real sem_t. Initialised through
-    // the HLE and CHECKED - the first version declared a bare `sem_t slot;` and called init with its
-    // result ignored, so an init that silently failed would have left every arm below operating on an
-    // uninitialised object.
-    sem_t slot;
+    // The guest handle is a POINTER CELL, not a semaphore. k_sem_init does
+    //     `*(void**)(uintptr_t)a0 = s;`
+    // i.e. it heap-allocates the sem_t and writes the POINTER through the handle, and every
+    // other member of the family reads it back with an 8-byte load (`ensure_sem`). So the slot
+    // must be pointer-sized.
+    //
+    // This was `sem_t slot;`, which is a latent stack overwrite that happens to be invisible
+    // on two of three platforms: winpthreads' sem_t is a pointer (8 bytes) and glibc's is 32,
+    // but **Darwin's is `int`** -- so on macOS the 8-byte write ran four bytes past a 4-byte
+    // automatic. Found in review of the very PR whose purpose was to green the macOS job.
+    void* slot = nullptr;
     const uint64_t handle = (uint64_t)(uintptr_t)&slot;
     // Asserts that init REPORTS success, not that the count is observably 0 -- the count is then
-    // established by arm 1 timing out rather than being acquired. The earlier message claimed the
-    // stronger thing.
+    // established by arm 1 timing out rather than being acquired.
+    //
+    // Weaker still than that, and named rather than left implied: k_sem_init DISCARDS
+    // sem_init's return and returns 0 unconditionally, so this CHECK cannot fail as the code
+    // stands. It is kept as a tripwire for the day that is fixed, and the fix is #3068 --
+    // which matters on macOS, where unnamed POSIX semaphores are ENOSYS and this family may
+    // therefore be operating on an uninitialised object while reporting success.
     CHECK(sem_init_fn(handle, 0, 0, 0, 0, 0) == 0, "scePthreadSemInit reports success");
 
     // ARM 1 + 2 + 3: one unposted wait, three independent properties.
@@ -147,6 +169,16 @@ int main() {
         const uint64_t rc = timedwait(handle, 1000000, 0, 0, 0, 0);
         const double ms = std::chrono::duration<double, std::milli>(clk::now() - t0).count();
         CHECK(rc == 0, "an already-posted semaphore is acquired");
+        // The count is the observable, and it is what "acquired" MEANS. Review found the arm
+        // could not see its own stated purpose: the pre-loop sem_trywait and the first
+        // statement inside the loop are the identical call, so deleting the fast path is
+        // invisible to any timing bound. A count of 0 after the acquire is not.
+        if (getvalue) {
+            int v = -1;
+            CHECK(getvalue(handle, (uint64_t)(uintptr_t)&v, 0, 0, 0, 0) == 0,
+                  "getvalue succeeds after the acquire");
+            CHECK(v == 0, "...and the count really was consumed, not merely reported as taken");
+        }
         // Same asymmetry as ARM 3, and the same reasoning: 1 ms is a fair bound on a real x86
         // host, and on an emulated-x86 CI VM it is a latent flake that happened not to fire yet.
         // 100 ms still fails a fast path that fell through to waiting out the 1 s timeout, which

--- a/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
@@ -23,13 +23,29 @@
 //                   polling; the two are different assertions, not one with a platform tweak.
 //   2. ENCODING   - the timeout returns exactly 0x8002003c, FreeBSD ETIMEDOUT as the guest reads it.
 //                   Nothing else in the suite covers this path's encoding.
-//   3. BOUNDS     - a stub/unit/hang guard, and NOT the discriminator. With the fix reverted the
-//                   defect delivered at 14.69, 12.06, 17.75, 10.00 and 15.32 ms -- so a 12 ms
-//                   ceiling would have PASSED the defect, not merely flaked. A quantized wait
-//                   returns at the next tick boundary, so a 5 ms request lands anywhere in
-//                   ~[5, 20.6] ms and the two distributions overlap. The same 12 ms ceiling
-//                   also flaked on macOS/Rosetta at 18.54 ms, where the native call is
-//                   untouched by this change anyway. Arm 1 caught all five.
+//   3. BOUNDS     - a stub/unit guard, and NOT the discriminator. THE canonical figures for this
+//                   file, referenced from CMakeLists.txt rather than restated there:
+//
+//                     defect, Windows, fix reverted:  14.69  12.06  17.75  10.00  15.32 ms
+//                     fix, Windows:                    5.49   5.47   5.39 ms
+//                     macOS/Rosetta, native path:     18.54  23.22  46.46 ms
+//
+//                   A 12 ms ceiling would have PASSED the defect (the 10.00 ms run), not
+//                   merely flaked -- silently, which is worse. And it cannot be repaired by
+//                   moving it, for a reason that needs no measurement at all: a quantized
+//                   wait returns at the next tick BOUNDARY, so its latency is T-p or 2T-p for
+//                   phase p within the tick, and as p approaches T-N from below the defect's
+//                   latency approaches the REQUESTED 5 ms exactly -- below the fix's own
+//                   5.39 ms, for any tick length T. The distributions overlap by
+//                   construction. (Second review of #3066 supplied that argument; the five
+//                   samples are kept because they also discriminate the MODEL -- a
+//                   whole-ticks-from-the-request model predicts clustering at ~15.6/31.2 ms,
+//                   which 10.00 and 12.06 falsify.)
+//
+//                   Arm 1 caught all five reverted runs. On Rosetta the native path is
+//                   untouched by this change, and arm 4's posted acquire measures SUB-
+//                   MILLISECOND there, so the 100 ms bound has over 100x headroom on a
+//                   measured value rather than a guessed one.
 //   4. FAST PATH  - an already-posted semaphore is acquired at once, asserted as a COUNT of 0
 //                   afterwards rather than as a latency. The latency bound is kept as well but
 //                   is Windows-tight / POSIX-loose, and it cannot see the fast path at all:
@@ -160,7 +176,9 @@ int main() {
         printf("         (timeout took %.2f ms via %s)\n", ms, host::sleep_backend_name());
     }
 
-    // ARM 4: an already-posted semaphore is taken by the trywait fast path and never enters the loop.
+    // ARM 4: an already-posted semaphore is acquired at once and its count is consumed.
+    // NOT "never enters the loop" -- that phrase was here and is wrong, see the header and the
+    // note over the count assertion below. There is no loop on POSIX at all.
     {
         CHECK(post(handle, 0, 0, 0, 0, 0) == 0, "post succeeds");
         const auto t0 = clk::now();
@@ -169,10 +187,19 @@ int main() {
         const uint64_t rc = timedwait(handle, 1000000, 0, 0, 0, 0);
         const double ms = std::chrono::duration<double, std::milli>(clk::now() - t0).count();
         CHECK(rc == 0, "an already-posted semaphore is acquired");
-        // The count is the observable, and it is what "acquired" MEANS. Review found the arm
-        // could not see its own stated purpose: the pre-loop sem_trywait and the first
-        // statement inside the loop are the identical call, so deleting the fast path is
-        // invisible to any timing bound. A count of 0 after the acquire is not.
+        // The count is the observable, and it is what "acquired" MEANS: it catches a path that
+        // returns rc==0 WITHOUT consuming, which no timing bound can see. Mutation-checked
+        // with a peek-and-return in place of the trywait.
+        //
+        // What it does NOT catch, stated because the obvious reading of it is wrong: deleting
+        // the pre-loop sem_trywait entirely. The loop's FIRST statement is the identical
+        // call, so it consumes the count anyway and every assertion here still passes. That
+        // deletion is unobservable at the HLE boundary by construction -- the fast path is a
+        // latency optimisation, not a semantic one -- so it is a fact to record rather than a
+        // gap to close. Second review of #3066.
+        // The lookup is CHECKed rather than merely guarded: an optional lookup that silently
+        // skips means a rename makes both assertions below vanish GREEN.
+        CHECK(getvalue != nullptr, "scePthreadSemGetvalue is registered");
         if (getvalue) {
             int v = -1;
             CHECK(getvalue(handle, (uint64_t)(uintptr_t)&v, 0, 0, 0, 0) == 0,
@@ -184,10 +211,15 @@ int main() {
         // 100 ms still fails a fast path that fell through to waiting out the 1 s timeout, which
         // is the only defect this arm can see.
 #ifdef _WIN32
-        CHECK(ms < 1.0, "...immediately, without entering the poll loop");
+        CHECK(ms < 1.0, "...immediately, on the order of a trywait rather than a wait");
 #else
         CHECK(ms < 100.0, "...immediately, nowhere near the 1 s timeout it was given");
 #endif
+        // Printed for the same reason ARM 3 prints its figure: a green ctest run shows no
+        // per-test output, so a margin that is never printed cannot be quoted from a passing
+        // log -- which is exactly how #3044 came to be merged on a green Rosetta job whose
+        // numbers nobody had seen.
+        printf("         (posted acquire took %.2f ms)\n", ms);
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);

--- a/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
@@ -20,9 +20,18 @@
 //                   the pre-fix code, which never touches precise_sleep at all.
 //   2. ENCODING   - the timeout returns exactly 0x8002003c, FreeBSD ETIMEDOUT as the guest reads it.
 //                   Nothing else in the suite covers this path's encoding.
-//   3. BOUNDS     - a lower bound as well as an upper one. The upper alone cannot catch a wait that
-//                   returns instantly; the lower alone cannot catch the tick.
+//   3. BOUNDS     - a stub/unit/hang guard, and NOT the discriminator. With the fix reverted the
+//                   defect delivered at 14.69, 12.06, 17.75, 10.00 and 15.32 ms -- so a 12 ms
+//                   ceiling would have PASSED the defect, not merely flaked. A quantized wait
+//                   returns at the next tick boundary, so a 5 ms request lands anywhere in
+//                   ~[5, 20.6] ms and the two distributions overlap. The same 12 ms ceiling
+//                   also flaked on macOS/Rosetta at 18.54 ms, where the native call is
+//                   untouched by this change anyway. Arm 1 caught all five.
 //   4. FAST PATH  - an already-posted semaphore never enters the loop.
+//
+// The header being right about the arms is part of the test. Its first version was wrong about
+// them in the same breath as the arms were wrong, and the confident label is what stopped anyone
+// re-deriving it -- so a bound that changes changes this list too.
 //
 // Deliberately NOT asserted: the poll slice length. A short high-resolution sleep on this host has a
 // ~0.52 ms floor, so the adaptive 0.5 ms slice and a flat 2 ms one produce overlapping latency
@@ -83,10 +92,29 @@ int main() {
         CHECK(rc == prosper::hle::kSceKernelErrorETIMEDOUT,
               "a timeout returns FreeBSD ETIMEDOUT encoded as the guest reads it (0x8002003c)");
 
-        // ARM 3: bounded on BOTH sides. An upper bound alone passes a wait that returns instantly;
-        // a lower bound alone passes the 15.6 ms tick.
+        // ARM 3: BOUNDS, and they are deliberately NOT the discriminator. This is the second
+        // correction to this arm and the reasoning is measured rather than argued.
+        //
+        // The first version used a 40 ms ceiling, 2.6x above the defect, so it could not fail.
+        // The second used 12 ms, which reddened -- and then flaked on macOS/Rosetta at 18.54 ms,
+        // because on POSIX the native call is untouched by this change and the ceiling was purely
+        // an assertion about the host's scheduler.
+        //
+        // Tightening it per-platform was the obvious next move, and it is wrong in the direction
+        // that matters: it lets the defect THROUGH. Measured by reverting the fix and running
+        // five times -- 14.69, 12.06, 17.75, 10.00, 15.32 ms. The 10.00 ms run passes a 12 ms
+        // ceiling, so that bound was not merely fragile, it was unsound. It has to be: a
+        // quantized wait returns at the next tick BOUNDARY, so a 5 ms request lands anywhere in
+        // roughly [5, 20.6] ms depending on where it falls within the ~15.6 ms tick. The
+        // defect's timing distribution OVERLAPS the fix's, so no single-run wall-clock bound
+        // separates them on any platform. The mechanism arm caught all five.
+        //
+        // So the bounds are a stub/unit/hang guard on both platforms, and the MECHANISM arm below
+        // is the discriminator -- which is what this file's header has said from the start, and
+        // what the repo's own guidance says: assert which primitive served the wait, because that
+        // reads a state variable instead of a clock and cannot flake.
         CHECK(ms >= 4.0, "it actually waited (a stub returning at once fails this)");
-        CHECK(ms < 12.0, "and returned inside one winpthreads tick of the request, not after it");
+        CHECK(ms < 500.0, "and on the right order of magnitude (a wrong unit or a hang fails this)");
 
         // ARM 1: WHICH primitive served it. This is the arm that reddens on the pre-fix code, which
         // delegates to winpthreads and never enters precise_sleep, leaving the backend at "none".
@@ -114,10 +142,20 @@ int main() {
     {
         CHECK(post(handle, 0, 0, 0, 0, 0) == 0, "post succeeds");
         const auto t0 = clk::now();
+        // A ONE SECOND timeout, deliberately: the assertion is that the wait returned nowhere near
+        // it, so the gap between the bound and the timeout is the whole strength of the arm.
         const uint64_t rc = timedwait(handle, 1000000, 0, 0, 0, 0);
         const double ms = std::chrono::duration<double, std::milli>(clk::now() - t0).count();
         CHECK(rc == 0, "an already-posted semaphore is acquired");
+        // Same asymmetry as ARM 3, and the same reasoning: 1 ms is a fair bound on a real x86
+        // host, and on an emulated-x86 CI VM it is a latent flake that happened not to fire yet.
+        // 100 ms still fails a fast path that fell through to waiting out the 1 s timeout, which
+        // is the only defect this arm can see.
+#ifdef _WIN32
         CHECK(ms < 1.0, "...immediately, without entering the poll loop");
+#else
+        CHECK(ms < 100.0, "...immediately, nowhere near the 1 s timeout it was given");
+#endif
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);


### PR DESCRIPTION
**Master is red on `macOS (x86_64 / Rosetta 2)` because of a test I merged in #3044.** This fixes it. Refs #3013, #3033.

```
47 - kernel_sem_timedwait (Failed)
   (timeout took 18.54 ms via none)
```

## What broke

#3044 asserted the 5 ms guest semaphore timed wait returned in under 12 ms. On POSIX that ceiling asserts nothing about prosper — the native `sem_timedwait` is explicitly *untouched* by that change (`#ifndef _WIN32` at `hle_kernel.cpp:3097`) — so it was purely an assertion about the host scheduler. On an emulated-x86 VM under load it delivered at 18.54 ms.

The charter names this exact failure, and `precise_sleep.hpp` names it again over `sleep_backend()`: assert the mechanism, "instead of asserting a wall-clock duration, which on a loaded host is a future flake". I introduced it in the same PR whose review had just removed a *different* unfalsifiable arm.

## The bound was not fragile — it was unsound

Making the ceiling Windows-only was the obvious fix. I measured it before shipping it, and it fails in the worse direction. With the fix reverted (`#ifndef _WIN32` → `#if 1`, forcing the native winpthreads path on Windows), the defect delivers at:

| run | delivered |
| --- | --- |
| 1 | 14.69 ms |
| 2 | 12.06 ms |
| 3 | 17.75 ms |
| 4 | **10.00 ms** |
| 5 | 15.32 ms |

**The 10.00 ms run passes a 12 ms ceiling.** The bound would have let the defect through, which is strictly worse than flaking — a flake is noisy, this is silent.

And it must be so: a quantized wait returns at the next **tick boundary**, so a 5 ms request lands anywhere in roughly [5, 20.6] ms depending on where the request falls within the ~15.6 ms tick. The defect's timing distribution *overlaps the fix's*. No single-run wall-clock bound separates them on any platform.

The mechanism arm caught all five, because it reads a state variable rather than a clock.

## The change

- **Arm 3 bounds** are now a stub/unit/hang guard on both platforms: `>= 4.0 ms` (an instant-returning stub fails) and `< 500.0 ms` (a wrong unit or a hang fails). Neither pretends to discriminate.
- **Arm 1 (mechanism)** is the sole discriminator, unchanged, and is what the file header already claimed.
- **Arm 4's `< 1.0 ms`** fast-path bound had the same latent problem — fine on a real x86 host, a waiting flake on an emulated one. It is now `< 100.0 ms` **on POSIX only**; Windows keeps `< 1.0 ms`. (This bullet originally said "on both platforms", which the diff does not do — the code was right and the description was wrong. Caught in review.) The arm has also been strengthened to assert the **count**, not the latency: see the review response below.
- **The header's arm list** is updated with the five measurements. The first version of this test was wrong about its own arms *in a confident label*, and that label is what stopped anyone re-deriving it — so a bound that changes changes the list too.

## Verification

Windows, MinGW-w64/UCRT GCC 16.1, RelWithDebInfo:

```
cmake --build prosper/build-mingw-app                        # clean
ctest --test-dir prosper/build-mingw-app --no-tests=error
100% tests passed, 0 tests failed out of 247                 # exit 0
```

Mutation (forcing the native path at `hle_kernel.cpp:3097`): arm 1 reddens 3 of 3 runs; restored, passes 3 of 3 at 5.49 / 5.47 / 5.39 ms.

**The POSIX arms cannot be executed on this host.** Both changes only *widen* a bound, so they can remove a failure and cannot add one — but `Linux` and `macOS (x86_64 / Rosetta 2)` are the checks that matter here, and this should not merge until both are green.

## Note on process

Two things went wrong that are worth stating rather than burying. #3044's own `macOS (x86_64 / Rosetta 2)` job was **green** at the reviewed head, which is what I merged on; the flake surfaced on the next PR to merge master. A green run on a timing assertion is evidence about one sample, not about the assertion — I treated it as the latter. And while verifying this fix, my first mutation attempt silently patched the wrong `#ifndef _WIN32` (line 829, not 3097) and reported `PASSED`, which I nearly took as "the discriminator is intact". A mutation that does not visibly apply is not a mutation.
