### PR TITLE
recompiler: a LITERAL is a scalar source for the Wave64 VCC_LO select

### DIFF
--- a/prosper/src/gpu/recompiler/rdna2_alu_support.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_alu_support.hpp
@@ -124,7 +124,21 @@ inline uint32_t mbcnt_source_bit(SpirvCompute& b, const RegState& rs, const Oper
 // breaks both.
 inline bool is_wave64_vcc_lo_scalar_cselect(const Rdna2Inst& in) {
     const auto scalar_source_kind = [](const Operand& o) {
+        // `Literal` belongs here for the same reason the two Inline kinds do, and it is arguably the
+        // strongest member of the set: a literal is a 32-bit constant dword embedded in the
+        // instruction stream, so it is uniform across the wave BY CONSTRUCTION -- it cannot carry a
+        // per-lane value the way an SGPR at least notionally could. Its absence was an omission
+        // rather than a safety property; the paragraph above this function documents why VCC_HI is
+        // deliberately excluded and says nothing about literals.
+        //
+        // Measured on The House of the Dead 2: Remake (#1907), whose Training 1 world renders black:
+        // TWO full-resolution screen-space compute passes (240x135 groups of 8x8 = 1920x1080) are
+        // declined ~2,600 times each, and both decline on the byte-identical instruction
+        // `856aff6a 00000000` -- `s_cselect_b32 vcc_lo, vcc_lo, <literal>`. src[0] is VCC_LO and was
+        // already admitted; src[1] is the literal and was not, so the pair failed to classify as a
+        // B32 VCC scalar write and the whole program fell out.
         return o.kind == OperandKind::InlineInt || o.kind == OperandKind::InlineFloat ||
+               o.kind == OperandKind::Literal ||
                o.kind == OperandKind::SGPR ||
                (o.kind == OperandKind::Special && o.value == 106);
     };

--- a/prosper/tests/gpu/recompiler/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/gpu/recompiler/test_rdna2_to_spirv.cpp
@@ -1595,6 +1595,37 @@ int main() {
                              native_cfg17d).empty(),
           "Wave64 low-only VCC scalar select accepts GTA's 1/-1 inline pair");
 
+    // The House of the Dead 2: Remake takes the same site with a LITERAL rather than an inline
+    // constant, and that was not admitted (#1907). Its Training 1 world renders black while TWO
+    // full-resolution screen-space passes (240x135 groups of 8x8 = 1920x1080) decline ~2,600 times
+    // each, both on the byte-identical instruction below. A literal is a 32-bit constant dword
+    // embedded in the instruction stream, so it is uniform across the wave BY CONSTRUCTION -- the
+    // strongest scalar source of the set, not a weaker one.
+    const uint32_t code17d1_vcc_low_literal[] = {
+        0xbe8f0380u, 0xbf08800fu,
+        0x856aff6au, 0x00000000u,  // exact HotD2 pc297: s_cselect_b32 vcc_lo, vcc_lo, lit(0)
+        0x7e02026au,               // one-dword scalar consumer
+        0x7d840100u,               // complete VCC replacement
+        0xbf810000u,
+    };
+    CHECK(!recompile_compute(code17d1_vcc_low_literal,
+                             std::size(code17d1_vcc_low_literal), nullptr,
+                             native_cfg17d).empty(),
+          "Wave64 low-only VCC scalar select accepts a LITERAL source (HotD2)");
+
+    // CONTROL at the same site: replacing that literal with VCC_HI -- a live mask half rather than a
+    // constant -- must STILL reject. This is what keeps the change "a literal is scalar" rather than
+    // "any source at this site is scalar", which is the mistake that would silently admit a mask.
+    const uint32_t code17d1_vcc_low_literal_control[] = {
+        0xbe8f0380u, 0xbf08800fu,
+        0x856a6b6au,               // same site, src1 = VCC_HI mask state instead of a literal
+        0x7e02026au, 0x7d840100u, 0xbf810000u,
+    };
+    CHECK(recompile_compute(code17d1_vcc_low_literal_control,
+                            std::size(code17d1_vcc_low_literal_control), nullptr,
+                            native_cfg17d).empty(),
+          "control: a mask half at the literal's operand slot still rejects");
+
     // Same-site packet mutation and a surviving implicit VCC read both remain fail-visible. The
     // first changes an inline scalar source to a mask half at the production instruction; the
     // second proves the old high-half mask really must be dead, not merely unused by the assertion.


### PR DESCRIPTION
## What this fixes

The House of the Dead 2: Remake reaches Training 1 gameplay and renders the world black (#1907). Two
**full-resolution** screen-space compute passes — `240x135` groups of `8x8`, i.e. **1920x1080
threads** — were declined about **2,600 times each**, and both declined on the byte-identical
instruction:

```
856aff6a 00000000    s_cselect_b32 vcc_lo, vcc_lo, <literal 0>
```

`is_wave64_vcc_lo_scalar_cselect` admitted `InlineInt`, `InlineFloat`, `SGPR` and `VCC_LO` as scalar
sources — but not `Literal`. `src[0]` here is VCC_LO and was already admitted; `src[1]` is the literal
and was not, so the pair failed to classify as a B32 VCC scalar write and the whole program fell out.

**A literal is a 32-bit constant dword embedded in the instruction stream.** It is uniform across the
wave *by construction* — the strongest member of that set rather than a weaker one, since unlike an
SGPR it cannot even notionally carry a per-lane value. Its absence was an omission, not a safety
property: the paragraph above the function documents why VCC_HI is deliberately excluded and says
nothing about literals.

## Measured, live, same settings either side

| | programs seen | never executing |
| --- | --- | --- |
| before | 38 | 8, **including both 1920x1080 `s_cselect` passes** (2618 skips each) |
| after | **63** | both are **gone** from the list |

The count rising **38 → 63** is the load-bearing half: unblocking these two lets the frame reach 25
programs it had never got to, and the new entries in the never-executing list are downstream passes
that had never been attempted before.

## NO VISUAL CHANGE IS CLAIMED

The world is still black. The gameplay window measures **5.8% non-black pixels both before and after**
(median 121,107 vs 121,044 of 2,073,600). This advances the pipeline and reveals the next blockers; it
does not render the scene, and **#1907 stays open**.

I am stating that plainly because the census result is the kind that invites overclaiming: two
full-screen passes going from "never runs" to "runs" reads like a fix, and the picture is unchanged.

## Verification

- **Mutation**: removing `Literal` again reddens exactly the new discriminator (**1 of 1089 checks**)
  and leaves the control green.
- The **control** substitutes VCC_HI — a live mask half — for the literal at the same site, and must
  still reject. That is what keeps this *"a literal is scalar"* rather than *"any source at this site
  is scalar"*, which would silently admit a mask.
- The test uses the guest's exact bytes (`0x856aff6a, 0x00000000`) inside the same low-only liveness
  prologue the neighbouring GTA V cases use.
- `ctest --no-tests=error`: **314/314 passed**, exit 0.

## Reproduction notes worth having

Two things cost me a run and are now on the issue: the phase timeline runs **~60 s later** than
#1907 records on a quiet box (a 270 s window stops on the loading tip, which is pre-rendered art and
reads convincingly as a scene), and `PROSPER_GUEST_FS=1` does nothing on Linux — the variable actually
read is the opt-OUT `PROSPER_NO_GUEST_FS`.

Refs #1907, #1896.
