### PR TITLE
diag: PROSPER_DCCLOG names the uniform colour a DCC fast-clear materialises

### DIFF
--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -51,6 +51,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <utility>
 #include <tuple>
 #include <map>
 #include <unordered_map>
@@ -2361,6 +2362,37 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         for (uint32_t channel = 0; channel < 4; ++channel)
                             found->second.uniform_color[channel] =
                                 clear_rgba[channel] ? 1.0f : 0.0f;
+                        // PROSPER_DCCLOG=1 -- diagnostic only, no behaviour change. A surface
+                        // materialised from a DCC fast-clear code becomes a UNIFORM colour for the
+                        // whole target, so if this decode is wrong the entire frame is one wrong
+                        // colour with no content -- which is exactly Little Nightmares III's
+                        // uniform-yellow presents (#2014). Deduped per (address, decoded colour) so a
+                        // run costs a handful of lines.
+                        if (const char* dcclog = std::getenv("PROSPER_DCCLOG")) {
+                            if (dcclog[0] == '1' && dcclog[1] == '\0') {
+                                static std::mutex dcc_mutex;
+                                static std::set<std::pair<uint64_t, uint32_t>> dcc_seen;
+                                const uint32_t packed = (uint32_t)clear_rgba[0] |
+                                    ((uint32_t)clear_rgba[1] << 8) |
+                                    ((uint32_t)clear_rgba[2] << 16) |
+                                    ((uint32_t)clear_rgba[3] << 24);
+                                bool first = false;
+                                {
+                                    std::lock_guard<std::mutex> lock(dcc_mutex);
+                                    first = dcc_seen.emplace((uint64_t)found->first, packed).second;
+                                }
+                                if (first)
+                                    fprintf(stderr,
+                                            "[dcclog] addr=0x%llx %ux%u fmt=%d ncomp=%u "
+                                            "alpha_msb=%d clear_rgba=(%u,%u,%u,%u) -> uniform=(%.0f,%.0f,%.0f,%.0f)\n",
+                                            (unsigned long long)found->first,
+                                            found->second.w, found->second.h, (int)format,
+                                            resource.num_components, (int)resource.alpha_is_on_msb,
+                                            clear_rgba[0], clear_rgba[1], clear_rgba[2], clear_rgba[3],
+                                            found->second.uniform_color[0], found->second.uniform_color[1],
+                                            found->second.uniform_color[2], found->second.uniform_color[3]);
+                            }
+                        }
                         found->second.dcc_metadata_dirty = false;
                         ++dcc_materialize_surfaces;
                         dcc_materialize_bytes += sizeof(found->second.uniform_color);


### PR DESCRIPTION
## What this is

A diagnostic, **no behaviour change** — and it is landing because it produced a *negative*.

A surface materialised from a DCC fast-clear code becomes a **uniform colour for the whole target**,
so a wrong decode there yields an entire frame of one wrong colour with no content. That is exactly
the shape of Little Nightmares III's uniform-yellow presents (#2014), which made this the obvious
suspect.

## It is not the cause

In a 320 s run that reproduced **43 yellow frames of 64**, every DCC decode reports:

```
[dcclog] addr=0x3072f20000 3840x2160 fmt=37 ncomp=4 alpha_msb=1
         clear_rgba=(0,0,0,0) -> uniform=(0,0,0,0)
```

Black. Six surfaces, no exceptions, while the run was producing yellow frames.

## Three independent exclusions now retire the whole "wrong clear colour" family

#2014 points at clear/target setup. It should not:

| exclusion | evidence |
| --- | --- |
| CB fast-clear value | every clear word in the run is `0x00000000` (#3113's `PROSPER_CLEARLOG`) |
| the render-pass clear | `PROSPER_CLEAR_DEBUG=1` forces it to **blue** and yields **zero** blue frames |
| DCC uniform colour | every code decodes to `(0,0,0,0)` (this PR) |

The second is a positive control that could have shown a lever moving and did not; the first and third
are exhaustive over their runs.

## Why keep it when the answer was no

Because the negative is the useful part. The next person to see a uniform-colour frame can rule this
path in or out in one run instead of reasoning about it — and the boolean quantisation on the line
above it (`clear_rgba[channel] ? 1.0f : 0.0f`) *looks* like a bug until you know the decoder only
emits the `0000/0001/1110/1111` codes, where each channel really is 0 or 255. I spent a while on that
line before checking the contract; the diagnostic prints both sides so nobody repeats it.

Deduped per `(address, decoded colour)`; off unless `PROSPER_DCCLOG=1`.

## Verification, including a false alarm worth recording

`ctest --no-tests=error`: **314/314 passed**, exit 0.

My first run of it reported **5 failures** (`indexed_render`, `multidraw_render`, `gpu_execute`,
`descriptor_array_render`, `recompiled_shaders_render`) and I nearly wrote that up as a regression on
master. It was GPU contention: I had a capture still running. Reverting my commit reproduced the same
failures, `test_gpu_execute` passed when run standalone, and the full suite is green once the box is
quiet. **Do not run the Vulkan execution tests while a title is rendering** — they fail in a way that
reads exactly like a real regression.

Refs #2014, #3113.
