### PR TITLE
feat(snapshot): one-command authoring (snaps.py author)

### DIFF
--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -10,7 +10,20 @@ reaches the entrance hall inside 300–780 s any more.
 
 ## Authoring: play the game
 
-Run the title normally — a real window, audio, a pad — and record the route while you play:
+```bash
+python3 prosper/tools/snapshot/snaps.py author --name blue-prince --dump PPSA25009-app0
+```
+
+That launches the title with a real window, audio and pad, records the input route, and puts the
+snaps in `~/snaps/blue-prince`. One command rather than four environment variables, because getting
+`PROSPER_PAD_RECORD` wrong is not a *visible* mistake: you play the whole session, press F6/F7
+happily, and only discover at import time that there is no route and none of it can be replayed.
+
+It refuses to reuse a session directory, for the same class of reason — snap indices restart at 0
+each run, so a second session into one directory would overwrite the first session's images while
+appending to its manifest. Use a fresh `--out`, or `--append` if you mean it.
+
+The equivalent by hand, if you want to add your own variables:
 
 ```bash
 PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \

--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -138,6 +138,22 @@ Two further consequences worth knowing before you debug something surprising:
   why the origin must never be established by a host hotkey — see the comment on
   `prosper_pad_flip_ordinal()` in `src/hle/input/hle_pad.cpp`.
 
+## FMVs, and why the anchor survives them
+
+**Movies play in the check exactly as they do when you author.** Nothing here disables video decode,
+and neither do the old guards.
+
+This is the case where a flip anchor earns its keep. An FMV of N frames contributes N flips however
+slowly it renders — so Blue Prince's intro, measured at **4.8 fps** against ~180 fps at its menu
+(#2215), shifts the run's wall-clock enormously and its flip anchors **not at all**. A wall-clock
+anchor would be useless here; a flip anchor is unaffected.
+
+What the movie *does* eat is real seconds. So the check does **not** stop on a timer: it runs until
+the last anchor has been captured, and the timeout is a safety net for a hung run. Sizing a timeout
+for a quick boot would cut the route off mid-run and report every later snap as `NOT REACHED` — a
+failure with nothing to do with rendering, which is the whole class of bug this system exists to
+remove.
+
 ## Where things live, and what is never committed
 
 | path | committed? | what |

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -37,6 +37,7 @@ clone the numbers still work, but "show me what it used to look like" only works
 authored the run (or anyone who re-authors it).
 
 USAGE
+    snaps.py author --name <name> --dump <TITLE-app0>              play, and press F6/F7
     snaps.py import <capture-dir> --name <name> [--route <file>]   adopt an authoring session
     snaps.py check [name ...]                                      replay and compare; exit 1 on failure
     snaps.py accept <name> <index> [<index> ...]                   promote an actual to be the new snap
@@ -227,6 +228,67 @@ def list_names():
     if not os.path.isdir(SNAP_STORE):
         return []
     return sorted(f[:-5] for f in os.listdir(SNAP_STORE) if f.endswith(".json"))
+
+
+# ---------------------------------------------------------------------------------------------
+# author
+# ---------------------------------------------------------------------------------------------
+
+def cmd_author(args):
+    """Launch the game for an authoring session: real window, audio, pad, route recording on.
+
+    This exists so authoring is one command rather than four environment variables remembered
+    correctly. Getting PROSPER_PAD_RECORD wrong is not a visible mistake -- you play the whole
+    session, press F6/F7 happily, and only discover at import time that there is no route and the
+    snaps can never be replayed.
+    """
+    dump = args.dump
+    if not dump:
+        raise SystemExit("snaps: --dump is required (e.g. --dump PPSA25009-app0)")
+    dump_path = dump if os.path.isabs(dump) else os.path.join(GAME_ROOT, dump)
+    if not os.path.isdir(dump_path):
+        raise SystemExit(f"snaps: dump not found: {dump_path}")
+    if not os.path.exists(APP):
+        raise SystemExit(f"snaps: prosper-app not found at {APP} (set PROSPER_APP_BIN)")
+
+    out_dir = args.out or os.path.join(os.path.expanduser("~"), "snaps", args.name)
+    if os.path.exists(os.path.join(out_dir, "snaps.jsonl")) and not args.append:
+        raise SystemExit(
+            f"snaps: {out_dir} already holds an authoring session.\n"
+            f"       Snap indices restart at 0 each run, so a second session would overwrite the\n"
+            f"       first session's images while appending to its manifest. Use a fresh --out, or\n"
+            f"       --append if you really mean to continue into the same directory.")
+    os.makedirs(out_dir, exist_ok=True)
+    route = os.path.join(out_dir, "route.pad")
+
+    env = dict(os.environ)
+    env.update({
+        "PROSPER_RENDER": "1",
+        "PROSPER_GUEST_ARGS": "-force-gfx-direct",
+        "PROSPER_SNAP_DIR": out_dir,
+        "PROSPER_PAD_RECORD": route,
+    })
+    # Deliberately NOT offscreen: authoring is a person looking at a window.
+    env.pop("SDL_VIDEODRIVER", None)
+
+    print(f"authoring '{args.name}' -> {out_dir}")
+    print("  F6 = this frame looks CORRECT     F7 = this frame looks WRONG")
+    print("  take negative snaps too: they are the only thing that will tell you a broken")
+    print("  title got fixed.\n")
+    subprocess.run([APP, dump_path], env=env, check=False)
+
+    manifest = os.path.join(out_dir, "snaps.jsonl")
+    taken = 0
+    if os.path.exists(manifest):
+        with open(manifest, "r", encoding="utf-8") as handle:
+            taken = sum(1 for line in handle if line.strip())
+    print(f"\nsession ended: {taken} snap(s) in {out_dir}")
+    if not taken:
+        print("  nothing to import -- no F6/F7 presses were recorded")
+        return 0
+    print(f"  import with: python3 {os.path.relpath(__file__, os.getcwd())} import {out_dir} "
+          f"--name {args.name}")
+    return 0
 
 
 # ---------------------------------------------------------------------------------------------
@@ -540,6 +602,14 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="command", required=True)
+
+    aut = sub.add_parser("author", help="play the game and take snaps (F6/F7)")
+    aut.add_argument("--name", required=True)
+    aut.add_argument("--dump", required=True, help="e.g. PPSA25009-app0")
+    aut.add_argument("--out", help="capture directory (default ~/snaps/<name>)")
+    aut.add_argument("--append", action="store_true",
+                     help="continue into an existing session directory")
+    aut.set_defaults(func=cmd_author)
 
     imp = sub.add_parser("import", help="adopt an authoring session")
     imp.add_argument("capture_dir")

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -52,6 +52,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PROSPER_ROOT = os.path.dirname(os.path.dirname(HERE))
@@ -446,22 +447,53 @@ def run_replay(entry, out_dir):
         "PROSPER_PAD_SCRIPT": "@" + os.path.join(REPO_ROOT, entry["route"]),
     })
     log = os.path.join(out_dir, "run.log")
-    with open(log, "w", encoding="utf-8") as handle:
-        try:
-            subprocess.run([APP, dump_path], env=env, stdout=handle, stderr=subprocess.STDOUT,
-                           timeout=entry.get("timeout", 900), check=False)
-        except subprocess.TimeoutExpired:
-            pass   # the run is bounded by design; whatever it captured before the bound still counts
-    actuals = {}
     manifest = os.path.join(out_dir, "actuals.jsonl")
-    if os.path.exists(manifest):
-        with open(manifest, "r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if line:
-                    record = json.loads(line)
-                    actuals[record["target_flip"]] = record
-    return actuals, log
+
+    def read_actuals():
+        found = {}
+        if os.path.exists(manifest):
+            with open(manifest, "r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if line:
+                        try:
+                            record = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue     # a record still being written; it will be there next poll
+                        found[record["target_flip"]] = record
+        return found
+
+    # Stop when the LAST anchor has been captured, not when a wall-clock timer expires. The timeout
+    # is a safety net for a run that hangs, not the normal way the run ends.
+    #
+    # This matters because of FMVs. The anchor is a flip count, so a movie contributes the same
+    # number of flips however slowly it renders -- which is exactly why flips beat wall-clock and why
+    # an authored route survives a title whose intro plays at 4.8 fps (measured on Blue Prince,
+    # ~37x slower than its menu). But the movie still eats real SECONDS, so a fixed timeout sized for
+    # a quick boot would cut the run off mid-route and report every later snap as NOT REACHED -- a
+    # failure with nothing to do with rendering, which is the whole class of bug this system exists
+    # to remove.
+    last_anchor = max(candidate_flips(entry)) if entry["snaps"] else 0
+    deadline = time.time() + entry.get("timeout", 3600)
+    with open(log, "w", encoding="utf-8") as handle:
+        proc = subprocess.Popen([APP, dump_path], env=env, stdout=handle,
+                                stderr=subprocess.STDOUT)
+        try:
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    break                      # the guest exited on its own
+                if last_anchor in read_actuals():
+                    break                      # everything the check needs has been captured
+                time.sleep(2)
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=20)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=20)
+    return read_actuals(), log
 
 
 def cmd_check(args):
@@ -616,7 +648,9 @@ def main():
     imp.add_argument("--name", required=True)
     imp.add_argument("--route")
     imp.add_argument("--dump")
-    imp.add_argument("--timeout", type=int, default=900)
+    imp.add_argument("--timeout", type=int, default=3600,
+                     help="safety net only; the run normally ends when the last "
+                          "anchor is captured")
     imp.add_argument("--min-ssim", dest="min_ssim", type=float, default=DEFAULT_MIN_SSIM)
     imp.add_argument("--flip-window", dest="flip_window", type=int, default=DEFAULT_FLIP_WINDOW,
                      help="flips either side of each anchor to search (0 = exact anchor only)")


### PR DESCRIPTION
Authoring required four environment variables set correctly. `snaps.py author --name X --dump Y`
now does it in one.

**Why it matters more than convenience:** getting `PROSPER_PAD_RECORD` wrong is not a *visible*
mistake. You play a whole session, press F6/F7 happily, and only discover at import time that there
is no route — so none of the judgements you just made can ever be replayed.

Two guards, both against silent loss:

- **Refuses to reuse a session directory.** Snap indices restart at 0 each run, so a second session
  into one directory would overwrite the first session's images while appending to its manifest,
  leaving a manifest describing frames that no longer exist. `--append` for when it is intended.
- **Refuses a missing dump** with the resolved path, rather than launching and failing obscurely.

Clears `SDL_VIDEODRIVER` explicitly — authoring is a person looking at a window, and inheriting
`offscreen` from a shell that ran a headless check would produce a session with nothing to look at.

## Verification

- `ctest snapshot_snaps_tool` and `prosper_app_snap_author`: pass.
- Both refusals exercised by hand (reused directory, missing dump) — messages quoted in the commit.
- Docs updated with the one-command form and the by-hand equivalent.


---

# Also: the replay ends when the last anchor is captured, not on a timer

Raised as a question — *do the snapshot checks run the FMVs?* They do; nothing here or in the old
guards disables video decode. But the question exposed a real bug.

**The anchor survives a movie; the timeout did not.** A flip anchor is a frame count, so an FMV of N
frames contributes N flips however slowly it renders — Blue Prince's intro plays at **4.8 fps**
against ~180 fps at its menu (#2215), a ~37× wall-clock difference that moves its flip anchors *not
at all*. That is exactly why flips beat wall-clock.

What the movie eats is real **seconds**. The check ran under a fixed wall-clock timeout and took
whatever had been captured when it expired — so a timeout sized for a quick boot would cut the route
off mid-run and report every later snap as `NOT REACHED`. A failure with nothing to do with
rendering, which is the precise class of bug this system exists to remove, reintroduced through the
timeout.

Now the run ends when the highest anchor has been captured (or the guest exits), and the timeout is
a safety net for a hung run. Default raised 900 → 3600s to match that role. A partially-written
manifest record is skipped and re-read on the next poll rather than aborting the wait.
