### PR TITLE
diag(gpu): say what WAS available when a descriptor lookup misses (#3126)

### DIFF
--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -1946,6 +1946,20 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     if (vs_words.empty() || fs_words.empty() ||
         ((interpolation.requires_geometry || rect_list_synthesis) && gs.empty())) {
+        if (getenv("PROSPER_PROLOGLOG")) {
+            // #3126: name the FAILING program by the same content hash the prolog recogniser uses,
+            // so the reject and the chain decision can be joined inside ONE run.
+            const uint32_t* fc = reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.es_addr));
+            uint64_t fh = 0xcbf29ce484222325ull;
+            if (fc && vertex_dwords)
+                for (size_t i = 0; i < vertex_dwords && i < 4096; ++i) fh = (fh ^ fc[i]) * 0x100000001b3ull;
+            static std::set<uint64_t> seen_fail; static std::mutex fm;
+            std::lock_guard<std::mutex> lk(fm);
+            if (seen_fail.insert(fh).second)
+                fprintf(stderr, "[failshader] hash=%016llx dwords=%zu vs_empty=%d fs_empty=%d chain=%d\n",
+                        (unsigned long long)fh, vertex_dwords, (int)vs_words.empty(),
+                        (int)fs_words.empty(), (int)vertex_chain);
+        }
         report_dropped_draw_target(rs.color0_base, "shader-recompile", rs.cb_target_mask,
                                    rs.cb_shader_mask);
         if (failure) failure->reason = RealizationFailureReason::ShaderRecompile;

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -6969,6 +6969,33 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         pa ? (pa->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
                         sreg_range_written(rs, in.src[1].value, 8) ? 1 : 0,
                         rt->resources.size());
