### PR TITLE
scripts(stray): a deterministic flip-anchored route to the title screen (#3126)

### DIFF
--- a/prosper/scripts/stray-PPSA02101/README.md
+++ b/prosper/scripts/stray-PPSA02101/README.md
@@ -3,6 +3,23 @@
 `reach-first-map.pad` drives the boot past the **brightness-calibration screen** to the first map
 load.
 
+`reach-title-flip.pad` stops one screen earlier — it reaches the **title screen** and holds there —
+and it is the one to use for anything that has to be reproducible.
+
+## Why the title route is anchored on flips, not seconds
+
+A wall-clock route cannot hit this title reliably: an earlier 150 s/160 s version fired before
+calibration on slower boots and reached the title only sometimes (`max_nonblack` 0.1095 once, then
+0.0063 / 0.0000 / 0.0063 on three unmodified reruns — a single lucky sample adopted as a baseline is
+how that hour was lost). The flip anchor works because the target is a **steady state** rather than a
+moment: a no-input boot reaches calibration at `present_count` ≈ 1764 and then holds it unchanged
+(identical nonblack 0.1070 from present 1838 through 3205), because that screen waits for input. Any
+anchor after it arrives lands on it however slow the boot was.
+
+```bash
+export PROSPER_PAD_SCRIPT=@prosper/scripts/stray-PPSA02101/reach-title-flip.pad
+```
+
 ```bash
 export PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct
 export PROSPER_PAD_SCRIPT=@prosper/scripts/stray-PPSA02101/reach-first-map.pad

--- a/prosper/scripts/stray-PPSA02101/reach-title-flip.pad
+++ b/prosper/scripts/stray-PPSA02101/reach-title-flip.pad
@@ -1,0 +1,32 @@
+# Stray (PPSA02101) -- reach the title screen DETERMINISTICALLY and hold there.
+#
+# Anchored on FLIPS, not seconds. Measured 2026-08-30: a no-input boot reaches the
+# brightness-calibration screen at present_count ~1764 and then HOLDS it unchanged
+# (identical nonblack 0.1070 from present 1838 through 3205, i.e. t=140s..248s), because
+# that screen waits for input.
+#
+# That is what makes a single late anchor deterministic: the target state is not a moment,
+# it is a steady state, so any anchor after it arrives lands on it however slow the boot was.
+# A wall-clock route cannot do this -- the earlier 150s/160s version fired before calibration
+# on slower boots and reached the title only sometimes (measured 0.1095 once, then
+# 0.0063/0.0000/0.0063 on three unmodified reruns).
+#
+# ONE press: Cross accepts calibration (its own prompt bar names it). Nothing after it, so the
+# title screen holds instead of being selected past into the game.
+f2500-2515:cross
+#
+# MEASURED RESULT, 4 runs: every run that does not fault reaches the title screen at EXACTLY
+# max_nonblack 0.1097. The route contributes no variance at all. What varies is an intermittent
+# guest fault on accepting calibration -- 2 of 4 runs -- at a fixed
+# rip=image+0x12cc536 on 'RenderThread 1', WITH PROSPER_NULL_PAGE=1 already set. See #3126.
+#
+# RUN IT WITH PROSPER_NULL_PAGE=1. Without it the fault is worse, not absent.
+#
+#   PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+#   PROSPER_PAD_SCRIPT=@prosper/scripts/stray-PPSA02101/reach-title-flip.pad \
+#     ./build-linux/screenshot <DUMP_ROOT>/PPSA02101-app0 \
+#       --seconds 8 --count 10 --warmup-seconds 230 --timeout 305 --out <OUT>
+#
+# WHAT THE TITLE SCREEN CURRENTLY SHOWS: the menu only. START GAME / SETTINGS / CREDITS, the
+# highlight, the (X) Select prompt and the version stamp are correct; the cat-head logo, the STRAY
+# wordmark and the entire lit background are absent. Oracle screenshot on tracker #2883.


### PR DESCRIPTION
Adds `prosper/scripts/stray-PPSA02101/reach-title-flip.pad` — the first route that reaches *Stray*'s title screen reliably.

## Why the existing route cannot

`reach-first-map.pad` presses Cross every 3 s from t=3 and **selects START GAME**, landing in the black game: 12 of 12 sampled frames measured exactly `0.0000`. The title screen was being passed through transiently, which is why it had never been captured.

A wall-clock route cannot fix it here. Measured 2026-08-30: a no-input boot does not reach the brightness-calibration screen until `present_count ≈ 1764` (t ≈ 134 s), and that arrival moves between runs — so a seconds-anchored press fires before there is anything to accept.

**I learned that the expensive way.** A 150 s/160 s version reached the title once at `0.1095`, and I used that as an A/B baseline for four hypotheses before re-running an *unmodified* tree three times and getting `0.0063 / 0.0000 / 0.0063`. Those comparisons were measuring route variance. All four are retracted on #3126.

## Why one anchor is enough

The target is a **steady state**, not a moment: calibration waits for input and holds unchanged from `present 1838` through `3205`. Any flip anchor after it arrives therefore lands on it, however slow the boot was — and flips are boot-speed-invariant by design (#302). One Cross, nothing after it, so the title holds instead of being selected past.

## Measured

Four runs:

| run | fault | `max_nonblack` |
|---|---|---|
| 1 | no | **0.1097** |
| 2 | yes | 0.0000 |
| 3 | no | **0.1097** |
| 4 | yes | 0.0000 |

**Every non-faulting run reaches the title at exactly 0.1097.** The route contributes no variance.

## The remaining variance is a guest fault, not the route

2 of 4 runs die accepting calibration, at a fixed `rip=image+0x12cc536` on `RenderThread 1`, **with `PROSPER_NULL_PAGE=1` already set**. An earlier claim of mine that the flag cleared this fault was a single lucky run and is withdrawn. That fault is now the blocker for this title and is tracked in #3126.

## What the title screen draws today

Menu only: `START GAME` (highlighted), `SETTINGS`, `CREDITS`, the ✕ Select prompt and the version stamp all correct — the cat-head logo, the STRAY wordmark and the entire lit background absent. Oracle screenshot is on tracker #2883.

## Scope

Route file plus its header. **No code changes**, so no build or test impact; the header carries the run recipe, the fault, and the current visual state so the next reader does not re-derive any of it.

Refs #3126, #2883.
