### PR TITLE
diag: PROSPER_UNIFORMLOG names the origin of a uniform RETAINED frame

### DIFF
--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -9474,6 +9474,46 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             last_scanout_present_from_guest =
                                 frame_origin == prosper::gpu::PresentFrameOrigin::GuestScanout;
                             present_frames_stored.fetch_add(1, std::memory_order_relaxed);
+                            // `retained_frame_action` decides on BYTE SIZES ALONE -- by design, since
+                            // it cannot know what a frame should look like. The consequence is that a
+                            // correctly-sized but CONTENTLESS frame is retained just as readily as a
+                            // good one, and is then re-served on every later submit that produces no
+                            // present source. Little Nightmares III presents a uniform (255,255,0)
+                            // frame on ~2/3 of samples for exactly that reason (#2014): the retained
+                            // frame is itself uniform.
+                            //
+                            // This names the ORIGIN of a uniform retained frame, which is the one
+                            // fact the existing counters cannot supply -- `fresh=N retained=M` says a
+                            // substitution happened, not what was substituted or where it came from.
+                            // Sampled, not exhaustive: a full uniformity scan of a 33 MB frame on the
+                            // present path would cost more than the render.
+                            if (const char* uni = std::getenv("PROSPER_UNIFORMLOG")) {
+                                if (uni[0] == '1' && uni[1] == '\0' && selected_pixels &&
+                                    selected_pixels->size() >= 4) {
+                                    const uint8_t* px = selected_pixels->data();
+                                    const size_t n = selected_pixels->size();
+                                    bool uniform = true;
+                                    for (size_t off = 4; off + 4 <= n; off += ((n / 4096) | 4u) & ~3u)
+                                        if (px[off] != px[0] || px[off+1] != px[1] ||
+                                            px[off+2] != px[2] || px[off+3] != px[3]) {
+                                            uniform = false; break;
+                                        }
+                                    if (uniform) {
+                                        static std::atomic<uint64_t> uniform_stores{0};
+                                        const uint64_t ord =
+                                            uniform_stores.fetch_add(1, std::memory_order_relaxed) + 1;
+                                        if (prosper::diag_should_print(ord))
+                                            fprintf(stderr,
+                                                    "[uniformlog] #%llu retaining a UNIFORM frame "
+                                                    "rgba=(%u,%u,%u,%u) bytes=%zu origin=%s\n",
+                                                    (unsigned long long)ord,
+                                                    px[0], px[1], px[2], px[3], n,
+                                                    frame_origin ==
+                                                        prosper::gpu::PresentFrameOrigin::GuestScanout
+                                                        ? "GuestScanout" : "Composited");
+                                    }
+                                }
+                            }
                             break;
                         case prosper::frontend::RetainedFrameAction::ServeRetained:
                             selected_pixels = last_scanout_present;


### PR DESCRIPTION
## What this is

A diagnostic, **no behaviour change**, off unless `PROSPER_UNIFORMLOG=1`. It supplies the one fact
that closed out #2014's investigation.

## The gap it fills

`retained_frame_action()` decides on **byte sizes alone**. That is correct by design — it cannot know
what a frame should look like — but the consequence is that a correctly-sized *contentless* frame is
retained as readily as a good one, and then re-served on every later submit that produces no present
source.

Little Nightmares III presents a uniform frame on ~2/3 of samples for exactly that reason. The
existing counters say a substitution happened (`fresh=5672 retained=N`); they cannot say **what** was
substituted or where it came from.

## What it found

```
[uniformlog] #1 retaining a UNIFORM frame rgba=(255,255,0,0) bytes=33177600 origin=Composited
```

66 of them in a 320 s run, and two things follow that no previous instrument could give:

- **`origin=Composited`** — the uniform frame comes from the composite, not the guest-scanout fallback
  (which declined all 66 times in the same run).
- **Alpha is zero, and the texel is `0x0000FFFF`** read little-endian. Low 16 bits set, high 16 clear
  is the signature of a **16-bit-per-channel surface read as RGBA8** — an `R16G16` holding
  `(1.0, 0.0)` decodes to exactly `(255,255,0,0)`.

That retires the clear-colour family this defect was filed under — three prior exclusions across
#3113/#3114, plus the guest-scanout and null-page paths — and redirects to present-source **selection
or format**.

Sampled rather than exhaustive: a full uniformity scan of a 33 MB frame on the present path would cost
more than the render, so it strides.

## Verification — stated plainly because it is not clean

**Five Vulkan render tests currently fail on this machine independently of this change**:
`recompiled_shaders_render`, `multidraw_render`, `indexed_render`, `descriptor_array_render`,
`gpu_execute`. Established as machine state, not a regression:

- clean master (`2e384d3a`, this change stashed) fails the same assertions;
- an **unrelated lane's build of a different commit** in the main checkout fails the same four;
- consistent across three consecutive runs, serial and parallel, with the box otherwise idle.

The remaining **309 pass**. I SIGKILLed several GPU processes earlier in the session, which is the
likely cause. **CI is the trustworthy signal for this PR**, and I am not claiming a green local suite.

Worth flagging separately: anyone reading a local red suite on this box today should check the main
checkout before assuming a regression — I nearly filed one.

Refs #2014, #3113, #3114.
