### PR TITLE
evidence: correct the ceiling-removal figures — the probe behind them saw 7% of its population

### DIFF
--- a/prosper/tools/evidence/AGENTS.md
+++ b/prosper/tools/evidence/AGENTS.md
@@ -52,7 +52,8 @@ Derive it rather than quoting it — it was first published here as 63.75, which
 pixels' own contribution (a pixel counted as matching may differ by up to 8 per channel, not 0;
 0.75 × 8 = 6.00 is exactly the gap), and a hand-built frame reaches mean 69.67 at overlap 75.00%,
 above the figure the same paragraph called unreachable. A companion claim that the worst case was
-partial coverage was backwards too: at f = 0.25 the bound is only 28.69. Measured alongside it, **100 of 233** structured assets (42.9%) carrying a bright
+partial coverage was backwards too: at f = 0.25 the bound is only 28.69. Measured alongside it,
+**100 of 233** structured assets (42.9%) carrying a bright
 caption panel reach mean 40.5–59.25 while still exceeding the bar, so a ceiling of 40 silently
 dropped nearly half. The case that motivated the ceiling was already rejected by the bar anyway.
 
@@ -60,8 +61,13 @@ The count was first published here as "4 of 13", from a probe that filtered to 1
 excluded every 4K asset — where the worst means live. A structured-asset sample runs roughly 6
 such 1080p assets to 79 4K ones, so that probe saw about 7% of its own population and could not
 express the case it was measuring. The observed worst mean, 59.25, sits under the analytic bound of
-69.75 — a consistency check rather than an agreement, since real assets cannot saturate a bound that
-requires every matching pixel to differ by exactly 8.
+69.75 — a consistency check rather than an agreement. Real assets *approach* the bound without being
+observed to reach it: saturating it needs every matching pixel to differ by exactly 8 *and* the
+non-matching quarter to be pure black. But do not read that as "cannot". An ordinary defect gets
+close — a blit with slightly wrong colour conversion shifts every pixel by a small constant, which
+keeps them inside the 8/255 match window while adding up to 6.00 to the mean. Measured on a real
+asset (`PPSA03001` `sce_sys/pic0.dds`, 24% caption panel): overlap 75.47% at mean 59.36, and with a
+uniform +8 shift overlap 75.97% at mean **65.43** — 94% of the bound, from real content.
 
 **And the two statistics need different gates**, which conflating them hid: `mean` is a whole-frame
 average that darkness cannot corrupt, so two structured images at mean 0.00 are the same image

--- a/prosper/tools/evidence/AGENTS.md
+++ b/prosper/tools/evidence/AGENTS.md
@@ -43,10 +43,17 @@ matches nothing at any brightness, and is not progression evidence in the first 
 **A mean ceiling was tried here and removed, which is worth knowing before adding one back.** It
 looked reasonable — "a high matching fraction alone is not domination" — but an overlap bar of 75%
 already bounds the mean at ≤ 63.75/255, so any ceiling below that can only discard frames the bar
-would have flagged. It cannot prevent a false positive and can only manufacture false negatives:
-4 of 13 real assets carrying a bright caption panel reach mean 40.5–54.3 while still exceeding the
-bar, and a ceiling of 40 silently dropped every one. The case that motivated it was already rejected
-by the bar.
+would have flagged. It cannot prevent a false positive and can only manufacture false negatives.
+That bound is the argument, and it is worth preferring to any count: it is derivable, so it belongs
+to nobody's sample. Measured alongside it, **100 of 233** structured assets (42.9%) carrying a bright
+caption panel reach mean 40.5–59.25 while still exceeding the bar, so a ceiling of 40 silently
+dropped nearly half. The case that motivated the ceiling was already rejected by the bar anyway.
+
+The count was first published here as "4 of 13", from a probe that filtered to 1920×1080 and so
+excluded every 4K asset — where the worst means live. A structured-asset sample runs roughly 6
+such 1080p assets to 79 4K ones, so that probe saw about 7% of its own population and could not
+express the case it was measuring. The observed worst mean, 59.25, sits just under the analytic
+bound of 63.75, which is the reassuring part: two independent routes agree at the boundary.
 
 **And the two statistics need different gates**, which conflating them hid: `mean` is a whole-frame
 average that darkness cannot corrupt, so two structured images at mean 0.00 are the same image

