### PR TITLE
recompiler: image_get_resinfo accepts a 2D_ARRAY T#, closing one Frontiers gap

### DIFF
--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -377,6 +377,35 @@ shapes. `rdna2_emit_alu.cpp` only ever specialises this op away after proving th
 the resource is single-level; a 12-mip resource has no such proof, so it declines. Tracked as
 [#2818](https://github.com/mattias800/prosper/issues/2818).
 
+### `image_get_resinfo` on a 2D_ARRAY T# no longer declines (2026-08-29)
+
+Separate from the three scene-width kernels above, one stage program (`0x200581bb00`, `1x1x6` groups
+of `256x1`) declined at **pc=31** on `image_get_resinfo` with `dim=5` (2D_ARRAY), `dmask=0x3`. The
+SPIR-V lowering had already been widened for the arrayed form by #325 — `image_get_resinfo` branches
+on `tex_is_arrayed(binding)`, asks for the ivec3 query and reports its third component as the layer
+count, which is exactly what GET_RESINFO's third result means for a 2D_ARRAY T#. What still declined
+were the two *gates* in front of it: `emit_alu`'s dim dispatch and the coverage predicate — the same
+lag #2265 records for the atomic coverage predicate.
+
+Measured on the route, `boot_trace` + `PROSPER_COMPUTE_TRANSLATE_ONLY=1`, compared at the same census
+denominator (1,048,576 dispatch decisions over 32 programs):
+
+| | reject site | opcode |
+| --- | --- | --- |
+| before | pc=**31** | `fmt=14 op=0xe` — `image_get_resinfo` dim=5 |
+| after | pc=**130** | `fmt=4 op=0x5` — `s_cbranch_scc1` |
+
+`op=0xe dim=5` goes from one occurrence to **none** anywhere in the run, and the program advances 99
+instructions to an unrelated gap.
+
+**No program leaves the skip list and no image change is claimed** — 14 listed before and after. This
+closes one gap on one program's path; that program is still blocked further along, and the three
+scene-width kernels above are untouched by it.
+
+CUBE (`dim=3`) is deliberately still declined — two other stage programs issue it (`0xf0380118`,
+`dmask=0x1`), and admitting it would need the stacked-face lowering (#273) to promise what
+GET_RESINFO's third result means for a cube, which this did not establish.
+
 ### `image_load_mip` is the FIRST blocker of at least two, not the only one (2026-08-21)
 
 **This section used to say "All three now block on exactly one instruction", and #2818's summary

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -7253,6 +7253,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (in.mimg_dim == 0u) dim = Dim_1D;
                 else if (in.mimg_dim == 1u) dim = Dim_2D;
                 else if (in.mimg_dim == 2u) dim = Dim_3D;
+                // #2790: 2D_ARRAY (dim 5) queries as SPIR-V Dim_2D with Arrayed set, which is the
+                // representation #325 already uploads and declares for these resources -- and
+                // `image_get_resinfo` already branches on `tex_is_arrayed(binding)` to ask for the
+                // ivec3 form and report its third component as the layer COUNT, which is exactly
+                // what GET_RESINFO's third result means for a 2D_ARRAY T#. The lowering was widened
+                // for the array case and this dispatch is the site that still declined it -- the
+                // same lag #2265 records for the atomic coverage predicate.
+                //
+                // `res_arrayed` above, not `mimg_dim == 5`, decides which query shape is emitted,
+                // and the distinction is load-bearing. `guest_texture_is_uploaded_array()` is dim-5
+                // AND depth>1 AND block-compressed; a dim-5 T# that fails it (Sonic Frontiers' own
+                // is depth=1) is a plain 2D image on both sides, so the ivec2 path runs and out[2]
+                // keeps its default of 1 -- the true layer count for a one-layer array.
+                //
+                // What this does NOT do is report a layer count for a MULTI-layer non-BC array,
+                // because prosper does not materialize one; the query then answers for the resource
+                // as actually uploaded, consistent with what every sample of it reads.
+                // CONFIDENCE: MED on that case alone -- no title in the corpus is known to issue
+                // one, so it is reasoned rather than measured.
+                else if (in.mimg_dim == 5u) dim = Dim_2D;
                 else { ok = false; return true; }
                 if (res->cls != ResourceClass::Texture) { ok = false; return true; }
                 if (!b.declare_texture(res->binding, dim, uint_texture, res_arrayed)) {

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -2814,7 +2814,11 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords,
                         // lowering gate, which rejects only `len_dwords < 2`.
                         return (i.mimg_dim == 1u || i.mimg_dim == 5u) && i.mimg_dmask == 1u &&
                                !i.mimg_unorm && i.len_dwords >= 2u;
-                    if (i.opcode == 0x0eu) return i.mimg_dim <= 2u;             // image_get_resinfo 1D/2D/3D
+                    // image_get_resinfo 1D/2D/3D, plus 2D_ARRAY (dim 5), which lowers as Dim_2D with
+                    // Arrayed and reports the layer count as its third result (#2790). CUBE (dim 3) is
+                    // still declined: its stacked-face lowering (#273) would have to promise face-count
+                    // semantics for the third result that this has not established.
+                    if (i.opcode == 0x0eu) return i.mimg_dim <= 2u || i.mimg_dim == 5u;
                     if (i.opcode == 0x60u)                                     // fragment image_get_lod 2D
                         return i.mimg_dim == 1u && i.len_dwords == 2u &&
                                !mimg_get_lod_has_unmodeled_controls(i) &&

--- a/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
@@ -5502,6 +5502,76 @@ int main() {
     }
     printf("  [ok]   image_get_resinfo 3D lowers to size/level image queries\n");
 
+    // Sonic Frontiers' Cyber Space stage queries a 2D_ARRAY T# with image_get_resinfo before its
+    // screen-space passes (#2790). These are the guest's EXACT bytes: word1 names VADDR=v3,
+    // VDATA=v17 and SRSRC at s36, all three of which the live `[compute] skip` line reports as
+    // `dst=17(kind2) src=3(k2),36(k1)`, so the test cannot drift from the instruction it is about.
+    // dmask:xy (0x3) takes width and height only; the layer count is the third result and is not
+    // requested here.
+    ShaderResourceTable rt_2d_array;
+    { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 9; t.img_dim = 5;
+      t.width = 2048; t.height = 2048; t.depth = 1; t.sgpr_base = 36;
+      rt_2d_array.resources.push_back(t); }
+    const uint32_t cs_resinfo_2d_array[] = {
+        0x7e060280u,                        // v_mov_b32 v3, 0 (LOD)
+        0xf0380328u, 0x00091103u,           // image_get_resinfo v[17:18], v3, s[36:43] dmask:xy dim:2D_ARRAY
+        0xbf810000u,
+    };
+    std::vector<uint32_t> resinfo_2d_array_spv = recompile_valu(
+        cs_resinfo_2d_array, sizeof(cs_resinfo_2d_array)/sizeof(cs_resinfo_2d_array[0]), 0, 0,
+        &rt_2d_array);
+    if (resinfo_2d_array_spv.empty() || !has_opcode(resinfo_2d_array_spv, OpImageQuerySizeLod)) {
+        printf("  [FAIL] image_get_resinfo 2D_ARRAY did not lower to a SPIR-V image query\n");
+        return 1;
+    }
+    printf("  [ok]   image_get_resinfo 2D_ARRAY lowers to a size query\n");
+
+    // CONTROL, and it is the arm that keeps the change honest rather than merely wide: CUBE (dim 3)
+    // must STILL reject. Two of this stage's other programs issue exactly that form
+    // (`0xf0380118`, dmask:x), and admitting them would need the stacked-face lowering (#273) to
+    // promise what GET_RESINFO's third result means for a cube, which this change does not
+    // establish. Same word as the accepted case with DIM alone changed 5 -> 3, so a widening that
+    // reached past 2D_ARRAY reddens here.
+    std::vector<uint32_t> cs_resinfo_cube(std::begin(cs_resinfo_2d_array),
+                                          std::end(cs_resinfo_2d_array));
+    cs_resinfo_cube[1] = 0xf0380318u;       // DIM 5 -> 3 (CUBE), everything else identical
+    if (!recompile_valu(cs_resinfo_cube.data(), cs_resinfo_cube.size(), 0, 0,
+                        &rt_2d_array).empty()) {
+        printf("  [FAIL] control: image_get_resinfo CUBE was accepted\n");
+        return 1;
+    }
+    printf("  [ok]   control: image_get_resinfo CUBE still rejects\n");
+
+    // The two arms above pin the LOWERING (emit_alu's dispatch). They do not pin the COVERAGE
+    // predicate, which is the half the live `[compute] skip` decision actually consults -- verified
+    // by mutation: reverting the predicate alone leaves both of them green. So pin it directly.
+    // `recompile_coverage` runs table-less, so a MIMG form it accepts lands in `table_dependent`
+    // and an accepted dim leaves `unsupported` at zero, while a declined one is counted and named.
+    {
+        RecompileCoverage cov_2d_array = recompile_coverage(
+            cs_resinfo_2d_array, sizeof(cs_resinfo_2d_array)/sizeof(cs_resinfo_2d_array[0]));
+        if (cov_2d_array.unsupported != 0 || cov_2d_array.first_bad_fmt != -1) {
+            printf("  [FAIL] coverage still reports image_get_resinfo 2D_ARRAY unsupported "
+                   "(unsupported=%u fmt=%d op=0x%x)\n",
+                   cov_2d_array.unsupported, cov_2d_array.first_bad_fmt, cov_2d_array.first_bad_op);
+            return 1;
+        }
+        printf("  [ok]   coverage counts image_get_resinfo 2D_ARRAY as supported\n");
+
+        // Control on the same seam, and it names the opcode rather than only counting: CUBE must
+        // still be reported as the unsupported site, or a widening past 2D_ARRAY would go unnoticed
+        // by the census that decides whether the program runs at all.
+        RecompileCoverage cov_cube = recompile_coverage(
+            cs_resinfo_cube.data(), cs_resinfo_cube.size());
+        if (cov_cube.unsupported == 0 || cov_cube.first_bad_op != 0x0eu) {
+            printf("  [FAIL] control: coverage no longer reports image_get_resinfo CUBE as the "
+                   "unsupported site (unsupported=%u op=0x%x)\n",
+                   cov_cube.unsupported, cov_cube.first_bad_op);
+            return 1;
+        }
+        printf("  [ok]   control: coverage still names image_get_resinfo CUBE unsupported\n");
+    }
+
     // GTA V's exact stride-8/25-record BUFFER_ATOMIC_SWAP_X2 must be one qword exchange. Include an
     // ordinary dword load through the same binding so both the u32 and u64 Block variables are
     // statically used; reflection must coalesce those compatible aliases into one Vulkan binding.


### PR DESCRIPTION
## What this does

`image_get_resinfo` now accepts a **2D_ARRAY** T# (`dim=5`). Sonic Frontiers' Cyber Space stage runs
a compute program that queries one, and prosper declined it.

The SPIR-V lowering was already right. #325 widened `image_get_resinfo` to branch on
`tex_is_arrayed(binding)`, ask for the ivec3 query and report its third component as the layer
**count** — which is what GET_RESINFO's third result means for a 2D_ARRAY T#. What still declined
were the two gates in front of it:

- `emit_alu`'s dim dispatch, whose `else` rejected anything past dim 2;
- the coverage predicate that decides whether the census calls the instruction supported.

That is the same lag #2265 records for the atomic coverage predicate, in the same opcode family.

## Measured

Route + `boot_trace` + `PROSPER_COMPUTE_TRANSLATE_ONLY=1`, isolated `PROSPER_SAVE0`, compared at one
shared census denominator (1,048,576 dispatch decisions over 32 programs):

| | reject site | opcode |
| --- | --- | --- |
| before | pc=**31** | `fmt=14 op=0xe` — `image_get_resinfo` dim=5 |
| after | pc=**130** | `fmt=4 op=0x5` — `s_cbranch_scc1` |

`op=0xe dim=5` goes from one occurrence to **none** anywhere in the run; the program advances 99
instructions to an unrelated gap.

## What this does NOT do, stated plainly

**No image change, and no program leaves the skip list** — 14 listed before, 14 after. This closes one
gap on one program's path; that program is still blocked further along.

The three **scene-width** kernels the world actually depends on are untouched by this. They decline on
`image_load_mip` against a **12-level** mip chain (`[mimg-mip] ... proven_zero_mip=0 mips=12
dmask=0x3 unorm=0 glc=0`), which needs the compute path to stop hard-setting `mipLevels = 1`
(`live_compute.cpp`) plus a non-specialised lowering. That is the real frontier and it is not this PR.

## Verification, including a defect in my own first test

Both halves are pinned by mutation — which is how I found my first version pinned only one:

| mutation | lowering arm | coverage arm | CUBE controls |
| --- | --- | --- | --- |
| dispatch mapping removed | **FAIL** | — | green |
| coverage predicate reverted only | green | **FAIL** | green |
| restored | green | green | green |

The lowering arms alone stayed green when the coverage predicate was reverted, so the coverage seam is
now tested directly through `recompile_coverage()` rather than assumed. The test uses the guest's exact
bytes (`0xf0380328, 0x00091103`) — word1 names VADDR=v3, VDATA=v17, SRSRC at s36, all three of which the
live `[compute] skip` line reports, so it cannot drift from the instruction it is about.

`ctest --no-tests=error`: **315/315 passed**, exit 0. (Four cases report `(Skipped)` because
`-DGAME_DUMP` points at `PPSA03831` rather than `PPSA24651`, per #1573.)

## Scope and risk

CUBE (`dim=3`) is **deliberately still declined**. Two other stage programs issue it (`0xf0380118`,
`dmask=0x1`); admitting it would need the stacked-face lowering (#273) to promise what GET_RESINFO's
third result means for a cube, which this does not establish. A control arm reddens if a later
widening reaches past 2D_ARRAY.

- **CONFIDENCE: HIGH** for the measured case — a dim-5 T# with `depth=1` takes the ivec2 path and
  out[2] keeps its default of 1, the true layer count for a one-layer array.
- **CONFIDENCE: MED** for a **multi-layer non-BC** array, which prosper does not materialize as an
  array (`guest_texture_is_uploaded_array()` requires dim-5 AND depth>1 AND block-compressed). The
  query then answers for the resource as actually uploaded, consistent with what every sample of it
  reads, but it is reasoned rather than measured — no title in the corpus is known to issue one. This
  is the point most worth a reviewer's attention.

Refs #2790, #2818, #1891.
