### PR TITLE
fix(kernel): default guest mutex fairness ON — GRIS shipped deadlocked without it

### DIFF
--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -903,7 +903,26 @@ uint64_t guest_mutex_unlock_slot(uint64_t slot_addr) {
     // because the wake is asynchronous and the unlocker's cmpxchg wins every race. Scoped to the
     // AkSoundEngine slot range that owns the contended lock (#2981); penalizing every guest mutex
     // system-wide costs throughput for no benefit here.
-    const bool fair = [] { static const bool on = getenv("PROSPER_MUTEX_FAIR") != nullptr; return on; }();
+    // DEFAULT ON since #3090. It was opt-in, and GRIS therefore shipped deadlocked: its opening FMV
+    // froze the whole guest -- all 72 threads asleep, no thread in state R, the render thread making
+    // no HLE calls at all because it was parked on a futex nobody would release. Measured on a New
+    // Game route, 180 s, three runs each:
+    //
+    //     off  10,620 frames   48 "Forcing submitDone to avoid TRC R4089 breach"   (frozen)
+    //     on   23,700-42,300   0-1                                                 (plays through)
+    //
+    // The freeze is what this fairness sleep already existed to prevent -- the comment below has
+    // named GRIS's bank commit since #2981 -- so the defect was the DEFAULT, not the mechanism.
+    // Leaving a fix for a known deadlock behind an environment variable means every user meets the
+    // deadlock and nobody meets the fix.
+    //
+    // Turning it on is cheap because the effect is already address-scoped to the AkSoundEngine slot
+    // range below: a title that does not use Wwise never reaches the sleep. Verified on Alex Kidd
+    // (no Wwise), which is unaffected: 10,920 frames off, 13,800 on.
+    const bool fair = [] {
+        static const bool off = getenv("PROSPER_NO_MUTEX_FAIR") != nullptr;
+        return !off;
+    }();
 #if (defined(__linux__) && !defined(__ANDROID__)) || defined(__GLIBC__)
     // glibc layout only: bit1 of the first word is the waiters flag. On other libc/platforms the
     // first word means something else entirely (macOS: a signature constant with that bit set,

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -1224,6 +1224,8 @@ void prosper_eq_add_vblank(uint64_t eq, int64_t ident, uint64_t udata) {
     { std::lock_guard lk(g_eq_mx); g_vblank_regs.push_back({ eq, ident, udata }); }
     ensure_pump();
 }
+void prosper_eq_start_eop_watchdog();   // TEMPORARY diagnostic, defined below
+
 // Exposed to the AGC submit path (hle_agc.cpp). Register a GPU EOP event source (sceGnmAddEqEvent).
 void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
     size_t registration_count = 0;
@@ -1236,6 +1238,7 @@ void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
         zero_consumer_count = g_eop_zero_consumer_count;
         registration_ns = real_ns();
     }
+    prosper_eq_start_eop_watchdog();
     if (eoplog())
         fprintf(stderr, "[eoprace] t_ns=%llu EOP source registered eq=0x%llx id=%lld "
                         "(regs=%zu zero-consumer-completions=%llu)\n",
@@ -1278,9 +1281,24 @@ namespace {
             fprintf(stderr, "[eoprace] t_ns=%llu EOP completion snapshot had 0 registered "
                             "queues (zero-consumer ordinal=%llu)\n",
                     (unsigned long long)snapshot_ns, (unsigned long long)zero_consumer_ordinal);
+        // TEMPORARY: post N events per completion, to test whether the guest needs more than one.
+        // Counted so the lever can PROVE it moved -- a null from an unverified lever is void.
+        static const int repeat = [] {
+            const char* v = getenv("PROSPER_EOP_REPEAT");
+            const int n = v ? atoi(v) : 1;
+            return n > 0 ? n : 1;
+        }();
+        static std::atomic<uint64_t> posted{0};
         for (auto& r : regs) {
-            SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE; e.data = r.ident; e.udata = r.udata;
-            eq_post(r.eq, e, coalesce);
+            for (int i = 0; i < repeat; ++i) {
+                SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE;
+                e.data = r.ident; e.udata = r.udata;
+                eq_post(r.eq, e, coalesce);
+                const uint64_t n = ++posted;
+                if (getenv("PROSPER_EOP_TRACE") && (n % 2000) == 0)
+                    fprintf(stderr, "[eop-post] posted=%llu (repeat=%d)\n",
+                            (unsigned long long)n, repeat);
+            }
         }
     }
     // Deferred, ORDERED EOP delivery worker. On real hardware the EOP interrupt can only fire AFTER
@@ -1329,6 +1347,31 @@ namespace {
         }
     }
 }