--- a/prosper/tools/evidence/AGENTS.md
+++ b/prosper/tools/evidence/AGENTS.md
@@ -42,18 +42,26 @@ matches nothing at any brightness, and is not progression evidence in the first 
 
 **A mean ceiling was tried here and removed, which is worth knowing before adding one back.** It
 looked reasonable — "a high matching fraction alone is not domination" — but an overlap bar of 75%
-already bounds the mean at ≤ 63.75/255, so any ceiling below that can only discard frames the bar
-would have flagged. It cannot prevent a false positive and can only manufacture false negatives.
-That bound is the argument, and it is worth preferring to any count: it is derivable, so it belongs
-to nobody's sample. Measured alongside it, **100 of 233** structured assets (42.9%) carrying a bright
+already bounds the mean, so any ceiling below that can only discard frames the bar would have
+flagged. It cannot prevent a false positive and can only manufacture false negatives. The bound is
+
+    mean ≤ 0.75·f·8 + 0.25·f·255 + (1−f)·15  =  f·69.75 + (1−f)·15
+
+for informative fraction `f`. It increases in `f`, so it maximises at **full** coverage: **69.75**.
+Derive it rather than quoting it — it was first published here as 63.75, which dropped the matching
+pixels' own contribution (a pixel counted as matching may differ by up to 8 per channel, not 0;
+0.75 × 8 = 6.00 is exactly the gap), and a hand-built frame reaches mean 69.67 at overlap 75.00%,
+above the figure the same paragraph called unreachable. A companion claim that the worst case was
+partial coverage was backwards too: at f = 0.25 the bound is only 28.69. Measured alongside it, **100 of 233** structured assets (42.9%) carrying a bright
 caption panel reach mean 40.5–59.25 while still exceeding the bar, so a ceiling of 40 silently
 dropped nearly half. The case that motivated the ceiling was already rejected by the bar anyway.
 
 The count was first published here as "4 of 13", from a probe that filtered to 1920×1080 and so
 excluded every 4K asset — where the worst means live. A structured-asset sample runs roughly 6
 such 1080p assets to 79 4K ones, so that probe saw about 7% of its own population and could not
-express the case it was measuring. The observed worst mean, 59.25, sits just under the analytic
-bound of 63.75, which is the reassuring part: two independent routes agree at the boundary.
+express the case it was measuring. The observed worst mean, 59.25, sits under the analytic bound of
+69.75 — a consistency check rather than an agreement, since real assets cannot saturate a bound that
+requires every matching pixel to differ by exactly 8.
 
 **And the two statistics need different gates**, which conflating them hid: `mean` is a whole-frame
 average that darkness cannot corrupt, so two structured images at mean 0.00 are the same image

--- a/prosper/tools/evidence/prerender_check.py
+++ b/prosper/tools/evidence/prerender_check.py
@@ -198,10 +198,17 @@ def main(argv):
         return 1
 
     # There is deliberately NO separate mean ceiling here. One was added and removed: an overlap of
-    # >= 75% already bounds the mean at <= 63.75/255 (and <= 75.75 in the worst coverage case), so
+    # >= 75% already bounds the mean at <= 69.75/255, so
     # any ceiling below that can only discard frames the bar would have flagged -- it cannot prevent
-    # a false positive, only manufacture false negatives. The BOUND is what settles this -- it is
-    # derivable and belongs to nobody's sample. Measured alongside it, 100 of 233 structured assets
+    # a false positive, only manufacture false negatives. The bound is
+    #     mean <= 0.75*f*8 + 0.25*f*255 + (1-f)*15  =  f*69.75 + (1-f)*15
+    # for informative fraction f -- increasing in f, so it maximises at FULL coverage, at 69.75. It
+    # was first written here as 63.75, which dropped the matching pixels' own contribution: a pixel
+    # counted as matching may differ by up to 8 per channel, not 0, and 0.75*8 = 6.00 is exactly the
+    # gap. A hand-built frame (75% of pixels differing by exactly 8, 25% by 255) reaches mean 69.67
+    # at overlap 75.00% -- above the figure the earlier comment said could not be reached, so the
+    # tool refuted its own comment. Derive it rather than quoting it. Measured alongside it, 100 of
+    # 233 structured assets
     # (42.9%) carrying a bright caption panel reach mean 40.5-59.25 while still exceeding the bar,
     # so a ceiling of 40 silently dropped nearly half of them. (An earlier "4 of 13" here came from
     # a probe that filtered to 1920x1080 and so excluded every 4K asset -- which is exactly where the

