### PR TITLE
snaps: four human-authored render snapshot sets (evergate, balan, joe-mac, greak)

### DIFF
--- a/prosper/scripts/balan/route.pad
+++ b/prosper/scripts/balan/route.pad
@@ -1,0 +1,10 @@
+# recorded PROSPER_PAD_SCRIPT route; fN is display flips since first pad poll
+f474-477:up
+f498-500:cross
+f612-615:cross
+f672-675:up
+f864-867:left-stick-up
+f889-891:cross
+f934-938:cross
+f1235-1239:cross
+f1345-1346:cross

--- a/prosper/scripts/evergate/route.pad
+++ b/prosper/scripts/evergate/route.pad
@@ -1,0 +1,5 @@
+# recorded PROSPER_PAD_SCRIPT route; fN is display flips since first pad poll
+f492-498:options
+f570-577:cross
+f634-640:cross
+f734-740:cross

--- a/prosper/scripts/greak/route.pad
+++ b/prosper/scripts/greak/route.pad
@@ -1,0 +1,26 @@
+# recorded PROSPER_PAD_SCRIPT route; fN is display flips since first pad poll
+f530-538:cross
+f721-724:cross
+f759-763:cross
+f802-806:cross
+f839-842:cross
+f935-943:cross
+f1172-1178:cross
+f1238-1245:cross
+f1495-1502:cross
+f1594-1687:circle
+f2501-2554:right
+f2554-2562:right+cross
+f2562-2680:right
+f2680-2701:right+cross
+f2701-2761:right
+f2761-2775:right+cross
+f2775-2783:right
+f2783-2811:right+cross
+f2811-2820:right
+f2820-2831:right+cross
+f2831-2842:right
+f2842-2857:right+cross
+f2857-2868:right
+f2868-2878:right+cross
+f2878-2951:right

--- a/prosper/scripts/joe-mac/route.pad
+++ b/prosper/scripts/joe-mac/route.pad
@@ -1,0 +1,24 @@
+# recorded PROSPER_PAD_SCRIPT route; fN is display flips since first pad poll
+f1931-1938:cross
+f2233-2239:cross
+f2315-2321:cross
+f2396-2401:cross
+f2615-2620:cross
+f3241-3246:cross
+f3511-3519:cross
+f3519-3525:right+cross
+f3525-3646:right
+f3646-3666:right+cross
+f3666-3727:right
+f3727-3742:right+cross
+f3742-3820:right
+f3842-3863:cross
+f3892-3911:right
+f3926-3931:right
+f3937-3945:cross
+f3945-3952:left+cross
+f3952-3964:left
+f3971-4115:right
+f4120-4129:cross
+f4129-4135:right+cross
+f4135-4157:right

--- a/prosper/tools/snapshot/snaps/balan.json
+++ b/prosper/tools/snapshot/snaps/balan.json
@@ -1,0 +1,26 @@
+{
+  "det_clock": "off",
+  "det_fps": 60,
+  "dump": "PPSA02058-app0",
+  "flip_window": 900,
+  "min_structural_similarity": 0.85,
+  "name": "balan",
+  "route": "prosper/scripts/balan/route.pad",
+  "savedata": "fresh",
+  "snaps": [
+    {
+      "distinct_colors": 44639,
+      "height": 2160,
+      "index": 0,
+      "luma16x9": "3147575e5350464d4e423c372722231c33383f433c4238353e36343648371c130d1e333c38333739423c57737366410e544a5c4a48383a514a3b3d3c503b2812182f424e393c3d3e463e313d453d2a1314202e362f302d3437352c3433342b161a2e39413a3937433a3a393f4c3b3116090b1b2323241d2f2324272b2e261e142122211a1f210f172e452a292a2d2817",
+      "mode": "anchor",
+      "nonblack_ratio": 0.978702,
+      "pad_flip": 240,
+      "verdict": "correct",
+      "width": 3840
+    }
+  ],
+  "timeout": 3600,
+  "title_id": "PPSA02058",
+  "window_samples": 7
+}

