### PR TITLE
feat(pad): record analog sticks as directions, so stick-driven routes replay

### DIFF
--- a/prosper/src/hle/input/hle_pad.cpp
+++ b/prosper/src/hle/input/hle_pad.cpp
@@ -378,7 +378,7 @@ PadRecordAxis pad_record_axis() {
 // Record the final button stream as explicit flip or successful-pad-read ranges. Completed intervals
 // are flushed immediately; only a button still held when a process is force-killed can be absent from
 // the route tail. Metadata polls do not initialize or advance a pad-read-axis recording.
-void pad_record(int64_t frame, int64_t read, uint32_t buttons) {
+void pad_record(int64_t frame, int64_t read, uint32_t buttons, uint32_t sticks) {
     static const char* output = getenv("PROSPER_PAD_RECORD");
     if (!output || !*output) return;
     const PadRecordAxis axis = pad_record_axis();
@@ -418,7 +418,7 @@ void pad_record(int64_t frame, int64_t read, uint32_t buttons) {
         }
     }
     if (!recorder.file) return;
-    const std::string completed = recorder.state.observe(position, buttons);
+    const std::string completed = recorder.state.observe(position, buttons, sticks);
     if (completed.empty()) return;
     fputs(completed.c_str(), recorder.file);
     fflush(recorder.file);
@@ -441,7 +441,11 @@ HostPadState poll_controller(int /*handle*/, const char* what, bool consume_inpu
     const int64_t frame = pad_frame_now();
     const int64_t read = consume_input_read ? pad_read_now() : -1;
     apply_pad_script(s, frame, read);
-    pad_record(frame, read, s.buttons);
+    // Sticks are recorded as DIRECTIONS, like a d-pad: the script vocabulary is full-deflection
+    // only, so there is nothing finer to record. Without this a stick-driven route replayed as
+    // standing still, which is silent and total -- the guest simply never moves.
+    pad_record(frame, read, s.buttons,
+               pad_stick_mask(s.left_x, s.left_y, s.right_x, s.right_y));
     padlog_once(what, &s);
     return s;
 }

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -167,21 +167,45 @@ std::string pad_button_names(uint32_t mask) {
     return result;
 }
 
-std::string PadRecordState::observe(int64_t position, uint32_t buttons) {
-    if (buttons == previous_) return {};
+std::string pad_stick_names(uint32_t stick_mask) {
+    static constexpr struct { uint32_t bit; const char* name; } names[] = {
+        {PAD_REC_LEFT_X_NEG, "left-stick-left"},   {PAD_REC_LEFT_X_POS, "left-stick-right"},
+        {PAD_REC_LEFT_Y_NEG, "left-stick-up"},     {PAD_REC_LEFT_Y_POS, "left-stick-down"},
+        {PAD_REC_RIGHT_X_NEG, "right-stick-left"}, {PAD_REC_RIGHT_X_POS, "right-stick-right"},
+        {PAD_REC_RIGHT_Y_NEG, "right-stick-up"},   {PAD_REC_RIGHT_Y_POS, "right-stick-down"},
+    };
+    std::string result;
+    for (const auto& name : names) {
+        if (!(stick_mask & name.bit)) continue;
+        if (!result.empty()) result += '+';
+        result += name.name;
+    }
+    return result;
+}
+
+std::string PadRecordState::observe(int64_t position, uint32_t buttons, uint32_t sticks) {
+    if (buttons == previous_ && sticks == previous_sticks_) return {};
 
     std::string completed;
-    if (previous_) {
+    if (previous_ || previous_sticks_) {
         // A press and release can be observed at the same count (for example, through two pad
         // polls during one display flip). Preserve the existing recorder's non-empty range rule.
         const int64_t end = position > start_ ? position : start_ + 1;
-        const std::string names = pad_button_names(previous_);
+        // Buttons first, then stick directions, both in the parser's vocabulary and '+'-joined --
+        // so a recorded interval round-trips through parse_pad_script unchanged.
+        std::string names = pad_button_names(previous_);
+        const std::string stick_names = pad_stick_names(previous_sticks_);
+        if (!stick_names.empty()) {
+            if (!names.empty()) names += '+';
+            names += stick_names;
+        }
         if (!names.empty()) {
             completed = (axis_ == PadRecordAxis::pad_read ? "p" : "f") +
                         std::to_string(start_) + "-" + std::to_string(end) + ":" + names + "\n";
         }
     }
     previous_ = buttons;
+    previous_sticks_ = sticks;
     start_ = position;
     return completed;
 }

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -197,6 +197,56 @@ uint32_t pad_button_by_name(const std::string& name);
 // stable order so recorded routes have deterministic text.
 std::string pad_button_names(uint32_t mask);
 
+// ---- Recording analog sticks as DIRECTIONS ----------------------------------------------------
+//
+// The script vocabulary is full-deflection only ("left-stick-left"), so recording treats each stick
+// as a d-pad: past the dead zone in one direction, or centered. That is a deliberate fidelity limit,
+// not an oversight -- a gentle tilt records and replays as a full push, so a route that depends on
+// fine analog control will not reproduce its exact path. Recording nothing at all was the previous
+// behaviour and is strictly worse: a stick-driven route replayed as standing still.
+//
+// Bits are the PAD_SCRIPT_* axis flags paired with a sign bit, so one integer compares cheaply in
+// the recorder's change detection.
+enum : uint32_t {
+    PAD_REC_LEFT_X_NEG = 1u << 0, PAD_REC_LEFT_X_POS = 1u << 1,
+    PAD_REC_LEFT_Y_NEG = 1u << 2, PAD_REC_LEFT_Y_POS = 1u << 3,
+    PAD_REC_RIGHT_X_NEG = 1u << 4, PAD_REC_RIGHT_X_POS = 1u << 5,
+    PAD_REC_RIGHT_Y_NEG = 1u << 6, PAD_REC_RIGHT_Y_POS = 1u << 7,
+};
+
+// Sony axis bytes are 0=min, 0x80=center, 0xff=max. The dead zone is generous on purpose: a resting
+// stick drifts, and a recorder that emits an interval every time it wobbles produces a route full of
+// one-flip noise entries that replay as real input.
+inline constexpr uint8_t kPadRecordDeadZone = 48;
+
+// -1, 0 or +1 for one axis byte.
+constexpr int pad_axis_direction(uint8_t value, uint8_t dead_zone = kPadRecordDeadZone) {
+    const int centered = static_cast<int>(value) - 0x80;
+    if (centered <= -static_cast<int>(dead_zone)) return -1;
+    if (centered >= static_cast<int>(dead_zone)) return 1;
+    return 0;
+}
+
+// Pack the four axes into one comparable mask.
+constexpr uint32_t pad_stick_mask(uint8_t left_x, uint8_t left_y,
+                                  uint8_t right_x, uint8_t right_y,
+                                  uint8_t dead_zone = kPadRecordDeadZone) {
+    uint32_t mask = 0;
+    const int lx = pad_axis_direction(left_x, dead_zone);
+    const int ly = pad_axis_direction(left_y, dead_zone);
+    const int rx = pad_axis_direction(right_x, dead_zone);
+    const int ry = pad_axis_direction(right_y, dead_zone);
+    if (lx < 0) mask |= PAD_REC_LEFT_X_NEG; else if (lx > 0) mask |= PAD_REC_LEFT_X_POS;
+    if (ly < 0) mask |= PAD_REC_LEFT_Y_NEG; else if (ly > 0) mask |= PAD_REC_LEFT_Y_POS;
+    if (rx < 0) mask |= PAD_REC_RIGHT_X_NEG; else if (rx > 0) mask |= PAD_REC_RIGHT_X_POS;
+    if (ry < 0) mask |= PAD_REC_RIGHT_Y_NEG; else if (ry > 0) mask |= PAD_REC_RIGHT_Y_POS;
+    return mask;
+}
+
+// '+'-joined direction names, in the exact vocabulary parse_pad_script accepts, so a recorded route
+// round-trips through the parser.
+std::string pad_stick_names(uint32_t stick_mask);
+
 // Recording uses the same explicit-range syntax accepted by PROSPER_PAD_SCRIPT. Keep transition
 // tracking pure so interval boundaries and axis prefixes can be tested without an output file or
 // a controller backend. The caller supplies either the current display-flip or successful-read
@@ -209,11 +259,14 @@ enum class PadRecordAxis : uint8_t {
 class PadRecordState {
 public:
     explicit PadRecordState(PadRecordAxis axis = PadRecordAxis::display_flip) : axis_(axis) {}
-    std::string observe(int64_t position, uint32_t buttons);
+    // `sticks` is a pad_stick_mask(). A change in EITHER buttons or stick direction closes the
+    // current interval, so a route records "walked left, then pressed cross" as two entries.
+    std::string observe(int64_t position, uint32_t buttons, uint32_t sticks = 0);
 
 private:
     PadRecordAxis axis_;
     uint32_t previous_ = 0;
+    uint32_t previous_sticks_ = 0;
     int64_t start_ = 0;
 };
 

--- a/prosper/tests/input/test_pad.cpp
+++ b/prosper/tests/input/test_pad.cpp
@@ -629,6 +629,64 @@ int main() {
         CHECK(missing.empty() && !route_error.empty(), "route: missing @path reports an error");
     }
 
+    // ---- Recording analog sticks as directions --------------------------------------------
+    // Previously the recorder took buttons only, so a stick-driven route replayed as standing
+    // still: silent, total, and indistinguishable from the game ignoring input.
+    {
+        // Sony axis bytes: 0 = min, 0x80 = center, 0xff = max.
+        CHECK(pad_axis_direction(0x80) == 0, "stick: a centered axis is neutral");
+        CHECK(pad_axis_direction(0x00) == -1, "stick: fully negative reads as -1");
+        CHECK(pad_axis_direction(0xff) == 1, "stick: fully positive reads as +1");
+        // The dead zone must swallow rest drift, or every wobble emits a one-flip interval that
+        // replays as real input.
+        CHECK(pad_axis_direction(0x80 + 8) == 0 && pad_axis_direction(0x80 - 8) == 0,
+              "stick: small drift around center stays neutral");
+        CHECK(pad_axis_direction(0x80 + kPadRecordDeadZone) == 1,
+              "stick: exactly at the dead-zone edge counts as deflected");
+
+        CHECK(pad_stick_mask(0x80, 0x80, 0x80, 0x80) == 0, "stick: all centered packs to zero");
+        const uint32_t left_only = pad_stick_mask(0x00, 0x80, 0x80, 0x80);
+        CHECK(pad_stick_names(left_only) == "left-stick-left", "stick: one axis names one direction");
+        const uint32_t diagonal = pad_stick_mask(0xff, 0x00, 0x80, 0x80);
+        CHECK(pad_stick_names(diagonal) == "left-stick-right+left-stick-up",
+              "stick: a diagonal names both axes, '+'-joined");
+        CHECK(pad_stick_names(pad_stick_mask(0x80, 0x80, 0x00, 0xff)) ==
+                  "right-stick-left+right-stick-down",
+              "stick: the right stick is named independently");
+
+        // The recorder closes an interval when the STICK changes, not only when a button does.
+        PadRecordState rec(PadRecordAxis::display_flip);
+        CHECK(rec.observe(100, 0, left_only).empty(), "stick: the first observation opens an interval");
+        const std::string closed = rec.observe(140, 0, 0);
+        // observe() includes the trailing newline: pad_record writes it with a bare fputs, so the
+        // newline has to come from here or every entry would land on one line.
+        CHECK(closed == "f100-140:left-stick-left\n",
+              "stick: releasing the stick closes an interval naming the direction");
+
+        // Buttons and sticks together, and the result must round-trip through the parser -- a
+        // recorded route that the script loader drops is worse than no recording, because it looks
+        // like a working route and replays as nothing.
+        PadRecordState both(PadRecordAxis::display_flip);
+        both.observe(10, SCE_PAD_BUTTON_CROSS, left_only);
+        const std::string combined = both.observe(30, 0, 0);
+        CHECK(combined == "f10-30:cross+left-stick-left\n",
+              "stick: buttons and directions record together");
+        auto parsed = parse_pad_script(combined);
+        CHECK(parsed.size() == 1, "stick: a recorded combined interval parses back to one entry");
+        if (parsed.size() == 1) {
+            CHECK(parsed[0].button_mask == SCE_PAD_BUTTON_CROSS,
+                  "stick: the button survives the round trip");
+            CHECK((parsed[0].axis_mask & PAD_SCRIPT_LEFT_X) != 0 && parsed[0].left_x < 0,
+                  "stick: the direction survives the round trip as a left deflection");
+        }
+
+        // A neutral interval is still not recorded: nothing held is not an event.
+        PadRecordState quiet(PadRecordAxis::display_flip);
+        quiet.observe(5, 0, 0);
+        CHECK(quiet.observe(9, SCE_PAD_BUTTON_CROSS, 0).empty(),
+              "stick: a wholly neutral interval emits nothing");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -207,6 +207,25 @@ speeds with the clock on — 78.2 fps against 52.4 fps, a 1.49x spread:
 All three comfortably above the 0.85 bar, where the uncorrected rate difference had pushed an anchor
 past its whole window.
 
+## Analog sticks record as DIRECTIONS, like a d-pad
+
+A stick past its dead zone records as `left-stick-left`, `right-stick-down` and so on, `+`-joined
+with any buttons held at the same time, in the exact vocabulary `PROSPER_PAD_SCRIPT` replays. A
+recorded interval round-trips through the parser unchanged.
+
+This is deliberately coarse, because the script vocabulary is **full-deflection only** — there is
+nothing finer to record. The consequence is worth knowing before authoring a 3D title: a gentle tilt
+records and replays as a full push, so a route that depends on fine analog control will not
+reproduce its exact path. Prefer short, decisive movements when authoring, and take the snap once
+the camera has settled.
+
+The previous behaviour was strictly worse: sticks were not recorded at all, so a stick-driven route
+replayed as **standing still** — silent, total, and indistinguishable from the game ignoring input.
+
+The dead zone (48 of 128) is generous on purpose: a resting stick drifts, and a recorder that emits
+an interval on every wobble produces a route full of one-flip noise entries that replay as real
+input.
+
 ## Save state: fresh by default, and why that is not optional
 
 Both halves run with **both** save roots redirected to empty per-run directories:


### PR DESCRIPTION
The recorder took **buttons only**. A stick-driven route therefore replayed as **standing still** —
silent, total, and indistinguishable from the game ignoring input. Every 3D title (Blue Prince,
Sonic, GTA V…) was unauthorable, and the failure mode is the worst kind: the session looks fine while
you play it, and the replay quietly goes nowhere.

## What it does

Sticks record as **directions, like a D-pad** — past the dead zone, or centered:

```
f4550-4561:cross
f4858-4920:circle+left-stick-left
```

This is not a lossy simplification of a richer signal: the script vocabulary is **full-deflection
only** (`left-stick-left`), so there is nothing finer to record. Directions are `+`-joined with
buttons held at the same instant, and **a recorded interval round-trips through `parse_pad_script`
unchanged** — the property that actually matters, since a recorded route the loader silently drops
would look like a working route and replay as nothing.

The dead zone is 48 of 128, generous on purpose: a resting stick drifts, and a recorder that emits an
interval on every wobble produces a route full of one-flip noise entries that replay as real input.

The change detector now closes an interval when **either** buttons or stick direction change, so
"walked left, then pressed cross" records as two entries rather than one smeared one.

## Documented consequence

A gentle tilt records and replays as a **full push**, so a route depending on fine analog control
will not reproduce its exact path. Short decisive movements author well; fine steering does not.
Stated in `AGENTS_SNAPS.md` rather than left to be discovered mid-session.

## Verification

`ctest --no-tests=error -j4` → **315/315**. New arms cover the dead zone in both directions and at
its exact edge, single-axis and diagonal naming, both sticks independently, combined
button+direction intervals, **the round trip back through the parser**, and that a wholly neutral
interval still emits nothing.