### PR TITLE
hle(systemservice): log a guest reporting its OWN abnormal termination (#3119)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -871,6 +871,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_addcontent_unmount PRIVATE prosper_core)
   add_test(NAME addcontent_unmount COMMAND test_addcontent_unmount)
 
+  add_executable(test_abnormal_termination_stops tests/hle/service/test_abnormal_termination_stops.cpp)
+  target_include_directories(test_abnormal_termination_stops PRIVATE tests)
+  target_link_libraries(test_abnormal_termination_stops PRIVATE prosper_core)
+  add_test(NAME abnormal_termination_stops COMMAND test_abnormal_termination_stops)
+
   add_executable(test_addcontent_mount_report tests/hle/service/test_addcontent_mount_report.cpp)
   # Includes a shared fixture, which resolves from the `tests` root.
   target_include_directories(test_addcontent_mount_report PRIVATE tests)

--- a/prosper/src/hle/dispatch/nid.cpp
+++ b/prosper/src/hle/dispatch/nid.cpp
@@ -143,6 +143,12 @@ const std::vector<std::string>& builtin_symbol_names() {
         "pthread_cond_wait","pthread_cond_signal","pthread_condattr_setclock","pthread_condattr_getclock",
         "pthread_condattr_setpshared","pthread_condattr_getpshared","pthread_self","pthread_once",
         // libkernel memory
+        // libSceSystemService. Registering a handler names a NID only inside the HLE registry; the
+        // NidDb this list feeds is what self_dump, nid_census and every other NID-resolving
+        // diagnostic read, so a name absent here still prints as a bare hash everywhere else. This
+        // one mattered: a title reporting its own crash showed up as `3s8cHiCBKBE` and needed a hand
+        // lookup against the PS5 3.20 stub table to read at all (#3119).
+        "sceSystemServiceReportAbnormalTermination",
         "sceKernelAllocateDirectMemory","sceKernelReleaseDirectMemory","sceKernelMapDirectMemory",
         "sceKernelMapNamedFlexibleMemory","sceKernelMapFlexibleMemory","sceKernelReserveVirtualRange",
         "sceKernelMunmap","sceKernelMmap","sceKernelAvailableDirectMemorySize","sceKernelGetDirectMemorySize",

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -3538,52 +3538,55 @@ HLE(s_syss_safearea) {
     return 0;
 }
 
-// sceSystemServiceReportAbnormalTermination(cause) — THE GUEST IS TELLING US IT HAS CRASHED.
+// sceSystemServiceReportAbnormalTermination(cause) — the guest reporting a crash to the system.
 //
-// This is not a service prosper provides to the guest; it is the guest reporting its own abnormal
-// termination to the system. Unregistered, the dispatcher's default fired -- one opaque
-// `unimplemented: libSceSystemService::3s8cHiCBKBE -> returning 0` line among a dozen others -- and
-// the guest was allowed to carry on, so a self-reported crash presented as a live process with a
-// black window: indistinguishable from a hang, a stall, or a renderer defect.
-//
-// Found on Tactics Ogre: Reborn (PPSA03839, #1892), where it was the ONLY informative line in a
-// 50-line log with no faults, no compute rejects, no device loss and no missing present source.
-// Four other titles in the same sweep produced black screens with four different signatures; this
-// was the one where the guest said it had failed, and that fact was invisible.
-//
-// NID verified in the PS5 3.20 stub table:
+// Registered so the line is READABLE. Unregistered, the dispatcher default fired as one opaque
+// `unimplemented: libSceSystemService::3s8cHiCBKBE -> returning 0` among a dozen others, and
+// resolving it needed a hand lookup against the PS5 3.20 stub table:
 //   libSceSystemService.c:3976  sprx_dlsym(__handle, "3s8cHiCBKBE",
 //                                          &__ptr_sceSystemServiceReportAbnormalTermination)
 //
-// The return stays 0, exactly what the dispatcher default already produced, so what the guest
-// observes is unchanged and this cannot regress a title by answering differently. The only new
-// behaviour is that we SAY so and stop.
+// IT DOES NOT MEAN THE TITLE IS FAILING NOW, and an earlier revision of this handler assumed it did.
+// Independent review of #3120 opened five archived Tactics Ogre (PPSA03839) runs: the call is in ALL
+// of them, always at line 8, during boot before the first frame -- including the run that then
+// rendered 40,936 frames over 470 s and reached the tutorial battle, and the runs that stalled at
+// ~frame 993. `prosper_on_unimpl` logs only on FIRST invocation, so that is the title's one call.
+// It therefore has zero discriminating power: it is something this title does unconditionally at
+// startup. One reading consistent with all five logs, offered as hypothesis and not finding: the API
+// may report that the PREVIOUS session ended abnormally, and these runs are killed by `timeout`.
 //
-// Stopping uses the existing cooperative signal (host/platform/lifecycle.hpp). Note what that does
-// and does not do: run_entry() never observes it (game_path.hpp:82), so the guest thread is not
-// torn down -- the frontend run-loop winds down at its next boundary instead. That is the right
-// scope. Set PROSPER_ABNORMAL_TERMINATION_CONTINUE=1 to keep running anyway, which is what you want
-// when attaching a debugger to the post-crash state.
+// So the default is to LOG AND CONTINUE. Stopping is opt-in via PROSPER_ABNORMAL_TERMINATION_STOP.
+// Stopping by default would have been a live regression rather than a theoretical one: 23 of the 56
+// local dumps import this NID, four of them rung-6 guarded (The Messenger, Blasphemous 2, Alex Kidd,
+// Blue Prince), and `prosper_stop_requested()` is polled only by prosper-app -- so the snapshot
+// matrix, which drives boot_trace and screenshot, cannot see the breakage at all. It would have
+// failed only in a human's hands.
 //
-// The argument is logged raw. Its meaning is NOT established -- no layout for it has been confirmed
-// against any primary source -- so it is printed as an opaque value rather than decoded.
-// CONFIDENCE: HIGH that this NID is sceSystemServiceReportAbnormalTermination (firmware stub table)
-// and that a call means the guest reported abnormal termination. LOW on the argument's meaning.
+// SCOPE, stated because the opt-in is not uniform across frontends. prosper-app winds its run-loop
+// down (main.cpp) and run_entry() never observes the stop, so the guest thread is not torn down. On
+// screenshot and boot_trace nothing polls it, so the flag does not stop those runs -- and note it is
+// not inert there either: prosper_wait_while_paused() returns false permanently once stop latches,
+// which mutes the SDL3 audio sink in a frontend that keeps running.
+//
+// The return stays 0, identical to the dispatcher default, so no guest observes a different answer.
+// The argument is logged raw; no layout for it is confirmed against any primary source.
+// CONFIDENCE: HIGH on the NID identity. LOW on the argument, and on what a call implies about the
+// title's state.
 HLE(s_syss_report_abnormal_termination) {
     (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
     // Read per call rather than caching in a static: this fires at most once in a run, so there is
-    // nothing to optimise, and a cached sample would make the escape hatch untestable in-process.
-    const bool keep_running = getenv("PROSPER_ABNORMAL_TERMINATION_CONTINUE") != nullptr;
+    // nothing to optimise, and a cached sample would make the opt-in untestable in-process.
+    const bool stop_run = getenv("PROSPER_ABNORMAL_TERMINATION_STOP") != nullptr;
     fprintf(stderr,
             "[prosper] GUEST REPORTED ABNORMAL TERMINATION: "
             "sceSystemServiceReportAbnormalTermination(0x%llx). The title has decided it is "
             "crashing -- this is the guest's own verdict, not prosper's. %s\n",
             (unsigned long long)a0,
-            keep_running ? "PROSPER_ABNORMAL_TERMINATION_CONTINUE is set; continuing anyway."
-                         : "Stopping the run; set PROSPER_ABNORMAL_TERMINATION_CONTINUE=1 to keep "
-                           "the process alive for debugging.");
+            stop_run ? "PROSPER_ABNORMAL_TERMINATION_STOP is set; stopping the run."
+                     : "Continuing: this title may call it at boot and run fine. Set "
+                       "PROSPER_ABNORMAL_TERMINATION_STOP=1 to stop on it.");
     fflush(stderr);
-    if (!keep_running) prosper::prosper_request_stop();
+    if (stop_run) prosper::prosper_request_stop();
     return 0;
 }
 

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -17,6 +17,7 @@
 #include "gpu/texture/guest_texture_layout.hpp" // exact HLE-produced sampled-linear layouts
 #include "host/platform/posix_shim.hpp"   // Darwin process_vm_readv shim + asm portability
 #include "host/image/boot_program.hpp"  // guest_module_name: is a callback target guest code?
+#include "host/platform/lifecycle.hpp"  // cooperative stop when the guest reports its own crash (#3119)
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
@@ -3537,6 +3538,55 @@ HLE(s_syss_safearea) {
     return 0;
 }
 
+// sceSystemServiceReportAbnormalTermination(cause) — THE GUEST IS TELLING US IT HAS CRASHED.
+//
+// This is not a service prosper provides to the guest; it is the guest reporting its own abnormal
+// termination to the system. Unregistered, the dispatcher's default fired -- one opaque
+// `unimplemented: libSceSystemService::3s8cHiCBKBE -> returning 0` line among a dozen others -- and
+// the guest was allowed to carry on, so a self-reported crash presented as a live process with a
+// black window: indistinguishable from a hang, a stall, or a renderer defect.
+//
+// Found on Tactics Ogre: Reborn (PPSA03839, #1892), where it was the ONLY informative line in a
+// 50-line log with no faults, no compute rejects, no device loss and no missing present source.
+// Four other titles in the same sweep produced black screens with four different signatures; this
+// was the one where the guest said it had failed, and that fact was invisible.
+//
+// NID verified in the PS5 3.20 stub table:
+//   libSceSystemService.c:3976  sprx_dlsym(__handle, "3s8cHiCBKBE",
+//                                          &__ptr_sceSystemServiceReportAbnormalTermination)
+//
+// The return stays 0, exactly what the dispatcher default already produced, so what the guest
+// observes is unchanged and this cannot regress a title by answering differently. The only new
+// behaviour is that we SAY so and stop.
+//
+// Stopping uses the existing cooperative signal (host/platform/lifecycle.hpp). Note what that does
+// and does not do: run_entry() never observes it (game_path.hpp:82), so the guest thread is not
+// torn down -- the frontend run-loop winds down at its next boundary instead. That is the right
+// scope. Set PROSPER_ABNORMAL_TERMINATION_CONTINUE=1 to keep running anyway, which is what you want
+// when attaching a debugger to the post-crash state.
+//
+// The argument is logged raw. Its meaning is NOT established -- no layout for it has been confirmed
+// against any primary source -- so it is printed as an opaque value rather than decoded.
+// CONFIDENCE: HIGH that this NID is sceSystemServiceReportAbnormalTermination (firmware stub table)
+// and that a call means the guest reported abnormal termination. LOW on the argument's meaning.
+HLE(s_syss_report_abnormal_termination) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    // Read per call rather than caching in a static: this fires at most once in a run, so there is
+    // nothing to optimise, and a cached sample would make the escape hatch untestable in-process.
+    const bool keep_running = getenv("PROSPER_ABNORMAL_TERMINATION_CONTINUE") != nullptr;
+    fprintf(stderr,
+            "[prosper] GUEST REPORTED ABNORMAL TERMINATION: "
+            "sceSystemServiceReportAbnormalTermination(0x%llx). The title has decided it is "
+            "crashing -- this is the guest's own verdict, not prosper's. %s\n",
+            (unsigned long long)a0,
+            keep_running ? "PROSPER_ABNORMAL_TERMINATION_CONTINUE is set; continuing anyway."
+                         : "Stopping the run; set PROSPER_ABNORMAL_TERMINATION_CONTINUE=1 to keep "
+                           "the process alive for debugging.");
+    fflush(stderr);
+    if (!keep_running) prosper::prosper_request_stop();
+    return 0;
+}
+
 // sceSystemServiceGetHdrToneMapLuminance(out). Kyty models the output as three floats in this order:
 // max-full-frame, max, and min tone-map luminance. The imported function previously fell through to
 // success-without-output, so display setup consumed poisoned values. Use Kyty's 80/1000/0 values as
@@ -5415,6 +5465,9 @@ void register_service_hle() {
     Hle::register_fn("1n37q1Bvc5Y", (HleFn)s_syss_safearea, "sceSystemServiceGetDisplaySafeAreaInfo");
     Hle::register_fn("mPpPxv5CZt4", (HleFn)s_syss_hdr_luminance,
                      "sceSystemServiceGetHdrToneMapLuminance");
+    // #3119: the guest reporting its OWN crash must not look like a hang. See the handler.
+    Hle::register_fn("3s8cHiCBKBE", (HleFn)s_syss_report_abnormal_termination,
+                     "sceSystemServiceReportAbnormalTermination");
 
     // ---- Issue #232 services (raw NIDs; every pair verified against the PS5 3.20 stub tables) ----
     // libScePlayGo — everything installed & locus-local.

--- a/prosper/tests/hle/service/test_abnormal_termination_stops.cpp
+++ b/prosper/tests/hle/service/test_abnormal_termination_stops.cpp
@@ -1,0 +1,98 @@
+// test_abnormal_termination_stops — a guest that reports its OWN crash must stop the run (#3119).
+//
+// WHY THIS PROPERTY IS LOAD-BEARING, and why asserting the return value would prove nothing.
+//
+// sceSystemServiceReportAbnormalTermination is the guest telling the system it has crashed. Before
+// #3119 the NID was unregistered, so the dispatcher default answered 0 and the guest carried on:
+// the process stayed alive with a black window, indistinguishable from a hang, a stall, or a
+// renderer defect. Found on Tactics Ogre: Reborn (PPSA03839, #1892), where that one opaque
+// `unimplemented:` line was the ONLY informative content in a 50-line log showing no faults, no
+// compute rejects, no device loss and no missing present source.
+//
+// The handler deliberately STILL RETURNS 0 -- identical to the dispatcher default -- so what the
+// guest observes is unchanged and registering the NID cannot regress a title by answering
+// differently. That is precisely why asserting `rc == 0` proves nothing: it passes with the entire
+// feature deleted. The only observable separating the fix from its absence is the cooperative stop
+// signal, so that is what this test is about.
+//
+// The suppression arm is a discriminator, not a courtesy. Without it, a stop signal latched by
+// unrelated code anywhere in the process would make the first arm pass forever.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+#include "host/platform/lifecycle.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("FAIL: %s\n", (msg)); ++fails; } \
+                              else printf("ok: %s\n", (msg)); } while (0)
+
+static void set_continue(bool on) {
+#ifdef _WIN32
+    _putenv_s("PROSPER_ABNORMAL_TERMINATION_CONTINUE", on ? "1" : "");
+#else
+    if (on) setenv("PROSPER_ABNORMAL_TERMINATION_CONTINUE", "1", 1);
+    else    unsetenv("PROSPER_ABNORMAL_TERMINATION_CONTINUE");
+#endif
+}
+
+// Spelled literally so a change to either the NID or the registration breaks here loudly rather
+// than silently unhooking the handler. Verified against the PS5 3.20 libSceSystemService stub table.
+static const char* kNid = "3s8cHiCBKBE";
+
+int main() {
+    register_builtin_hle();
+
+    HleFn fn = Hle::lookup(kNid);
+    CHECK(fn != nullptr,
+          "sceSystemServiceReportAbnormalTermination is registered (unregistered, it falls to the "
+          "dispatcher default and can never stop the run)");
+    if (!fn) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
+
+    // ---- arm 1: the default path requests a stop --------------------------------------------
+    set_continue(false);
+    prosper_reset_stop();
+    CHECK(!prosper_stop_requested(), "precondition: no stop is pending before the call");
+
+    uint64_t rc = fn(0xDEADull, 0, 0, 0, 0, 0);
+
+    CHECK(rc == 0,
+          "the handler still returns 0, so the guest observes exactly what the dispatcher default "
+          "gave it and registering this NID changes no guest-visible answer");
+    CHECK(prosper_stop_requested(),
+          "reporting abnormal termination requests a stop -- THE fix; without it the guest's own "
+          "crash report presents as a hang");
+
+    // ---- arm 2 (mutation arm): the escape hatch suppresses the stop --------------------------
+    // Kills two implementations that would pass arm 1: one that ignores the environment variable
+    // and always stops, and one where arm 1's pass came from a stop latched by something other
+    // than this handler.
+    set_continue(true);
+    prosper_reset_stop();
+    CHECK(!prosper_stop_requested(), "precondition: the signal was cleared for arm 2");
+
+    rc = fn(0xBEEFull, 0, 0, 0, 0, 0);
+
+    CHECK(rc == 0, "the suppressed path returns 0 as well");
+    CHECK(!prosper_stop_requested(),
+          "PROSPER_ABNORMAL_TERMINATION_CONTINUE keeps the process alive for debugging");
+
+    // ---- arm 3: clearing the variable restores the stop --------------------------------------
+    // Proves arm 2's pass came from the variable rather than from the signal having become
+    // permanently unsettable after the first request.
+    set_continue(false);
+    prosper_reset_stop();
+    rc = fn(0xF00Dull, 0, 0, 0, 0, 0);
+    CHECK(prosper_stop_requested(),
+          "clearing the variable restores the stop, so arm 2 was the variable and not a latched "
+          "or exhausted signal");
+
+    prosper_reset_stop();
+    if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/hle/service/test_abnormal_termination_stops.cpp
+++ b/prosper/tests/hle/service/test_abnormal_termination_stops.cpp
@@ -33,10 +33,10 @@ static int fails = 0;
 
 static void set_continue(bool on) {
 #ifdef _WIN32
-    _putenv_s("PROSPER_ABNORMAL_TERMINATION_CONTINUE", on ? "1" : "");
+    _putenv_s("PROSPER_ABNORMAL_TERMINATION_STOP", on ? "1" : "");
 #else
-    if (on) setenv("PROSPER_ABNORMAL_TERMINATION_CONTINUE", "1", 1);
-    else    unsetenv("PROSPER_ABNORMAL_TERMINATION_CONTINUE");
+    if (on) setenv("PROSPER_ABNORMAL_TERMINATION_STOP", "1", 1);
+    else    unsetenv("PROSPER_ABNORMAL_TERMINATION_STOP");
 #endif
 }
 
@@ -53,7 +53,7 @@ int main() {
           "dispatcher default and can never stop the run)");
     if (!fn) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
 
-    // ---- arm 1: the default path requests a stop --------------------------------------------
+    // ---- arm 1: the DEFAULT path does NOT stop ----------------------------------------------
     set_continue(false);
     prosper_reset_stop();
     CHECK(!prosper_stop_requested(), "precondition: no stop is pending before the call");
@@ -63,11 +63,12 @@ int main() {
     CHECK(rc == 0,
           "the handler still returns 0, so the guest observes exactly what the dispatcher default "
           "gave it and registering this NID changes no guest-visible answer");
-    CHECK(prosper_stop_requested(),
-          "reporting abnormal termination requests a stop -- THE fix; without it the guest's own "
-          "crash report presents as a hang");
+    CHECK(!prosper_stop_requested(),
+          "the default does NOT stop the run -- titles call this at boot and go on to render "
+          "(Tactics Ogre: present in a 470 s / 40,936-frame run), so stopping by default would "
+          "break 23 importing dumps including four rung-6 guarded ones");
 
-    // ---- arm 2 (mutation arm): the escape hatch suppresses the stop --------------------------
+    // ---- arm 2: the opt-in DOES stop --------------------------------------------------------
     // Kills two implementations that would pass arm 1: one that ignores the environment variable
     // and always stops, and one where arm 1's pass came from a stop latched by something other
     // than this handler.
@@ -78,8 +79,8 @@ int main() {
     rc = fn(0xBEEFull, 0, 0, 0, 0, 0);
 
     CHECK(rc == 0, "the suppressed path returns 0 as well");
-    CHECK(!prosper_stop_requested(),
-          "PROSPER_ABNORMAL_TERMINATION_CONTINUE keeps the process alive for debugging");
+    CHECK(prosper_stop_requested(),
+          "PROSPER_ABNORMAL_TERMINATION_STOP=1 opts into stopping the run");
 
     // ---- arm 3: clearing the variable restores the stop --------------------------------------
     // Proves arm 2's pass came from the variable rather than from the signal having become
@@ -87,9 +88,9 @@ int main() {
     set_continue(false);
     prosper_reset_stop();
     rc = fn(0xF00Dull, 0, 0, 0, 0, 0);
-    CHECK(prosper_stop_requested(),
-          "clearing the variable restores the stop, so arm 2 was the variable and not a latched "
-          "or exhausted signal");
+    CHECK(!prosper_stop_requested(),
+          "clearing the variable restores the continue default, so arm 2 was the variable and not "
+          "a signal that had latched permanently");
 
     prosper_reset_stop();
     if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }


### PR DESCRIPTION
`sceSystemServiceReportAbnormalTermination` was unregistered, so the dispatcher's default `return 0`
answered it as success while recording nothing. A guest reporting *its own* crash was therefore
invisible in the log — the one event most worth seeing passed silently.

## What ships

The NID is registered and the call is **logged**. The default is **log and continue**; stopping the
run is opt-in via `PROSPER_ABNORMAL_TERMINATION_STOP`. The return stays `0`, identical to the
dispatcher default, so **no guest observes a different answer than before**.

> **This PR body previously described a different design** — stop-by-default with a
> `PROSPER_ABNORMAL_TERMINATION_CONTINUE` escape hatch. That was the first commit's approach; it was
> reworked in the second commit and the body was never updated, so the description and its entire
> "Risk" section litigated a design this PR had already abandoned. `..._CONTINUE` does not exist
> anywhere in the diff. Corrected here after an independent review caught it. The code was always the
> reworked version; only this text was stale.

## Why not stop by default

Stopping by default would have been a **live regression, not a theoretical one**, and the evidence is
what drove the rework:

- A 5-run Tactics Ogre archive shows the call has **zero discriminating power** — the title makes it
  unconditionally at startup, in runs that were fine. One reading consistent with all five logs,
  offered as hypothesis rather than finding: the API may report that the *previous* session ended
  abnormally, and those runs are killed by `timeout`.
- **23 of 56 local dumps import this NID**, four of them rung-6 guarded (*The Messenger*,
  *Blasphemous 2*, *Alex Kidd*, *Blue Prince*).
- `prosper_stop_requested()` is polled **only by prosper-app**. The snapshot matrix drives
  `boot_trace` and `screenshot`, so it **could not have seen the breakage at all** — it would have
  failed only in a human's hands.

That last point is the reason this matters more than the diff size suggests: the change most likely to
be waved through is the one whose damage is invisible to every automated gate.

## Scope, stated because the opt-in is not uniform

- **prosper-app**: winds its run-loop down; `run_entry()` never observes the stop, so the guest thread
  is not torn down.
- **screenshot / boot_trace**: nothing polls the flag, so it does not stop those runs — and it is *not*
  inert there either: `prosper_wait_while_paused()` returns false permanently once stop latches, which
  mutes the SDL3 audio sink in a frontend that keeps running.

## Confidence

`CONFIDENCE: HIGH` on the NID identity. `CONFIDENCE: LOW` on the argument layout — it is logged raw and
no layout is confirmed against any primary source — and on what a call implies about the title's state.

## Verification

`ctest --no-tests=error`: **315/315**, exit 0, on the merge result against current master (the branch
tip alone is behind).

Mutations, both reproduced by the independent reviewer on the merge result:

| mutation | result |
| --- | --- |
| registration removed | 1 FAIL |
| `prosper_request_stop()` call removed | 1 FAIL |

**Correction:** an earlier revision of this body claimed the second mutation produced "2 checks FAIL".
Measured, it is 1. A checkable number stated wrongly is worse than no number, since it is exactly the
kind of claim a reader takes on trust.
