### PR TITLE
test(tile): pin the 12-level layout IMAGE_LOAD_MIP would have to materialise

### DIFF
--- a/prosper/tests/gpu/texture/test_tile.cpp
+++ b/prosper/tests/gpu/texture/test_tile.cpp
@@ -1170,6 +1170,41 @@ int main() {
               "64KB_R_X 3D golden: z3 maps to byte-offset bit 8");
     }
 
+    {
+        // Sonic Frontiers' Cyber Space scene-width kernels read one resource through
+        // IMAGE_LOAD_MIP: 2048x2048, R32G32_FLOAT (8 B/texel), tile_mode 27, TWELVE levels
+        // (#2818/#2790). Before any of that can be materialised, every level has to be locatable,
+        // so pin the placement the uploader would have to trust: all 12 supported, tail levels
+        // sharing one block, non-tail levels strictly disjoint and inside the chain.
+        const uint32_t ew = 2048, eh = 2048, bpe = 8, tm = 27, max_mip = 11;
+        const size_t chain = tiled_mip_chain_bytes(ew, eh, bpe, tm, max_mip);
+        CHECK(chain != 0, "Frontiers' 12-level 2048x2048 R32G32F chain is modeled");
+        bool all_ok = true, disjoint = true, in_chain = true;
+        uint32_t tail_levels = 0;
+        std::vector<std::pair<size_t, size_t>> spans;   // [begin, end) per non-tail level
+        for (uint32_t level = 0; level <= max_mip; ++level) {
+            const TiledMipLevelLayout l = tiled_mip_level_layout(ew, eh, bpe, tm, max_mip, level);
+            if (!l.supported) { all_ok = false; break; }
+            if (l.in_tail) { tail_levels++; continue; }   // tail levels share the first block
+            const uint32_t lw = std::max(ew >> level, 1u), lh = std::max(eh >> level, 1u);
+            const size_t bytes = (size_t)lw * lh * bpe;
+            if (l.byte_offset + bytes > chain) in_chain = false;
+            spans.emplace_back(l.byte_offset, l.byte_offset + bytes);
+        }
+        // Pairwise, NOT against a running end: a tiled chain stores its levels smallest-first, so
+        // byte_offset DEcreases as the level index rises and an ascending-order check reports a
+        // false overlap on a correct layout. (It did -- that was this test's first version.)
+        for (size_t a = 0; a < spans.size() && disjoint; ++a)
+            for (size_t b = a + 1; b < spans.size(); ++b)
+                if (spans[a].first < spans[b].second && spans[b].first < spans[a].second) {
+                    disjoint = false; break;
+                }
+        CHECK(all_ok, "every one of Frontiers' 12 mip levels reports a supported placement");
+        CHECK(in_chain, "no Frontiers mip level is placed past the end of its own chain");
+        CHECK(disjoint, "Frontiers' non-tail mip levels occupy disjoint byte ranges");
+        CHECK(tail_levels > 0, "the small Frontiers levels are packed into the shared mip tail");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## What this is

A test, no behaviour change. It pins step 1 of #2818: **can the guest's own mip levels be located at
all**, for the resource that blocks all three of Sonic Frontiers' scene-width Cyber Space kernels.

They can. That needed establishing before anyone writes an uploader on the assumption — and if it had
gone the other way, the honest outcome was to say the rest of #2818 could not be built.

## The resource, decoded rather than described

`format=1` is `Float32`, `ncomp=2`. So `0x2026900000` is **2048x2048 R32G32_FLOAT, 8 bytes/texel,
tile_mode 27, twelve levels**. A full 2048→1 pyramid in two float channels is a hierarchical depth or
motion-vector pyramid — independent support for the mip operand being a real pyramid walk, i.e. for
#2818's insistence that forcing `Lod = 0` would read the wrong level rather than merely being
inelegant.

## What it asserts

On that exact surface shape, via `tiled_mip_level_layout()`:

```
[ok]   Frontiers' 12-level 2048x2048 R32G32F chain is modeled
[ok]   every one of Frontiers' 12 mip levels reports a supported placement
[ok]   no Frontiers mip level is placed past the end of its own chain
[ok]   Frontiers' non-tail mip levels occupy disjoint byte ranges
[ok]   the small Frontiers levels are packed into the shared mip tail
```

## The part worth reading in the diff

The disjointness arm is written **pairwise**, and it is commented, because its first version compared
each level against a running end — and **failed on a correct layout**. A tiled chain stores levels
smallest-first, so `byte_offset` *decreases* as the level index rises. Had I believed that run, this
PR would instead have reported "the mip layout overlaps and cannot be trusted", which is the kind of
finding that stops a lane on a defect that does not exist.

Verified by mutation: forcing every level to claim origin 0 reddens the disjointness arm and nothing
else.

## Why this PR is only step 1

The rest of #2818 — compute-path `mipLevels`, per-level staging and copy regions, level-covering views
and barriers, plus an `OpImageFetch`-with-`Lod` lowering — spans `live_compute.cpp` and the recompiler
and lands in the path **every title's compute textures** go through. The charter requires independent
review for changes of that class, and no reviewer was available in this session. Landing the verified,
inert part and handing the rest over with the call sites located is the honest split; I have written
that handoff on #2818 rather than leaving it in a branch.

`ctest --no-tests=error`: **314/314 passed**, exit 0. (314 rather than 315 because this tree is
configured `PROSPER_APP=OFF` — checked against the cache rather than assumed.)

Refs #2818, #2790.
