### PR TITLE
fix(snapshot): sample the anchor window geometrically, and say not to snap mid-fade

### DIFF
--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -154,6 +154,30 @@ for a quick boot would cut the route off mid-run and report every later snap as 
 failure with nothing to do with rendering, which is the whole class of bug this system exists to
 remove.
 
+### Do not anchor a snap mid-fade — measured, and it is the one real trap
+
+Two identical headless runs were driven through Blue Prince's New Game intro and sampled at the same
+anchors. At flip 8000 they agreed (**SSIM 0.995**). At flip 10000 they scored **0.465** — a failure.
+
+Opening both frames explains it, and the explanation is reassuring about FMVs and unforgiving about
+transitions: **both runs were on the same page of the same cutscene text, word for word.** The drift
+across the movie was small. What differed was that one run was *mid-fade* (non-black 0.695 vs 0.365)
+and had a subtitle the other had not yet shown.
+
+So the rule is not "avoid FMVs". It is:
+
+> **Take snaps on visually STABLE moments.** A title screen, a menu, a held gameplay view. Not
+> during a fade, a wipe, a subtitle transition, or a rapidly cutting cinematic.
+
+A few flips of drift on a stable scene is invisible. The same drift during a fade is a large
+luminance change, and SSIM is sensitive to luminance by design — it is what makes it catch a
+collapse to black.
+
+The window sampling is geometric for this reason (dense near the anchor, sparse at the edges), since
+drift is small: with `--window-samples 9` over ±900 the offsets are `0, ±43, ±196, ±478, ±900`
+rather than uniform ±225 steps. That resolves a short fade far better than even spacing, but it
+cannot rescue a snap taken in the middle of one.
+
 ## Where things live, and what is never committed
 
 | path | committed? | what |

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -382,14 +382,28 @@ def cmd_import(args):
 # ---------------------------------------------------------------------------------------------
 
 def window_offsets(entry):
-    """Flip offsets sampled either side of each anchor, always including 0 (the exact anchor)."""
+    """Flip offsets sampled either side of each anchor, always including 0 (the exact anchor).
+
+    Spacing is GEOMETRIC, not uniform: dense near the anchor and sparse at the edges. Measured
+    reason -- two identical runs through Blue Prince's intro cutscene reached the same page of the
+    same text at flip 10000, so drift across an FMV is SMALL. What made them score 0.465 was that
+    one was mid-fade: a few flips of drift during a transition is a large luminance change even
+    though the scene is the same. Uniform spacing puts most of its samples far away, where the match
+    almost never is, and leaves the near region -- where a fade needs resolving -- coarse.
+    """
     span = entry.get("flip_window", DEFAULT_FLIP_WINDOW)
     samples = max(1, entry.get("window_samples", DEFAULT_WINDOW_SAMPLES))
     if span <= 0 or samples == 1:
         return [0]
-    step = (2 * span) // (samples - 1)
-    offsets = sorted({-span + i * step for i in range(samples)} | {0})
-    return offsets
+    per_side = max(1, (samples - 1) // 2)
+    offsets = {0}
+    for i in range(1, per_side + 1):
+        # i/per_side raised to a power > 1 clusters the samples toward the anchor.
+        magnitude = int(round(span * (i / per_side) ** 2.2))
+        magnitude = max(magnitude, i)          # never collapse two samples onto each other
+        offsets.add(magnitude)
+        offsets.add(-magnitude)
+    return sorted(offsets)
 
 
 def candidate_flips(entry):

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -227,6 +227,24 @@ def main():
         check(score >= snaps.DEFAULT_MIN_SSIM,
               "...and it scores as a pass, where exact-anchor matching would have failed")
 
+        # ---- 6c2. Sampling is DENSE near the anchor, because that is where the match is ------
+        # Measured: two identical runs through Blue Prince's intro cutscene reached the same page of
+        # the same text at flip 10000 -- so drift across an FMV is small. They scored 0.465 anyway
+        # because one was mid-fade, and a few flips of drift during a transition is a large
+        # luminance change. Uniform spacing spends its samples far from the anchor, where the match
+        # almost never is.
+        geo = snaps.window_offsets({"flip_window": 900, "window_samples": 9})
+        positives = [o for o in geo if o > 0]
+        check(positives == sorted(positives), "offsets are ordered")
+        first_gap = positives[0]
+        last_gap = positives[-1] - positives[-2]
+        check(last_gap > first_gap * 2,
+              "spacing widens away from the anchor (dense near, sparse far)")
+        check(positives[0] < 900 // (len(positives) + 1),
+              "the nearest sample is much closer than uniform spacing would place it")
+        check(geo == [-o for o in reversed(geo)], "the window is symmetric about the anchor")
+        check(len(set(geo)) == len(geo), "no two samples collapse onto the same offset")
+
         # ---- 6d. An edge match is detectable, because that is how "the window is too narrow"
         # is told apart from "the picture changed" ----------------------------------------------
         edge_entry = {"flip_window": 600, "window_samples": 7}


### PR DESCRIPTION
Answers "will FMVs break the new snapshot system?" with an experiment rather than an argument.

## The measurement

Two identical headless runs, driven through Blue Prince's New Game intro, sampled at the same
anchors:

| anchor | SSIM(A,B) | |
| --- | --- | --- |
| flip 8000 | **0.995** | agree |
| flip 10000 | **0.465** | diverge |

## What the frames say, which the numbers could not

**Both runs were on the same page of the same cutscene text, word for word.** Drift across the movie
is *small* — flip anchoring survives an FMV, exactly as intended (a movie of N frames is N flips
however slowly it renders).

What differed: one run was **mid-fade** — non-black 0.695 vs 0.365 — with a subtitle the other had
not yet shown.

So the trap is not the movie. It is anchoring during a **transition**. A few flips of drift on a
stable scene is invisible; the same drift during a fade is a large luminance change. SSIM is
sensitive to luminance *by design* — that is what makes it catch a collapse to black — so it cannot
be tuned around without losing the property the guard exists for.

## Two changes

- **Geometric window sampling** instead of uniform: dense near the anchor, sparse at the edges,
  because the measurement says drift is small. Over ±900 with 9 samples the offsets become
  `0, ±43, ±196, ±478, ±900` rather than uniform ±225 steps — far better resolution of a short fade,
  at identical capture cost.
- **The docs state the authoring rule**: take snaps on visually stable moments — a title screen, a
  menu, a held gameplay view — not during a fade, wipe, subtitle transition or rapidly cutting
  cinematic.

## Verification

`ctest snapshot_snaps_tool` + `prosper_app_snap_author`: **2/2 pass**. New arms pin the sampling
shape — spacing widens away from the anchor, the nearest sample is closer than uniform spacing would
place it, the window is symmetric, and no two samples collapse onto one offset.