### PR TITLE
fix(snapshot): the deterministic clock is per-title — it breaks GRIS outright

### DIFF
--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -226,6 +226,31 @@ The dead zone (48 of 128) is generous on purpose: a resting stick drifts, and a 
 an interval on every wobble produces a route full of one-flip noise entries that replay as real
 input.
 
+### The clock is not universally safe — GRIS is the counterexample
+
+`--det-clock off` exists because the pinned clock **breaks some titles outright**, and this was found
+by a person trying to author one.
+
+GRIS, with a New Game route reaching its opening FMV, measured over 150 s:
+
+| | frames | `Forcing submitDone` stalls |
+| --- | --- | --- |
+| clock **off** | **42,000** | 0 |
+| clock **on** | **1,680** | **47** |
+
+A 25x collapse and a frozen white screen where the movie should play. Booting to its title screen is
+unaffected — the FMV is the trigger, and the mechanism is obvious in hindsight: video playback is
+A/V-sync sensitive, and a clock advancing per *flip* rather than per *second* makes the decoder wait
+for a presentation time that never arrives at the rate it expects. `PROSPER_DET_CLOCK` is marked
+`CONFIDENCE: MED` in `hle_kernel_time.cpp`, and this is what that caveat looks like in practice.
+
+**If a title freezes or an FMV stops during authoring, re-author with `--det-clock off`.** The
+symptom is unmistakable and appears while you are sitting there. With the clock off the anchors are
+frame-rate dependent again, which is what the search window absorbs — such a set may need a wider
+`--flip-window`.
+
+The setting is recorded per title, so the check reproduces how the session was authored.
+
 ## Save state: fresh by default, and why that is not optional
 
 Both halves run with **both** save roots redirected to empty per-run directories:

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -245,7 +245,29 @@ def list_names():
 DEFAULT_DET_FPS = 60
 
 
-def apply_deterministic_clock(env, det_fps):
+def apply_deterministic_clock(env, det_fps, enabled=True):
+    """Pin the guest clock, unless this title is one the clock breaks.
+
+    IT IS NOT UNIVERSALLY SAFE, and that has to be a per-title decision rather than a default nobody
+    can override. GRIS is the measured counterexample: with a New Game route reaching its opening
+    FMV, 150 s of run produced 42,000 frames with the clock OFF and 1,680 with it ON, plus 47
+    "Forcing submitDone to avoid TRC R4089 breach" messages -- a 25x collapse and a frozen white
+    screen where the movie should play. Booting to its title screen is unaffected; the FMV is the
+    trigger.
+
+    The mechanism is the obvious one in hindsight: video playback is A/V-sync sensitive, and a clock
+    that advances per FLIP rather than per second makes the decoder wait for a presentation time that
+    never arrives at the rate it expects.
+
+    With the clock OFF the anchors become frame-rate dependent again, which is what the search window
+    exists to absorb. A title that needs the clock off may therefore need a wider --flip-window.
+    """
+    if not enabled:
+        # Explicitly clear, so an authoring shell that exported these does not leak them into a run
+        # whose entry says the clock is off -- the check would then disagree with the authoring.
+        env.pop("PROSPER_DET_CLOCK", None)
+        env.pop("PROSPER_DET_FPS", None)
+        return
     env["PROSPER_DET_CLOCK"] = "1"
     env["PROSPER_DET_FPS"] = str(det_fps)
 
@@ -311,15 +333,21 @@ def cmd_author(args):
         "PROSPER_SNAP_DIR": out_dir,
         "PROSPER_PAD_RECORD": route,
     })
-    apply_deterministic_clock(env, args.det_fps)
+    apply_deterministic_clock(env, args.det_fps, args.det_clock == "on")
     # Pace the guest flips to the SAME rate the clock advances at, so guest time equals real time
     # while you play. Without this the deterministic clock makes the game speed track the render
     # rate -- measured on one authoring session: 3.1x during splash screens, 0.47x in a heavy scene,
     # mean 1.58x. Nobody can judge "does this look right" against that. The check deliberately does
     # NOT pace: there the point is to finish quickly, and the clock makes the anchors agree anyway.
-    env["PROSPER_FLIP_PACE_FPS"] = str(args.det_fps)
-    print(f"  guest clock: deterministic at {args.det_fps} fps, flips paced to match "
-          f"(real-time feel, and anchors that do not depend on this machine's speed)")
+    if args.det_clock == "on":
+        env["PROSPER_FLIP_PACE_FPS"] = str(args.det_fps)
+        print(f"  guest clock: deterministic at {args.det_fps} fps, flips paced to match "
+              f"(real-time feel, and anchors that do not depend on this machine's speed)")
+    else:
+        print("  guest clock: REAL time (--det-clock off). Anchors will depend on this machine's\n"
+              "              speed, so this set may need a wider --flip-window. Use this for titles\n"
+              "              the deterministic clock breaks -- GRIS freezes on its opening FMV with\n"
+              "              it on.")
     if args.savedata == "fresh":
         apply_fresh_savedata(env, out_dir)
         print("  savedata: FRESH (your real saves are untouched, and the check starts here too)")
@@ -424,6 +452,7 @@ def cmd_import(args):
         "min_structural_similarity": args.min_ssim,
         "savedata": args.savedata,
         "det_fps": args.det_fps,
+        "det_clock": args.det_clock,
         "flip_window": args.flip_window,
         "window_samples": args.window_samples,
         "snaps": sorted(snaps, key=lambda s: s["pad_flip"]),