+                // #3126: say what WAS available, not only what failed. "key_res=null pc_res=null"
+                // tells you the lookups missed; it does not tell you whether the table holds the
+                // descriptor under a different key, holds it classified as something else, or does
+                // not hold it at all -- and those are three different bugs. Print every resource's
+                // class and provenance so the miss can be diagnosed from one line instead of a
+                // rebuild. Bounded, and only on a reject.
+                {
+                    std::string avail;
+                    size_t shown = 0;
+                    for (const ShaderResource& r : rt->resources) {
+                        if (shown++ >= 16) { avail += " ..."; break; }
+                        char one[96];
+                        const char* cls =
+                            r.cls == ResourceClass::Texture         ? "tex"
+                          : r.cls == ResourceClass::StorageImage    ? "simg"
+                          : r.cls == ResourceClass::ConstantBuffer  ? "cbuf"
+                          : r.cls == ResourceClass::VertexBuffer    ? "vbuf"
+                          : r.cls == ResourceClass::Sampler         ? "samp" : "other";
+                        if (r.sgpr_base == 0xFFFFFFFFu)
+                            snprintf(one, sizeof one, " [b%u %s srt=0x%x]", r.binding, cls, r.srt_offset);
+                        else
+                            snprintf(one, sizeof one, " [b%u %s s%u]", r.binding, cls, r.sgpr_base);
+                        avail += one;
+                    }
+                    fprintf(stderr, "[mimg-unresolved]   available:%s\n",
+                            avail.empty() ? " (none)" : avail.c_str());
+                }
             }
             if (!res) { ok = false; return true; }
             const bool uint_texture = res->format == DataFormat::Uint8 ||

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -3359,6 +3359,8 @@ VertexPrologInfo rdna2_vertex_prolog_info(const uint32_t* code, size_t dwords) {
                 (unsigned long long)phash, dwords, what, at ? at->pc : 0u, at ? (int)at->fmt : -1);
     };
     for (const Rdna2Inst& instruction : instructions) {
+        // A fetch prolog has no architectural output or program termination of its own. Encountering
+        // either before the transfer means this is a complete/different shader, not the split ABI.
         if (instruction.is_end || instruction.fmt == Rdna2Format::EXP ||
             instruction.fmt == Rdna2Format::Unknown) {
             prolog_note("BAIL", &instruction);

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -3346,12 +3346,24 @@ VertexPrologInfo rdna2_vertex_prolog_info(const uint32_t* code, size_t dwords) {
 
     std::vector<Rdna2Inst> instructions;
     rdna2_walk(code, dwords, instructions);
+    const bool prologlog = getenv("PROSPER_PROLOGLOG") != nullptr;
+    uint64_t phash = 0xcbf29ce484222325ull;
+    if (prologlog)
+        for (size_t i = 0; i < dwords && i < 4096; ++i) phash = (phash ^ code[i]) * 0x100000001b3ull;
+    auto prolog_note = [&](const char* what, const Rdna2Inst* at) {
+        if (!prologlog) return;
+        static std::set<uint64_t> seen; static std::mutex mx;
+        std::lock_guard<std::mutex> lk(mx);
+        if (!seen.insert(phash).second) return;
+        fprintf(stderr, "[prologlog] hash=%016llx dwords=%zu %s pc=%u fmt=%d\n",
+                (unsigned long long)phash, dwords, what, at ? at->pc : 0u, at ? (int)at->fmt : -1);
+    };
     for (const Rdna2Inst& instruction : instructions) {
-        // A fetch prolog has no architectural output or program termination of its own. Encountering
-        // either before the transfer means this is a complete/different shader, not the split ABI.
         if (instruction.is_end || instruction.fmt == Rdna2Format::EXP ||
-            instruction.fmt == Rdna2Format::Unknown)
+            instruction.fmt == Rdna2Format::Unknown) {
+            prolog_note("BAIL", &instruction);
             return {};
+        }
         if (instruction.fmt != Rdna2Format::SOP1 || instruction.opcode != 0x20)
             continue;
 
@@ -3361,6 +3373,7 @@ VertexPrologInfo rdna2_vertex_prolog_info(const uint32_t* code, size_t dwords) {
         if (instruction.n_src != 1 || instruction.src[0].kind != OperandKind::SGPR ||
             instruction.src[0].value != 6 || instruction.len_dwords != 1)
             return {};
+        prolog_note("TRANSFER", &instruction);
         result.valid = instruction.pc != 0;
         result.setpc_pc = instruction.pc;
         result.prefix_dwords = instruction.pc;


### PR DESCRIPTION
Three GPU diagnostics that each answer a "why" question which previously required editing the source and rebuilding. Written while chasing *Stray*'s missing title-screen background (#3126) — **the first one found the cause on its first run**, after several hours of indirect approaches had not.

## 1. `[mimg-unresolved]` now lists the resource table

The line already said which lookup routes returned null. It did **not** say whether the table holds the descriptor under a different key, holds it classified as something else, or does not hold it at all — three different bugs with an identical symptom.

Now:

```
[mimg-unresolved] program=0x0 pc=32 srsrc=s8 srt_tag=NONE key_res=null pc_res=null ... (9 res)
[mimg-unresolved]   available: [b2 cbuf s16] [b3 cbuf s20] [b4 cbuf s8] [b5 vbuf s8] [b6 vbuf s8] ...
```

**That is Stray's answer in one line.** The image instruction wants a **texture** at sgpr base 8; the table holds a **ConstantBuffer** there. The descriptor is present and **mis-classified**, not missing — a completely different fix from the one the old line implied. A shader that works in the same frame prints `[b37 tex s8] [b38 tex s16]`.

Prints only inside the existing reject path, bounded to 16 entries.

## 2. `[prologlog]` — why vertex-prolog recognition failed

`rdna2_vertex_prolog_info` returns `{}` from several places and the caller sees only `valid=false`. It now names the instruction that ended the scan, so *"not a prolog"* can be distinguished from *"a prolog we failed to recognise"*. Env-gated (`PROSPER_PROLOGLOG`), off by default.

## 3. `[failshader]` — name a failing draw's vertex program by CONTENT HASH

GPU addresses are run-local, and on some titles **so is the program set**. An address therefore cannot join a recompile reject to a layout decision — not across two runs, and not between a capture and a live run.

A content hash can. That join is what revealed a captured frame and the live route were reaching *different programs entirely*, which invalidated several hours of cross-referencing on #3126. The prolog log is keyed the same way so the two can be matched directly. Env-gated, off by default.

## Behaviour

**None.** (1) sits inside a path that was already rejecting; (2) and (3) are environment-gated and off by default.

## Verification

```
cmake --build prosper/build-linux -j6     # rc=0
ctest --no-tests=error -j4                # 314/314 passed, exit 0
git diff --check origin/master...HEAD     # clean
```

Refs #3126, #1634, #2883.
