### PR TITLE
resources: a zero-pad tail buffer may hold more than one record

### DIFF
--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -51,6 +51,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <tuple>
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
@@ -6652,6 +6653,52 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     "[buffer-materialization-reject] set=%u binding=%u addr=%llx "
                                     "declared=%u\n",
                                     set, r.binding, (unsigned long long)r.gpu_addr, r.size);
+                            // Name the sub-condition, once per (set,binding,address). The line above
+                            // collapses every reason into one string, and an investigation cannot act
+                            // on that: "the descriptor carries a partial zero-pad marker set" and
+                            // "the resource is the wrong class" are different pieces of work. Same
+                            // shape and the same justification as [mimg-mip] in rdna2_emit_alu.cpp.
+                            //
+                            // Deduped rather than gated, because the volume is the whole problem:
+                            // Dragon Quest VII emits 549,623 of the line above in one routed run,
+                            // ALL of them for a single address (0x20013f1bc0, set 0 binding 10) with
+                            // 257 different declared sizes -- so the useful signal is one line
+                            // describing that binding, not half a million repetitions of it (#1486).
+                            {
+                                static std::mutex why_mutex;
+                                static std::set<std::tuple<uint32_t, uint32_t, uint64_t>> why_seen;
+                                bool first_why = false;
+                                {
+                                    std::lock_guard<std::mutex> lock(why_mutex);
+                                    first_why = why_seen.emplace(set, r.binding,
+                                                                 (uint64_t)r.gpu_addr).second;
+                                }
+                                if (first_why) {
+                                    const auto& d = *reflected_binding;
+                                    const bool has_logical = d.zero_pad_logical_bytes != 0;
+                                    const bool has_binding_pad = d.zero_pad_binding_bytes != 0;
+                                    const bool has_semantic =
+                                        d.zero_pad_semantic !=
+                                        prosper::gpu::StorageBufferTailSemantic::None;
+                                    fprintf(stderr,
+                                            "[buffer-why] set=%u binding=%u addr=%llx declared=%u "
+                                            "markers=%d/%d/%d kind=%d readable=%d writable=%d "
+                                            "atomic=%d dynamic=%d required=%llu "
+                                            "pad_logical=%u pad_binding=%u semantic=%d "
+                                            "res_cls=%d fmt=%d ncomp=%u stride=%u size=%u "
+                                            "scalar_dwords=%u\n",
+                                            set, r.binding, (unsigned long long)r.gpu_addr, r.size,
+                                            (int)has_logical, (int)has_binding_pad,
+                                            (int)has_semantic,
+                                            (int)d.kind, (int)d.readable, (int)d.writable,
+                                            (int)d.atomic_access, (int)d.dynamic_access,
+                                            (unsigned long long)d.required_bytes,
+                                            d.zero_pad_logical_bytes, d.zero_pad_binding_bytes,
+                                            (int)d.zero_pad_semantic,
+                                            (int)r.cls, (int)r.format, r.num_components,
+                                            r.stride, r.size, r.scalar_buffer_dword_count);
+                                }
+                            }
                             continue;
                         }
                         // #1427: the guest's declared V#/V-buffer size is the real requirement — a

--- a/prosper/src/gpu/resources/shader_resources.cpp
+++ b/prosper/src/gpu/resources/shader_resources.cpp
@@ -703,13 +703,26 @@ StorageBufferMaterializationPlan plan_storage_buffer_materialization(
          resource.format == DataFormat::Uint16) ||
         (descriptor.zero_pad_semantic == StorageBufferTailSemantic::Float16 &&
          resource.format == DataFormat::Float16);
+    // `resource.size` is the RESOURCE's byte count, not the shader's. It used to be pinned to
+    // exactly 2 -- one Float16/Uint16 record -- which silently excluded every guest buffer that
+    // holds a record ARRAY and is read at element zero. The shader's own access is already bounded
+    // by the three terms above it: `required_bytes == 4` (one zero-padded record) and
+    // `dynamic_access == false` (that access is static), so a larger resource cannot be indexed past
+    // the record this plan materialises. What is required of the resource is therefore that it hold
+    // AT LEAST one whole record, which is what the two terms below now say.
+    //
+    // Measured on Dragon Quest VII (#1486): its field phase emits 549,623 materialisation rejects in
+    // one routed run, ALL for one address at set 0, and every one of them matched every term here
+    // except this one -- `size=16` at `stride=2`, i.e. eight records read at element zero. Each
+    // reject SKIPS the binding (`continue` at the call site), so the shader ran with the descriptor
+    // absent.
     if (descriptor.kind != SpirvDescriptorKind::StorageBuffer || !buffer_resource ||
         !descriptor.readable || descriptor.writable || descriptor.atomic_access ||
         descriptor.dynamic_access || descriptor.required_bytes != 4u ||
         descriptor.zero_pad_logical_bytes != 2u ||
         descriptor.zero_pad_binding_bytes != 4u ||
         !semantic_matches || resource.num_components != 1u ||
-        resource.stride != 2u || resource.size != 2u)
+        resource.stride != 2u || resource.size < 2u || (resource.size % 2u) != 0u)
         return plan;
 
     plan.logical_bytes = 2;

--- a/prosper/tests/gpu/resources/test_shader_resources.cpp
+++ b/prosper/tests/gpu/resources/test_shader_resources.cpp
@@ -312,6 +312,42 @@ int main() {
           tail_destination[0] == 0x34 && tail_destination[1] == 0x12 &&
           tail_destination[2] == 0 && tail_destination[3] == 0,
           "one-record Uint16 materialization copies two bytes and deterministically clears the tail");