--- a/prosper/tools/evidence/prerender_check.py
+++ b/prosper/tools/evidence/prerender_check.py
@@ -200,9 +200,12 @@ def main(argv):
     # There is deliberately NO separate mean ceiling here. One was added and removed: an overlap of
     # >= 75% already bounds the mean at <= 63.75/255 (and <= 75.75 in the worst coverage case), so
     # any ceiling below that can only discard frames the bar would have flagged -- it cannot prevent
-    # a false positive, only manufacture false negatives. Measured: 4 of 13 real assets with a bright
-    # caption panel reach mean 40.5-54.3 while still exceeding the bar, and a 40 ceiling silently
-    # dropped every one of them.
+    # a false positive, only manufacture false negatives. The BOUND is what settles this -- it is
+    # derivable and belongs to nobody's sample. Measured alongside it, 100 of 233 structured assets
+    # (42.9%) carrying a bright caption panel reach mean 40.5-59.25 while still exceeding the bar,
+    # so a ceiling of 40 silently dropped nearly half of them. (An earlier "4 of 13" here came from
+    # a probe that filtered to 1920x1080 and so excluded every 4K asset -- which is exactly where the
+    # worst means live. Cite the bound; a count is a property of whoever's sample.)
     dominant = max(usable, key=lambda row: row[1])
     if dominant[1] >= overlap:
         print("\nDOMINATED: %.2f%% of this frame's INFORMATIVE pixels are within 8/255 of the\n"


### PR DESCRIPTION
Refs #2998. Follow-up to #3060.

A background probe from #3060's review completed **after** that PR merged, and contradicted a number
it had published — which by then was in a shipped code comment and in `tools/evidence/AGENTS.md`.

| | published | actual |
| --- | --- | --- |
| assets probed | 13 | **233** |
| above the 40 ceiling at overlap ≥ 75% | 4 (31%) | **100 (42.9%)** |
| worst mean | 54.33 | **59.25** |

Same direction — the disproof of the removed mean ceiling is **stronger** than recorded — but an
understated figure sat in the very paragraph written to stop someone re-proposing that ceiling, which
is where a weak number does the most damage.

## The cause, recorded next to the number

The original probe filtered assets to `1920×1080` and so **excluded every 4K asset** — exactly where
the worst means live. A structured-asset sample runs roughly 6 such 1080p assets against 79 4K ones,
so it measured about **7%** of its own population, and specifically the slice that omitted the
`sce_sys/pic*` store art dominating the corrected list.

Its silence about the worst case was therefore *guaranteed rather than informative* — the same shape
as the charter's positive-control trap, where a control drawn from the source under test cannot
express the class it is meant to detect.

## The fix is to stop citing a count

Both sites now lead with the **analytic bound**: an overlap of ≥ 75% bounds the mean at ≤ 63.75/255
at full coverage. That is derivable, belongs to nobody's sample, and is what actually settled the
removal. The corrected count is kept beside it as a cross-check, along with a note that the earlier
figure came from a resolution-filtered probe.

The observed worst mean of **59.25** sitting just under the bound of **63.75** is the reassuring
part: two independent routes agreeing at the boundary is good evidence the bound is right.

## Verification

Comment and documentation only — no behaviour change. The tool's arms are unaffected and re-checked
(EXACT on the retracted frame still exits 2). `check_numbered_table.py` over all 152 tracked `.md`
files passes; `diff --check` clean.

Not merged under the docs-only exception, since the diff touches a `.py` file — even though only its
comments changed.
