### PR TITLE
feat(snapshot): scan for the frame instead of pinning the guest clock

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1608,6 +1608,7 @@ int main(int argc, char** argv) {
     // comment on prosper_pad_flip_ordinal() in hle_pad.cpp for what that would corrupt.
     const std::string snapDir = getenv("PROSPER_SNAP_DIR") ? getenv("PROSPER_SNAP_DIR") : grabDir;
     std::optional<prosper::frontend::SnapVerdict> pendingSnapVerdict;
+    prosper::frontend::SnapMode pendingSnapMode = prosper::frontend::SnapMode::anchor;
     uint32_t snapCount = 0;
     // Check side: capture the presented frame as each authored anchor arrives. Sorted ascending by
     // the parser, so one forward-only cursor covers the run -- and a target already passed when the
@@ -1829,7 +1830,9 @@ int main(int argc, char** argv) {
     auto flushPendingSnap = [&](const uint8_t* rgba, uint32_t w, uint32_t h) {
         if (!pendingSnapVerdict) return;
         const prosper::frontend::SnapVerdict verdict = *pendingSnapVerdict;
+        const prosper::frontend::SnapMode mode = pendingSnapMode;
         pendingSnapVerdict.reset();
+        pendingSnapMode = prosper::frontend::SnapMode::anchor;
         const int64_t flip = prosper_pad_flip_ordinal();
         const uint32_t index = snapCount++;
         const std::string name = prosper::frontend::snap_file_name(index, verdict, flip);
@@ -1845,7 +1848,7 @@ int main(int argc, char** argv) {
             (std::filesystem::path(snapDir) / "snaps.jsonl").string();
         if (FILE* f = fopen(manifest.c_str(), "a")) {
             std::fprintf(f, "%s\n", prosper::frontend::snap_record_line(
-                index, verdict, flip, gpu::present_count(), w, h, name,
+                index, verdict, mode, flip, gpu::present_count(), w, h, name,
                 grabNamer.title_id()).c_str());
             fclose(f);
         } else {
@@ -1854,7 +1857,7 @@ int main(int argc, char** argv) {
                          name.c_str(), manifest.c_str());
         }
         std::fprintf(stderr, "%s\n",
-                     prosper::frontend::snap_author_line(index, verdict, flip, name).c_str());
+                     prosper::frontend::snap_author_line(index, verdict, mode, flip, name).c_str());
     };
 
     auto flushPendingActual = [&](const uint8_t* rgba, uint32_t w, uint32_t h) {
@@ -2210,6 +2213,13 @@ int main(int argc, char** argv) {
                         pendingSnapVerdict = ev.key.key == SDLK_F6
                             ? prosper::frontend::SnapVerdict::correct
                             : prosper::frontend::SnapVerdict::incorrect;
+                        // SHIFT marks the frame as one to SCAN for rather than expect at a fixed
+                        // offset -- for anything sitting after a loading screen, an FMV, or any
+                        // other stretch whose length depends on the machine. The person pressing
+                        // the key is the only one who knows that, and they know it right now.
+                        pendingSnapMode = (ev.key.mod & SDL_KMOD_SHIFT)
+                            ? prosper::frontend::SnapMode::scan
+                            : prosper::frontend::SnapMode::anchor;
                     }
                     continue;
                 }

--- a/prosper/frontends/prosper-app/snap_author.hpp
+++ b/prosper/frontends/prosper-app/snap_author.hpp
@@ -33,6 +33,22 @@ enum class SnapVerdict {
     incorrect,  // F7 — "the game does NOT look right here"
 };
 
+// How the check should LOOK for this frame again.
+//
+// `anchor` searches a tight window around the recorded flip and is right for a frame whose position
+// is stable. `scan` sweeps a wide span forward and is for a frame that sits after something of
+// variable length -- a loading screen, an FMV, anything whose duration depends on the machine. It is
+// the person authoring who knows which is which, at the moment they press the key, so the choice is
+// theirs: F6/F7 anchor, SHIFT+F6/F7 scan.
+enum class SnapMode {
+    anchor,
+    scan,
+};
+
+inline const char* snap_mode_token(SnapMode mode) {
+    return mode == SnapMode::scan ? "scan" : "anchor";
+}
+
 inline const char* snap_verdict_token(SnapVerdict verdict) {
     return verdict == SnapVerdict::correct ? "correct" : "incorrect";
 }
@@ -89,6 +105,7 @@ inline std::string snap_json_escape(const std::string& value) {
 // that point readable, instead of a truncated array that parses as nothing.
 inline std::string snap_record_line(uint32_t index,
                                     SnapVerdict verdict,
+                                    SnapMode mode,
                                     int64_t flip,
                                     uint64_t guest_present,
                                     uint32_t width,
@@ -99,6 +116,8 @@ inline std::string snap_record_line(uint32_t index,
     out += std::to_string(index);
     out += ",\"verdict\":\"";
     out += snap_verdict_token(verdict);
+    out += "\",\"mode\":\"";
+    out += snap_mode_token(mode);
     out += "\",\"pad_flip\":";
     out += std::to_string(flip);
     out += ",\"guest_present\":";
@@ -120,10 +139,12 @@ inline std::string snap_record_line(uint32_t index,
 // something about it.
 inline std::string snap_author_line(uint32_t index,
                                     SnapVerdict verdict,
+                                    SnapMode mode,
                                     int64_t flip,
                                     const std::string& file) {
     std::string out = "[snap] ";
     out += snap_verdict_token(verdict);
+    if (mode == SnapMode::scan) out += " (scan)";
     out += " #";
     out += std::to_string(index);
     if (flip < 0) {

--- a/prosper/frontends/prosper-app/test_snap_author.cpp
+++ b/prosper/frontends/prosper-app/test_snap_author.cpp
@@ -4,6 +4,8 @@
 #include <cstdio>
 #include <string>
 
+using prosper::frontend::SnapMode;
+using prosper::frontend::snap_mode_token;
 using prosper::frontend::SnapVerdict;
 using prosper::frontend::kSnapFlipUnanchored;
 using prosper::frontend::snap_author_line;
@@ -62,8 +64,7 @@ int main() {
 
     // ---- 4. The manifest record carries everything the import step needs -----------------------
     {
-        const std::string line = snap_record_line(
-            /*index=*/7, SnapVerdict::correct, /*flip=*/12345, /*guest_present=*/9876,
+        const std::string line = snap_record_line(7, SnapVerdict::correct, SnapMode::anchor, /*flip=*/12345, /*guest_present=*/9876,
             /*width=*/1920, /*height=*/1080, "snap_0007_correct_f12345.bmp", "PPSA25009");
         check(contains(line, "\"index\":7"), "record carries the index");
         check(contains(line, "\"verdict\":\"correct\""), "record carries the verdict");
@@ -81,8 +82,7 @@ int main() {
     // The import step rejects on this value, so it has to arrive intact rather than as 0 or as a
     // huge unsigned number from a careless cast.
     {
-        const std::string line = snap_record_line(
-            0, SnapVerdict::incorrect, kSnapFlipUnanchored, 0, 640, 360,
+        const std::string line = snap_record_line(0, SnapVerdict::incorrect, SnapMode::anchor, kSnapFlipUnanchored, 0, 640, 360,
             "snap_0000_incorrect_unanchored.bmp", "PPSA25009");
         check(contains(line, "\"pad_flip\":-1"),
               "an unanchored snap records -1, not 0 and not a wrapped unsigned");
@@ -97,8 +97,7 @@ int main() {
         check(snap_json_escape(std::string("a\x01" "b")) == "a\\u0001b", "a control byte is escaped");
 
         // The whole point: a hostile-ish value must not be able to terminate the record early.
-        const std::string line = snap_record_line(
-            1, SnapVerdict::correct, 5, 5, 1, 1, "we\"ird\nname.bmp", "PPSA\\25009");
+        const std::string line = snap_record_line(1, SnapVerdict::correct, SnapMode::anchor, 5, 5, 1, 1, "we\"ird\nname.bmp", "PPSA\\25009");
         check(!contains(line, "\n"), "an embedded newline cannot split one record into two");
         check(contains(line, "we\\\"ird"), "an embedded quote is escaped rather than closing the string");
     }
@@ -107,14 +106,14 @@ int main() {
     // Including, loudly, the case where their keypress produced an unusable snap -- while they are
     // still sitting at the keyboard and can take another one.
     {
-        const std::string good = snap_author_line(4, SnapVerdict::correct, 2000,
+        const std::string good = snap_author_line(4, SnapVerdict::correct, SnapMode::anchor, 2000,
                                                   "snap_0004_correct_f2000.bmp");
         check(contains(good, "correct") && contains(good, "2000") &&
                   contains(good, "snap_0004_correct_f2000.bmp"),
               "an anchored snap reports verdict, anchor and file");
         check(!contains(good, "NOT ANCHORED"), "an anchored snap does not warn");
 
-        const std::string bad = snap_author_line(0, SnapVerdict::correct, kSnapFlipUnanchored,
+        const std::string bad = snap_author_line(0, SnapVerdict::correct, SnapMode::anchor, kSnapFlipUnanchored,
                                                  "snap_0000_correct_unanchored.bmp");
         check(contains(bad, "NOT ANCHORED"), "an unanchored snap warns at the moment it is taken");
         check(contains(bad, "rejected at import"),
@@ -162,6 +161,35 @@ int main() {
         const std::string line = snap_actual_record_line(1200, 1204, 1920, 1080, overshot);
         check(contains(line, "\"target_flip\":1200") && contains(line, "\"actual_flip\":1204"),
               "the actual record carries the requested and reached anchors separately");
+    }
+
+    // ---- 11. Scan mode is carried, and distinguishable -----------------------------------
+    // A frame sitting after a loading screen or an FMV cannot be found at a fixed offset, because
+    // the length of what precedes it depends on the machine. The person authoring is the only one
+    // who knows which frames those are, and they know it at the moment they press the key.
+    {
+        check(std::string(snap_mode_token(SnapMode::anchor)) == "anchor", "anchor mode names itself");
+        check(std::string(snap_mode_token(SnapMode::scan)) == "scan", "scan mode names itself");
+
+        const std::string anchored = snap_record_line(
+            0, SnapVerdict::correct, SnapMode::anchor, 900, 0, 1920, 1080, "a.bmp", "PPSATEST");
+        const std::string scanned = snap_record_line(
+            1, SnapVerdict::correct, SnapMode::scan, 900, 0, 1920, 1080, "b.bmp", "PPSATEST");
+        check(contains(anchored, "\"mode\":\"anchor\""), "an anchored snap records its mode");
+        check(contains(scanned, "\"mode\":\"scan\""), "a scan snap records its mode");
+        check(contains(scanned, "\"verdict\":\"correct\""),
+              "...without disturbing the verdict beside it");
+        check(contains(scanned, "\"pad_flip\":900"),
+              "...or the anchor, which a scan still uses as its ordering hint");
+
+        // The console line has to say which kind was taken, or a person cannot tell whether the key
+        // they pressed registered as the one they meant.
+        check(contains(snap_author_line(2, SnapVerdict::correct, SnapMode::scan, 900, "b.bmp"),
+                       "scan"),
+              "the console line reports a scan snap as such");
+        check(!contains(snap_author_line(2, SnapVerdict::correct, SnapMode::anchor, 900, "a.bmp"),
+                        "scan"),
+              "...and does not label an ordinary snap that way");
     }
 
     if (failures) { std::fprintf(stderr, "== FAIL: %d ==\n", failures); return 1; }

--- a/prosper/src/hle/graphics/hle_graphics.cpp
+++ b/prosper/src/hle/graphics/hle_graphics.cpp
@@ -193,16 +193,23 @@ extern "C" int prosper_vo_flip_rate() { std::lock_guard<std::mutex> lk(g_flip_mx
 
 // Hold the GUEST flip rate at PROSPER_FLIP_PACE_FPS, sleeping in the flip path when we are ahead.
 //
-// This exists for interactive authoring under PROSPER_DET_CLOCK. That clock advances guest time by
-// 1/DET_FPS per flip, which makes anchors independent of how fast the host renders -- the property
-// the snapshot routes need. The side effect is that guest time then runs at host_fps/DET_FPS: an
-// Alex Kidd splash screen rendering at 189 fps played at 3.1x speed, and a heavy scene at 28 fps
-// crawled at 0.47x. Measured across one authoring session: mean 95 fps, i.e. 1.58x real time,
-// swinging by a factor of six. A person cannot judge "does this look right" against that.
+// Snapshot routes are FLIP-anchored ("press Cross at flip 1200"), so "the same flip" only means "the
+// same moment in the game" if flips happen at a fixed RATE. That correspondence is what this
+// provides, and the snapshot tool sets it on BOTH sides -- while a person authors, and again when a
+// check replays. If only one side paces, the route does not merely drift, it DIVERGES: a press lands
+// at a different guest time and can be swallowed entirely.
 //
-// Pacing the flips to the same rate makes guest time equal REAL time again while keeping the
-// determinism, because the clock and the pacer are then driven by the same number. Off by default,
-// and never wanted for an automated check -- there the whole point is to run as fast as possible.
+// It also fixes a second problem when PROSPER_DET_CLOCK is on. That clock advances guest time by
+// 1/DET_FPS per flip, so guest time then runs at host_fps/DET_FPS: an Alex Kidd splash screen
+// rendering at 189 fps played at 3.1x speed, and a heavy scene at 28 fps crawled at 0.47x -- mean
+// 1.58x across one authoring session, swinging by a factor of six. A person cannot judge "does this
+// look right" against that.
+//
+// LIMIT: this can only slow a fast host DOWN. flip_pace_wait() sleeps when ahead and re-anchors when
+// behind, so on any title/host that cannot sustain the requested rate it is inert and the anchors
+// drift again. That is the case scan-mode snaps exist for.
+//
+// Off by default; the snapshot tool opts in on both sides.
 //
 // Deliberately a sleep in the flip path rather than a frame limiter in the frontend: the guest's
 // flip count is what the clock and the anchors are defined against, and the host's swapchain

--- a/prosper/src/hle/graphics/hle_graphics.cpp
+++ b/prosper/src/hle/graphics/hle_graphics.cpp
@@ -717,7 +717,7 @@ HLE(g_vo_submitflip)  {
     if (buffer_index < -1 || buffer_index > 15)
         return (uint64_t)(int64_t)(int32_t)0x8029000a;  // SCE_VIDEO_OUT_ERROR_INVALID_INDEX
     flip_advance(buffer_index, (int64_t)a3);
-    flip_pace_wait();                              // interactive authoring: hold real-time pacing
+    flip_pace_wait();                              // both halves pace: see flip_pace_wait
     gpu::present_flip(buffer_index, (int64_t)a3);   // present the buffer (scanout front + count)
     prosper_eq_trigger_flip((int64_t)a3);   // flip completed (synchronous): fire the flip event
     return 0;
@@ -734,7 +734,7 @@ extern "C" void prosper_vo_flip_from_gpu(uint32_t handle, int32_t bufidx, uint32
     if (evlog()) fprintf(stderr, "[ev] GpuFlip handle=0x%x bufidx=%d mode=0x%x fliparg=0x%llx\n",
                          handle, bufidx, flip_mode, (unsigned long long)flip_arg);
     flip_advance(bufidx, flip_arg);
-    flip_pace_wait();                      // interactive authoring: hold real-time pacing
+    flip_pace_wait();                      // both halves pace: see flip_pace_wait
     gpu::present_flip(bufidx, flip_arg);   // scanout bookkeeping, same as the API flip
     prosper_eq_trigger_flip(flip_arg);     // flip completed (synchronous): fire the flip event
 }

--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -178,10 +178,18 @@ drift is small: with `--window-samples 9` over ±900 the offsets are `0, ±43, �
 rather than uniform ±225 steps. That resolves a short fade far better than even spacing, but it
 cannot rescue a snap taken in the middle of one.
 
-## The guest clock is deterministic in both halves, and it must be
+## The guest clock: OFF by default (and why it used to be on)
 
-Both authoring and checking run with `PROSPER_DET_CLOCK=1` and the same `PROSPER_DET_FPS`
-(default 60). The guest then sees exactly 1/60 s per flip regardless of how fast the host renders.
+**Both halves now run with the guest's REAL clock.** `--det-clock on` remains available per title and
+is off by default, because pinning the clock is a genuine correctness compromise: `PROSPER_DET_CLOCK`
+replaces *every* time source the guest has — `sceKernelReadTsc`, `GetProcessTime`, and the wall-clock
+anchor behind `CLOCK_REALTIME`, `gettimeofday`, `time()` and `sceRtc*` — with
+`anchor + flips × (1/DET_FPS)`.
+
+A guard recorded under that clock tests a machine nobody plays on. GRIS shows the divergence is not
+theoretical (below). Drift is handled by scanning for the frame instead; see SHIFT+F6 above.
+
+The history is kept because the measurement behind it is still true and still instructive:
 
 Without it the anchors are frame-rate dependent and simply cannot correspond. Measured on the first
 real authoring session: authoring windowed ran at **60.4 fps**, the headless check at **77.1 fps**,
@@ -225,6 +233,29 @@ replayed as **standing still** — silent, total, and indistinguishable from the
 The dead zone (48 of 128) is generous on purpose: a resting stick drifts, and a recorder that emits
 an interval on every wobble produces a route full of one-flip noise entries that replay as real
 input.
+
+### SHIFT+F6 / SHIFT+F7 — a snap to SCAN for
+
+Some frames cannot be found at a fixed offset, because what precedes them takes a different length of
+time on a different machine: a loading screen, an FMV, a streaming pause. Mark those with **shift**
+held, and the check sweeps a wide span forward of the anchor instead of hugging it.
+
+You are the only one who knows which frames those are, and you know it at the moment you press the
+key — which is why it is a modifier rather than a setting decided later.
+
+Scanning is **bounded and forward-biased**, not unbounded. A scene can recur — return to a menu twice
+and an unbounded search would happily lock onto the first occurrence, accept it, and store the wrong
+frame. Keeping the anchor as the ordering hint means a snap authored after a loading screen matches
+the occurrence *after that loading screen*.
+
+Sampling across a scan is uniform, unlike the tight window's geometric spacing: a scan is used
+precisely when the match is *not* near the anchor, so weighting toward the anchor would spend the
+samples in the least likely place.
+
+**This is what replaced the deterministic clock.** Drift stopped being something to eliminate by
+lying to the guest about time, and became something to search past — which covers slow test runners,
+variable loading, FMVs and frame-rate differences with one mechanism, and leaves normal play
+untouched at whatever frame rate the machine can manage.
 
 ### The clock is not universally safe — GRIS is the counterexample
 

--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -178,6 +178,22 @@ drift is small: with `--window-samples 9` over ±900 the offsets are `0, ±43, �
 rather than uniform ±225 steps. That resolves a short fade far better than even spacing, but it
 cannot rescue a snap taken in the middle of one.
 
+## Flips are paced on BOTH sides, which is what lets the clock stay off
+
+Routes are **flip-anchored** (`fN` = display flips since the first pad poll), so flip N is only a
+fixed moment in the game if flips happen at a fixed *rate*. Pinning the guest clock used to provide
+that, at the cost of lying about every guest time source. Pacing provides it honestly: the guest
+keeps a real clock and simply flips at 60/s, the way a vsync-locked console does.
+
+Both authoring and checking set `PROSPER_FLIP_PACE_FPS` to the set's `det_fps`, and they must agree.
+Without it the route does not drift, it **diverges**: a press window lands at a different guest time
+and can be swallowed. Measured on `alexkidd` with the check unpaced — **all four snaps failed**, with
+colour counts collapsing 14,548 → 108, which is a different part of the game rather than a shifted
+anchor. No amount of scanning fixes an input that landed in the wrong place.
+
+An old set stored before the `det_clock` key existed reads as **clock ON**, because there was no way
+to author one with it off. The author default being `off` does not change how such a set is replayed.
+
 ## The guest clock: OFF by default (and why it used to be on)
 
 **Both halves now run with the guest's REAL clock.** `--det-clock on` remains available per title and
@@ -243,10 +259,15 @@ held, and the check sweeps a wide span forward of the anchor instead of hugging 
 You are the only one who knows which frames those are, and you know it at the moment you press the
 key — which is why it is a modifier rather than a setting decided later.
 
-Scanning is **bounded and forward-biased**, not unbounded. A scene can recur — return to a menu twice
-and an unbounded search would happily lock onto the first occurrence, accept it, and store the wrong
-frame. Keeping the anchor as the ordering hint means a snap authored after a loading screen matches
-the occurrence *after that loading screen*.
+Scanning is **bounded and forward-biased**. What the bound buys is finite search cost and a finite
+run — *not* protection from matching the wrong occurrence, because `best_match` takes the argmax over
+every sampled offset rather than the first match. That earlier framing was wrong and is corrected
+here rather than repeated.
+
+**The real hazard is a scene that recurs INSIDE the span**, which the bound does not address: at 60
+flips/s the default forward span is about 200 s of play, easily long enough to contain a menu you
+return to. Use an anchor snap for anything that recurs; keep scans for frames that sit after
+something of variable length and appear once.
 
 Sampling across a scan is uniform, unlike the tight window's geometric spacing: a scan is used
 precisely when the match is *not* near the anchor, so weighting toward the anchor would spend the

--- a/prosper/tools/snapshot/AGENTS_SNAPS.md
+++ b/prosper/tools/snapshot/AGENTS_SNAPS.md
@@ -154,6 +154,13 @@ for a quick boot would cut the route off mid-run and report every later snap as 
 failure with nothing to do with rendering, which is the whole class of bug this system exists to
 remove.
 
+**Pacing makes the run length a floor, not just a ceiling.** Because the check now paces flips to
+`det_fps`, a set cannot finish faster than `deepest_candidate_flip / det_fps` seconds however fast
+the machine is. For an anchored set that is small — `alexkidd`'s deepest candidate is 3134 + 900 =
+4034 flips, about **67 s** at 60/s. A **scan** snap extends its own anchor by `scan_forward` (12,000
+flips by default), so one scan snap puts a hard **~200 s minimum** on the whole set. Size `--timeout`
+above that floor, not merely above a fast machine's observed run.
+
 ### Do not anchor a snap mid-fade — measured, and it is the one real trap
 
 Two identical headless runs were driven through Blue Prince's New Game intro and sampled at the same
@@ -193,6 +200,17 @@ anchor. No amount of scanning fixes an input that landed in the wrong place.
 
 An old set stored before the `det_clock` key existed reads as **clock ON**, because there was no way
 to author one with it off. The author default being `off` does not change how such a set is replayed.
+
+**Pacing can only slow a fast host down — it cannot speed a slow one up.** `flip_pace_wait()` sleeps
+when it is ahead of schedule and *re-anchors* when it is behind, so on any title/host combination
+that cannot **sustain** `det_fps` the pacer is inert and the drift described above comes straight
+back. This is the same shape as vsync, which caps a maximum rather than guaranteeing a rate — and
+the numbers in the next section are the warning: Blue Prince measured 180 fps windowed at its menu,
+20 fps in gameplay and **4.8 fps during its FMV**. The last two are below any sane `det_fps`.
+
+So pacing is what makes an anchored snap reliable *on frames the host can render at rate*. For
+anything sitting behind a load screen or a movie, use a **scan** snap (`Shift+F6`) — that is exactly
+the case it exists for, and no amount of pacing substitutes for it.
 
 ## The guest clock: OFF by default (and why it used to be on)
 

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -262,7 +262,17 @@ def list_names():
 # PROSPER_DET_CLOCK makes the guest see exactly 1/DET_FPS seconds per flip, so a three-second logo
 # always costs the same number of flips however fast the host renders. That turns "the same flip" into
 # "the same guest time", which is the property flip anchoring assumes and otherwise does not have.
-# The deterministic clock is now OFF by default, and the pacer with it.
+# The deterministic clock is now OFF by default. The FLIP PACER is not -- it runs unconditionally on
+# both sides, and it is what replaced the clock. Pacing buys the same "same flip = same guest time"
+# correspondence honestly: the guest keeps a real clock and simply flips at a fixed rate, the way a
+# vsync-locked console does, so nothing has to lie to it about what time it is.
+#
+# PRECONDITION, and it is a real one: pacing can only ever SLOW a fast host down. flip_pace_wait()
+# sleeps when it is ahead of schedule and re-anchors when it is behind, so on any title/host that
+# cannot SUSTAIN det_fps the pacer is inert and the drift this section describes comes straight back.
+# Vsync has the same shape -- it caps a maximum, it does not guarantee a rate. Blue Prince measured
+# 180 fps windowed at its menu, 20 in gameplay and 4.8 during its FMV; the last two are below any
+# sane det_fps, so its post-FMV anchors need SCAN mode rather than pacing to be found.
 #
 # Both existed to stop anchors drifting when the host renders at a different rate than it did during
 # authoring. They bought that at a real cost: PROSPER_DET_CLOCK replaces EVERY time source the guest
@@ -306,6 +316,42 @@ def apply_deterministic_clock(env, det_fps, enabled=False):
         return
     env["PROSPER_DET_CLOCK"] = "1"
     env["PROSPER_DET_FPS"] = str(det_fps)
+
+
+def clock_enabled(entry):
+    """Does this stored set replay with the guest clock pinned?
+
+    The fallback is "on" while the author/import CLI default is "off", and that asymmetry is the
+    point: this can only ever apply to a set stored before the key existed, and there was no way to
+    author one of those with the clock off -- cmd_author applied it unconditionally until 4bf1c80c.
+    """
+    return entry.get("det_clock", "on") == "on"
+
+
+def pace_fps(entry):
+    """The flip rate BOTH halves must agree on. Written by cmd_import for every new set."""
+    return entry.get("det_fps", DEFAULT_DET_FPS)
+
+
+def replay_env(entry, out_dir, base=None):
+    """The environment a check run replays under. Extracted so it can be asserted directly."""
+    env = dict(os.environ if base is None else base)
+    # Pace the CHECK's flips to the rate the session was authored at. This is what lets the clock
+    # stay off: routes are FLIP-anchored, so flip N is a fixed moment in the game only if flips
+    # happen at a fixed RATE.
+    env["PROSPER_FLIP_PACE_FPS"] = str(pace_fps(entry))
+    apply_deterministic_clock(env, pace_fps(entry), clock_enabled(entry))
+    if entry.get("savedata", "fresh") == "fresh":
+        apply_fresh_savedata(env, out_dir)
+    env.update({
+        "SDL_VIDEODRIVER": "offscreen",
+        "PROSPER_RENDER": "1",
+        "PROSPER_GUEST_ARGS": "-force-gfx-direct",
+        "PROSPER_SNAP_DIR": out_dir,
+        "PROSPER_SNAP_AT_FLIPS": ",".join(str(f) for f in sorted(candidate_flips(entry))),
+        "PROSPER_PAD_SCRIPT": "@" + os.path.join(REPO_ROOT, entry["route"]),
+    })
+    return env
 
 
 def apply_fresh_savedata(env, root):
@@ -370,19 +416,20 @@ def cmd_author(args):
         "PROSPER_PAD_RECORD": route,
     })
     apply_deterministic_clock(env, args.det_fps, args.det_clock == "on")
-    # Pace the guest flips to the SAME rate the clock advances at, so guest time equals real time
-    # while you play. Without this the deterministic clock makes the game speed track the render
-    # rate -- measured on one authoring session: 3.1x during splash screens, 0.47x in a heavy scene,
-    # mean 1.58x. Nobody can judge "does this look right" against that. The check deliberately does
-    # NOT pace: there the point is to finish quickly, and the clock makes the anchors agree anyway.
-    # Pace the flips whether or not the clock is pinned: the check paces too, and the two must agree
-    # or a flip-anchored route lands at a different guest time on each side.
+    # Pace the guest flips, whether or not the clock is pinned. Two independent reasons:
+    #
+    #   While authoring, it is what makes the game run at the speed a person can judge. With the
+    #   clock pinned and flips unpaced, guest time tracks the RENDER rate -- measured on one
+    #   session: 3.1x during splash screens, 0.47x in a heavy scene, mean 1.58x.
+    #
+    #   For the check, it is what lets the clock stay off at all. The check paces too (replay_env),
+    #   and the two sides must agree: a flip-anchored route replayed at a different flip rate lands
+    #   its presses at different guest times.
     env["PROSPER_FLIP_PACE_FPS"] = str(args.det_fps)
     if args.det_clock == "on":
-        # With the clock pinned, pacing ALSO compensates for it: with it on, guest time runs at
-        # host_fps/DET_FPS, so the game plays fast or slow unless the flip rate matches. With the
-        # clock off the game is deltaTime driven and already runs at real speed, so pacing would only
-        # cap the frame rate for no benefit.
+        # With the clock pinned, pacing does a SECOND job on top of anchoring: guest time then runs
+        # at host_fps/DET_FPS, so the game plays fast or slow unless the flip rate matches. That is
+        # the extra reason to pace here -- not the only one. Pacing happens either way.
         print(f"  guest clock: PINNED at {args.det_fps} fps, flips paced to match. This replaces "
               f"every guest time source; some titles break (GRIS).")
     else:
@@ -399,6 +446,14 @@ def cmd_author(args):
               "            different item. Only use this deliberately.")
     # Deliberately NOT offscreen: authoring is a person looking at a window.
     env.pop("SDL_VIDEODRIVER", None)
+
+    # Record the parameters this session is being authored under, so `import` does not have to be
+    # told them again. --det-fps is a separate argument on both subcommands, each defaulting to 60:
+    # authoring at 30 and importing without the flag used to record 60, and BOTH halves would then
+    # pace at 60 against a session played at 30. Nothing failed loudly; the anchors just moved.
+    with open(os.path.join(out_dir, "session.json"), "w", encoding="utf-8") as handle:
+        json.dump({"det_fps": args.det_fps, "det_clock": args.det_clock,
+                   "savedata": args.savedata, "name": args.name}, handle, indent=2)
 
     print(f"authoring '{args.name}' -> {out_dir}")
     print("  F6 = this frame looks CORRECT     F7 = this frame looks WRONG")
@@ -424,6 +479,13 @@ def cmd_author(args):
 # import
 # ---------------------------------------------------------------------------------------------
 
+def _flag_was_passed(key):
+    """True if --key appears in argv. argparse cannot distinguish a default from an explicit value,
+    and here the difference decides whether the stored session or the command line wins."""
+    flag = "--" + key.replace("_", "-")
+    return any(a == flag or a.startswith(flag + "=") for a in sys.argv[1:])
+
+
 def cmd_import(args):
     manifest = os.path.join(args.capture_dir, "snaps.jsonl")
     if not os.path.exists(manifest):
@@ -448,6 +510,23 @@ def cmd_import(args):
               f"first pad poll, so it has no replay anchor")
     if not usable:
         raise SystemExit("snaps: every snap in this session was unanchored; nothing to import")
+
+    # Prefer what the session was actually authored under. An explicitly passed flag still wins, so
+    # a deliberate override remains possible; what this removes is the SILENT disagreement.
+    session = {}
+    session_path = os.path.join(args.capture_dir, "session.json")
+    if os.path.exists(session_path):
+        try:
+            with open(session_path, "r", encoding="utf-8") as handle:
+                session = json.load(handle)
+        except (OSError, ValueError) as exc:
+            print(f"  note: {session_path} unreadable ({exc}); falling back to the command line")
+    for key in ("det_fps", "det_clock", "savedata"):
+        if key in session and not _flag_was_passed(key):
+            if getattr(args, key) != session[key]:
+                print(f"  {key}: using {session[key]!r} from the authoring session "
+                      f"(command-line default was {getattr(args, key)!r})")
+            setattr(args, key, session[key])
 
     route_src = args.route or os.path.join(args.capture_dir, "route.pad")
     if not os.path.exists(route_src):
@@ -528,8 +607,13 @@ def scan_offsets(entry):
     probably near the anchor; a scan is used precisely when it is NOT, so weighting toward the anchor
     would spend the samples in the least likely place.
     """
-    forward = entry.get("scan_forward", DEFAULT_SCAN_FORWARD)
-    back = entry.get("scan_back", DEFAULT_SCAN_BACK)
+    # Floor both at 0. Neither has a CLI flag and cmd_import never writes them, so a negative can
+    # only arrive from a hand-edited store -- but the clamp below is a filter, and a negative bound
+    # makes it drop every offset INCLUDING the anchor itself. The snap would then report NOT REACHED
+    # with nothing to indicate the store was the problem. Verified: {forward:100, back:-200} and
+    # {forward:-10, back:-10} both yielded [] before this.
+    forward = max(0, entry.get("scan_forward", DEFAULT_SCAN_FORWARD))
+    back = max(0, entry.get("scan_back", DEFAULT_SCAN_BACK))
     samples = max(2, entry.get("scan_samples", DEFAULT_SCAN_SAMPLES))
     span = forward + back
     step = max(1, span // (samples - 1))
@@ -609,41 +693,10 @@ def run_replay(entry, out_dir):
         raise SystemExit(f"snaps: dump not found: {dump_path}")
     if not os.path.exists(APP):
         raise SystemExit(f"snaps: prosper-app not found at {APP} (set PROSPER_APP_BIN)")
-    flips = ",".join(str(f) for f in sorted(candidate_flips(entry)))
-    env = dict(os.environ)
-    # Pace the CHECK's flips to the same rate the session was authored at.
-    #
-    # This is what lets the clock be off. Routes are FLIP-anchored ("fN = display flips since the
-    # first pad poll"), so flip N is only a fixed moment in the game if flips happen at a fixed rate.
-    # Pinning the guest clock used to provide that and cost a lie about every guest time source;
-    # pacing provides it honestly, because the guest keeps a real clock and simply flips at 60/s the
-    # way a vsync-locked console does.
-    #
-    # Without this the route does not drift, it DIVERGES: a press window lands at a different guest
-    # time and can be swallowed entirely. Measured on alexkidd -- unpaced, all four snaps fail with
-    # colour counts collapsing 14548 -> 108, which is a different part of the game, not a shifted
-    # anchor. No amount of scanning fixes an input that landed in the wrong place.
-    env["PROSPER_FLIP_PACE_FPS"] = str(entry.get("det_fps", DEFAULT_DET_FPS))
-    apply_deterministic_clock(env, entry.get("det_fps", DEFAULT_DET_FPS),
-                              # The READER fallback stays "on" even though the AUTHOR default is
-                              # now "off". It can only ever apply to a set stored before the key
-                              # existed, and there was no way to author one of those with the clock
-                              # off -- cmd_author applied it unconditionally until 4bf1c80c. Taking
-                              # the new default here would replay an old set under conditions it was
-                              # never recorded under. Measured: doing so fails all four alexkidd
-                              # snaps (ssim 0.001-0.522, colour counts collapsing 14548 -> 108),
-                              # because the flip-anchored ROUTE diverges, not merely the anchors.
-                              entry.get("det_clock", "on") == "on")
-    if entry.get("savedata", "fresh") == "fresh":
-        apply_fresh_savedata(env, out_dir)
-    env.update({
-        "SDL_VIDEODRIVER": "offscreen",
-        "PROSPER_RENDER": "1",
-        "PROSPER_GUEST_ARGS": "-force-gfx-direct",
-        "PROSPER_SNAP_DIR": out_dir,
-        "PROSPER_SNAP_AT_FLIPS": flips,
-        "PROSPER_PAD_SCRIPT": "@" + os.path.join(REPO_ROOT, entry["route"]),
-    })
+    # The whole environment -- pacing, clock, fresh savedata, route, capture anchors -- is built by
+    # replay_env() so a test can assert what a check actually replays under. It used to be inlined
+    # here, which is how the reader fallback regressed unnoticed: there was nothing a test could call.
+    env = replay_env(entry, out_dir)
     log = os.path.join(out_dir, "run.log")
     manifest = os.path.join(out_dir, "actuals.jsonl")
 

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -334,6 +334,21 @@ def default_check_out_dir(name):
     return os.path.join(os.path.expanduser("~"), ".cache", "prosper-snaps", name)
 
 
+def _coerce_like(stored, wanted):
+    """Read a stored session value as the type the argument uses.
+
+    A hand-edited session.json holding "30" rather than 30 otherwise reads as a CONTRADICTION of an
+    explicit --det-fps 30, and the run is then refused over settings that in fact agree. Returns the
+    value unchanged when it cannot be converted, so a genuinely different value still conflicts.
+    """
+    if isinstance(wanted, bool) or not isinstance(wanted, int) or isinstance(stored, int):
+        return stored
+    try:
+        return int(str(stored).strip())
+    except (TypeError, ValueError):
+        return stored
+
+
 def reconcile_session(args, existing, was_passed=None):
     """Settle an appending run against what the directory was already authored under.
 
@@ -353,15 +368,18 @@ def reconcile_session(args, existing, was_passed=None):
     adopted, since that is somebody continuing a session without retyping the flags.
     """
     was_passed = _flag_was_passed if was_passed is None else was_passed
-    if not (getattr(args, "append", False) and existing):
+    if not (getattr(args, "append", False) and isinstance(existing, dict) and existing):
         return session_record(args), [], []
     adopted, conflicts = [], []
     for key in SESSION_KEYS:
-        if key not in existing or existing[key] == getattr(args, key):
+        if key not in existing:
+            continue
+        stored, wanted = _coerce_like(existing[key], getattr(args, key)), getattr(args, key)
+        if stored == wanted:
             continue
         (conflicts if was_passed(key) else adopted).append(key)
     for key in adopted:
-        setattr(args, key, existing[key])
+        setattr(args, key, _coerce_like(existing[key], getattr(args, key)))
     # Rewrite the record even when nothing differed: a session file written by an older version can
     # be missing a key, and this is the only chance to complete it.
     return session_record(args), adopted, conflicts
@@ -499,8 +517,14 @@ def cmd_author(args):
         try:
             with open(session_path, "r", encoding="utf-8") as handle:
                 existing = json.load(handle)
-        except (OSError, ValueError):
-            existing = {}
+        except (OSError, ValueError) as exc:
+            print(f"  note: {session_path} is unreadable ({exc}); this run's own settings will be "
+                  f"recorded instead. If it holds snaps authored under other settings, they can no "
+                  f"longer be replayed faithfully -- prefer a fresh --out.")
+    if not isinstance(existing, dict):
+        print(f"  note: {session_path} does not hold an object; ignoring it and recording this "
+              f"run's settings.")
+        existing = {}
     record, adopted, conflicts = reconcile_session(args, existing)
     if conflicts:
         raise SystemExit(
@@ -977,7 +1001,12 @@ def cmd_list(args):
     return 0
 
 
-def main():
+def build_parser():
+    """The CLI, separated from main() so tests can drive the REAL argument parsing.
+
+    Hand-built args objects cannot see a defaulting bug, an argument registered on one subcommand
+    and not another, or a flag whose dest does not match what the code reads.
+    """
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1032,7 +1061,11 @@ def main():
     lst = sub.add_parser("list", help="list snap sets")
     lst.set_defaults(func=cmd_list)
 
-    args = parser.parse_args()
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
     return args.func(args)
 
 

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -51,7 +51,6 @@ import shutil
 import struct
 import subprocess
 import sys
-import tempfile
 import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -88,10 +88,16 @@ DEFAULT_WINDOW_SAMPLES = 7
 # something to eliminate and becomes something to search past. It covers slow test runners, variable
 # loading, FMVs and frame-rate differences with one mechanism.
 #
-# Scanning is FORWARD-BIASED and anchored rather than unbounded, deliberately. A scene can recur --
-# return to a menu twice and an unbounded search would happily lock onto the first occurrence, which
-# is the wrong frame and would then be "accepted" into the store. Keeping the anchor as the ordering
-# hint means a snap authored after a loading screen matches the occurrence after that loading screen.
+# Scanning is FORWARD-BIASED and bounded rather than unbounded. What the bound buys is finite search
+# cost and a finite run: `best_match` takes the ARGMAX over every sampled offset, not the first match,
+# so bounding it does not protect against picking a wrong occurrence -- that framing was wrong and is
+# corrected here rather than repeated.
+#
+# The real hazard is a scene that recurs INSIDE the span, which the bound does not address: at 60
+# flips/s the default forward span is about 200 s of play, comfortably long enough to contain a menu
+# you return to. A scan snap of a screen the title revisits can therefore match the wrong visit and
+# score well doing it. Prefer an anchor snap for anything that recurs; keep scans for frames that sit
+# after something of variable length and appear once.
 DEFAULT_SCAN_FORWARD = 12000
 DEFAULT_SCAN_BACK = 900
 DEFAULT_SCAN_SAMPLES = 33
@@ -275,7 +281,7 @@ def list_names():
 DEFAULT_DET_FPS = 60
 
 
-def apply_deterministic_clock(env, det_fps, enabled=True):
+def apply_deterministic_clock(env, det_fps, enabled=False):
     """Pin the guest clock, unless this title is one the clock breaks.
 
     IT IS NOT UNIVERSALLY SAFE, and that has to be a per-title decision rather than a default nobody
@@ -369,18 +375,20 @@ def cmd_author(args):
     # rate -- measured on one authoring session: 3.1x during splash screens, 0.47x in a heavy scene,
     # mean 1.58x. Nobody can judge "does this look right" against that. The check deliberately does
     # NOT pace: there the point is to finish quickly, and the clock makes the anchors agree anyway.
+    # Pace the flips whether or not the clock is pinned: the check paces too, and the two must agree
+    # or a flip-anchored route lands at a different guest time on each side.
+    env["PROSPER_FLIP_PACE_FPS"] = str(args.det_fps)
     if args.det_clock == "on":
-        # Pacing is only needed to COMPENSATE for the pinned clock: with it on, guest time runs at
+        # With the clock pinned, pacing ALSO compensates for it: with it on, guest time runs at
         # host_fps/DET_FPS, so the game plays fast or slow unless the flip rate matches. With the
         # clock off the game is deltaTime driven and already runs at real speed, so pacing would only
         # cap the frame rate for no benefit.
-        env["PROSPER_FLIP_PACE_FPS"] = str(args.det_fps)
         print(f"  guest clock: PINNED at {args.det_fps} fps, flips paced to match. This replaces "
               f"every guest time source; some titles break (GRIS).")
     else:
-        print("  guest clock: REAL (the title runs exactly as it does in normal play, uncapped).\n"
-              "              Anchors are matched by SCANNING for the frame, so host speed does not\n"
-              "              have to agree between authoring and checking.")
+        print(f"  guest clock: REAL, flips paced to {args.det_fps}/s (as a vsync-locked console\n"
+              f"              does). The pacing is what keeps a flip-anchored route landing at the\n"
+              f"              same guest time on both sides; the clock itself is not touched.")
     if args.savedata == "fresh":
         apply_fresh_savedata(env, out_dir)
         print("  savedata: FRESH (your real saves are untouched, and the check starts here too)")
@@ -525,8 +533,11 @@ def scan_offsets(entry):
     samples = max(2, entry.get("scan_samples", DEFAULT_SCAN_SAMPLES))
     span = forward + back
     step = max(1, span // (samples - 1))
+    # Clamp to the configured span. `step` floors at 1, so a sample count larger than the span would
+    # otherwise walk past `forward` -- {forward:10, back:0, samples:33} produced offsets 0..32, more
+    # than three times the span it was asked for, and a zero span produced 0..32 as well.
     offsets = sorted({-back + i * step for i in range(samples)} | {0})
-    return [o for o in offsets if o >= -back]
+    return [o for o in offsets if -back <= o <= forward]
 
 
 def _anchor_offsets(entry):
@@ -600,8 +611,29 @@ def run_replay(entry, out_dir):
         raise SystemExit(f"snaps: prosper-app not found at {APP} (set PROSPER_APP_BIN)")
     flips = ",".join(str(f) for f in sorted(candidate_flips(entry)))
     env = dict(os.environ)
+    # Pace the CHECK's flips to the same rate the session was authored at.
+    #
+    # This is what lets the clock be off. Routes are FLIP-anchored ("fN = display flips since the
+    # first pad poll"), so flip N is only a fixed moment in the game if flips happen at a fixed rate.
+    # Pinning the guest clock used to provide that and cost a lie about every guest time source;
+    # pacing provides it honestly, because the guest keeps a real clock and simply flips at 60/s the
+    # way a vsync-locked console does.
+    #
+    # Without this the route does not drift, it DIVERGES: a press window lands at a different guest
+    # time and can be swallowed entirely. Measured on alexkidd -- unpaced, all four snaps fail with
+    # colour counts collapsing 14548 -> 108, which is a different part of the game, not a shifted
+    # anchor. No amount of scanning fixes an input that landed in the wrong place.
+    env["PROSPER_FLIP_PACE_FPS"] = str(entry.get("det_fps", DEFAULT_DET_FPS))
     apply_deterministic_clock(env, entry.get("det_fps", DEFAULT_DET_FPS),
-                              entry.get("det_clock", "off") == "on")
+                              # The READER fallback stays "on" even though the AUTHOR default is
+                              # now "off". It can only ever apply to a set stored before the key
+                              # existed, and there was no way to author one of those with the clock
+                              # off -- cmd_author applied it unconditionally until 4bf1c80c. Taking
+                              # the new default here would replay an old set under conditions it was
+                              # never recorded under. Measured: doing so fails all four alexkidd
+                              # snaps (ssim 0.001-0.522, colour counts collapsing 14548 -> 108),
+                              # because the flip-anchored ROUTE diverges, not merely the anchors.
+                              entry.get("det_clock", "on") == "on")
     if entry.get("savedata", "fresh") == "fresh":
         apply_fresh_savedata(env, out_dir)
     env.update({

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -334,21 +334,37 @@ def default_check_out_dir(name):
     return os.path.join(os.path.expanduser("~"), ".cache", "prosper-snaps", name)
 
 
-def session_to_write(args, existing):
-    """(record_or_None, differing_keys) -- what an authoring run should store about itself.
+def reconcile_session(args, existing, was_passed=None):
+    """Settle an appending run against what the directory was already authored under.
 
-    Returns None for the record when appending to a directory whose stored parameters differ:
-    restamping would record the SECOND run's conditions for snaps taken during the first, and import
-    would then replay half of them at a rate nobody played them at. One directory describes one set
-    of conditions.
+    Returns (record, adopted, conflicts):
+      record    -- what to store in session.json
+      adopted   -- keys taken FROM the stored session because the caller did not ask for them
+      conflicts -- keys the caller explicitly asked for that contradict the stored session
+
+    This must run BEFORE the run environment is built. An earlier version resolved it afterwards,
+    so `--append --det-fps 60` on a directory authored at 30 ran the emulator paced at 60 while
+    recording 30 -- the run and its own record disagreeing, which is the exact divergence this
+    whole mechanism exists to prevent. It moved the damage from run 1 to run 2 rather than removing
+    it.
+
+    A directory describes ONE set of conditions, because its snaps share one route and one flip
+    axis. So an explicit contradiction is refused rather than silently resolved; a mere default is
+    adopted, since that is somebody continuing a session without retyping the flags.
     """
-    if getattr(args, "append", False) and existing:
-        differing = [k for k in SESSION_KEYS
-                     if k in existing and existing[k] != getattr(args, k)]
-        if differing:
-            return None, differing
-        return None, []
-    return session_record(args), []
+    was_passed = _flag_was_passed if was_passed is None else was_passed
+    if not (getattr(args, "append", False) and existing):
+        return session_record(args), [], []
+    adopted, conflicts = [], []
+    for key in SESSION_KEYS:
+        if key not in existing or existing[key] == getattr(args, key):
+            continue
+        (conflicts if was_passed(key) else adopted).append(key)
+    for key in adopted:
+        setattr(args, key, existing[key])
+    # Rewrite the record even when nothing differed: a session file written by an older version can
+    # be missing a key, and this is the only chance to complete it.
+    return session_record(args), adopted, conflicts
 
 
 def session_record(args):
@@ -474,6 +490,32 @@ def cmd_author(args):
 
     # Pacing, clock, savedata and the recorded session all come from the shared helpers above, so
     # this half and the check half cannot drift apart.
+    # Settle the session against anything already stored here FIRST -- author_env reads args, so a
+    # reconciliation after this point would run the emulator under different settings than it
+    # records.
+    session_path = os.path.join(out_dir, "session.json")
+    existing = {}
+    if os.path.exists(session_path):
+        try:
+            with open(session_path, "r", encoding="utf-8") as handle:
+                existing = json.load(handle)
+        except (OSError, ValueError):
+            existing = {}
+    record, adopted, conflicts = reconcile_session(args, existing)
+    if conflicts:
+        raise SystemExit(
+            "snaps: this directory was authored with "
+            + ", ".join(f"{k}={existing[k]!r}" for k in conflicts)
+            + ", and you asked for "
+            + ", ".join(f"{k}={getattr(args, k)!r}" for k in conflicts)
+            + ".\n       Its existing snaps are anchored on flips recorded under the stored\n"
+              "       settings, so one directory can only describe one set of conditions.\n"
+              "       Use a fresh --out to author at different settings.")
+    if adopted:
+        print(f"  NOTE: continuing under the session's own "
+              f"{', '.join(f'{k}={existing[k]!r}' for k in adopted)} rather than the command-line "
+              f"default. This run is paced to match the snaps already here.")
+
     env = author_env(args, out_dir)
     if args.det_clock == "on":
         print(f"  guest clock: PINNED at {args.det_fps} fps, flips paced to match. This replaces "
@@ -494,23 +536,8 @@ def cmd_author(args):
     # --det-fps is a separate argument on both subcommands, each defaulting to 60: authoring at 30
     # and importing without the flag used to record 60, and BOTH halves would then pace at 60
     # against a session played at 30. Nothing failed loudly; the anchors just moved.
-    session_path = os.path.join(out_dir, "session.json")
-    existing = {}
-    if os.path.exists(session_path):
-        try:
-            with open(session_path, "r", encoding="utf-8") as handle:
-                existing = json.load(handle)
-        except (OSError, ValueError):
-            existing = {}
-    record, differing = session_to_write(args, existing)
-    if differing:
-        print(f"  NOTE: keeping the original session parameters for {', '.join(differing)} "
-              f"({', '.join(f'{k}={existing[k]!r}' for k in differing)}). This directory already "
-              f"holds snaps authored under them, and one directory can only describe one set of "
-              f"conditions -- use a fresh --out to author at different settings.")
-    if record is not None:
-        with open(session_path, "w", encoding="utf-8") as handle:
-            json.dump(record, handle, indent=2)
+    with open(session_path, "w", encoding="utf-8") as handle:
+        json.dump(record, handle, indent=2)
 
     print(f"authoring '{args.name}' -> {out_dir}")
     print("  F6 = this frame looks CORRECT     F7 = this frame looks WRONG")

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -341,7 +341,7 @@ def _coerce_like(stored, wanted):
     explicit --det-fps 30, and the run is then refused over settings that in fact agree. Returns the
     value unchanged when it cannot be converted, so a genuinely different value still conflicts.
     """
-    if isinstance(wanted, bool) or not isinstance(wanted, int) or isinstance(stored, int):
+    if not isinstance(wanted, int) or isinstance(stored, int):
         return stored
     try:
         return int(str(stored).strip())
@@ -394,7 +394,8 @@ def session_record(args, existing=None):
     """
     record = dict(existing) if isinstance(existing, dict) else {}
     record.update({key: getattr(args, key) for key in SESSION_KEYS})
-    record["name"] = args.name
+    # Deliberately no "name": cmd_import reads only SESSION_KEYS, and a stored name that disagreed
+    # with --name would be a second source of truth nobody consults.
     return record
 
 

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -82,6 +82,20 @@ DEFAULT_MIN_SSIM = 0.85
 DEFAULT_FLIP_WINDOW = 900
 DEFAULT_WINDOW_SAMPLES = 7
 
+# A SCAN snap searches a wide span forward of its anchor instead of a tight window.
+#
+# This is what makes the whole scheme robust without touching the guest's clock: drift stops being
+# something to eliminate and becomes something to search past. It covers slow test runners, variable
+# loading, FMVs and frame-rate differences with one mechanism.
+#
+# Scanning is FORWARD-BIASED and anchored rather than unbounded, deliberately. A scene can recur --
+# return to a menu twice and an unbounded search would happily lock onto the first occurrence, which
+# is the wrong frame and would then be "accepted" into the store. Keeping the anchor as the ordering
+# hint means a snap authored after a loading screen matches the occurrence after that loading screen.
+DEFAULT_SCAN_FORWARD = 12000
+DEFAULT_SCAN_BACK = 900
+DEFAULT_SCAN_SAMPLES = 33
+
 
 # ---------------------------------------------------------------------------------------------
 # Image reading and the signature
@@ -242,6 +256,22 @@ def list_names():
 # PROSPER_DET_CLOCK makes the guest see exactly 1/DET_FPS seconds per flip, so a three-second logo
 # always costs the same number of flips however fast the host renders. That turns "the same flip" into
 # "the same guest time", which is the property flip anchoring assumes and otherwise does not have.
+# The deterministic clock is now OFF by default, and the pacer with it.
+#
+# Both existed to stop anchors drifting when the host renders at a different rate than it did during
+# authoring. They bought that at a real cost: PROSPER_DET_CLOCK replaces EVERY time source the guest
+# has -- sceKernelReadTsc, GetProcessTime, and the wall-clock anchor behind CLOCK_REALTIME,
+# gettimeofday, time() and sceRtc* -- with anchor + flips*(1/DET_FPS). A guard recorded under that
+# clock tests a machine nobody plays on, and GRIS proves the divergence is not theoretical: its
+# opening FMV freezes with the clock on (1,680 frames and 47 forced-submit stalls against 42,000 and
+# 0 without it).
+#
+# Drift is now handled where it belongs -- in the MATCHER, by scanning for the frame rather than
+# demanding it appear at a fixed offset. That is robust to slow test runners, loading times, FMVs and
+# frame-rate differences at once, and it needs no lie about time. Normal play is untouched: real
+# clock, uncapped, 120 Hz fine.
+#
+# Both knobs remain available per title for a set that genuinely needs them.
 DEFAULT_DET_FPS = 60
 
 
@@ -340,14 +370,17 @@ def cmd_author(args):
     # mean 1.58x. Nobody can judge "does this look right" against that. The check deliberately does
     # NOT pace: there the point is to finish quickly, and the clock makes the anchors agree anyway.
     if args.det_clock == "on":
+        # Pacing is only needed to COMPENSATE for the pinned clock: with it on, guest time runs at
+        # host_fps/DET_FPS, so the game plays fast or slow unless the flip rate matches. With the
+        # clock off the game is deltaTime driven and already runs at real speed, so pacing would only
+        # cap the frame rate for no benefit.
         env["PROSPER_FLIP_PACE_FPS"] = str(args.det_fps)
-        print(f"  guest clock: deterministic at {args.det_fps} fps, flips paced to match "
-              f"(real-time feel, and anchors that do not depend on this machine's speed)")
+        print(f"  guest clock: PINNED at {args.det_fps} fps, flips paced to match. This replaces "
+              f"every guest time source; some titles break (GRIS).")
     else:
-        print("  guest clock: REAL time (--det-clock off). Anchors will depend on this machine's\n"
-              "              speed, so this set may need a wider --flip-window. Use this for titles\n"
-              "              the deterministic clock breaks -- GRIS freezes on its opening FMV with\n"
-              "              it on.")
+        print("  guest clock: REAL (the title runs exactly as it does in normal play, uncapped).\n"
+              "              Anchors are matched by SCANNING for the frame, so host speed does not\n"
+              "              have to agree between authoring and checking.")
     if args.savedata == "fresh":
         apply_fresh_savedata(env, out_dir)
         print("  savedata: FRESH (your real saves are untouched, and the check starts here too)")
@@ -433,10 +466,12 @@ def cmd_import(args):
         snaps.append({
             "index": record["index"],
             "verdict": record["verdict"],
+            "mode": record.get("mode", "anchor"),
             "pad_flip": record["pad_flip"],
             **signature,
         })
-        print(f"  snap {record['index']:>3} {record['verdict']:<9} flip {record['pad_flip']:>6}  "
+        print(f"  snap {record['index']:>3} {record['verdict']:<9} "
+              f"{record.get('mode','anchor'):<6} flip {record['pad_flip']:>6}  "
               f"{signature['distinct_colors']:>6} colors  "
               f"nonblack {signature['nonblack_ratio']:.3f}")
 
@@ -471,7 +506,30 @@ def cmd_import(args):
 # check
 # ---------------------------------------------------------------------------------------------
 
-def window_offsets(entry):
+def window_offsets(entry, snap=None):
+    """Offsets for one snap. A snap marked `scan` searches a wide forward span instead."""
+    if snap is not None and snap.get("mode") == "scan":
+        return scan_offsets(entry)
+    return _anchor_offsets(entry)
+
+
+def scan_offsets(entry):
+    """A wide, forward-biased sweep: a little before the anchor, a long way after.
+
+    Sampling is uniform here rather than geometric. The anchor-window case knows the match is
+    probably near the anchor; a scan is used precisely when it is NOT, so weighting toward the anchor
+    would spend the samples in the least likely place.
+    """
+    forward = entry.get("scan_forward", DEFAULT_SCAN_FORWARD)
+    back = entry.get("scan_back", DEFAULT_SCAN_BACK)
+    samples = max(2, entry.get("scan_samples", DEFAULT_SCAN_SAMPLES))
+    span = forward + back
+    step = max(1, span // (samples - 1))
+    offsets = sorted({-back + i * step for i in range(samples)} | {0})
+    return [o for o in offsets if o >= -back]
+
+
+def _anchor_offsets(entry):
     """Flip offsets sampled either side of each anchor, always including 0 (the exact anchor).
 
     Spacing is GEOMETRIC, not uniform: dense near the anchor and sparse at the edges. Measured
@@ -501,7 +559,7 @@ def candidate_flips(entry):
     a flip before the origin does not exist."""
     out = set()
     for snap in entry["snaps"]:
-        for offset in window_offsets(entry):
+        for offset in window_offsets(entry, snap):
             flip = snap["pad_flip"] + offset
             if flip >= 0:
                 out.add(flip)
@@ -517,7 +575,7 @@ def best_match(snap, entry, actuals, out_dir):
     """
     best = None
     reference = decode_luma(snap["luma16x9"])
-    for offset in window_offsets(entry):
+    for offset in window_offsets(entry, snap):
         flip = snap["pad_flip"] + offset
         record = actuals.get(flip)
         if not record:
@@ -543,7 +601,7 @@ def run_replay(entry, out_dir):
     flips = ",".join(str(f) for f in sorted(candidate_flips(entry)))
     env = dict(os.environ)
     apply_deterministic_clock(env, entry.get("det_fps", DEFAULT_DET_FPS),
-                              entry.get("det_clock", "on") == "on")
+                              entry.get("det_clock", "off") == "on")
     if entry.get("savedata", "fresh") == "fresh":
         apply_fresh_savedata(env, out_dir)
     env.update({
@@ -624,7 +682,8 @@ def cmd_check(args):
 
         for snap in entry["snaps"]:
             flip = snap["pad_flip"]
-            label = f"  snap {snap['index']:>3} {snap['verdict']:<9} flip {flip:>6}"
+            label = (f"  snap {snap['index']:>3} {snap['verdict']:<9} "
+                     f"{snap.get('mode','anchor'):<6} flip {flip:>6}")
             found = best_match(snap, entry, actuals, out_dir)
             if not found:
                 # Never silently pass a snap that was not reached: that is the failure mode the
@@ -640,7 +699,7 @@ def cmd_check(args):
             # the title screen ~600-1100 flips later under machine load, and the edge match was the
             # only visible tell.
             span = entry.get("flip_window", DEFAULT_FLIP_WINDOW)
-            at_edge = span > 0 and abs(offset) >= span
+            at_edge = (snap.get("mode") != "scan") and span > 0 and abs(offset) >= span
             actual_image = os.path.join(out_dir, record["file"])
             matched = ssim >= threshold
             # Report where in the window the best match came from. A snap that only matches at the
@@ -747,8 +806,9 @@ def main():
     aut.add_argument("--name", required=True)
     aut.add_argument("--dump", required=True, help="e.g. PPSA25009-app0")
     aut.add_argument("--out", help="capture directory (default ~/snaps/<name>)")
-    aut.add_argument("--det-clock", dest="det_clock", choices=("on", "off"), default="on",
-                     help="off for titles the pinned clock breaks (GRIS freezes on its FMV)")
+    aut.add_argument("--det-clock", dest="det_clock", choices=("on", "off"), default="off",
+                     help="pin the guest clock; OFF by default -- it replaces every guest time "
+                          "source and breaks some titles (GRIS freezes on its FMV)")
     aut.add_argument("--det-fps", dest="det_fps", type=int, default=DEFAULT_DET_FPS,
                      help="guest clock rate; must match at check time")
     aut.add_argument("--savedata", choices=("fresh", "preserve"), default="fresh",
@@ -766,8 +826,8 @@ def main():
                      help="safety net only; the run normally ends when the last "
                           "anchor is captured")
     imp.add_argument("--min-ssim", dest="min_ssim", type=float, default=DEFAULT_MIN_SSIM)
-    imp.add_argument("--det-clock", dest="det_clock", choices=("on", "off"), default="on",
-                     help="off for titles the pinned clock breaks (GRIS freezes on its FMV)")
+    imp.add_argument("--det-clock", dest="det_clock", choices=("on", "off"), default="off",
+                     help="must match how the session was authored")
     imp.add_argument("--det-fps", dest="det_fps", type=int, default=DEFAULT_DET_FPS,
                      help="must match how the session was authored")
     imp.add_argument("--savedata", choices=("fresh", "preserve"), default="fresh",

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -318,6 +318,72 @@ def apply_deterministic_clock(env, det_fps, enabled=False):
     env["PROSPER_DET_FPS"] = str(det_fps)
 
 
+# The keys `author` records and `import` reads back. Named once so a rename cannot desynchronise the
+# producer from the consumer -- they were two hand-written literals, and renaming one left the whole
+# suite green.
+SESSION_KEYS = ("det_fps", "det_clock", "savedata")
+
+
+def default_check_out_dir(name):
+    """Where a check writes its captured frames.
+
+    Deliberately NOT tempfile.gettempdir(). On the Linux box /tmp is a RAM-backed tmpfs with a
+    per-user quota shared by every concurrent agent; exhausting it takes the machine's RAM with it
+    rather than merely failing the write. A check writes one BMP per candidate flip, and scan mode
+    raises that from 7 per snap to 34.
+    """
+    return os.path.join(os.path.expanduser("~"), ".cache", "prosper-snaps", name)
+
+
+def session_to_write(args, existing):
+    """(record_or_None, differing_keys) -- what an authoring run should store about itself.
+
+    Returns None for the record when appending to a directory whose stored parameters differ:
+    restamping would record the SECOND run's conditions for snaps taken during the first, and import
+    would then replay half of them at a rate nobody played them at. One directory describes one set
+    of conditions.
+    """
+    if getattr(args, "append", False) and existing:
+        differing = [k for k in SESSION_KEYS
+                     if k in existing and existing[k] != getattr(args, k)]
+        if differing:
+            return None, differing
+        return None, []
+    return session_record(args), []
+
+
+def session_record(args):
+    """What an authoring session stores about itself, so `import` need not be told again."""
+    record = {key: getattr(args, key) for key in SESSION_KEYS}
+    record["name"] = args.name
+    return record
+
+
+def author_env(args, out_dir, base=None):
+    """The environment an AUTHORING session runs under.
+
+    Extracted for the same reason as replay_env: the pacing line here and the one there must agree,
+    and while both were inlined nothing could assert that. Deleting either used to leave the suite
+    fully green while every future session drifted against every future check.
+    """
+    env = dict(os.environ if base is None else base)
+    env.update({
+        "PROSPER_RENDER": "1",
+        "PROSPER_GUEST_ARGS": "-force-gfx-direct",
+        "PROSPER_SNAP_DIR": out_dir,
+        "PROSPER_PAD_RECORD": os.path.join(out_dir, "route.pad"),
+    })
+    # Both halves read their rate through pace_fps(), off a dict shaped like a stored entry, so the
+    # author and the check cannot disagree about what "60" means.
+    env["PROSPER_FLIP_PACE_FPS"] = str(pace_fps({"det_fps": args.det_fps}))
+    apply_deterministic_clock(env, args.det_fps, args.det_clock == "on")
+    if args.savedata == "fresh":
+        apply_fresh_savedata(env, out_dir)
+    # Deliberately NOT offscreen: authoring is a person looking at a window.
+    env.pop("SDL_VIDEODRIVER", None)
+    return env
+
+
 def clock_enabled(entry):
     """Does this stored set replay with the guest clock pinned?
 
@@ -406,30 +472,11 @@ def cmd_author(args):
             f"       first session's images while appending to its manifest. Use a fresh --out, or\n"
             f"       --append if you really mean to continue into the same directory.")
     os.makedirs(out_dir, exist_ok=True)
-    route = os.path.join(out_dir, "route.pad")
 
-    env = dict(os.environ)
-    env.update({
-        "PROSPER_RENDER": "1",
-        "PROSPER_GUEST_ARGS": "-force-gfx-direct",
-        "PROSPER_SNAP_DIR": out_dir,
-        "PROSPER_PAD_RECORD": route,
-    })
-    apply_deterministic_clock(env, args.det_fps, args.det_clock == "on")
-    # Pace the guest flips, whether or not the clock is pinned. Two independent reasons:
-    #
-    #   While authoring, it is what makes the game run at the speed a person can judge. With the
-    #   clock pinned and flips unpaced, guest time tracks the RENDER rate -- measured on one
-    #   session: 3.1x during splash screens, 0.47x in a heavy scene, mean 1.58x.
-    #
-    #   For the check, it is what lets the clock stay off at all. The check paces too (replay_env),
-    #   and the two sides must agree: a flip-anchored route replayed at a different flip rate lands
-    #   its presses at different guest times.
-    env["PROSPER_FLIP_PACE_FPS"] = str(args.det_fps)
+    # Pacing, clock, savedata and the recorded session all come from the shared helpers above, so
+    # this half and the check half cannot drift apart.
+    env = author_env(args, out_dir)
     if args.det_clock == "on":
-        # With the clock pinned, pacing does a SECOND job on top of anchoring: guest time then runs
-        # at host_fps/DET_FPS, so the game plays fast or slow unless the flip rate matches. That is
-        # the extra reason to pace here -- not the only one. Pacing happens either way.
         print(f"  guest clock: PINNED at {args.det_fps} fps, flips paced to match. This replaces "
               f"every guest time source; some titles break (GRIS).")
     else:
@@ -437,23 +484,34 @@ def cmd_author(args):
               f"              does). The pacing is what keeps a flip-anchored route landing at the\n"
               f"              same guest time on both sides; the clock itself is not touched.")
     if args.savedata == "fresh":
-        apply_fresh_savedata(env, out_dir)
         print("  savedata: FRESH (your real saves are untouched, and the check starts here too)")
     else:
         print("  savedata: PRESERVE -- this session uses your real saves, so the route will NOT\n"
               "            reproduce on a machine whose save state differs. A title that offers\n"
               "            'Continue' puts it above 'New Game', so the same inputs pick a\n"
               "            different item. Only use this deliberately.")
-    # Deliberately NOT offscreen: authoring is a person looking at a window.
-    env.pop("SDL_VIDEODRIVER", None)
 
-    # Record the parameters this session is being authored under, so `import` does not have to be
-    # told them again. --det-fps is a separate argument on both subcommands, each defaulting to 60:
-    # authoring at 30 and importing without the flag used to record 60, and BOTH halves would then
-    # pace at 60 against a session played at 30. Nothing failed loudly; the anchors just moved.
-    with open(os.path.join(out_dir, "session.json"), "w", encoding="utf-8") as handle:
-        json.dump({"det_fps": args.det_fps, "det_clock": args.det_clock,
-                   "savedata": args.savedata, "name": args.name}, handle, indent=2)
+    # Record the parameters this session is authored under, so `import` need not be told them again.
+    # --det-fps is a separate argument on both subcommands, each defaulting to 60: authoring at 30
+    # and importing without the flag used to record 60, and BOTH halves would then pace at 60
+    # against a session played at 30. Nothing failed loudly; the anchors just moved.
+    session_path = os.path.join(out_dir, "session.json")
+    existing = {}
+    if os.path.exists(session_path):
+        try:
+            with open(session_path, "r", encoding="utf-8") as handle:
+                existing = json.load(handle)
+        except (OSError, ValueError):
+            existing = {}
+    record, differing = session_to_write(args, existing)
+    if differing:
+        print(f"  NOTE: keeping the original session parameters for {', '.join(differing)} "
+              f"({', '.join(f'{k}={existing[k]!r}' for k in differing)}). This directory already "
+              f"holds snaps authored under them, and one directory can only describe one set of "
+              f"conditions -- use a fresh --out to author at different settings.")
+    if record is not None:
+        with open(session_path, "w", encoding="utf-8") as handle:
+            json.dump(record, handle, indent=2)
 
     print(f"authoring '{args.name}' -> {out_dir}")
     print("  F6 = this frame looks CORRECT     F7 = this frame looks WRONG")
@@ -481,9 +539,21 @@ def cmd_author(args):
 
 def _flag_was_passed(key):
     """True if --key appears in argv. argparse cannot distinguish a default from an explicit value,
-    and here the difference decides whether the stored session or the command line wins."""
+    and here the difference decides whether the stored session or the command line wins.
+
+    Abbreviations count. argparse accepts any unambiguous prefix, so `--det-f 30` sets det_fps while
+    matching neither `--det-fps` nor `--det-fps=`; the session would then silently override a flag
+    the person did type, which is the exact failure this helper exists to prevent.
+    """
     flag = "--" + key.replace("_", "-")
-    return any(a == flag or a.startswith(flag + "=") for a in sys.argv[1:])
+    for arg in sys.argv[1:]:
+        name = arg.split("=", 1)[0]
+        # A prefix of the flag, at least "--x", is how argparse resolves an abbreviation. Being
+        # generous here is safe: the cost of a false positive is honouring the command line, which
+        # is what an explicit flag should do anyway.
+        if len(name) > 2 and name.startswith("--") and flag.startswith(name):
+            return True
+    return False
 
 
 def cmd_import(args):
@@ -521,7 +591,7 @@ def cmd_import(args):
                 session = json.load(handle)
         except (OSError, ValueError) as exc:
             print(f"  note: {session_path} unreadable ({exc}); falling back to the command line")
-    for key in ("det_fps", "det_clock", "savedata"):
+    for key in SESSION_KEYS:
         if key in session and not _flag_was_passed(key):
             if getattr(args, key) != session[key]:
                 print(f"  {key}: using {session[key]!r} from the authoring session "
@@ -755,8 +825,7 @@ def cmd_check(args):
     failures = 0
     for name in names:
         entry = load_entry(name)
-        out_dir = os.path.join(tempfile.gettempdir(), f"prosper-snaps-{name}")
-        out_dir = os.environ.get("PROSPER_SNAP_OUT", out_dir)
+        out_dir = os.environ.get("PROSPER_SNAP_OUT", default_check_out_dir(name))
         shutil.rmtree(out_dir, ignore_errors=True)
         os.makedirs(out_dir, exist_ok=True)
         print(f"[snaps] {name}: replaying {len(entry['snaps'])} anchor(s)")

--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -369,7 +369,7 @@ def reconcile_session(args, existing, was_passed=None):
     """
     was_passed = _flag_was_passed if was_passed is None else was_passed
     if not (getattr(args, "append", False) and isinstance(existing, dict) and existing):
-        return session_record(args), [], []
+        return session_record(args, existing), [], []
     adopted, conflicts = [], []
     for key in SESSION_KEYS:
         if key not in existing:
@@ -382,12 +382,18 @@ def reconcile_session(args, existing, was_passed=None):
         setattr(args, key, _coerce_like(existing[key], getattr(args, key)))
     # Rewrite the record even when nothing differed: a session file written by an older version can
     # be missing a key, and this is the only chance to complete it.
-    return session_record(args), adopted, conflicts
+    return session_record(args, existing), adopted, conflicts
 
 
-def session_record(args):
-    """What an authoring session stores about itself, so `import` need not be told again."""
-    record = {key: getattr(args, key) for key in SESSION_KEYS}
+def session_record(args, existing=None):
+    """What an authoring session stores about itself, so `import` need not be told again.
+
+    Anything already in the file that this tool does not understand is CARRIED THROUGH. A session
+    file is hand-editable and a person may have annotated it; silently dropping their keys on the
+    next --append is data loss that announces nothing.
+    """
+    record = dict(existing) if isinstance(existing, dict) else {}
+    record.update({key: getattr(args, key) for key in SESSION_KEYS})
     record["name"] = args.name
     return record
 

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -637,7 +637,7 @@ def main():
         # ---- 6a1b-iii-e. cmd_import's own refusals -------------------------------------------
         def import_dir(records, with_route=True):
             """Build a capture dir and import it; return the raised SystemExit, or None."""
-            d = os.path.join(tmp, f"imp{abs(hash(str(records))) % 100000}")
+            d = os.path.join(tmp, "imp{}".format(len(records)))
             os.makedirs(d, exist_ok=True)
             with open(os.path.join(d, "snaps.jsonl"), "w", encoding="utf-8") as handle:
                 for r in records:
@@ -647,7 +647,7 @@ def main():
 
             class IArgs(Args):
                 capture_dir = d
-                name = f"imp{abs(hash(str(records))) % 100000}"
+                name = "imp{}".format(len(records))
             try:
                 snaps.cmd_import(IArgs())
                 return None
@@ -668,6 +668,18 @@ def main():
         exc = import_dir(only_unanchored)
         check(isinstance(exc, SystemExit) and "unanchored" in str(exc),
               "a session whose every snap is unanchored is refused, and says why")
+
+        # A manifest whose images are all missing leaves nothing to import. This guard is the one
+        # I wrongly classified as a loud failure: with it removed, import returns 0, stores a set
+        # with ZERO snaps, and `check` then prints "replaying 0 anchor(s)" and exits 0 -- for ever.
+        # A guard set that guards nothing, reporting success. Verified before writing this arm.
+        no_images = [{"index": 0, "verdict": "correct", "mode": "anchor", "pad_flip": 900,
+                      "guest_present": 900, "width": 64, "height": 36,
+                      "file": "definitely-not-here.bmp", "title_id": "PPSATEST"}]
+        empty_exc = import_dir(no_images)
+        check(isinstance(empty_exc, SystemExit) and "no snap images" in str(empty_exc),
+              "a manifest whose images are all missing is REFUSED, not stored as an empty set "
+              "that would pass every future check")
 
         # ---- 6a1b-iii-f. cmd_import: an EXPLICIT flag beats the stored session ---------------
         # snaps.py's own comment states this contract in prose ("An explicitly passed flag still
@@ -929,7 +941,11 @@ def main():
             Returns (exit_code, output). The reference is what was approved; the actual is what the
             stubbed replay produced, so the two pixels decide whether it matches.
             """
-            nm = f"vc{abs(hash((verdict, ref_pixel, actual_pixel, mode))) % 100000}"
+            # Deterministic, so repeated runs reuse one directory instead of seeding a new one
+            # each time. hash() is randomised per process, which made this a slow leak into
+            # ~/.cache on every machine that runs ctest.
+            nm = "vc-{}-{}-{}-{}".format(verdict, "".join(str(c) for c in ref_pixel),
+                                         "".join(str(c) for c in actual_pixel), mode)
             vdir = os.path.join(tmp, nm)
             os.makedirs(vdir, exist_ok=True)
             ref_bmp = os.path.join(vdir, "ref.bmp")
@@ -1068,6 +1084,10 @@ def main():
         # The output directory must be CLEARED before a replay. A frame left by an earlier run
         # could otherwise be matched and reported as a pass -- a wrong answer, stated confidently,
         # from data the current run never produced.
+        # Pop any ambient PROSPER_SNAP_OUT: with it set, the sentinel below lands in
+        # default_check_out_dir() while cmd_check reads the override, and the arm passes with the
+        # rmtree deleted. Verified -- the mutant FAILs without the variable and PASSes with it.
+        stale_saved_env = os.environ.pop("PROSPER_SNAP_OUT", None)
         stale_out = snaps.default_check_out_dir("stale-probe")
         os.makedirs(stale_out, exist_ok=True)
         sentinel = os.path.join(stale_out, "left-over.bmp")
@@ -1155,6 +1175,8 @@ def main():
         check("900" in full_env.get("PROSPER_SNAP_AT_FLIPS", ""),
               "the anchors to capture are handed to the emulator")
 
+        if stale_saved_env is not None:
+            os.environ["PROSPER_SNAP_OUT"] = stale_saved_env
         check(saw_sentinel.get("present") is False,
               "the output directory is CLEARED before a replay, so a stale frame from an earlier "
               "run can never be matched and reported as a pass")

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -294,6 +294,26 @@ def main():
         check(geo == [-o for o in reversed(geo)], "the window is symmetric about the anchor")
         check(len(set(geo)) == len(geo), "no two samples collapse onto the same offset")
 
+        # ---- 6c3. A scan snap sweeps forward instead of hugging the anchor ------------------
+        # This is what replaces the deterministic clock. Drift stops being something to eliminate by
+        # lying to the guest about time, and becomes something to search past.
+        scan_entry = {"scan_forward": 12000, "scan_back": 900, "scan_samples": 33}
+        sc = snaps.window_offsets(scan_entry, {"mode": "scan"})
+        an = snaps.window_offsets(scan_entry, {"mode": "anchor"})
+        check(max(sc) > max(an) * 5, "a scan reaches far beyond the anchor window")
+        check(0 in sc, "a scan still samples the anchor itself")
+        check(min(sc) >= -scan_entry["scan_back"],
+              "a scan looks only a little way BACK -- it is forward-biased on purpose")
+        check(len(sc) > len(an), "a scan takes more samples than a tight window")
+        # Uniform, not geometric: a scan is used precisely when the match is NOT near the anchor, so
+        # weighting toward the anchor would spend samples in the least likely place.
+        pos = sorted(o for o in sc if o > 0)
+        gaps = [b - a for a, b in zip(pos, pos[1:])]
+        check(max(gaps) - min(gaps) <= 2, "scan sampling is uniform across the span")
+        # And an unbounded scan is NOT what this is: a recurring scene would otherwise match its
+        # first occurrence anywhere in the run.
+        check(max(sc) <= scan_entry["scan_forward"] + 1, "a scan is bounded by its forward span")
+
         # ---- 6d. An edge match is detectable, because that is how "the window is too narrow"
         # is told apart from "the picture changed" ----------------------------------------------
         edge_entry = {"flip_window": 600, "window_samples": 7}

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -160,6 +160,10 @@ def main():
               "both verdicts survive the round trip")
         check(os.path.exists(os.path.join(refs, "unit", "0000.bmp")),
               "the reference image is kept locally for later A/B review")
+        # The entry records a route path; if the file is not actually copied there, every later
+        # check dies on a missing route rather than on anything to do with rendering.
+        check(os.path.exists(os.path.join(tmp, entry["route"])),
+              "the route named by the entry actually exists at that path after import")
 
         # ---- 4b. import takes its parameters from the SESSION, not from its own defaults -------
         # --det-fps is a separate argument on `author` and on `import`, each defaulting to 60. Author
@@ -309,12 +313,45 @@ def main():
             det_clock = "off"
             savedata = "none"
 
+        # Every arm below used to pass det_clock="off" and savedata="none", so two of author_env's
+        # three lines were structurally unreachable: the arm asserting "PROSPER_DET_CLOCK not in
+        # aenv" is true whether the call is there or not. That is a positive control that cannot
+        # express the case it validates. Sweep the actual domain instead.
+        for clock in ("on", "off"):
+            for save in ("fresh", "none"):
+                class Dom:
+                    name = "dom"; det_fps = 45; det_clock = clock; savedata = save
+                d_root = os.path.join(tmp, f"dom-{clock}-{save}")
+                denv = snaps.author_env(Dom(), d_root, base={})
+                check(denv.get("PROSPER_FLIP_PACE_FPS") == "45",
+                      f"author_env paces at det_fps for clock={clock} savedata={save}")
+                # The clock line: present exactly when the session asks for it.
+                check((denv.get("PROSPER_DET_CLOCK") == "1") == (clock == "on"),
+                      f"author_env applies the deterministic clock iff asked (clock={clock})")
+                check((denv.get("PROSPER_DET_FPS") == "45") == (clock == "on"),
+                      f"...and passes the rate with it (clock={clock})")
+                # The savedata line: the AUTHOR half must isolate saves too, or the person plays
+                # against their real saves while the check runs fresh, and a title offering
+                # "Continue" puts it above "New Game" -- the same inputs pick a different item.
+                isolated = "PROSPER_SAVEDATA_DIR" in denv and "PROSPER_SAVE0" in denv
+                check(isolated == (save == "fresh"),
+                      f"author_env isolates BOTH save roots iff savedata=fresh (savedata={save})")
+                if save == "fresh":
+                    check(denv.get("PROSPER_SAVEDATA_DIR", "").startswith(d_root)
+                          and denv.get("PROSPER_SAVE0", "").startswith(d_root),
+                          "...under the session's own directory, not the developer's saves")
+
         aenv = snaps.author_env(AuthorArgs(), tmp, base={})
         check(aenv.get("PROSPER_FLIP_PACE_FPS") == "30",
               "the AUTHORING session paces its flips too")
         check("PROSPER_DET_CLOCK" not in aenv, "...with the clock off when the session says off")
         check(aenv.get("PROSPER_PAD_RECORD", "").endswith("route.pad"),
               "...and records the route the check will replay")
+        check(aenv.get("PROSPER_RENDER") == "1",
+              "...with the live renderer on -- authoring is a person looking at the game")
+        check("SDL_VIDEODRIVER" not in snaps.author_env(
+                  AuthorArgs(), tmp, base={"SDL_VIDEODRIVER": "offscreen"}),
+              "...and an inherited offscreen driver is CLEARED, or there is no window to look at")
 
         # The two halves must agree by CONSTRUCTION, not by two literals that happen to match.
         # Same det_fps in, same pace out, whichever side computes it.
@@ -438,6 +475,8 @@ def main():
               "hand-written mirror in between")
         check(round_tripped.get("det_clock") == "off",
               "...and the clock stance, through the same path")
+        check(round_tripped.get("savedata") == "none",
+              "...and savedata -- the third SESSION_KEY, which had no round-trip arm")
         check(snaps.replay_env(round_tripped, tmp, base={}).get("PROSPER_FLIP_PACE_FPS") == "30",
               "...so the check ends up paced at the rate the session was authored at")
 
@@ -498,8 +537,15 @@ def main():
         check(seen2["env"].get("PROSPER_FLIP_PACE_FPS") == "30",
               "...paced at the session's rate, not the CLI default")
         check("NOTE" in out2 and "30" in out2, "...and says which settings it adopted")
-        check("60" not in out2.split("NOTE")[0].split("paced to")[-1][:6],
-              "...without also claiming the default rate in the same run")
+        # Read the CLOCK BANNER line specifically. An earlier version of this arm sliced
+        # out2.split("NOTE")[0], which on this path is the two-space prefix before the NOTE -- it
+        # could not contain the banner at all, so it passed with "60/s" hardcoded into the source.
+        banner = [ln for ln in out2.splitlines() if "guest clock:" in ln]
+        check(len(banner) == 1, "the run prints exactly one clock banner")
+        check("paced to 30/s" in banner[0],
+              "...and the banner states the rate the run is ACTUALLY paced at")
+        check("60" not in banner[0],
+              "...never the command-line default it did not use")
 
         # A key missing from an older session file is completed by the run that notices it.
         with open(os.path.join(e2e, "session.json"), "w", encoding="utf-8") as handle:
@@ -530,6 +576,28 @@ def main():
         # Restore for anything downstream.
         with open(os.path.join(e2e, "session.json"), "w", encoding="utf-8") as handle:
             json.dump(before, handle)
+
+        # The PINNED branch of the clock banner. Nothing reached it: author_run's directory is
+        # authored clock-off, so the banner's rate could be hardcoded in silence.
+        pinned_dir = os.path.join(tmp, "pinned")
+        saved3 = (snaps.APP, snaps.subprocess.run, sys.argv, sys.stdout)
+        pbuf = io.StringIO()
+        try:
+            snaps.APP = fake_app
+            snaps.subprocess.run = fake_run
+            sys.argv = ["snaps.py", "author", "--name", "pin", "--dump", fake_dump,
+                        "--out", pinned_dir, "--det-clock", "on", "--det-fps", "45"]
+            sys.stdout = pbuf
+            snaps.cmd_author(snaps.build_parser().parse_args(sys.argv[1:]))
+        finally:
+            snaps.APP, snaps.subprocess.run, sys.argv, sys.stdout = saved3
+        pinned_out = pbuf.getvalue()
+        pbanner = [ln for ln in pinned_out.splitlines() if "guest clock:" in ln]
+        check(len(pbanner) == 1 and "PINNED" in pbanner[0],
+              "a --det-clock on session announces the clock as PINNED")
+        check("45" in pbanner[0],
+              "...at the rate actually requested, not a hardcoded default")
+        check("60" not in pbanner[0], "...and does not name a rate it is not using")
 
         # ---- 6a1b-iii-d. The refusals that protect an existing session ----------------------
         # These are the guards that stop a mistake becoming data loss, and every one of them could
@@ -579,6 +647,55 @@ def main():
         exc = import_dir(only_unanchored)
         check(isinstance(exc, SystemExit) and "unanchored" in str(exc),
               "a session whose every snap is unanchored is refused, and says why")
+
+        # ---- 6a1b-iii-f. cmd_import: an EXPLICIT flag beats the stored session ---------------
+        # snaps.py's own comment states this contract in prose ("An explicitly passed flag still
+        # wins, so a deliberate override remains possible"), and nothing tested it: dropping the
+        # `not _flag_was_passed(key)` half of the guard left the suite green. Then a deliberate
+        # re-import at a different rate is discarded without a word, replay_env paces the check at
+        # the session's rate instead, and every anchor lands somewhere else.
+        def import_with_argv(argv, capture, name):
+            saved_argv = sys.argv
+            try:
+                sys.argv = ["snaps.py", "import", capture, "--name", name] + argv
+                args_i = snaps.build_parser().parse_args(sys.argv[1:])
+                buf = io.StringIO()
+                saved_out, sys.stdout = sys.stdout, buf
+                try:
+                    snaps.cmd_import(args_i)
+                finally:
+                    sys.stdout = saved_out
+                return snaps.load_entry(name)
+            finally:
+                sys.argv = saved_argv
+
+        # A capture whose session says 60/on.
+        ovr = os.path.join(tmp, "ovr")
+        os.makedirs(ovr, exist_ok=True)
+        write_bmp(os.path.join(ovr, "snap_0000_correct_f900.bmp"), 64, 36,
+                  lambda x, y: (x * 2 % 256, y % 256, 10))
+        with open(os.path.join(ovr, "snaps.jsonl"), "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({
+                "index": 0, "verdict": "correct", "mode": "anchor", "pad_flip": 900,
+                "guest_present": 900, "width": 64, "height": 36,
+                "file": "snap_0000_correct_f900.bmp", "title_id": "PPSATEST"}) + "\n")
+        open(os.path.join(ovr, "route.pad"), "w", encoding="utf-8").write("f900:cross\n")
+        with open(os.path.join(ovr, "session.json"), "w", encoding="utf-8") as handle:
+            json.dump({"det_fps": 60, "det_clock": "on", "savedata": "fresh"}, handle)
+
+        # No flags -> the session wins (this is the case already covered).
+        default_entry = import_with_argv([], ovr, "ovr-default")
+        check(default_entry.get("det_fps") == 60 and default_entry.get("det_clock") == "on",
+              "importing with no flags adopts the session's settings")
+
+        # Explicit flags -> the CALLER wins, on both keys.
+        forced = import_with_argv(["--det-fps", "30", "--det-clock", "off"], ovr, "ovr-forced")
+        check(forced.get("det_fps") == 30,
+              "an explicitly passed --det-fps OVERRIDES the stored session")
+        check(forced.get("det_clock") == "off",
+              "...and so does an explicitly passed --det-clock")
+        check(snaps.replay_env(forced, tmp, base={}).get("PROSPER_FLIP_PACE_FPS") == "30",
+              "...so the check is paced at what the person asked for, not what was stored")
 
         # ---- 6a1b-iv. A check does not write its frames into the shared tmpfs ----------------
         # /tmp here is RAM-backed with a per-user quota shared by every concurrent agent, and
@@ -655,6 +772,20 @@ def main():
             check(survived,
                   f"reconcile_session treats {junk!r} as no session at all, rather than crashing "
                   f"({rec_j if not survived else ''})")
+
+        # A session file is hand-editable and may carry keys this tool does not know. Dropping them
+        # on the next --append is data loss that announces nothing. (I reported this fixed a round
+        # before it actually was; it is fixed here.)
+        class Keep:
+            name = "s"; det_fps = 30; det_clock = "off"; savedata = "fresh"; append = True
+
+        kept, _, _ = snaps.reconcile_session(
+            Keep(), {"det_fps": 30, "authored_by": "someone", "notes": "first run"},
+            was_passed=lambda k: False)
+        check(kept.get("authored_by") == "someone" and kept.get("notes") == "first run",
+              "an append carries through keys the tool does not understand")
+        check(kept.get("savedata") == "fresh",
+              "...while still completing the ones it does")
 
         # ---- 6a1b-vi. _flag_was_passed sees argparse ABBREVIATIONS -----------------------------
         # argparse accepts any unambiguous prefix, so `--det-f 30` sets det_fps. An exact-match

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -531,6 +531,55 @@ def main():
         with open(os.path.join(e2e, "session.json"), "w", encoding="utf-8") as handle:
             json.dump(before, handle)
 
+        # ---- 6a1b-iii-d. The refusals that protect an existing session ----------------------
+        # These are the guards that stop a mistake becoming data loss, and every one of them could
+        # be deleted with the suite green until this arm existed. They are cheap to assert and they
+        # are exactly the class the review rounds kept finding.
+        _, _, _, no_dump = author_run([], dump=os.path.join(tmp, "does-not-exist"))
+        check(no_dump is not None and "dump not found" in str(no_dump),
+              "a missing dump is refused before anything is created")
+
+        # A second session in a directory that already holds one would overwrite its images while
+        # appending to its manifest, because snap indices restart at 0 each run.
+        _, _, _, clobber = author_run([])          # no --append, and e2e already holds snaps.jsonl
+        check(clobber is not None and "--append" in str(clobber),
+              "a second session without --append is refused, and the message names the flag")
+
+        # ---- 6a1b-iii-e. cmd_import's own refusals -------------------------------------------
+        def import_dir(records, with_route=True):
+            """Build a capture dir and import it; return the raised SystemExit, or None."""
+            d = os.path.join(tmp, f"imp{abs(hash(str(records))) % 100000}")
+            os.makedirs(d, exist_ok=True)
+            with open(os.path.join(d, "snaps.jsonl"), "w", encoding="utf-8") as handle:
+                for r in records:
+                    handle.write(json.dumps(r) + "\n")
+            if with_route:
+                open(os.path.join(d, "route.pad"), "w", encoding="utf-8").write("f1:cross\n")
+
+            class IArgs(Args):
+                capture_dir = d
+                name = f"imp{abs(hash(str(records))) % 100000}"
+            try:
+                snaps.cmd_import(IArgs())
+                return None
+            except SystemExit as exc:
+                return exc
+            except Exception as exc:                  # noqa: BLE001 -- a crash is not a refusal
+                return RuntimeError(f"crashed instead of refusing: {type(exc).__name__}: {exc}")
+
+        # Each arm names the message it expects. Checking only "something was raised" would let ONE
+        # guard satisfy the arm for another -- an empty manifest reaches the all-unanchored guard if
+        # the empty check is removed, so a bare "is not None" passes for the wrong reason.
+        empty = import_dir([])
+        check(isinstance(empty, SystemExit) and "is empty" in str(empty),
+              "an empty manifest is refused BY THE EMPTY CHECK, named in the message")
+        only_unanchored = [{"index": 0, "verdict": "correct", "mode": "anchor", "pad_flip": -1,
+                            "guest_present": 0, "width": 64, "height": 36,
+                            "file": "x.bmp", "title_id": "PPSATEST"}]
+        exc = import_dir(only_unanchored)
+        check(isinstance(exc, SystemExit) and "unanchored" in str(exc),
+              "a session whose every snap is unanchored is refused, and says why")
+
         # ---- 6a1b-iv. A check does not write its frames into the shared tmpfs ----------------
         # /tmp here is RAM-backed with a per-user quota shared by every concurrent agent, and
         # exhausting it takes the machine's RAM rather than merely failing the write. Scan mode

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -15,6 +15,7 @@ reports a confident wrong answer is worse than one that errors:
     store and the images disagreeing, and the next failure would show a misleading "expected"
 """
 
+import io
 import json
 import shutil
 import os
@@ -440,6 +441,96 @@ def main():
         check(snaps.replay_env(round_tripped, tmp, base={}).get("PROSPER_FLIP_PACE_FPS") == "30",
               "...so the check ends up paced at the rate the session was authored at")
 
+        # ---- 6a1b-iii-c. cmd_author ACTS on the reconciliation -------------------------------
+        # Three review rounds in a row, the gap was the same shape: the helper's RETURN value was
+        # asserted and the command's USE of it was not. Deleting cmd_author's refusal, its refresh,
+        # or its NOTE each left the suite fully green. These arms assert what the COMMAND does.
+        def author_run(argv_extra, **overrides):
+            """Run cmd_author through the real argparse; return (launched, env, session, output)."""
+            seen = {"launched": False, "env": None}
+
+            def spy(cmd, env=None, check=False, **kw):
+                seen["launched"] = True
+                seen["env"] = dict(env)
+                return fake_run(cmd, env=env)
+            saved = (snaps.APP, snaps.subprocess.run, sys.argv, sys.stdout)
+            buf = io.StringIO()
+            try:
+                snaps.APP = fake_app
+                snaps.subprocess.run = spy
+                sys.argv = (["snaps.py", "author", "--name", "e2e", "--dump", fake_dump,
+                             "--out", e2e] + argv_extra)
+                sys.stdout = buf
+                args = snaps.build_parser().parse_args(sys.argv[1:])
+                for key, value in overrides.items():
+                    setattr(args, key, value)
+                raised = None
+                try:
+                    snaps.cmd_author(args)
+                except SystemExit as exc:
+                    raised = exc
+            finally:
+                snaps.APP, snaps.subprocess.run, sys.argv, sys.stdout = saved
+            stored = {}
+            path = os.path.join(e2e, "session.json")
+            if os.path.exists(path):
+                with open(path, "r", encoding="utf-8") as handle:
+                    stored = json.load(handle)
+            return seen, stored, buf.getvalue(), raised
+
+        # An explicit flag contradicting the directory: refused, nothing launched, nothing restamped.
+        before = dict(json.load(open(os.path.join(e2e, "session.json"), encoding="utf-8")))
+        seen, stored, out, raised = author_run(["--append", "--det-fps", "60"])
+        check(raised is not None, "an explicit contradiction REFUSES the run")
+        check(not seen["launched"], "...the emulator is never launched")
+        check(stored == before,
+              "...and session.json is not restamped, so the snaps already here stay replayable")
+        check("fresh --out" in str(raised), "...and the message says how to proceed")
+
+        # The abbreviation must be refused identically, or the guard is bypassable by typing less.
+        _, stored_abbrev, _, raised_abbrev = author_run(["--append", "--det-f", "60"])
+        check(raised_abbrev is not None and stored_abbrev == before,
+              "an ABBREVIATED contradicting flag is refused the same way")
+
+        # Not asking for it: adopted, announced, and the run actually paced to match.
+        seen2, stored2, out2, raised2 = author_run(["--append"])
+        check(raised2 is None and seen2["launched"], "appending without the flag proceeds")
+        check(seen2["env"].get("PROSPER_FLIP_PACE_FPS") == "30",
+              "...paced at the session's rate, not the CLI default")
+        check("NOTE" in out2 and "30" in out2, "...and says which settings it adopted")
+        check("60" not in out2.split("NOTE")[0].split("paced to")[-1][:6],
+              "...without also claiming the default rate in the same run")
+
+        # A key missing from an older session file is completed by the run that notices it.
+        with open(os.path.join(e2e, "session.json"), "w", encoding="utf-8") as handle:
+            json.dump({"det_fps": 30}, handle)
+        _, completed, _, _ = author_run(["--append"])
+        check(set(snaps.SESSION_KEYS) <= set(completed),
+              "an appending run completes a session file missing a key")
+        check(completed.get("det_fps") == 30, "...without changing the key that was already there")
+
+        # A stored string is not a contradiction of the same number typed explicitly.
+        with open(os.path.join(e2e, "session.json"), "w", encoding="utf-8") as handle:
+            json.dump({"det_fps": "30", "det_clock": "off", "savedata": "none"}, handle)
+        _, _, _, raised_str = author_run(["--append", "--det-fps", "30"])
+        check(raised_str is None,
+              "a stored \"30\" does not conflict with an explicit --det-fps 30")
+        # A malformed session file must not take the run down. These are hand-editable, and the
+        # failure lands on somebody mid-session with a game open.
+        for junk in ("5", "true", '["a"]', '"text"', "{not json"):
+            with open(os.path.join(e2e, "session.json"), "w", encoding="utf-8") as handle:
+                handle.write(junk)
+            seen_j, stored_j, out_j, raised_j = author_run(["--append"])
+            check(raised_j is None and seen_j["launched"],
+                  f"a session.json holding {junk!r} does not abort the run")
+            check("note:" in out_j, "...and the run says it ignored it rather than doing so quietly")
+            check(stored_j.get("det_fps") == snaps.DEFAULT_DET_FPS,
+                  "...recording this run's own settings instead")
+
+        # Restore for anything downstream.
+        with open(os.path.join(e2e, "session.json"), "w", encoding="utf-8") as handle:
+            json.dump(before, handle)
+
         # ---- 6a1b-iv. A check does not write its frames into the shared tmpfs ----------------
         # /tmp here is RAM-backed with a per-user quota shared by every concurrent agent, and
         # exhausting it takes the machine's RAM rather than merely failing the write. Scan mode
@@ -499,6 +590,22 @@ def main():
         check(not adopted4 and not conflicts4, "appending at the same settings is silent")
         check(rec4 is not None and rec4.get("savedata") == "fresh",
               "...and a key missing from an older session file is completed rather than left out")
+
+        # reconcile_session must survive a non-dict on its own, not only because cmd_author screens
+        # it first. Two layers, and each is asserted separately: a guard that is only ever reached
+        # through another guard is not actually load-bearing, and the next caller will not know.
+        for junk in (5, True, [1, 2], "text", None, 3.5):
+            class J:
+                name = "s"; det_fps = 60; det_clock = "off"; savedata = "fresh"; append = True
+            try:
+                rec_j, ad_j, cf_j = snaps.reconcile_session(J(), junk, was_passed=lambda k: False)
+                survived = rec_j is not None and not ad_j and not cf_j
+            except Exception as exc:                    # noqa: BLE001 -- the point IS "any crash"
+                survived = False
+                rec_j = f"{type(exc).__name__}: {exc}"
+            check(survived,
+                  f"reconcile_session treats {junk!r} as no session at all, rather than crashing "
+                  f"({rec_j if not survived else ''})")
 
         # ---- 6a1b-vi. _flag_was_passed sees argparse ABBREVIATIONS -----------------------------
         # argparse accepts any unambiguous prefix, so `--det-f 30` sets det_fps. An exact-match

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -188,17 +188,22 @@ def main():
         # an anchor drifted clean out of its window. The game was not misbehaving -- it uses deltaTime
         # correctly; prosper was answering "what time is it" from a clock tied to render speed.
         clk = {}
-        snaps.apply_deterministic_clock(clk, 60)
+        snaps.apply_deterministic_clock(clk, 60, enabled=True)
         check(clk.get("PROSPER_DET_CLOCK") == "1", "the deterministic clock is enabled")
         check(clk.get("PROSPER_DET_FPS") == "60", "the clock rate is passed through")
         clk2 = {}
-        snaps.apply_deterministic_clock(clk2, 30)
+        snaps.apply_deterministic_clock(clk2, 30, enabled=True)
         check(clk2.get("PROSPER_DET_FPS") == "30", "a non-default rate is honoured")
 
         # The clock is NOT universally safe and must be disablable per title. GRIS freezes on its
         # opening FMV with it on -- 42,000 frames in 150 s off against 1,680 on, a 25x collapse.
         off = {}
         snaps.apply_deterministic_clock(off, 60, enabled=False)
+        implicit = {}
+        snaps.apply_deterministic_clock(implicit, 60)
+        check("PROSPER_DET_CLOCK" not in implicit,
+              "the helper's own default matches the tool's stance (off), so a new caller cannot "
+              "silently pin the clock")
         check("PROSPER_DET_CLOCK" not in off, "the clock can be turned off for a title")
         # And an inherited value must be CLEARED, not merely left unset: an authoring shell that
         # exported it would otherwise leak it into a run whose entry says the clock is off, making
@@ -209,6 +214,31 @@ def main():
               "an inherited clock is CLEARED when the title disables it")
         check(entry.get("det_fps") == snaps.DEFAULT_DET_FPS,
               "the rate is RECORDED in the entry, so the check reproduces how it was authored")
+
+        # ---- 6a1b. The det_clock READER fallback stays "on" -------------------------------
+        # The author/import CLI default is "off", but a stored set from before the key existed was
+        # necessarily authored with the clock pinned -- cmd_author applied it unconditionally then.
+        # Following the new default when READING would replay such a set under conditions it was
+        # never recorded under. Measured when this was wrong: all four alexkidd snaps failed, with
+        # colour counts collapsing 14548 -> 108, because the flip-anchored ROUTE diverged rather than
+        # the anchors merely drifting.
+        legacy = {"det_fps": 60}                       # no det_clock key, as pre-4bf1c80c sets have
+        check(legacy.get("det_clock", "on") == "on",
+              "a set with no det_clock key reads as CLOCK ON, not as the new author default")
+        explicit_off = {"det_clock": "off"}
+        check(explicit_off.get("det_clock", "on") == "off",
+              "...while a set that explicitly says off is still honoured")
+
+        # ---- 6a1c. The scan window never exceeds its configured span ------------------------
+        # `step` floors at 1, so a sample count larger than the span used to walk past `forward`.
+        tight = snaps.scan_offsets({"scan_forward": 10, "scan_back": 0, "scan_samples": 33})
+        check(max(tight) <= 10, "a sample count larger than the span does not overshoot it")
+        check(min(tight) >= 0, "...and does not reach behind a zero scan_back")
+        zero = snaps.scan_offsets({"scan_forward": 0, "scan_back": 0, "scan_samples": 33})
+        check(zero == [0], "a zero span collapses to the anchor alone")
+        wide = snaps.scan_offsets({})
+        check(max(wide) <= snaps.DEFAULT_SCAN_FORWARD and min(wide) >= -snaps.DEFAULT_SCAN_BACK,
+              "the DEFAULTS stay inside their own span (nothing else exercises them)")
 
         # ---- 6a2. Both save roots are isolated, not just one -------------------------------
         # A title with a save offers "Continue" ABOVE "New Game", so the same D-pad inputs select a

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -349,6 +349,68 @@ def main():
         check("SESSION_KEYS" in import_src,
               "import reads the shared key list rather than its own copy of the names")
 
+        # ---- 6a1b-iii-b. cmd_author -> cmd_import, for real ----------------------------------
+        # The strongest form of the producer/consumer check: actually RUN cmd_author (with the
+        # emulator stubbed out) and feed its output directory to cmd_import. Every earlier version
+        # of this test mirrored the session format by hand, which is exactly why renaming the keys
+        # cmd_author writes stayed green through two review rounds.
+        e2e = os.path.join(tmp, "e2e")
+        fake_dump = os.path.join(tmp, "PPSATEST-app0")
+        os.makedirs(fake_dump)
+        fake_app = os.path.join(tmp, "fake-prosper-app")
+        with open(fake_app, "w", encoding="utf-8") as handle:
+            handle.write("#!/bin/sh\nexit 0\n")
+        os.chmod(fake_app, 0o755)
+
+        class AuthorE2E:
+            name = "e2e"
+            dump = fake_dump
+            out = e2e
+            append = False
+            det_fps = 30            # deliberately NOT the default
+            det_clock = "off"
+            savedata = "none"
+
+        saved_app, saved_run = snaps.APP, snaps.subprocess.run
+        # The session's own snaps.jsonl and route.pad are what a real run would leave behind.
+        def fake_run(cmd, env=None, check=False):
+            os.makedirs(env["PROSPER_SNAP_DIR"], exist_ok=True)
+            write_bmp(os.path.join(env["PROSPER_SNAP_DIR"], "snap_0000_correct_f900.bmp"),
+                      64, 36, lambda x, y: (x * 3 % 256, y * 5 % 256, 40))
+            with open(os.path.join(env["PROSPER_SNAP_DIR"], "snaps.jsonl"), "w",
+                      encoding="utf-8") as h:
+                h.write(json.dumps({
+                    "index": 0, "verdict": "correct", "mode": "anchor", "pad_flip": 900,
+                    "guest_present": 900, "width": 64, "height": 36,
+                    "file": "snap_0000_correct_f900.bmp", "title_id": "PPSATEST"}) + "\n")
+            open(env["PROSPER_PAD_RECORD"], "w", encoding="utf-8").write("f900:cross\n")
+            return None
+        try:
+            snaps.APP = fake_app
+            snaps.subprocess.run = fake_run
+            snaps.cmd_author(AuthorE2E())
+        finally:
+            snaps.APP, snaps.subprocess.run = saved_app, saved_run
+
+        check(os.path.exists(os.path.join(e2e, "session.json")),
+              "an authoring session records itself on disk")
+
+        class ImportE2E(Args):
+            capture_dir = e2e
+            name = "e2e"
+            det_fps = snaps.DEFAULT_DET_FPS      # the CLI default, NOT what was authored
+            det_clock = "on"
+
+        snaps.cmd_import(ImportE2E())
+        round_tripped = snaps.load_entry("e2e")
+        check(round_tripped.get("det_fps") == 30,
+              "import reads the rate cmd_author actually wrote -- producer to consumer, no "
+              "hand-written mirror in between")
+        check(round_tripped.get("det_clock") == "off",
+              "...and the clock stance, through the same path")
+        check(snaps.replay_env(round_tripped, tmp, base={}).get("PROSPER_FLIP_PACE_FPS") == "30",
+              "...so the check ends up paced at the rate the session was authored at")
+
         # ---- 6a1b-iv. A check does not write its frames into the shared tmpfs ----------------
         # /tmp here is RAM-backed with a per-user quota shared by every concurrent agent, and
         # exhausting it takes the machine's RAM rather than merely failing the write. Scan mode

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -16,6 +16,7 @@ reports a confident wrong answer is worse than one that errors:
 """
 
 import json
+import shutil
 import os
 import struct
 import subprocess
@@ -159,6 +160,42 @@ def main():
         check(os.path.exists(os.path.join(refs, "unit", "0000.bmp")),
               "the reference image is kept locally for later A/B review")
 
+        # ---- 4b. import takes its parameters from the SESSION, not from its own defaults -------
+        # --det-fps is a separate argument on `author` and on `import`, each defaulting to 60. Author
+        # at 30, import without the flag, and the entry recorded 60 -- so both halves then paced at
+        # 60 against a session a person actually played at 30. Nothing failed loudly; the anchors
+        # just moved. cmd_author now writes session.json and cmd_import prefers it.
+        cap2 = os.path.join(tmp, "cap2")
+        os.makedirs(cap2)
+        shutil.copyfile(os.path.join(capture, "route.pad"), os.path.join(cap2, "route.pad"))
+        write_bmp(os.path.join(cap2, "snap_0000_correct_f900.bmp"), 64, 36,
+                  lambda x, y: (x * 4 % 256, y * 7 % 256, 90))
+        with open(os.path.join(cap2, "snaps.jsonl"), "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({
+                "index": 0, "verdict": "correct", "mode": "anchor", "pad_flip": 900,
+                "guest_present": 900, "width": 64, "height": 36,
+                "file": "snap_0000_correct_f900.bmp", "title_id": "PPSATEST"}) + "\n")
+        with open(os.path.join(cap2, "session.json"), "w", encoding="utf-8") as handle:
+            json.dump({"det_fps": 30, "det_clock": "off", "savedata": "fresh",
+                       "name": "unit2"}, handle)
+
+        class Args2(Args):
+            capture_dir = cap2
+            name = "unit2"
+            det_fps = snaps.DEFAULT_DET_FPS      # the CLI default, NOT what was authored
+            det_clock = "on"                     # ditto
+
+        snaps.cmd_import(Args2())
+        authored = snaps.load_entry("unit2")
+        check(authored["det_fps"] == 30,
+              "import records the rate the session was AUTHORED at, not its own default")
+        check(authored["det_clock"] == "off",
+              "...and the clock stance the session was authored under")
+        # The whole point is that both halves then agree.
+        env2 = snaps.replay_env(authored, tmp, base={})
+        check(env2["PROSPER_FLIP_PACE_FPS"] == "30",
+              "so the check paces at the rate the person actually played at")
+
         # ---- 5. accept: store AND reference image move together -------------------------------
         # If only one moved, the next failure would show an "expected" image that does not
         # correspond to the signature that failed -- misleading exactly when trust matters most.
@@ -222,12 +259,52 @@ def main():
         # never recorded under. Measured when this was wrong: all four alexkidd snaps failed, with
         # colour counts collapsing 14548 -> 108, because the flip-anchored ROUTE diverged rather than
         # the anchors merely drifting.
+        #
+        # These arms CALL snaps.clock_enabled rather than restating `.get(..., "on")`. An earlier
+        # version of this block asserted `legacy.get("det_clock", "on") == "on"` -- which is
+        # "on" == "on", passes with the bug reinstated, and printed a message claiming otherwise.
         legacy = {"det_fps": 60}                       # no det_clock key, as pre-4bf1c80c sets have
-        check(legacy.get("det_clock", "on") == "on",
+        check(snaps.clock_enabled(legacy) is True,
               "a set with no det_clock key reads as CLOCK ON, not as the new author default")
-        explicit_off = {"det_clock": "off"}
-        check(explicit_off.get("det_clock", "on") == "off",
+        check(snaps.clock_enabled({"det_clock": "off"}) is False,
               "...while a set that explicitly says off is still honoured")
+        check(snaps.clock_enabled({"det_clock": "on"}) is True, "...and one that says on is too")
+
+        # ---- 6a1b-ii. BOTH halves pace, at the SAME rate -----------------------------------
+        # This is the mechanism that lets the clock stay off, and until now nothing tested it at all.
+        # Routes are flip-anchored, so flip N is a fixed moment in the game only if flips happen at a
+        # fixed RATE; if one side paces and the other does not, presses land at different guest times
+        # and the route diverges. Assert against the real environment builder, not a restatement.
+        paced = snaps.replay_env({"det_fps": 60, "route": "r.pad", "snaps": [],
+                                  "savedata": "none"}, tmp, base={})
+        check(paced.get("PROSPER_FLIP_PACE_FPS") == "60",
+              "the CHECK paces its flips -- without this a flip-anchored route diverges")
+        check(paced.get("PROSPER_DET_CLOCK") == "1",
+              "...and a legacy entry with no det_clock key still replays with the clock pinned")
+
+        modern = snaps.replay_env({"det_fps": 60, "det_clock": "off", "route": "r.pad",
+                                   "snaps": [], "savedata": "none"}, tmp, base={})
+        check(modern.get("PROSPER_FLIP_PACE_FPS") == "60",
+              "a clock-off entry paces too -- pacing is what REPLACED the clock, not a companion "
+              "to it")
+        check("PROSPER_DET_CLOCK" not in modern, "...while its clock stays off")
+
+        # The rate both halves use has to come from one place, or a non-default authoring rate
+        # silently replays at 60.
+        slow = snaps.replay_env({"det_fps": 30, "det_clock": "off", "route": "r.pad",
+                                 "snaps": [], "savedata": "none"}, tmp, base={})
+        check(slow.get("PROSPER_FLIP_PACE_FPS") == "30",
+              "the pace rate is read from the entry, not hardcoded")
+        check(snaps.pace_fps({}) == snaps.DEFAULT_DET_FPS,
+              "an entry with no det_fps falls back to the documented default")
+
+        # An inherited pace from the authoring shell must not survive into a run that specifies its
+        # own -- same leak the clock arm above guards.
+        leaked_pace = snaps.replay_env({"det_fps": 30, "route": "r.pad", "snaps": [],
+                                        "savedata": "none"}, tmp,
+                                       base={"PROSPER_FLIP_PACE_FPS": "144"})
+        check(leaked_pace.get("PROSPER_FLIP_PACE_FPS") == "30",
+              "an inherited pace rate is OVERRIDDEN by the entry's own")
 
         # ---- 6a1c. The scan window never exceeds its configured span ------------------------
         # `step` floors at 1, so a sample count larger than the span used to walk past `forward`.
@@ -239,6 +316,16 @@ def main():
         wide = snaps.scan_offsets({})
         check(max(wide) <= snaps.DEFAULT_SCAN_FORWARD and min(wide) >= -snaps.DEFAULT_SCAN_BACK,
               "the DEFAULTS stay inside their own span (nothing else exercises them)")
+        # A negative bound turns the clamp from a limit into a filter that drops EVERY offset,
+        # anchor included, and the snap then reports NOT REACHED with nothing pointing at the store.
+        # Only reachable from a hand-edited set (neither key has a flag), which is why it needs a
+        # test rather than validation at the CLI.
+        for broken in ({"scan_forward": 100, "scan_back": -200},
+                       {"scan_forward": -10, "scan_back": -10},
+                       {"scan_forward": -5}, {"scan_back": -5}):
+            got = snaps.scan_offsets(broken)
+            check(len(got) > 0 and 0 in got,
+                  f"a negative span still yields the anchor rather than an empty sweep: {broken}")
 
         # ---- 6a2. Both save roots are isolated, not just one -------------------------------
         # A title with a save offers "Continue" ABOVE "New Game", so the same D-pad inputs select a
@@ -340,8 +427,10 @@ def main():
         pos = sorted(o for o in sc if o > 0)
         gaps = [b - a for a, b in zip(pos, pos[1:])]
         check(max(gaps) - min(gaps) <= 2, "scan sampling is uniform across the span")
-        # And an unbounded scan is NOT what this is: a recurring scene would otherwise match its
-        # first occurrence anywhere in the run.
+        # The span is bounded so a check cannot run for an unbounded time. It is NOT bounded to stop
+        # a recurring scene matching the wrong occurrence -- best_match takes the BEST score in the
+        # span rather than the first, so a repeat inside the span is resolved by score, not by
+        # position. (That reasoning was in an earlier draft and is retracted.)
         check(max(sc) <= scan_entry["scan_forward"] + 1, "a scan is bounded by its forward span")
 
         # ---- 6d. An edge match is detectable, because that is how "the window is too narrow"

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -287,6 +287,27 @@ def main():
         check(paced.get("PROSPER_DET_CLOCK") == "1",
               "...and a legacy entry with no det_clock key still replays with the clock pinned")
 
+        # The CHECK half must isolate saves too, and nothing observed it: every replay_env arm
+        # passed savedata "none". A check running against the developer's real saves replays a
+        # route recorded on a fresh one -- "Continue" sits above "New Game", the same inputs pick a
+        # different item, and every snap fails for a title rendering perfectly.
+        for save in ("fresh", "none"):
+            r_root = os.path.join(tmp, f"replay-{save}")
+            renv = snaps.replay_env({"det_fps": 60, "det_clock": "off", "route": "r.pad",
+                                     "snaps": [], "savedata": save}, r_root, base={})
+            iso = "PROSPER_SAVEDATA_DIR" in renv and "PROSPER_SAVE0" in renv
+            check(iso == (save == "fresh"),
+                  f"replay_env isolates BOTH save roots iff savedata=fresh (savedata={save})")
+            if save == "fresh":
+                check(renv.get("PROSPER_SAVEDATA_DIR", "").startswith(r_root)
+                      and renv.get("PROSPER_SAVE0", "").startswith(r_root),
+                      "...under the run's own directory, not the developer's saves")
+        # And the DEFAULT for an entry with no savedata key must be fresh, matching cmd_author's.
+        implicit_save = snaps.replay_env({"det_fps": 60, "route": "r.pad", "snaps": []},
+                                         os.path.join(tmp, "replay-implicit"), base={})
+        check("PROSPER_SAVEDATA_DIR" in implicit_save,
+              "an entry with no savedata key still replays with isolated saves")
+
         modern = snaps.replay_env({"det_fps": 60, "det_clock": "off", "route": "r.pad",
                                    "snaps": [], "savedata": "none"}, tmp, base={})
         check(modern.get("PROSPER_FLIP_PACE_FPS") == "60",
@@ -697,6 +718,80 @@ def main():
         check(snaps.replay_env(forced, tmp, base={}).get("PROSPER_FLIP_PACE_FPS") == "30",
               "...so the check is paced at what the person asked for, not what was stored")
 
+        # ---- 6a1b-iii-g. SCAN MODE survives from the manifest to the search window ----------
+        # This is the PR's headline feature, and both of its plumbing steps could be neutered in
+        # silence: cmd_import could store "anchor" for a scan snap, and either caller of
+        # window_offsets could drop the snap argument. Each degrades a 12,000-flip forward sweep to
+        # a +/-900 anchor window, so a frame behind an FMV reports NOT REACHED -- a FAILURE, for a
+        # title rendering perfectly. The person pressed SHIFT+F6 and the console confirmed "(scan)".
+        scan_cap = os.path.join(tmp, "scancap")
+        os.makedirs(scan_cap, exist_ok=True)
+        write_bmp(os.path.join(scan_cap, "snap_0000_correct_f5000.bmp"), 64, 36,
+                  lambda x, y: (x % 256, 200, y % 256))
+        with open(os.path.join(scan_cap, "snaps.jsonl"), "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({
+                "index": 0, "verdict": "correct", "mode": "scan", "pad_flip": 5000,
+                "guest_present": 5000, "width": 64, "height": 36,
+                "file": "snap_0000_correct_f5000.bmp", "title_id": "PPSATEST"}) + "\n")
+        open(os.path.join(scan_cap, "route.pad"), "w", encoding="utf-8").write("f5000:cross\n")
+
+        class ScanArgs(Args):
+            capture_dir = scan_cap
+            name = "scanset"
+
+        snaps.cmd_import(ScanArgs())
+        scan_entry = snaps.load_entry("scanset")
+        check(scan_entry["snaps"][0].get("mode") == "scan",
+              "a scan snap is IMPORTED as a scan, not silently demoted to an anchor")
+
+        # ...and the stored mode must actually reach the search. This is the half that matters:
+        # storing "scan" and then searching a +/-900 window helps nobody.
+        scan_flips = snaps.candidate_flips(scan_entry)
+        check(max(scan_flips) > 5000 + snaps.DEFAULT_FLIP_WINDOW * 2,
+              "the replay captures far beyond the anchor window for a scan snap")
+        check(max(scan_flips) >= 5000 + snaps.DEFAULT_SCAN_FORWARD - 10,
+              "...out to the configured scan_forward, which is the point of the mode")
+        check(len(scan_flips) > snaps.DEFAULT_WINDOW_SAMPLES,
+              "...with more samples than an anchor window would take")
+
+        # The same entry with the mode removed must NOT produce that window -- otherwise the arms
+        # above pass for a reason unrelated to the mode.
+        demoted = json.loads(json.dumps(scan_entry))
+        demoted["snaps"][0]["mode"] = "anchor"
+        demoted_flips = snaps.candidate_flips(demoted)
+        check(max(demoted_flips) < max(scan_flips),
+              "...and an anchor snap at the same flip searches a strictly narrower span")
+
+        # best_match must ask the same question: it drives its own offsets off the snap.
+        offsets_used = snaps.window_offsets(scan_entry, scan_entry["snaps"][0])
+        check(max(offsets_used) >= snaps.DEFAULT_SCAN_FORWARD - 10,
+              "window_offsets for a scan snap spans the scan range, not the anchor window")
+
+        # ...and best_match must actually ASK for that span. The arm above tests the helper; this
+        # one tests the caller, by putting the only matching frame far beyond the anchor window.
+        # A best_match that narrowed to +/-900 finds nothing and the snap reports NOT REACHED.
+        far_dir = os.path.join(tmp, "far")
+        os.makedirs(far_dir, exist_ok=True)
+        scan_snap = scan_entry["snaps"][0]
+        far_offset = max(o for o in snaps.window_offsets(scan_entry, scan_snap))
+        shutil.copyfile(os.path.join(scan_cap, "snap_0000_correct_f5000.bmp"),
+                        os.path.join(far_dir, "far.bmp"))
+        far_flip = scan_snap["pad_flip"] + far_offset
+        far_actuals = {far_flip: {"target_flip": far_flip, "actual_flip": far_flip,
+                                  "file": "far.bmp"}}
+        far_found = snaps.best_match(scan_snap, scan_entry, far_actuals, far_dir)
+        check(far_found is not None,
+              "best_match finds a scan frame sitting far past the anchor window -- the caller "
+              "passes the snap, not just the entry")
+        check(far_found is not None and far_found[3] == far_offset,
+              "...and reports the offset it was actually found at")
+        # The control: an ANCHOR snap at the same flip must NOT reach that frame, or the arm above
+        # would pass for a reason unrelated to scan mode.
+        anchor_snap = json.loads(json.dumps(scan_snap))
+        anchor_snap["mode"] = "anchor"
+        check(snaps.best_match(anchor_snap, scan_entry, far_actuals, far_dir) is None,
+              "...while an anchor snap at the same flip does not reach it")
+
         # ---- 6a1b-iv. A check does not write its frames into the shared tmpfs ----------------
         # /tmp here is RAM-backed with a per-user quota shared by every concurrent agent, and
         # exhausting it takes the machine's RAM rather than merely failing the write. Scan mode
@@ -786,6 +881,60 @@ def main():
               "an append carries through keys the tool does not understand")
         check(kept.get("savedata") == "fresh",
               "...while still completing the ones it does")
+
+        # ---- 6a1b-iv-b. cmd_check USES the safe scratch directory ---------------------------
+        # default_check_out_dir was asserted directly; nothing asserted cmd_check calls it, so the
+        # call site could be reverted to /tmp in silence. A scan-mode check writes 34 BMPs per snap
+        # (24 MB each at 4K) -- into a RAM-backed tmpfs with a per-user quota shared by every
+        # concurrent agent, that does not merely fail this run, it takes the machine's RAM with it.
+        got_out = {}
+
+        def spy_replay(entry_, out_dir_):
+            got_out["dir"] = out_dir_
+            return {}, os.path.join(out_dir_, "run.log")
+
+        saved_replay = snaps.run_replay
+        saved_env_out = os.environ.pop("PROSPER_SNAP_OUT", None)
+        try:
+            snaps.run_replay = spy_replay
+
+            class CheckArgs:
+                names = ["scanset"]
+            buf_c = io.StringIO()
+            saved_out_c, sys.stdout = sys.stdout, buf_c
+            try:
+                snaps.cmd_check(CheckArgs())
+            finally:
+                sys.stdout = saved_out_c
+        finally:
+            snaps.run_replay = saved_replay
+            if saved_env_out is not None:
+                os.environ["PROSPER_SNAP_OUT"] = saved_env_out
+
+        check("dir" in got_out, "cmd_check actually ran a replay")
+        check(got_out.get("dir") == snaps.default_check_out_dir("scanset"),
+              "cmd_check writes its frames to the safe scratch directory, not wherever it likes")
+        check(not got_out.get("dir", "").startswith(tempfile.gettempdir() + os.sep),
+              "...which is not the shared RAM-backed tmpfs")
+
+        # ---- 6a1b-v-b. The CLI defaults ARE the behaviour change -----------------------------
+        # --det-clock defaulting to off is this PR's headline change, and reverting either default
+        # was silent. With it back on, every new session re-pins the guest clock -- which freezes
+        # GRIS's opening FMV (1,680 frames against 42,000) and records guards under a clock nobody
+        # plays on.
+        parser = snaps.build_parser()
+        for sub in ("author", "import"):
+            base_argv = (["author", "--name", "n", "--dump", "d"] if sub == "author"
+                         else ["import", "somedir", "--name", "n"])
+            defaults = parser.parse_args(base_argv)
+            check(defaults.det_clock == "off",
+                  f"`{sub}` defaults to the REAL guest clock, not the pinned one")
+            check(defaults.det_fps == snaps.DEFAULT_DET_FPS,
+                  f"`{sub}` defaults to the documented pace rate")
+            check(defaults.savedata == "fresh",
+                  f"`{sub}` defaults to isolated saves, so a run cannot touch real ones by default")
+            forced = parser.parse_args(base_argv + ["--det-clock", "on"])
+            check(forced.det_clock == "on", f"`{sub}` still accepts --det-clock on explicitly")
 
         # ---- 6a1b-vi. _flag_was_passed sees argparse ABBREVIATIONS -----------------------------
         # argparse accepts any unambiguous prefix, so `--det-f 30` sets det_fps. An exact-match
@@ -902,6 +1051,32 @@ def main():
               "the windowed sample wins over a black frame sitting exactly on the anchor")
         check(score >= snaps.DEFAULT_MIN_SSIM,
               "...and it scores as a pass, where exact-anchor matching would have failed")
+
+        # best_match must take the BEST score in the span, not the first frame that exists.
+        # The arm above cannot show that: `off` is the most negative offset, so it is iterated
+        # FIRST and a first-match-wins implementation picks it too. Put a decoy at the earliest
+        # offset and the real match at a LATER one, so the two strategies disagree.
+        offs = snaps.window_offsets(entry)
+        early, late = offs[0], offs[-1]
+        check(early < 0 < late, "the fixture needs offsets on both sides to discriminate")
+        write_bmp(os.path.join(win_dir, "decoy.bmp"), 64, 36,
+                  lambda x, y: (255 if (x // 8 + y // 8) % 2 else 0,) * 3)
+        ordered = {
+            anchor + early: {"target_flip": anchor + early, "actual_flip": anchor + early,
+                             "file": "decoy.bmp"},
+            anchor + late: {"target_flip": anchor + late, "actual_flip": anchor + late,
+                            "file": "off.bmp"},
+        }
+        best = snaps.best_match(target, entry, ordered, win_dir)
+        check(best is not None, "best_match finds something when both samples exist")
+        best_score, best_record, _, best_offset = best
+        check(best_offset == late and best_record["file"] == "off.bmp",
+              "best_match takes the BEST match in the span, not the earliest frame present")
+        decoy_score = snaps.structural_similarity(
+            snaps.decode_luma(target["luma16x9"]),
+            snaps.decode_luma(snaps.signature_of(os.path.join(win_dir, "decoy.bmp"))["luma16x9"]))
+        check(decoy_score < best_score,
+              "...and the decoy really was the worse of the two, so the choice was not arbitrary")
 
         # ---- 6c2. Sampling is DENSE near the anchor, because that is where the match is ------
         # Measured: two identical runs through Blue Prince's intro cutscene reached the same page of

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -395,6 +395,35 @@ def main():
         check(os.path.exists(os.path.join(e2e, "session.json")),
               "an authoring session records itself on disk")
 
+        # The reviewer's exact reproduction, end to end: append to this directory WITHOUT repeating
+        # --det-fps and confirm the emulator is actually launched at the session's rate, not the
+        # CLI default. Asserting on `saw` -- the env handed to the process -- is the whole point:
+        # the previous version recorded 30 and ran at 60, and only the env can tell them apart.
+        saw = {}
+
+        class AppendE2E(AuthorE2E):
+            append = True
+            det_fps = snaps.DEFAULT_DET_FPS       # 60 -- the default, NOT what was authored
+
+        def capture_run(cmd, env=None, check_=False, **kw):
+            saw.update(env)
+            return fake_run(cmd, env=env)
+        saved_app, saved_run = snaps.APP, snaps.subprocess.run
+        try:
+            snaps.APP = fake_app
+            snaps.subprocess.run = capture_run
+            snaps.cmd_author(AppendE2E())
+        finally:
+            snaps.APP, snaps.subprocess.run = saved_app, saved_run
+
+        check(saw.get("PROSPER_FLIP_PACE_FPS") == "30",
+              "an appending run is PACED at the session's own rate, not the command-line default")
+        with open(os.path.join(e2e, "session.json"), "r", encoding="utf-8") as handle:
+            after = json.load(handle)
+        check(after.get("det_fps") == 30, "...and still records that rate")
+        check(saw.get("PROSPER_FLIP_PACE_FPS") == str(after.get("det_fps")),
+              "...so the run and its own record agree, which is the whole invariant")
+
         class ImportE2E(Args):
             capture_dir = e2e
             name = "e2e"
@@ -421,26 +450,76 @@ def main():
         check(out.startswith(os.path.expanduser("~")), "...it lands on real disk under $HOME")
         check("somegame" in out, "...in a per-set directory, so two sets cannot collide")
 
-        # ---- 6a1b-v. --append must not restamp a session authored at other settings ----------
-        # Appending would otherwise record the SECOND run's parameters for snaps taken during the
-        # first, and import would replay half of them at a rate nobody played them at.
+        # ---- 6a1b-v. --append: the run and its own record must agree -------------------------
+        # The first version of this fix resolved the stored session AFTER building the run
+        # environment, so `--append --det-fps 60` on a directory authored at 30 ran the emulator
+        # paced at 60 while recording 30. Every snap from that run would then be anchored on flips
+        # taken at 60 and replayed at 30 -- the divergence this whole mechanism exists to prevent,
+        # moved from run 1 to run 2 rather than removed.
         class Fresh:
             name = "s"; det_fps = 60; det_clock = "off"; savedata = "fresh"; append = False
 
-        class Appending:
+        rec, adopted, conflicts = snaps.reconcile_session(Fresh(), {}, was_passed=lambda k: False)
+        check(rec is not None and rec.get("det_fps") == 60 and not adopted and not conflicts,
+              "a fresh session records its own parameters")
+
+        # Not explicitly asked for -> adopt the stored value, AND mutate args so the run matches.
+        class Defaulted:
+            name = "s"; det_fps = 60; det_clock = "off"; savedata = "fresh"; append = True
+
+        d = Defaulted()
+        rec2, adopted2, conflicts2 = snaps.reconcile_session(
+            d, {"det_fps": 30, "det_clock": "off", "savedata": "fresh"},
+            was_passed=lambda k: False)
+        check(adopted2 == ["det_fps"] and not conflicts2,
+              "appending without the flag adopts the session's own rate")
+        check(d.det_fps == 30,
+              "...and ARGS is updated, so author_env paces the run to match what is recorded")
+        check(rec2.get("det_fps") == 30, "...so the run and its record cannot disagree")
+
+        # Explicitly asked for and contradicting -> a conflict the caller must resolve.
+        class Explicit:
+            name = "s"; det_fps = 60; det_clock = "off"; savedata = "fresh"; append = True
+
+        e = Explicit()
+        rec3, adopted3, conflicts3 = snaps.reconcile_session(
+            e, {"det_fps": 30, "det_clock": "off", "savedata": "fresh"},
+            was_passed=lambda k: k == "det_fps")
+        check(conflicts3 == ["det_fps"] and not adopted3,
+              "an explicit flag contradicting the session is a CONFLICT, not a silent override")
+        check(e.det_fps == 60, "...and args is left alone, so the caller sees what they asked for")
+
+        # Same settings -> silent, and the record still gets rewritten so a key missing from an
+        # older session file can be completed.
+        class Same:
             name = "s"; det_fps = 30; det_clock = "off"; savedata = "fresh"; append = True
 
-        rec, diff = snaps.session_to_write(Fresh(), {})
-        check(rec is not None and rec.get("det_fps") == 60 and diff == [],
-              "a fresh session records its own parameters")
-        rec2, diff2 = snaps.session_to_write(Appending(), {"det_fps": 60, "det_clock": "off",
-                                                           "savedata": "fresh"})
-        check(rec2 is None and diff2 == ["det_fps"],
-              "appending at a DIFFERENT rate keeps the original and names what differed")
-        rec3, diff3 = snaps.session_to_write(
-            Appending(), {"det_fps": 30, "det_clock": "off", "savedata": "fresh"})
-        check(rec3 is None and diff3 == [],
-              "appending at the SAME settings is silent and still does not restamp")
+        rec4, adopted4, conflicts4 = snaps.reconcile_session(
+            Same(), {"det_fps": 30}, was_passed=lambda k: False)
+        check(not adopted4 and not conflicts4, "appending at the same settings is silent")
+        check(rec4 is not None and rec4.get("savedata") == "fresh",
+              "...and a key missing from an older session file is completed rather than left out")
+
+        # ---- 6a1b-vi. _flag_was_passed sees argparse ABBREVIATIONS -----------------------------
+        # argparse accepts any unambiguous prefix, so `--det-f 30` sets det_fps. An exact-match
+        # check missed it, and the stored session would then silently override a flag the person
+        # did type. This is the arm that was missing when the fix landed.
+        saved_argv = sys.argv
+        try:
+            for argv, key, want in (
+                    (["--det-fps", "30"], "det_fps", True),
+                    (["--det-f", "30"], "det_fps", True),      # abbreviation
+                    (["--det-fps=30"], "det_fps", True),
+                    (["--det-f", "30"], "det_clock", False),   # must not bleed across flags
+                    (["--savedata", "none"], "det_fps", False),
+                    (["--"], "det_fps", False),                # end-of-options, not a flag
+                    ([], "det_fps", False)):
+                sys.argv = ["snaps.py", "import", "d"] + argv
+                got = snaps._flag_was_passed(key)
+                check(got == want,
+                      f"_flag_was_passed({key}) is {want} for {argv or 'no flags'}")
+        finally:
+            sys.argv = saved_argv
 
         # An inherited pace from the authoring shell must not survive into a run that specifies its
         # own -- same leak the clock arm above guards.

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -917,6 +917,248 @@ def main():
         check(not got_out.get("dir", "").startswith(tempfile.gettempdir() + os.sep),
               "...which is not the shared RAM-backed tmpfs")
 
+        # ---- 6a1b-iv-c. cmd_check's VERDICT LOGIC -- the whole point of the tool -------------
+        # An AST sweep of cmd_check found 29 of its 39 statements deletable with the suite green,
+        # including `matched = ssim >= threshold` and the correct/incorrect asymmetry. That
+        # asymmetry IS the design: a correct snap that stops matching is a FAILURE; an incorrect one
+        # that stops matching is INFO, because a known-bad frame may have been fixed and this is the
+        # only signal that would ever say so. None of it was asserted.
+        def check_run(verdict, ref_pixel, actual_pixel, mode="anchor", flip=900):
+            """Run cmd_check over one snap with a controlled reference/actual pair.
+
+            Returns (exit_code, output). The reference is what was approved; the actual is what the
+            stubbed replay produced, so the two pixels decide whether it matches.
+            """
+            nm = f"vc{abs(hash((verdict, ref_pixel, actual_pixel, mode))) % 100000}"
+            vdir = os.path.join(tmp, nm)
+            os.makedirs(vdir, exist_ok=True)
+            ref_bmp = os.path.join(vdir, "ref.bmp")
+            write_bmp(ref_bmp, 64, 36, lambda x, y: ref_pixel)
+            os.makedirs(snaps.ref_dir(nm), exist_ok=True)
+            shutil.copyfile(ref_bmp, os.path.join(snaps.ref_dir(nm), "0000.bmp"))
+            sig = snaps.signature_of(ref_bmp)
+            entry_v = {"name": nm, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                       "timeout": 60, "savedata": "none",
+                       "snaps": [dict(sig, index=0, verdict=verdict, mode=mode, pad_flip=flip)]}
+            with open(snaps.store_path(nm), "w", encoding="utf-8") as handle:
+                json.dump(entry_v, handle)
+
+            def stub(entry_, out_dir_):
+                os.makedirs(out_dir_, exist_ok=True)
+                write_bmp(os.path.join(out_dir_, "a.bmp"), 64, 36, lambda x, y: actual_pixel)
+                return ({flip: {"target_flip": flip, "actual_flip": flip, "file": "a.bmp"}},
+                        os.path.join(out_dir_, "run.log"))
+
+            saved_r, saved_here = snaps.run_replay, snaps.HERE
+            snaps.HERE = vdir
+            buf_v = io.StringIO()
+            saved_o, sys.stdout = sys.stdout, buf_v
+            try:
+                snaps.run_replay = stub
+
+                class VArgs:
+                    names = [nm]
+                rc_v = snaps.cmd_check(VArgs())
+            finally:
+                snaps.run_replay, snaps.HERE, sys.stdout = saved_r, saved_here, saved_o
+            return rc_v, buf_v.getvalue()
+
+        same, different = (10, 20, 30), (240, 250, 200)
+
+        # A CORRECT snap that still matches: pass, exit 0.
+        rc_v, out_v = check_run("correct", same, same)
+        check(rc_v == 0 and "OK" in out_v,
+              "a correct snap that still matches PASSES")
+
+        # A CORRECT snap that no longer matches: failure, NONZERO EXIT. This is the regression
+        # signal the whole system exists to produce.
+        rc_v, out_v = check_run("correct", same, different)
+        check(rc_v != 0, "a correct snap that no longer matches FAILS the run")
+        check("FAIL" in out_v, "...and says so")
+
+        # An INCORRECT snap that still looks wrong: reported, but NOT a failure.
+        rc_v, out_v = check_run("incorrect", same, same)
+        check(rc_v == 0, "a known-bad frame that is still bad does NOT fail the run")
+        check("still wrong" in out_v, "...and is reported as still wrong")
+
+        # An INCORRECT snap that CHANGED: info, not failure -- it may have been fixed.
+        rc_v, out_v = check_run("incorrect", same, different)
+        check(rc_v == 0,
+              "a known-bad frame that CHANGED does not fail the run -- it may have been fixed")
+        check("CHANGED" in out_v, "...and is surfaced so a person looks at it")
+
+        # NOT REACHED: a failure for a correct snap, not for an incorrect one. Never silently pass.
+        def check_unreached(verdict):
+            nm = f"nr{verdict}"
+            vdir = os.path.join(tmp, nm)
+            os.makedirs(vdir, exist_ok=True)
+            ref_bmp = os.path.join(vdir, "ref.bmp")
+            write_bmp(ref_bmp, 64, 36, lambda x, y: same)
+            entry_v = {"name": nm, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                       "timeout": 60, "savedata": "none",
+                       "snaps": [dict(snaps.signature_of(ref_bmp), index=0, verdict=verdict,
+                                      mode="anchor", pad_flip=900)]}
+            with open(snaps.store_path(nm), "w", encoding="utf-8") as handle:
+                json.dump(entry_v, handle)
+            saved_r, saved_here = snaps.run_replay, snaps.HERE
+            snaps.HERE = vdir
+            buf_v = io.StringIO()
+            saved_o, sys.stdout = sys.stdout, buf_v
+            try:
+                snaps.run_replay = lambda e, o: ({}, "log")     # captured nothing at all
+
+                class VArgs:
+                    names = [nm]
+                return snaps.cmd_check(VArgs()), buf_v.getvalue()
+            finally:
+                snaps.run_replay, snaps.HERE, sys.stdout = saved_r, saved_here, saved_o
+
+        rc_v, out_v = check_unreached("correct")
+        check(rc_v != 0 and "NOT REACHED" in out_v,
+              "a correct snap the route never reached FAILS -- never silently passed")
+        rc_v, out_v = check_unreached("incorrect")
+        check(rc_v == 0 and "NOT REACHED" in out_v,
+              "...while an unreached known-bad snap is reported without failing the run")
+
+        # The threshold is read from the ENTRY, so a set can be more or less tolerant than default.
+        strict = check_run("correct", same, (12, 22, 32))
+        check(strict[0] == 0, "a near-identical frame passes at the default threshold")
+
+        # A FAILING snap must leave both images behind. This is the review workflow: on a failure
+        # the actual is rendered in the terminal and the person says whether it is acceptable. If
+        # retention silently stops, every failure becomes unreviewable and `accept` has nothing to
+        # act on -- and nothing would have said so.
+        nm_r = "retain-me"
+        rdir = os.path.join(tmp, nm_r)
+        os.makedirs(rdir, exist_ok=True)
+        ref_r = os.path.join(rdir, "ref.bmp")
+        write_bmp(ref_r, 64, 36, lambda x, y: same)
+        os.makedirs(snaps.ref_dir(nm_r), exist_ok=True)
+        shutil.copyfile(ref_r, os.path.join(snaps.ref_dir(nm_r), "0000.bmp"))
+        entry_r = {"name": nm_r, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                   "timeout": 60, "savedata": "none",
+                   "snaps": [dict(snaps.signature_of(ref_r), index=0, verdict="correct",
+                                  mode="anchor", pad_flip=900)]}
+        with open(snaps.store_path(nm_r), "w", encoding="utf-8") as handle:
+            json.dump(entry_r, handle)
+
+        def stub_r(entry_, out_dir_):
+            os.makedirs(out_dir_, exist_ok=True)
+            write_bmp(os.path.join(out_dir_, "a.bmp"), 64, 36, lambda x, y: different)
+            return ({900: {"target_flip": 900, "actual_flip": 900, "file": "a.bmp"}},
+                    os.path.join(out_dir_, "run.log"))
+
+        saved_r2, saved_here2 = snaps.run_replay, snaps.HERE
+        snaps.HERE = rdir
+        buf_r = io.StringIO(); saved_o2, sys.stdout = sys.stdout, buf_r
+        try:
+            snaps.run_replay = stub_r
+
+            class RArgs:
+                names = [nm_r]
+            snaps.cmd_check(RArgs())
+        finally:
+            snaps.run_replay, snaps.HERE, sys.stdout = saved_r2, saved_here2, saved_o2
+        review_dir = os.path.join(rdir, "failures")
+        check(os.path.exists(os.path.join(review_dir, f"{nm_r}-0000-actual.bmp")),
+              "a failing snap retains the ACTUAL frame for review")
+        check(os.path.exists(os.path.join(review_dir, f"{nm_r}-0000-expected.bmp")),
+              "...and the EXPECTED one beside it, or the pair cannot be compared")
+
+        # The output directory must be CLEARED before a replay. A frame left by an earlier run
+        # could otherwise be matched and reported as a pass -- a wrong answer, stated confidently,
+        # from data the current run never produced.
+        stale_out = snaps.default_check_out_dir("stale-probe")
+        os.makedirs(stale_out, exist_ok=True)
+        sentinel = os.path.join(stale_out, "left-over.bmp")
+        write_bmp(sentinel, 64, 36, lambda x, y: same)
+        nm_s = "stale-probe"
+        sdir = os.path.join(tmp, nm_s)
+        os.makedirs(sdir, exist_ok=True)
+        write_bmp(os.path.join(sdir, "ref.bmp"), 64, 36, lambda x, y: same)
+        entry_s = {"name": nm_s, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                   "timeout": 60, "savedata": "none",
+                   "snaps": [dict(snaps.signature_of(os.path.join(sdir, "ref.bmp")), index=0,
+                                  verdict="correct", mode="anchor", pad_flip=900)]}
+        with open(snaps.store_path(nm_s), "w", encoding="utf-8") as handle:
+            json.dump(entry_s, handle)
+        saw_sentinel = {}
+
+        def stub_s(entry_, out_dir_):
+            saw_sentinel["present"] = os.path.exists(os.path.join(out_dir_, "left-over.bmp"))
+            os.makedirs(out_dir_, exist_ok=True)
+            write_bmp(os.path.join(out_dir_, "a.bmp"), 64, 36, lambda x, y: same)
+            return ({900: {"target_flip": 900, "actual_flip": 900, "file": "a.bmp"}},
+                    os.path.join(out_dir_, "run.log"))
+
+        saved_r3, saved_here3 = snaps.run_replay, snaps.HERE
+        snaps.HERE = sdir
+        buf_s = io.StringIO(); saved_o3, sys.stdout = sys.stdout, buf_s
+        try:
+            snaps.run_replay = stub_s
+
+            class SArgs:
+                names = [nm_s]
+            snaps.cmd_check(SArgs())
+        finally:
+            snaps.run_replay, snaps.HERE, sys.stdout = saved_r3, saved_here3, saved_o3
+        # A negative snap that CHANGED must retain its images too. This is the half of the review
+        # workflow that reports good news -- a known-bad frame may have been fixed -- and it was the
+        # one path where retention could be deleted in silence.
+        nm_c = "changed-retain"
+        cdir = os.path.join(tmp, nm_c)
+        os.makedirs(cdir, exist_ok=True)
+        ref_c = os.path.join(cdir, "ref.bmp")
+        write_bmp(ref_c, 64, 36, lambda x, y: same)
+        os.makedirs(snaps.ref_dir(nm_c), exist_ok=True)
+        shutil.copyfile(ref_c, os.path.join(snaps.ref_dir(nm_c), "0000.bmp"))
+        entry_c = {"name": nm_c, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                   "timeout": 60, "savedata": "none",
+                   "snaps": [dict(snaps.signature_of(ref_c), index=0, verdict="incorrect",
+                                  mode="anchor", pad_flip=900)]}
+        with open(snaps.store_path(nm_c), "w", encoding="utf-8") as handle:
+            json.dump(entry_c, handle)
+
+        def stub_c(entry_, out_dir_):
+            os.makedirs(out_dir_, exist_ok=True)
+            write_bmp(os.path.join(out_dir_, "a.bmp"), 64, 36, lambda x, y: different)
+            return ({900: {"target_flip": 900, "actual_flip": 900, "file": "a.bmp"}},
+                    os.path.join(out_dir_, "run.log"))
+
+        saved_r4, saved_here4 = snaps.run_replay, snaps.HERE
+        snaps.HERE = cdir
+        buf_c2 = io.StringIO(); saved_o4, sys.stdout = sys.stdout, buf_c2
+        try:
+            snaps.run_replay = stub_c
+
+            class CArgs:
+                names = [nm_c]
+            snaps.cmd_check(CArgs())
+        finally:
+            snaps.run_replay, snaps.HERE, sys.stdout = saved_r4, saved_here4, saved_o4
+        check(os.path.exists(os.path.join(cdir, "failures", f"{nm_c}-0000-actual.bmp")),
+              "a CHANGED known-bad frame retains its image too -- that is how a fix gets noticed")
+
+        # replay_env's remaining statements. It was extracted so it could be asserted; five of its
+        # keys were still unobserved.
+        full_env = snaps.replay_env(
+            {"det_fps": 60, "det_clock": "off", "route": "scripts/x/route.pad",
+             "savedata": "none",
+             "snaps": [{"pad_flip": 900, "mode": "anchor"}]}, tmp, base={})
+        check(full_env.get("SDL_VIDEODRIVER") == "offscreen",
+              "a check runs headless -- it is automation, not a person at a window")
+        check(full_env.get("PROSPER_RENDER") == "1", "...with the live renderer on")
+        check(full_env.get("PROSPER_GUEST_ARGS") == "-force-gfx-direct",
+              "...and the guest arg that reaches the frame loop")
+        check(full_env.get("PROSPER_PAD_SCRIPT", "").startswith("@"),
+              "the route is passed as a FILE reference (@path), not as inline script text")
+        check("900" in full_env.get("PROSPER_SNAP_AT_FLIPS", ""),
+              "the anchors to capture are handed to the emulator")
+
+        check(saw_sentinel.get("present") is False,
+              "the output directory is CLEARED before a replay, so a stale frame from an earlier "
+              "run can never be matched and reported as a pass")
+
         # ---- 6a1b-v-b. The CLI defaults ARE the behaviour change -----------------------------
         # --det-clock defaulting to off is this PR's headline change, and reverting either default
         # was silent. With it back on, every new session re-pins the guest clock -- which freezes

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -187,13 +187,13 @@ def main():
 
         snaps.cmd_import(Args2())
         authored = snaps.load_entry("unit2")
-        check(authored["det_fps"] == 30,
+        check(authored.get("det_fps") == 30,
               "import records the rate the session was AUTHORED at, not its own default")
-        check(authored["det_clock"] == "off",
+        check(authored.get("det_clock") == "off",
               "...and the clock stance the session was authored under")
         # The whole point is that both halves then agree.
         env2 = snaps.replay_env(authored, tmp, base={})
-        check(env2["PROSPER_FLIP_PACE_FPS"] == "30",
+        check(env2.get("PROSPER_FLIP_PACE_FPS") == "30",
               "so the check paces at the rate the person actually played at")
 
         # ---- 5. accept: store AND reference image move together -------------------------------
@@ -297,6 +297,88 @@ def main():
               "the pace rate is read from the entry, not hardcoded")
         check(snaps.pace_fps({}) == snaps.DEFAULT_DET_FPS,
               "an entry with no det_fps falls back to the documented default")
+
+        # The AUTHOR half. Everything above this asserts the CHECK. An earlier revision headed this
+        # block "BOTH halves pace" while testing one of them, and deleting the author's pacing line
+        # left the whole suite green -- every future session would then run unpaced against a check
+        # paced at 60, which diverges rather than drifts.
+        class AuthorArgs:
+            name = "unit-author"
+            det_fps = 30
+            det_clock = "off"
+            savedata = "none"
+
+        aenv = snaps.author_env(AuthorArgs(), tmp, base={})
+        check(aenv.get("PROSPER_FLIP_PACE_FPS") == "30",
+              "the AUTHORING session paces its flips too")
+        check("PROSPER_DET_CLOCK" not in aenv, "...with the clock off when the session says off")
+        check(aenv.get("PROSPER_PAD_RECORD", "").endswith("route.pad"),
+              "...and records the route the check will replay")
+
+        # The two halves must agree by CONSTRUCTION, not by two literals that happen to match.
+        # Same det_fps in, same pace out, whichever side computes it.
+        for rate in (30, 60, 120):
+            class R:
+                name = "x"; det_fps = rate; det_clock = "off"; savedata = "none"
+            a = snaps.author_env(R(), tmp, base={}).get("PROSPER_FLIP_PACE_FPS")
+            c = snaps.replay_env({"det_fps": rate, "det_clock": "off", "route": "r.pad",
+                                  "snaps": [], "savedata": "none"}, tmp,
+                                 base={}).get("PROSPER_FLIP_PACE_FPS")
+            check(a == c == str(rate),
+                  f"author and check derive the SAME pace at det_fps={rate} ({a} vs {c})")
+
+        # ---- 6a1b-iii. What author WRITES is what import READS -------------------------------
+        # These were two hand-written literals. Renaming the keys cmd_author records left the suite
+        # fully green, because the import test mirrored the format by hand rather than obtaining it
+        # from the producer. Bind them to one list and assert the round trip.
+        class SessArgs:
+            name = "roundtrip"
+            det_fps = 30
+            det_clock = "off"
+            savedata = "fresh"
+
+        record = snaps.session_record(SessArgs())
+        check(set(snaps.SESSION_KEYS) <= set(record),
+              "the session record carries every key import looks up")
+        check(record.get("det_fps") == 30 and record.get("det_clock") == "off"
+              and record.get("savedata") == "fresh",
+              "...with the values the session was authored under")
+        # And import must consume exactly these -- not a superset, not a stale alias.
+        import inspect
+        import_src = inspect.getsource(snaps.cmd_import)
+        check("SESSION_KEYS" in import_src,
+              "import reads the shared key list rather than its own copy of the names")
+
+        # ---- 6a1b-iv. A check does not write its frames into the shared tmpfs ----------------
+        # /tmp here is RAM-backed with a per-user quota shared by every concurrent agent, and
+        # exhausting it takes the machine's RAM rather than merely failing the write. Scan mode
+        # raises the captures per snap from 7 to 34, so this got ~5x heavier than it used to be.
+        out = snaps.default_check_out_dir("somegame")
+        check(not out.startswith(tempfile.gettempdir() + os.sep) and out != tempfile.gettempdir(),
+              "a check's scratch does not land in the shared RAM-backed tmpfs")
+        check(out.startswith(os.path.expanduser("~")), "...it lands on real disk under $HOME")
+        check("somegame" in out, "...in a per-set directory, so two sets cannot collide")
+
+        # ---- 6a1b-v. --append must not restamp a session authored at other settings ----------
+        # Appending would otherwise record the SECOND run's parameters for snaps taken during the
+        # first, and import would replay half of them at a rate nobody played them at.
+        class Fresh:
+            name = "s"; det_fps = 60; det_clock = "off"; savedata = "fresh"; append = False
+
+        class Appending:
+            name = "s"; det_fps = 30; det_clock = "off"; savedata = "fresh"; append = True
+
+        rec, diff = snaps.session_to_write(Fresh(), {})
+        check(rec is not None and rec.get("det_fps") == 60 and diff == [],
+              "a fresh session records its own parameters")
+        rec2, diff2 = snaps.session_to_write(Appending(), {"det_fps": 60, "det_clock": "off",
+                                                           "savedata": "fresh"})
+        check(rec2 is None and diff2 == ["det_fps"],
+              "appending at a DIFFERENT rate keeps the original and names what differed")
+        rec3, diff3 = snaps.session_to_write(
+            Appending(), {"det_fps": 30, "det_clock": "off", "savedata": "fresh"})
+        check(rec3 is None and diff3 == [],
+              "appending at the SAME settings is silent and still does not restamp")
 
         # An inherited pace from the authoring shell must not survive into a run that specifies its
         # own -- same leak the clock arm above guards.


### PR DESCRIPTION
The deterministic clock was a correctness compromise, and the project owner named it as one.

`PROSPER_DET_CLOCK` replaces **every** time source the guest has — `sceKernelReadTsc`,
`GetProcessTime`, and the wall-clock anchor behind `CLOCK_REALTIME`, `gettimeofday`, `time()` and
`sceRtc*` — with `anchor + flips × (1/DET_FPS)`. A guard recorded under that clock **tests a machine
nobody plays on**, and GRIS proves the divergence is real: its opening FMV freezes with the clock on
(1,680 frames and 47 forced-submit stalls, against 42,000 and 0 without it).

## The fix is in the matcher, not the clock

The clock existed only to stop anchors drifting when the host renders at a different rate than during
authoring. **SHIFT+F6 / SHIFT+F7** now mark a snap to *scan* for: the check sweeps a wide span forward
of the anchor instead of expecting the frame at a fixed offset.

One mechanism covers **slow test runners, variable loading, FMVs and frame-rate differences** at once
— and normal play is left completely alone: real clock, uncapped, 120 Hz fine, which is what a PS5
actually does.

**The idea is the owner's — including the objection, which turned out to be right.** They asked
whether this would disturb the pad route's timing. An earlier revision of this PR said it would not,
on the reasoning that waiting to *capture* is passive. That reasoning is correct in isolation and
the conclusion was still wrong, because the check had stopped pacing its flips: a flip-anchored
route replayed at a different flip rate lands its presses at different guest times. Measured on
`alexkidd` — **all four snaps failed**, ssim 0.001–0.522, colour counts collapsing 14,548 → 108,
which is a different part of the game rather than a shifted anchor.

The fix is that **both halves now pace** (`PROSPER_FLIP_PACE_FPS`), which is what lets the clock stay
off at all. With that in place the capture is passive as described.

## Design details that are load-bearing

- **Bounded and forward-biased.** The bound exists so a check cannot run for an unbounded time, and
  the anchor stays as the ordering hint. (An earlier revision justified the bound as protection
  against a recurring scene matching its first occurrence; that is **retracted** — `best_match`
  takes the best score across the span, not the first hit, so a repeat inside the span is resolved
  by score. The reasoning is corrected in the code and tests as well as here.)
- **Uniform sampling across a scan**, where the tight window is geometric: a scan is used precisely
  when the match is *not* near the anchor, so weighting toward the anchor would spend samples in the
  least likely place.

## A defect this PR introduced and fixed

Worth recording because it is the failure mode the PR is about. The first version of the `--append`
guard built the run environment from the command line and only *afterwards* decided to keep the
directory's stored parameters — so `--append --det-fps 60` on a directory authored at 30 launched
the emulator paced at **60** while recording **30**, printing both "flips paced to 60/s" and
"keeping the original session parameters (det_fps=30)" in the same run. The pre-fix code corrupted
the *first* run's snaps; the fix corrupted the *second* run's instead. The damage moved rather than
went.

`reconcile_session` now runs before the environment is built, and separates two cases the old code
conflated: a parameter the caller did not ask for is **adopted** from the session and written back
onto `args` so the run matches, while one they explicitly passed that contradicts the session is
**refused** — a directory's snaps share one route and one flip axis, so it can only describe one set
of conditions.

## Consequences

`--det-clock` now defaults to **off**. The **flip pacer does not go with it** — it runs
unconditionally on both sides, and it is what *replaced* the clock rather than a companion to it.
Pacing buys the "same flip = same guest time" correspondence honestly: the guest keeps a real clock
and simply flips at a fixed rate, the way a vsync-locked console does, so nothing lies to it about
what time it is. `--det-clock on` remains available per title.

**Its precondition, stated because it is real:** pacing can only slow a fast host *down*. The wait
sleeps when ahead and re-anchors when behind, so on any title/host that cannot **sustain** `det_fps`
the pacer is inert and anchors drift again — Blue Prince measures 180 fps at its menu, 20 in
gameplay and 4.8 during its FMV. That is precisely the case **scan** snaps exist for.

A set stored before the `det_clock` key existed reads as **clock ON**, since there was no way to
author one with it off.

## Verification

`ctest --no-tests=error -j4` → **315/315**, exit 0, on the current head.

**End-to-end**, re-measured on this exact head (the earlier figures were from the superseded
commit): the `alexkidd` guard replays **4/4** — `ssim 1.000 / 0.983 / 0.978 / 1.000`, every snap
matching at offset **+0**. On master one anchor needed +80. GRIS runs 29,520 frames, TRC=1.

**The new default path is now measured too, which review N2 correctly said it was not.** The
committed `alexkidd.json` predates the `det_clock` key, so it replays clock-**ON**; that validated
the reader fallback but said nothing about the real-clock+paced default the tool now writes. Running
the same route and the same four anchors with `det_clock: "off"`: **4/4**, `ssim 1.000 / 0.973 /
0.983 / 1.000`. One anchor matched at −80 rather than +0 — real drift, comfortably inside the
window, and exactly what the window is for. So both configurations pass, and the new default is no
longer an untested path.

**Every fix is mutation-verified at the level the fix lives.** Each was deleted or reverted in turn,
on a cleared `__pycache__` with `python3 -B`, with the mutation asserted to have applied before the
run. All 16 redden; none aborts.

| mutation | reddens |
| --- | --- |
| `clock_enabled` fallback → `"off"` | 2 |
| `replay_env` drops its pacing line | 9 |
| `author_env` drops its pacing line | 7 |
| author paces at `det_fps * 2` (halves disagree) | 7 |
| `scan_forward` clamp floor removed | 2 |
| `cmd_import` ignores `session.json` | 17 |
| `session_record` keys renamed | 25 |
| check scratch → `/tmp` | 1 |
| `--append` does not write adopted values back onto args | 15 |
| **`cmd_author` drops the conflict refusal** | 7 |
| **`cmd_author` drops the adopted NOTE** | 1 |
| **stored-value coercion removed** | 1 |
| **`cmd_author`'s non-dict session guard removed** | 4 |
| **`reconcile_session`'s non-dict guard removed** | 3 |
| `_flag_was_passed` → exact-match | 2 |
| `author_env` inlined back into `cmd_author` without pacing | 3 |

144 assertions pass unmutated.

**The bolded rows are what review round 5 found, and they were all one mistake made three times.**
Rounds 3, 4 and 5 each caught the same structural error: a helper's *return value* asserted while
the command's *use* of it was not. The fix was correct every time and the guard around it could be
deleted with the suite fully green.

So rather than patch the instance, I audited every fix in the PR by deleting its command-level
action and asking whether anything noticed. Three were silent. The arms now drive `cmd_author`
through the **real argparse** — `build_parser` is extracted from `main` for exactly this — with
`subprocess.run` spied on, and assert on the environment the process actually received, whether it
was launched at all, and what `session.json` holds afterwards. A hand-built args object cannot see
a defaulting bug or a flag whose `dest` does not match what the code reads.

**A note on method, since it bit twice.** A mutation reporting "still green" must be checked before
it is believed. Once a stale `__pycache__` made one mutation replay another's failures; once a
harness sliced the file between two mis-ordered offsets and mangled it rather than reverting the
function, which also read as green. Both were **void** results, not negative ones. Every row above
was derived after clearing the cache and asserting the mutation applied and still parsed.




