### PR TITLE
diag: PROSPER_CLEARLOG names the fast-clear a resolve actually decided

### DIFF
--- a/prosper/src/gpu/state/render_state.cpp
+++ b/prosper/src/gpu/state/render_state.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <limits>
 #include <mutex>
+#include <set>
+#include <tuple>
 
 namespace prosper::gpu {
 
@@ -297,6 +299,31 @@ RenderState extract_render_state(const GpuState& st) {
     // CB fast-clear color (CB_COLOR0_CLEAR_WORD0/1). Present only when the game programs a fast-clear
     // for MRT 0; the words carry the clear value in the target's pixel format (decoded in resolve).
     rs.color0_has_clear   = st.cx.count(P::CB_COLOR0_CLEAR_WORD0) || st.cx.count(P::CB_COLOR0_CLEAR_WORD1);
+    // PROSPER_CLEARLOG=1 -- diagnostic only, no behaviour change. `st.cx` is the PERSISTENT context
+    // register map, so `count()` answers "has this register ever been written", not "was it written
+    // for THIS target". If a title programs a fast-clear once and later binds a different colour
+    // target without reprogramming it, the stale value still reaches the render pass as its loadOp
+    // clear. This prints what each resolve actually decided, keyed to the target it decided it for,
+    // so that hypothesis can be confirmed or killed on a real run before anything is changed (#2014).
+    if (const char* clearlog = std::getenv("PROSPER_CLEARLOG")) {
+        if (clearlog[0] == '1' && clearlog[1] == '\0') {
+            static std::mutex clear_mutex;
+            static std::set<std::tuple<uint64_t, uint32_t, uint32_t>> clear_seen;
+            bool first = false;
+            {
+                std::lock_guard<std::mutex> lock(clear_mutex);
+                first = clear_seen.emplace(rs.color0_base, rs.color0_format,
+                                           rs.color0_clear_word0).second;
+            }
+            if (first)
+                fprintf(stderr,
+                        "[clearlog] color0_base=0x%llx fmt=%u numtype=%u swap=%u has_clear=%d "
+                        "word0=0x%08x word1=0x%08x\n",
+                        (unsigned long long)rs.color0_base, rs.color0_format,
+                        rs.color0_number_type, rs.color0_comp_swap, (int)rs.color0_has_clear,
+                        rs.color0_clear_word0, rs.color0_clear_word1);
+        }
+    }
     rs.color0_clear_word0 = st.cx.count(P::CB_COLOR0_CLEAR_WORD0) ? rd(st.cx, P::CB_COLOR0_CLEAR_WORD0) : 0u;
     rs.color0_clear_word1 = st.cx.count(P::CB_COLOR0_CLEAR_WORD1) ? rd(st.cx, P::CB_COLOR0_CLEAR_WORD1) : 0u;
 


### PR DESCRIPTION
## What this is

A diagnostic. **No behaviour change.** It came out of #2014 and it is landing as an instrument
because it *falsified* the hypothesis it was built to confirm.

## The latch it makes visible

`resolve_pipeline_state` sets

```cpp
rs.color0_has_clear = st.cx.count(P::CB_COLOR0_CLEAR_WORD0) || st.cx.count(P::CB_COLOR0_CLEAR_WORD1);
```

and `st.cx` is the **persistent** context-register map — so `count()` answers *"has this register ever
been written"*, not *"was it written for this target"*. A title that programs a fast-clear once and
later binds a different colour target without reprogramming it still gets the old value as its
render-pass `loadOp` clear. That is a genuine latch and worth being able to see; the same hazard is
already documented one screen away for CB_COLOR_CONTROL's operation bits (#1706).

## But it is NOT what makes Little Nightmares III yellow

Two measurements, and the second is the one that settles it:

- Across a 320 s routed run, **all 33 distinct `(base, format, clear-word)` combinations report
  `word0=0x00000000`**. Every decoded clear in the run is black, and formats other than
  `COLOR_8_8_8_8` do not decode at all and take the opaque-black fallback. The decode can never
  produce yellow here.
- `PROSPER_CLEAR_DEBUG=1` forces the pass clear to **blue** — and produced **zero blue frames** in 24
  samples (23 black, 1 yellow). The visible background is not the render-pass clear value.

The second is a positive control that could have shown the lever moving and did not, which is the
stronger of the two: it rules out the whole path rather than one value on it.

## What #2014 actually looks like now (reported there in full)

The issue's model is *content compositing over a yellow background at correct alphas* — its degraded
title frame still contained the logo's 151,941 white pixels. That **does not reproduce on current
master**. Over 64 samples: **43 yellow / 21 black**, matching the issue's ~2/3 ratio, but **all 43
yellow frames are uniform (`colours == 1`)** and carry no content at all, while the black frames
composite the Bandai Namco logo correctly in white on black.

So the defect changed shape: it is now a fraction of presents collapsing to a uniform yellow frame,
which is the #2932 collapsed-present family rather than a clear-colour-under-content problem. That
redirects the investigation, and it is why I am not shipping a speculative fix to the latch above.

## Verification

`ctest --no-tests=error`: **314/314 passed**, exit 0. The diagnostic is off unless
`PROSPER_CLEARLOG=1`, deduped to one line per `(color0_base, format, clear_word0)` so a run costs a
handful of lines rather than one per draw.

Refs #2014, #1706, #2932.