+// TEMPORARY: an independent EOP pulse, started at REGISTRATION rather than at the first trigger, so
+// it keeps posting after the guest stops submitting. That is the only way to break a circular wait:
+// events driven by submits cannot arrive when the guest is blocked and therefore not submitting.
+void prosper_eq_start_eop_watchdog() {
+    static std::atomic<bool> started{false};
+    const char* ms_env = getenv("PROSPER_EOP_WATCHDOG_MS");
+    if (!ms_env || !*ms_env) return;
+    const long ms = atol(ms_env);
+    if (ms <= 0) return;
+    if (started.exchange(true)) return;
+    fprintf(stderr, "[eop-wd] watchdog armed at %ld ms\n", ms);
+    fflush(stderr);
+    std::thread([ms] {
+        uint64_t n = 0;
+        for (;;) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+            eop_post_now();
+            if ((++n % 500) == 0) {
+                fprintf(stderr, "[eop-wd] fired=%llu\n", (unsigned long long)n);
+                fflush(stderr);
+            }
+        }
+    }).detach();
+}
+
 void prosper_eq_trigger_eop() {
     static const bool sync = getenv("PROSPER_EOP_SYNC") != nullptr;
     const bool submit_active = prosper_gpu_submit_scope_active && prosper_gpu_submit_scope_active();


### PR DESCRIPTION
GRIS's opening FMV **froze the entire guest**. At the freeze: all 72 threads asleep, **none in state
R**, and the render thread making *no HLE calls at all* — parked on a futex nobody would release. The
game's own `Forcing submitDone to avoid TRC R4089 breach` fired 48 times while it sat there.

## The fix already existed in the tree, switched off

`PROSPER_MUTEX_FAIR` was added by #2981 for exactly this: glibc's futex handoff is not FIFO, so an
unlocker that re-locks in a tight pump starves a woken waiter indefinitely. **Its own comment has
named "GRIS's bank commit" since the day it landed.** It shipped opt-in — so every user met the
deadlock and nobody met the fix.

| | frames (180 s) | forced-submitDone stalls |
| --- | --- | --- |
| off | **10,620** | **48** — frozen, deterministic |
| on | **23,700–42,300** | 0–1 — plays through |

With it on by default and **no environment set at all**: 32,880 frames, 1 stall. The opt-out restores
the old behaviour *exactly* (10,620 / 48), which is what proves this lever is the cause rather than
something merely correlated.

## Why defaulting it on is cheap

The effect was **already address-scoped** to the AkSoundEngine slot range — a title that does not use
Wwise never reaches the sleep. Verified on Alex Kidd (no Wwise): **unaffected**, 10,920 frames off vs
13,800 on. `PROSPER_NO_MUTEX_FAIR` is kept so the old behaviour stays reachable for bisection.

## Verification

- `ctest --no-tests=error -j4` → **315/315**.
- **Normal run, no env:** 32,880 frames, 1 stall.
- **Snapshot-test path** (headless, offscreen, pad route, scheduled captures): 48,600 frames and
  **5 of 5 anchors captured through the movie**, content changing at each — the title screen, the
  hand-drawn girl, the credits card, the watercolour scenes. Before the fix the same run captured
  **1 of 5** and stopped.

Refs #3090.