--- a/prosper/tools/snapshot/snaps/evergate.json
+++ b/prosper/tools/snapshot/snaps/evergate.json
@@ -1,0 +1,48 @@
+{
+  "det_clock": "off",
+  "det_fps": 60,
+  "dump": "PPSA01885-app0",
+  "flip_window": 900,
+  "min_structural_similarity": 0.85,
+  "name": "evergate",
+  "route": "prosper/scripts/evergate/route.pad",
+  "savedata": "fresh",
+  "snaps": [
+    {
+      "distinct_colors": 50989,
+      "height": 1080,
+      "index": 0,
+      "luma16x9": "070a0d0e1019180f0f121114110d0a070b0f0f1012213a5a5a3017181011100c0d101112123783a1a68f3319121718131615191754182943634f27291616171359531e1d5e4f231f3049413924201716405e4d4a353a1c1c242e414f251b19614b36625e404f47454328365b376b778714264e505e5c76696c80596b56587a730c1b2d30332e2a31211e2f362429597b",
+      "mode": "anchor",
+      "nonblack_ratio": 0.995725,
+      "pad_flip": 372,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 14034,
+      "height": 1080,
+      "index": 1,
+      "luma16x9": "1019202a3333302e2d302f2f2d221e16181d2126283135373939353735332f251f2122292d2e3234323230292c302f2e1b20262a2f2e2c2d312b262b2a2428292b1f262a332e282824221e1e3428201e2e2627353c322d3428231c191d2d221d27323740322434302b2c211a162f3220292b3e3b4240463c343630352f2d3c2e18212b302e323b3d4430262120252228",
+      "mode": "anchor",
+      "nonblack_ratio": 0.998881,
+      "pad_flip": 892,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 58324,
+      "height": 1080,
+      "index": 2,
+      "luma16x9": "171b222322241e3810141a132026351b21302b26181a183b18171a15181e4023252a211f1c201f3c151b1c14172e4d4d1f25291f252c29421b1a1418192221261c201d1820253751201b1c27232a22181f3b3e183a4a325e1c265041633434240c414c66688a989f977f8b683935492d10297388836d544f606c948c8a745539293a4e4e4b626d68687370585c5f4d32",
+      "mode": "anchor",
+      "nonblack_ratio": 0.982299,
+      "pad_flip": 2922,
+      "verdict": "correct",
+      "width": 1920
+    }
+  ],
+  "timeout": 3600,
+  "title_id": "PPSA01885",
+  "window_samples": 7
+}

--- a/prosper/tools/snapshot/snaps/greak.json
+++ b/prosper/tools/snapshot/snaps/greak.json
@@ -1,0 +1,45 @@
+{
+  "det_clock": "off",
+  "det_fps": 60,
+  "dump": "PPSA02849-app0",
+  "flip_window": 900,
+  "min_structural_similarity": 0.85,
+  "name": "greak",
+  "route": "prosper/scripts/greak/route.pad",
+  "savedata": "fresh",
+  "snaps": [
+    {
+      "distinct_colors": 553,
+      "height": 1080,
+      "index": 0,
+      "luma16x9": "0000000000000000000000000000000000000000002d536b605f23000000000000000000003767464d5e1b000000000000000000000000000000000000000000000000000000001c200000000000000000000009060e0314070b0b090100000000000000000000000000000000000000000b060703050a06060807050404030000000000000000000000000000000000",
+      "nonblack_ratio": 0.038133,
+      "pad_flip": 377,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 33875,
+      "height": 1080,
+      "index": 1,
+      "luma16x9": "00337274728379766b677262563d0928000cadbeab8c9eae9f9e5e554822070a000082e0c3967c6e71654f4b3a2c0709000049d38b9566676e5a54493f250707000056a9277c4d4547495d5d530d07070000032e0d5a5548433f596b570c0b0b010202040b3640554d376383581919180808070308133161645380a3632f2f430e160c0811144a70757893b15a474c58",
+      "nonblack_ratio": 0.841096,
+      "pad_flip": 1025,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 33761,
+      "height": 1080,
+      "index": 2,
+      "luma16x9": "d7c4e0e3d8d3c9d8ecebe9bb98d4d761c9c0e9e6e7e4e4dee7ebd74d6b9eba74f0edeae7e5e8e5f0d3e8b7658badbd75ede9e5e2dfe2a0e6acdcbb7a96a0ab78ebe6e3dfa1e077c296c37f828d849b80e5e2dfc573d57e9bb0a8897b6f607c74c2cbcca796827a859588685049423735988f8f91814c61796e64584e4b3f3f46a1808f8f865e6471675b62625e524d5e",
+      "nonblack_ratio": 0.999954,
+      "pad_flip": 2426,
+      "verdict": "correct",
+      "width": 1920
+    }
+  ],
+  "timeout": 3600,
+  "title_id": "PPSA02849",
+  "window_samples": 7
+}