@@ -513,7 +542,8 @@ def run_replay(entry, out_dir):
         raise SystemExit(f"snaps: prosper-app not found at {APP} (set PROSPER_APP_BIN)")
     flips = ",".join(str(f) for f in sorted(candidate_flips(entry)))
     env = dict(os.environ)
-    apply_deterministic_clock(env, entry.get("det_fps", DEFAULT_DET_FPS))
+    apply_deterministic_clock(env, entry.get("det_fps", DEFAULT_DET_FPS),
+                              entry.get("det_clock", "on") == "on")
     if entry.get("savedata", "fresh") == "fresh":
         apply_fresh_savedata(env, out_dir)
     env.update({
@@ -717,6 +747,8 @@ def main():
     aut.add_argument("--name", required=True)
     aut.add_argument("--dump", required=True, help="e.g. PPSA25009-app0")
     aut.add_argument("--out", help="capture directory (default ~/snaps/<name>)")
+    aut.add_argument("--det-clock", dest="det_clock", choices=("on", "off"), default="on",
+                     help="off for titles the pinned clock breaks (GRIS freezes on its FMV)")
     aut.add_argument("--det-fps", dest="det_fps", type=int, default=DEFAULT_DET_FPS,
                      help="guest clock rate; must match at check time")
     aut.add_argument("--savedata", choices=("fresh", "preserve"), default="fresh",
@@ -734,6 +766,8 @@ def main():
                      help="safety net only; the run normally ends when the last "
                           "anchor is captured")
     imp.add_argument("--min-ssim", dest="min_ssim", type=float, default=DEFAULT_MIN_SSIM)
+    imp.add_argument("--det-clock", dest="det_clock", choices=("on", "off"), default="on",
+                     help="off for titles the pinned clock breaks (GRIS freezes on its FMV)")
     imp.add_argument("--det-fps", dest="det_fps", type=int, default=DEFAULT_DET_FPS,
                      help="must match how the session was authored")
     imp.add_argument("--savedata", choices=("fresh", "preserve"), default="fresh",

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -141,6 +141,7 @@ def main():
             min_ssim = snaps.DEFAULT_MIN_SSIM
             savedata = "fresh"
             det_fps = snaps.DEFAULT_DET_FPS
+            det_clock = "on"
             flip_window = snaps.DEFAULT_FLIP_WINDOW
             window_samples = snaps.DEFAULT_WINDOW_SAMPLES
 
@@ -193,6 +194,19 @@ def main():
         clk2 = {}
         snaps.apply_deterministic_clock(clk2, 30)
         check(clk2.get("PROSPER_DET_FPS") == "30", "a non-default rate is honoured")
+
+        # The clock is NOT universally safe and must be disablable per title. GRIS freezes on its
+        # opening FMV with it on -- 42,000 frames in 150 s off against 1,680 on, a 25x collapse.
+        off = {}
+        snaps.apply_deterministic_clock(off, 60, enabled=False)
+        check("PROSPER_DET_CLOCK" not in off, "the clock can be turned off for a title")
+        # And an inherited value must be CLEARED, not merely left unset: an authoring shell that
+        # exported it would otherwise leak it into a run whose entry says the clock is off, making
+        # the check silently disagree with how the session was authored.
+        leaked = {"PROSPER_DET_CLOCK": "1", "PROSPER_DET_FPS": "60"}
+        snaps.apply_deterministic_clock(leaked, 60, enabled=False)
+        check("PROSPER_DET_CLOCK" not in leaked and "PROSPER_DET_FPS" not in leaked,
+              "an inherited clock is CLEARED when the title disables it")
         check(entry.get("det_fps") == snaps.DEFAULT_DET_FPS,
               "the rate is RECORDED in the entry, so the check reproduces how it was authored")
 


### PR DESCRIPTION
Found by the project owner trying to author GRIS: it froze on a **white screen** where the opening
FMV should play. GRIS had worked the previous day — true, and not a contradiction: that day was not
an authoring session, so the clock was off.

## Measured

New Game route reaching the FMV, 150 s:

| | frames | `Forcing submitDone to avoid TRC R4089 breach` |
| --- | --- | --- |
| clock **off** | **42,000** | 0 |
| clock **on** | **1,680** | **47** |

A **25× collapse**. Booting to the title screen is unaffected — the FMV is the trigger, and the
mechanism is obvious in hindsight: video playback is A/V-sync sensitive, and a clock advancing per
*flip* rather than per *second* makes the decoder wait for a presentation time that never arrives at
the rate it expects. `PROSPER_DET_CLOCK` is marked `CONFIDENCE: MED` at its definition; this is what
that caveat looks like in practice.

## My error, precisely

Not the mechanism — the **shape of the evidence**. I made the clock unconditional because it fixed
Alex Kidd's anchoring, verified it on exactly *one* title, and shipped it as a default for every
title. A per-title setting is what that evidence actually supported.

## The fix

`--det-clock off`, recorded in the entry so the check reproduces the session. It **clears** an
inherited `PROSPER_DET_CLOCK` rather than merely not setting one — an authoring shell that exported
it would otherwise leak it into a run whose entry says the clock is off, making the check silently
disagree with how the snaps were authored.

With the clock off the anchors are frame-rate dependent again, which is what the search window
absorbs; such a set may need a wider `--flip-window`.

## A correction to something I said earlier

`gris-gameplay`'s failure in this morning's matrix is **not** explained by this — that run had no
deterministic clock. I had called it "the test is wrong" on the strength of the owner having played
the game, which was inference from a report rather than a measurement. It remains unexplained.

## Verification

`ctest --no-tests=error -j4` → **315/315**. New arms cover disabling the clock and clearing an
inherited one. GRIS confirmed at 42,000 frames / 0 stalls with the clock off.