### PR TITLE
gitignore: cover the F9 .prgbundle and F8 .prperf capture artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@
 *.self
 eboot.bin
 *.prgcap
+# F9 writes .prgbundle and F8 writes .prperf into PROSPER_CAPTURE_DIR, which defaults to the cwd --
+# so a capture taken while running from the repo root lands here. A .prgbundle carries game-derived
+# resource bytes and is routinely 200 MB - 2.7 GB, which must never reach a public repository.
+*.prgbundle
+*.prperf
 *.prgtl
 
 # ---- Build output ----


### PR DESCRIPTION
`*.prgcap`, `*.bmp` and `frame_*.png` are ignored; the two formats the in-app capture triggers
actually write are not.

**Failure scenario.** `PROSPER_CAPTURE_DIR` defaults to the cwd. Press **F9** while running
`prosper-app` from the repository root and a `.prgbundle` lands there as untracked — 356 MB in the
case that prompted this, and the documented range is 200 MB–2.7 GB. A `.prgbundle` carries
game-derived resource bytes, so `git add -A` would commit game content to a public repository. Same
for **F8**'s `.prperf`.

Secondary: untracked files mark a worktree **DIRTY**, and that is precisely the condition
`worktree_reclaim.py` refuses to reclaim — the charter records 35 of 49 trees blocked that way.

**Verification.** `git status` in a worktree holding a real 356 MB `frame_grab_*.prgbundle` and a
`perf_capture_*.prperf` reports clean with this patch and lists both without it. No code change.