--- a/prosper/tools/snapshot/snaps/joe-mac.json
+++ b/prosper/tools/snapshot/snaps/joe-mac.json
@@ -1,0 +1,70 @@
+{
+  "det_clock": "off",
+  "det_fps": 60,
+  "dump": "PPSA02801-app0",
+  "flip_window": 900,
+  "min_structural_similarity": 0.85,
+  "name": "joe-mac",
+  "route": "prosper/scripts/joe-mac/route.pad",
+  "savedata": "fresh",
+  "snaps": [
+    {
+      "distinct_colors": 37106,
+      "height": 1080,
+      "index": 0,
+      "luma16x9": "938d7e87898fa4b4afaeb0948e8e8e8ebc8d80869fa3a7b3a3a9b0b2a4c9b2b59360698ed2c2d8d6b6eab9aec7cdcabe7c658890bdbab69e87c2aaa3a6ac93a39e81a2a2a2956138408683b7c9a886a48e90ada39b99737376878cc5c39a8696987c9c9292a28e7c76b18e9f6f7866647c7f867d817a494d45536582747b746d786f798971717467595e766772746373",
+      "mode": "anchor",
+      "nonblack_ratio": 0.956651,
+      "pad_flip": 1314,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 36317,
+      "height": 1080,
+      "index": 1,
+      "luma16x9": "938d7e87898f90a1a29e9c948e8e8e8ebc8d807d9990956b848ba1a7a3c9b2b5c46e6a8385797a6f79507f6a8ac5cabe9b6a85ab948b9f8a85876f8684a8a8a3a39f97b9bb9b66654c7e848abaaa88a48d8c91c0b99774625c8280aacbaf9396987d8b8db5909c8b7b6a75879b9869647e8ea4879684828a707f8674737a79727976888b8da97f867c79917477979477",
+      "mode": "anchor",
+      "nonblack_ratio": 0.954367,
+      "pad_flip": 1834,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 76557,
+      "height": 1080,
+      "index": 2,
+      "luma16x9": "8d80808294bdecc9e9c9b2c5a9878c5d907671687c7c9a97a7b49d8c8c8d7e598977577a69889f7674a892a7807e805091756972757e73857972ada691828261887a818d929da4b1aeb4b48d8e9d8cda8b7b718c797482727f765a605976879a8e7a8780567b768e877d5f63746c91736d827d817b6f8f908e937f81817f846f67877e85799396979a949d9171675359",
+      "mode": "anchor",
+      "nonblack_ratio": 0.986867,
+      "pad_flip": 2147,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 69212,
+      "height": 1080,
+      "index": 3,
+      "luma16x9": "8d807c8091c7edcce9c9b0c5a5858c5d90766052577580789b817461656e7e598977577a6994c0b59e9c99a74e5180509387737f7586a8cfb1a2bba6373882618d8c917a676a82899ba2b594363689da8b79878f7a72816383a16e643845879a8e769a926f818171a8c76b40292b66736d827d817b78937f8b877057433c446f677a83787194a49881857e7a6f645359",
+      "mode": "anchor",
+      "nonblack_ratio": 0.989591,
+      "pad_flip": 2540,
+      "verdict": "correct",
+      "width": 1920
+    },
+    {
+      "distinct_colors": 69766,
+      "height": 1080,
+      "index": 4,
+      "luma16x9": "a59fa5bea39fb1a6aaa8b7a6a9976f82777a98a3728d9cc99ed0c9bcb3885e64274ecd997183a6af7fbcbbacb372545e252578707597b8967e9bc6b9b87b646a2b528b8a7ca1908a868da0b7bf987c783c6a84787b677b5a5a626770765b785e4751888a7288796378756557805a705c3f526a8a7682946f7f8073807f725f8a62444b3e242f4c454e36374e5c535153",
+      "mode": "anchor",
+      "nonblack_ratio": 0.997647,
+      "pad_flip": 3423,
+      "verdict": "correct",
+      "width": 1920
+    }
+  ],
+  "timeout": 3600,
+  "title_id": "PPSA02801",
+  "window_samples": 7
+}