+
+    // Dragon Quest VII's field phase binds this exact shape: a Float16 record ARRAY read at element
+    // zero (#1486). `size` is the RESOURCE's byte count, so pinning it to one record excluded every
+    // such buffer -- and the reject SKIPS the binding, so the shader ran with the descriptor absent.
+    // 549,623 rejects in one routed run, all for one address, all failing on this single term.
+    auto array_descriptor = tail_descriptor;
+    array_descriptor.zero_pad_semantic = StorageBufferTailSemantic::Float16;
+    ShaderResource array_resource;
+    array_resource.cls = ResourceClass::VertexBuffer;   // the class DQ7's own resource carries
+    array_resource.format = DataFormat::Float16;
+    array_resource.num_components = 1;
+    array_resource.size = 16;                            // eight records
+    array_resource.stride = 2;
+    const StorageBufferMaterializationPlan array_plan =
+        plan_storage_buffer_materialization(array_descriptor, array_resource);
+    const uint8_t array_source[16] = {0x78, 0x56, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+                                      0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee};
+    uint8_t array_destination[4] = {0x5a, 0x5a, 0x5a, 0x5a};
+    CHECK(array_plan.valid && array_plan.zero_padded_tail &&
+          array_plan.logical_bytes == 2 && array_plan.binding_bytes == 4 &&
+          materialize_storage_buffer_bytes(
+              array_plan, array_source, sizeof(array_source),
+              array_destination, sizeof(array_destination)) &&
+          array_destination[0] == 0x78 && array_destination[1] == 0x56 &&
+          array_destination[2] == 0 && array_destination[3] == 0,
+          "a Float16 record ARRAY materializes element zero and clears the tail");
+
+    // CONTROL: the resource must still hold at least one WHOLE record. A one-byte resource cannot,
+    // and a three-byte one is not a whole number of 2-byte records -- both stay rejected, so the
+    // relaxation is "more records", not "any size".
+    ShaderResource half_record = array_resource; half_record.size = 1;
+    ShaderResource odd_record  = array_resource; odd_record.size = 3;
+    CHECK(!plan_storage_buffer_materialization(array_descriptor, half_record).valid,
+          "control: a resource smaller than one record is still rejected");
+    CHECK(!plan_storage_buffer_materialization(array_descriptor, odd_record).valid,
+          "control: a resource that is not a whole number of records is still rejected");
     ShaderResource ordinary_four_byte_resource = tail_resource;
     ordinary_four_byte_resource.format = DataFormat::Uint32;
     ordinary_four_byte_resource.size = 4;


### PR DESCRIPTION
## What this fixes

Dragon Quest VII's field phase emits **549,623 `[buffer-materialization-reject]` lines in one routed
run** — 98% of the entire log — all for the same address at set 0. Each reject **skips the binding**
(`continue` at the call site in `live_renderer.cpp`), so the shader ran with that descriptor absent.

The zero-padded Uint16/Float16 tail plan required `resource.size == 2`: exactly **one** record. DQ7's
resource is `size=16 stride=2` — eight records, read at element zero.

## How the failing term was identified

By building the diagnostic, not by guessing. The existing reject line collapses every cause into one
string, so half a million repetitions of it cannot say which term failed. The new `[buffer-why]`
prints one deduped line per `(set, binding, address)`:

```
markers=1/1/1 kind=StorageBuffer readable=1 writable=0 atomic=0 dynamic=0
required=4 pad_logical=2 pad_binding=4 semantic=Float16 fmt=Float16
ncomp=1 stride=2   size=16   <-- the only failing term
```

Same shape and justification as `[mimg-mip]` in `rdna2_emit_alu.cpp`.

## Why relaxing it is correct, not just convenient

`resource.size` is the **resource's** byte count, not the shader's. The shader's access is already
bounded by two terms sitting directly above it — `required_bytes == 4` (one zero-padded record) and
`dynamic_access == false` (that access is static) — so a larger resource **cannot** be indexed past
the record this plan materialises. What the resource must supply is *at least one whole record*,
which is what the condition now says.

Rejects on the same route and settings: **549,623 → 0**.

## NO VISUAL CHANGE IS CLAIMED — and the reason is worth reading

I went into this expecting to fix the reported shading defect (water too dark, house/cliffs/boat
white). It does not, and more importantly **a single-frame before/after cannot decide the question on
this title at all**:

> the AFTER run's own four field frames span **mean 1.9 → 254.8** and **0.1% → 99.7% bright**

Black to white, inside one run. I ran a single-frame A/B first and it showed a large improvement —
that was frame lottery. Measured against the committed reference capture the world box is
`138.6 mean / 38.1% bright` against `142.6 / 42.2%`: indistinguishable, with both sitting inside the
run's own frame-to-frame range.

So this lands as what it is — a valid descriptor was being rejected and its binding dropped, half a
million times a run — and the shading defect in #1486 remains open.

## Verification

- **Mutation**: restoring `size == 2` reddens the record-array arm; both controls stay green (a
  sub-record resource and a non-whole-record size must still reject). The controls are what keep this
  "more records", not "any size".
- `ctest --no-tests=error`: **315/315 passed**, exit 0.
- Live: same route, same settings, rejects 549,623 → 0.

## Risk

The relaxed predicate is reached only when all three zero-pad markers are present and the descriptor
is a readable, non-writable, non-atomic, non-dynamic StorageBuffer requiring exactly 4 bytes with a
Uint16/Float16 semantic matching the resource format at `ncomp=1, stride=2`. Everything outside that
takes the same paths as before. `CONFIDENCE: HIGH` — the widened case is the guest's own, measured,
and the access bound comes from the descriptor rather than from an assumption about the resource.

Refs #1486.