### PR DESCRIPTION
Four human-authored snap sets (`snaps.py`), taken by the project owner playing each title in `prosper-app` and pressing F6 on frames they judged correct. Before this, `alexkidd` was the only set in the repository.

## What lands

| set | anchors | states covered | live gameplay anchor? |
|---|---|---|---|
| `evergate` | 3 | title screen, cloudscape, first-level gameplay | ✅ |
| `balan` | 1 | Language Settings at 4K, 21 scripts incl. Arabic/CJK/Cyrillic | — |
| `joe-mac` | 5 | title card, title screen, main menu, character select, level 1 "Ready?" | level render, not live play |
| `greak` | 3 | auto-save notice, main menu, cliff gameplay | ✅ |

12 anchors across 4 titles. Every one replay-verified on an independent run, and **re-verified after `#3122` landed** (see below).

## Verification on current master, including the HTILE fix

All sets were authored before `#3122` (the GTA V HTILE regression fix). Since that change alters depth invalidation for every title, they were re-checked against a build containing it — the cross-title check whose absence caused `#3121` in the first place:

```
alexkidd       4 anchors  1.000 / 0.981 / 0.980 / 1.000
evergate       3 anchors  0.995 / 0.975 / 0.993
balan          1 anchor   1.000
joe-mac        5 anchors  0.999 / 1.000 / 1.000 / 1.000 / 0.999
greak          3 anchors  1.000 / 0.943 / 0.965
```

All above the 0.85 floor. `alexkidd` is included as an untouched control — it is not modified by this PR and confirms the harness and the fixed build agree with a set neither authored nor adjusted here.

## Anchors deliberately dropped, and why

Three authored snaps were discarded rather than accepted, because each was measured **irreproducible** rather than merely different:

- **`joe-mac` snap 5** — live combat on the T-Rex, ssim 0.567. Not a renderer fault: colours 38,705 → 44,763, coverage 0.997 → 0.998, the same level correctly drawn. The **score read 200 against the reference's 300** and the health bar differed. Replaying an input route does not replay the outcome of live combat, and the best match across the whole ±900 window was still 0.567.
- **`greak` snap 4** — a forest ravine, authored full-frame at non-black 0.959 (the author waited for the letterbox to clear). Every replay found a *letterboxed* frame instead, at 0.667 — this title's cinematic ratio. Three attempts: anchor ±900 → 0.004 at the window edge; anchor ±2400 → 0.021 *inside* the window, so not drift; scan −900/+12000 over 33 samples → 0.004. The scene is not anywhere in ~200 s of forward play. Likely mechanism is already documented in `AGENTS_SNAPS.md`: analog sticks record as full-deflection **directions**, so a gentle tilt replays as a full push and a traversal-driven platformer takes a different path.
- **`summer-sports` (whole set, deferred)** — its 3D-event anchor failed at 0.506 on the fixed build, matching −369 flips away on a correctly-rendered "START" splash: the event-intro timing shifts, so the authored moment does not reproduce. That left only a menu anchor sitting **0.006** above the 0.85 floor, which would flake. Being re-authored rather than merged thin.

**The generalisation worth recording:** anchors in states where *the player's own actions determine what is on screen* — a fight, a traverse, a timed intro — may not be reproducible at all on this class of title. Menus, title screens and settled views reproduce at 0.94–1.000.

## Notes

- `balan`'s anchor sits before the route's first input (f240 vs f474), i.e. the pre-input phase `AGENTS_SNAPS.md` flags as fragile. It landed +80 on replay and the window absorbed it; the screen is a held state waiting for input, so drift has nothing to land on. Same shape for `evergate` snap 0.
- Scope on `balan` is the language screen only. It makes no claim about the rest of that title, where the wrong composite still takes most frames (#2932) and no stage has ever loaded.
- All four authored at `det_clock=off`, `det_fps=60`, `savedata=fresh`.
- Committed content is signatures, verdicts, anchors and routes. **No game imagery** — reference images stay in `~/.local/share/prosper/snap-refs/`.

Manual test reports for every title in the sweep, including the ones that produced no snaps, are on their trackers: #1868, #1876, #1883, #1887, #1890, #2867, #2880, #2882, #2883, #2884, #2885, #2887.
