### PR TITLE
recompiler: give fragment diagnostics the real guest program address (#3130)

### DIFF
--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -214,6 +214,10 @@ which is the recorded hazard: open the image before believing the number.
 
 ## Measured on CALIBRATION, and only one row survives as title-screen evidence
 
+(The one is the composite/tonemap row, which was established on the title-screen bundle. An earlier
+version of this section counted two, by crediting the colour-write-mask row with a surviving
+"mechanism" its own VOID marking denies.)
+
 Every number in this table was read on the 0.1140 calibration screen. The table is kept because it is
 cited, and annotated because three of its four rows were read as ruling out causes on the title
 screen, which they cannot do. **The next section has the title screen's own numbers, and they
@@ -223,7 +227,7 @@ disagree.**
 | --- | --- | --- |
 | dropped draws | 7 `shader-recompile`, ~30,000 draws executed | **FALSIFIED for the title screen** — ~3800 there, see below |
 | skipped compute | `0x300ba70000` executed **7455**, skipped **2** (`PROSPER_COMPUTE_PROGRAM_CENSUS=1`) | not re-measured on the title screen |
-| lost colour write masks | present and decoded on 32,649 of 32,649 traced draws | mechanism holds (no register lost); count is calibration's |
+| lost colour write masks | present and decoded on 32,649 of 32,649 traced draws | **VOID** — a trace run only on calibration says nothing about which registers reach the GPU on the title screen |
 | composite / tonemap | the HDR sources are black before it runs | holds — established on the title-screen bundle |
 
 ## The title screen's REAL numbers (measured on a 0.0069 frame)
@@ -300,8 +304,11 @@ contradictory new evidence.
 - **RETRACTED — "A wall-clock pad route reaches the title screen." (was: *Falsified*.)** The evidence
   was 0.1095 once, then 0.0063 / 0.0000 / 0.0063 on three unmodified reruns, read at the time as "the
   timed route works once by luck". Under the corrected number map that reading **inverts**: ~0.11 is
-  the *calibration* screen and ~0.006 is the *title* screen, so the three "failures" are the runs that
-  reached the title and the "lucky" sample is the one that did not. This doc now commits a wall-clock
+  the *calibration* screen and ~0.006 is the *title* screen, so **two** of the three "failures" (the
+  0.0063 pair) are the runs that reached the title, the "lucky" 0.1095 sample is the one that did not,
+  and 0.0000 is neither screen — a black frame is still a failure. Two of four, which is consistent
+  with the "roughly one run in three" this doc records elsewhere; an earlier version of this row said
+  three of four by counting the black frame as a success. This doc now commits a wall-clock
   route (`reach-title-hold.pad`, Cross at 150 s/160 s) as the title route for exactly that reason. The
   row is kept rather than deleted because the mistake it records — adopting a single sample as an A/B
   baseline — was real even though its conclusion was upside down. #3127.

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -91,10 +91,14 @@ completely empty table. Whether that is what its image ops want is untested — 
 
 > **VOID as title-screen evidence, and this warning covers BOTH censuses below it.** Every number in
 > this section was read on the brightness-calibration screen (`max_nonblack` 0.1140), not on the
-> title screen (0.0069). The section is kept because two *mechanism* findings survive the screen
-> mix-up — no `CB_TARGET_MASK` register is being lost (so this is not the *Oregon Trail* defect
-> #1946), and the colour-masked-off draws come from one shader — and because these numbers are cited
-> elsewhere and need somewhere to point. Every *quantity* here describes the wrong screen. Do not
+> title screen (0.0069). The section is kept because these numbers are cited elsewhere and need
+> somewhere to point — **not** because anything in it survives as title-screen evidence. An earlier
+> version of this banner claimed two *mechanism* findings did survive: that no `CB_TARGET_MASK`
+> register is being lost (so this is not the *Oregon Trail* defect #1946), and that the
+> colour-masked-off draws come from one shader. Both are marked VOID in `## Ruled out`, and the
+> banner cannot exempt them: a trace that ran only on calibration says nothing about which registers
+> reach the GPU on the title screen, mechanism or quantity. Every number here describes the wrong
+> screen. Do not
 > quote the 1024, the 7, the 32,649 or the 92% as facts about the title screen; § *The title
 > screen's REAL numbers* has that screen's own census, and it disagrees.
 

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -63,7 +63,11 @@ One compute program, `0x3011300000`, accounts for ~605 ms of that at roughly 32 
 3840×2160. So the cost is on the host side of the boundary, and pointing a GPU profiler at this title
 answers a question it does not have. Detail on [#3126](https://github.com/mattias800/prosper/issues/3126).
 
-## The title-screen defect, as far as it is established
+## The unresolved image ops — established on CALIBRATION
+
+> **The five-op census below was read on the calibration screen**, like every other live census above
+> § *The title screen's REAL numbers*. The resource-table finding it rests on is a statement about
+> shader stages and holds regardless of screen; the count of five does not.
 
 `[mimg-unresolved]` reports five image ops on one routed boot whose descriptor resolves to nothing;
 every draw using those shaders is discarded. What is **established**: for the shader stages that were
@@ -83,25 +87,28 @@ Separately, four stages declare a *writable* 8-dword T# that reaches no resource
 ([#3128](https://github.com/mattias800/prosper/issues/3128)); one of them has four image ops against a
 completely empty table. Whether that is what its image ops want is untested — see Ruled out.
 
-## Where the missing draws actually are
+## The dropped-draw census — measured on CALIBRATION
 
-`PROSPER_DROPPED_DRAW_CENSUS=1` on the title-screen route, at 1024 discarded draws:
+> **VOID as title-screen evidence, and this warning covers BOTH censuses below it.** Every number in
+> this section was read on the brightness-calibration screen (`max_nonblack` 0.1140), not on the
+> title screen (0.0069). The section is kept because two *mechanism* findings survive the screen
+> mix-up — no `CB_TARGET_MASK` register is being lost (so this is not the *Oregon Trail* defect
+> #1946), and the colour-masked-off draws come from one shader — and because these numbers are cited
+> elsewhere and need somewhere to point. Every *quantity* here describes the wrong screen. Do not
+> quote the 1024, the 7, the 32,649 or the 92% as facts about the title screen; § *The title
+> screen's REAL numbers* has that screen's own census, and it disagrees.
+
+`PROSPER_DROPPED_DRAW_CENSUS=1` on the **calibration** route, at 1024 discarded draws:
 
 | reason | count | targets |
 | --- | --- | --- |
 | `no-effect(early)` | 1015 | `0x9fc0000000` (511), `0x9fc2000000` (504), two others |
 | `shader-recompile` | 7 | `0x9fc2000000` (4), `0x9fc0000000` (3) |
 
-So the unresolved image ops cost **7 draws, not the picture**. Nearly everything discarded is dropped
-because every colour target's write mask is zero and there is no depth/stencil side effect.
-
-> **VOID as title-screen evidence — measured on the brightness-calibration screen (0.1140), not on
-> the title screen (0.0069).** The whole of this section is kept because its *mechanism* finding
-> stands (no `CB_TARGET_MASK` register is being lost, so this is not the *Oregon Trail* defect
-> #1946), and because the number is cited elsewhere and needs somewhere to point. Its *quantities*
-> describe the wrong screen and are contradicted by the title-screen census below: 8192 draws
-> discarded there against 1024 here. Do not quote the 92% or the 32,649 as facts about the title
-> screen.
+So **on calibration** the unresolved image ops cost 7 draws, and nearly everything discarded is
+dropped because every colour target's write mask is zero with no depth/stencil side effect. That
+conclusion does **not** transfer: the same census on the title screen reads ~3800 `shader-recompile`
+of 8192 discarded.
 
 **But the dropped draws are not where the missing picture is either.** `PROSPER_COLORSTATETRACE=1`
 over a shorter window traced **32,649** draws, and every single one carries a *decoded*
@@ -218,8 +225,9 @@ disagree.**
 ## The title screen's REAL numbers (measured on a 0.0069 frame)
 
 Everything above this section that quotes a live census was measured on calibration. Each such
-section now carries that warning at its own head rather than only here — a retraction a hundred lines
-below the number it retracts is one most readers never reach. These are the
+section carries that warning **at its own head, above the first number it covers** — a retraction a
+hundred lines below the number it retracts is one most readers never reach, and a banner placed
+mid-section silently exempts whatever sits above it. These are the
 title screen, `PROSPER_NULL_PAGE=1`, census read at the same cumulative total in every arm:
 
 | | calibration (0.1140) | **title screen (0.0069)** |
@@ -299,7 +307,9 @@ contradictory new evidence.
   one of those draws is a **full-screen 3840×2160 pass**. Draw *count* is not area, and the failing
   shaders are the composite. #3126.
 
-**VOID, not falsified — the next THREE rows only**, each individually marked. Every one was measured
+**VOID, not falsified — every row below whose bullet begins `VOID`**, and only those. The scoping is
+per-row and stated in the row itself, never positional: an earlier version of this paragraph said
+"the next three rows", which silently changed meaning the moment a row was inserted, and did. Every one was measured
 on a route that settles on the
 **brightness-calibration** screen (`max_nonblack` 0.1140), not the title screen (0.0069). They are
 correct statements about calibration and say nothing about the title screen, so they are neither
@@ -325,9 +335,11 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
 - **"The world renders into an HDR target that the composite then loses."** Falsified: every seeded
   scene target in the title-screen frame is black at source (brightest channel 0-6 across five HDR
   targets). #3126.
-- **"A skipped compute dispatch collapses the composite" (the charter's LUT/exposure shape).**
-  Falsified: `PROSPER_COMPUTE_PROGRAM_CENSUS` reports the only program with any skips at
-  **executed=7455, skipped=2**. #3126.
+- **VOID — "A skipped compute dispatch collapses the composite" (the charter's LUT/exposure shape).**
+  `PROSPER_COMPUTE_PROGRAM_CENSUS` reports the only program with any skips at **executed=7455,
+  skipped=2** — but that census was read on **calibration** and has not been re-run on the title
+  screen, so it is not a falsification for it. This row said `Falsified` and was corrected: the
+  measurement is real, the scope was overclaimed. #3126.
 - **MIMG `SRSRC` is not a user-SGPR index.** It names any SGPR, so a scan that treats every SRSRC as
   a user-data slot reports mostly false positives — scratch registers the shader loaded a descriptor
   into. An earlier list of "bases missing from the table" derived that way is discarded. #3126.

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -12,12 +12,40 @@ after that, and they are worth keeping apart because they have different evidenc
 | the world composites as a flat **letterboxed** clear — no scene renders | [#2932](https://github.com/mattias800/prosper/issues/2932) |
 | the **title screen** renders its menu but not its background | [#3126](https://github.com/mattias800/prosper/issues/3126) |
 
-## Two routes, and which to use
+## READ THIS BEFORE QUOTING A NUMBER FROM THIS DOC
 
-`reach-first-map.pad` drives past calibration to the map load. `reach-title-flip.pad` stops at the
-title screen and holds there; it is **anchored on flip ordinals, not wall-clock**, and it is the one
-to use for anything reproducible. The route README records why: a timed route reached the title only
-sometimes, and the flip anchor works because the target is a steady state rather than a moment.
+**`max_nonblack = 0.1140` is the brightness-calibration screen, NOT the title screen.** The title
+screen is **0.0069**. Both are held steady states and both look like "the run settled", so the two are
+easy to confuse — and every live A/B in the section below was originally run against the wrong one.
+
+| screen | `max_nonblack` | what it looks like |
+| --- | --- | --- |
+| brightness calibration | **0.1140** | **correct and complete** — three cat-head silhouettes at increasing brightness, the instruction text, the 16-step slider, `△ Defaults` / `✕ Accept` |
+| title screen | **0.0069** | menu only — `START GAME` / `SETTINGS` / `CREDITS`, the version string and `✕ Select`, everything else black at 8× brightness |
+
+The calibration screen rendering correctly is real, previously unrecorded progress: it is a full
+screen of the title's own art and UI, drawn right.
+
+**Reaching the title screen at all needs `PROSPER_NULL_PAGE=1`.** Without it a run either faults
+(`rc=90`, a `[nullpage]` report) or survives and renders pure black after Accept. With it the route
+still only lands roughly one run in three, so **repeat any A/B here** rather than trusting a single
+arm.
+
+**`reach-title-flip.pad` does not reach the title screen.** Measured over a 320 s run: 16 of 16
+captured frames are the calibration screen at 0.1140. The route README's claim that it stops at the
+title is wrong and needs correcting.
+
+## Three routes, and which to use
+
+| route | reaches | notes |
+| --- | --- | --- |
+| `reach-title-hold.pad` | the **title screen** (0.0069) | needs `PROSPER_NULL_PAGE=1`; lands about one run in three |
+| `reach-title-flip.pad` | the **calibration** screen (0.1140), held | flip-anchored and deterministic — a stable oracle for that screen, and *not* a title route despite its name |
+| `reach-first-map.pad` | past calibration to the first map load | |
+
+`reach-title-flip.pad` was landed as a title route and is not one; the banner above records the
+measurement. It is kept because holding calibration deterministically is genuinely useful — that
+screen renders correctly — and because renaming a committed route would break every citation of it.
 
 ## Performance: this title is not GPU-bound
 
@@ -53,6 +81,175 @@ Separately, four stages declare a *writable* 8-dword T# that reaches no resource
 ([#3128](https://github.com/mattias800/prosper/issues/3128)); one of them has four image ops against a
 completely empty table. Whether that is what its image ops want is untested — see Ruled out.
 
+## Where the missing draws actually are
+
+`PROSPER_DROPPED_DRAW_CENSUS=1` on the title-screen route, at 1024 discarded draws:
+
+| reason | count | targets |
+| --- | --- | --- |
+| `no-effect(early)` | 1015 | `0x9fc0000000` (511), `0x9fc2000000` (504), two others |
+| `shader-recompile` | 7 | `0x9fc2000000` (4), `0x9fc0000000` (3) |
+
+So the unresolved image ops cost **7 draws, not the picture**. Nearly everything discarded is dropped
+because every colour target's write mask is zero and there is no depth/stencil side effect.
+
+**But the dropped draws are not where the missing picture is either.** `PROSPER_COLORSTATETRACE=1`
+over a shorter window traced **32,649** draws, and every single one carries a *decoded*
+`CB_TARGET_MASK` — the presence flag is 1 on all of them, so no register is being lost, which is what
+would have made this the *Oregon Trail* defect (#1946):
+
+| `CB_TARGET_MASK` | draws |
+| --- | --- |
+| `0x0f` | 26,774 |
+| `0xff` | 1,655 |
+| `0x07` / `0x0c` | 884 / 838 |
+| **`0x00`** | **2,498** |
+
+Roughly **92% of draws write colour and execute**. The colour-masked-off draws all come from **one**
+fragment shader, `0x3010660000`, which exports a full `0xf` colour mask and runs with
+`DB_DEPTH_CONTROL` `0x70`/`0x62` — Z_WRITE off, no stencil — so under the RDNA rule (the masks are
+upstream hardware gates that an export can narrow but not enable) they genuinely write nothing, and
+`PROSPER_FORCE_COLORWRITE=1` admitting them makes the composite worse.
+
+**So the title screen is missing content while the overwhelming majority of its draws execute** — but
+see the frame dissection above before concluding, as I did at first, that the discarded draws
+therefore do not matter. They are few and each one is full-screen. The one thread still worth pulling on the dropped side is whether `CB_TARGET_MASK=0` is
+*stale* for that shader rather than current — #1706 established that prosper's decoded
+`CB_COLOR_CONTROL.MODE` is not per-draw-trustworthy because a utility sequence's bits stay latched
+onto later ordinary draws, and the same shape would explain one shader consistently reading zero.
+
+## The title-screen frame, dissected offline
+
+A **captured F9 bundle of the title screen already exists** and reproduces the defect deterministically
+without booting the game — the fastest loop this title has. Its submit-14072 capsule inspects as:
+
+```
+submit=14072 3840x2160 draws=92 computes=53 operations=156 shaders=113 failed=11
+```
+
+**Eleven of 156 operations never realize** — ten draws and one dispatch — and every one of the
+`shader-recompile` drops is a **full-screen 3840×2160 pass** with `CB_TARGET_MASK=0xf`, scissor
+`0,0..3840,2160`, alternating between the two swap targets `0x9fc0000000` / `0x9fc2000000`. That is
+why the count looked negligible and the picture is not: seven-to-eleven draws is nothing by count and
+the whole composite by area. **Do not dismiss these by draw count** — that mistake is what sent this
+investigation down the `no-effect` path.
+
+`gpu_replay --retry-failed-stage <failure>:<stage>` with `PROSPER_DBG=1` names each cause exactly:
+
+| failure | stage | reject |
+| --- | --- | --- |
+| 1, 2 | vertex `0x300f190000` | `v_mbcnt_lo/hi_u32_b32` with **SGPR masks** (`s4`/`s5`, `s6`/`s7`) at pc 277-286 |
+| 3 | fragment `0x30be800000` | MIMG `op=0x1`, `recompile-reject-mimg-address extra=1` at pc=134 |
+| 6-9 | fragment `0x300c010000` | `s_mov_b32 s0, m0` — `scalar-data-reject pc=37 special=s124 tracked=0` |
+| 10 | compute `0x300e390000` | the same `s_mov_b32 sX, m0` at pc=157, behind a `nested-backedge-in-body` loop reject at pc=688 |
+
+Two more fragment programs fail in other draws of the same frame: `0x300e500000` (`unsupported=29`,
+first reject pc=20) and `0x3011560000` (`unsupported=1`, first reject pc=383).
+
+The vertex one is the deepest. `0x300f190000` contains **both** MBCNT forms: the canonical all-ones
+lane-id pair at pc 4/7, which prosper can lower, *and* four general **SGPR-mask** MBCNTs at pc 277-286,
+which need real cross-lane mask state in a vertex stage. `rdna2_to_spirv.cpp` fails those closed on
+purpose — its comment says the wave approximations are "an exception for the one captured Astro
+wrapper, not a property of the GS_ALLOC_REQ opcode" — and the presence of a non-all-ones form is
+exactly what sets `logical_mbcnt_invalid` and disqualifies the `ngg_logical_lane` model. So this is a
+wave-semantics-in-vertex frontier, not a missing opcode.
+
+**Reproducing any of it takes seconds, not a boot:**
+
+```bash
+gpu_replay <capsule>.prgcap --inspect-only                     # the failure/operation list
+PROSPER_DBG=1 gpu_replay <capsule>.prgcap --retry-failed-stage 6:1
+gpu_replay <capsule>.prgcap --dump-failed-shader 1:1 vs.bin    # the raw guest program
+```
+
+## The scene targets are black AT SOURCE
+
+The obvious next hypothesis after "most draws execute" is that the world renders into an offscreen
+HDR target and the tonemap/composite that reads it is lost. **It is not.** Every render target the
+title-screen frame samples can be dumped straight out of the capture — no boot, no guessing which
+draw wrote what:
+
+```bash
+gpu_replay <capsule>.prgcap --dump-rtt-seed 0x3096fd0000 out.bin   # writes a BMP
+```
+
+| seeded target | format | brightest channel |
+| --- | --- | --- |
+| `0x3096fd0000` 3840×2160 | rgba16f | 5 |
+| `0x30a4a20000` 3840×2160 | rgba16f | 0 |
+| `0x3071dd0000` 1920×1080 | r11g11b10f | 6 |
+| `0x300a790000` / `0x3025380000` 480×270 | r11g11b10f | 4 / 0 |
+| `0x3092b10000` 3840×2160 | rgba8 | 0 |
+
+Every HDR scene target is black at source, so the world's colour never exists to be lost downstream.
+**This is not a composite defect.** The draws run and write nothing — the same family as *Grand Theft
+Auto V* and *Sonic Frontiers*, not a missing pass.
+
+**Two of the targets are traps rather than evidence.** `0x3094b60000` and `0x30a29e0000` score
+`nonblack=0.2543, mean=63.8` — by far the brightest things in the frame — and both are a **white
+quadrant covering the top-left 1920×1080**, i.e. prosper's own seed-miss fill. `0x30563d0000` carries
+the seed-miss *gradient*. A brightness metric ranks all three above any real content in this frame,
+which is the recorded hazard: open the image before believing the number.
+
+## Everything else is measured and is not the cause
+
+| candidate | measurement |
+| --- | --- |
+| dropped draws | 7 `shader-recompile`, ~30,000 draws executed |
+| skipped compute | `0x300ba70000` executed **7455**, skipped **2** (`PROSPER_COMPUTE_PROGRAM_CENSUS=1`) |
+| lost colour write masks | present and decoded on 32,649 of 32,649 traced draws |
+| composite / tonemap | the HDR sources are black before it runs |
+
+## The title screen's REAL numbers (measured on a 0.0069 frame)
+
+Everything above this section that quotes a live census was measured on calibration. These are the
+title screen, `PROSPER_NULL_PAGE=1`, census read at the same cumulative total in every arm:
+
+| | calibration (0.1140) | **title screen (0.0069)** |
+| --- | --- | --- |
+| draws discarded | 1024 | **8192** |
+| `shader-recompile` | 7 | **~3800** |
+| `no-effect` | 1015 | ~4400 |
+
+Two targets take almost all of it — `x1260` and `x835` in one run. **That**, not the seven drops this
+investigation spent hours on, is why the background is black.
+
+`PROSPER_DBG=1` on the same route gives the remaining work list, in order of instances:
+
+| reject | count | note |
+| --- | --- | --- |
+| `[vertex-recompile-reject] body or export lowering failed` | 15 | |
+| MUBUF `unresolved-operand`, `fmt=12` | 14 | see below |
+| MIMG `fmt=14` | 3 | #3134's family |
+| `scalar-data-reject special=s124` | 4 | fixed by #3133 |
+
+### The MUBUF class, decoded
+
+```
+sh=/77  pc=57 words=e00c2000,6a010000 op=0x3 src=0(k2),4(k1),106(k6)  stage=vertex
+sh=/221 pc=66 words=e0042000,6b020900 op=0x1 src=0(k2),8(k1),107(k6)  stage=vertex
+```
+
+Both are `buffer_load_format_*` with `idxen` — **vertex attribute fetch** — in small vertex shaders,
+with `VCC_LO`/`VCC_HI` as the soffset. The opcodes themselves are implemented (`0x0`-`0x3` are all
+handled), so the reject is an operand, not a missing instruction. The next thing to establish is
+whether the failing operand is the soffset or the SRSRC: `allow_smem` is `(rt != nullptr)` for
+graphics, so **a vertex stage that arrives with no resource table fails every buffer op it has**, and
+vertex fetch is a buffer op — that would take the draw with it. A probe on `rt == nullptr` at the
+vertex recompile answers it in one run.
+
+### What #3133 is worth here
+
+Measured on this screen, census at the same total, two arms per build:
+
+| build | `shader-recompile` @ 4096 discarded |
+| --- | --- |
+| baseline | 1026, 989 |
+| with #3133 | **866, 886** |
+
+A ~13% reduction, groups non-overlapping. The visible frame does not change — the remaining ~870
+drops still discard the background.
+
 ## Ruled out
 
 One line per falsified hypothesis, the evidence, and the link. Do not restart these without
@@ -74,6 +271,39 @@ contradictory new evidence.
 - **"A wall-clock pad route reaches the title screen."** Falsified: 0.1095 once, then 0.0063 / 0.0000
   / 0.0063 on three unmodified reruns. The single lucky sample was adopted as an A/B baseline and four
   hypotheses were run against it before the reruns exposed it. Use `reach-title-flip.pad`. #3127.
+- **"The unresolved image ops are what is missing from the title screen."** ~~Falsified by the
+  dropped-draw census~~ — **this row was wrong and is retained as a warning.** The census reading (7
+  of 1024 discarded draws are `shader-recompile`) is correct, and the inference from it is not: every
+  one of those draws is a **full-screen 3840×2160 pass**. Draw *count* is not area, and the failing
+  shaders are the composite. #3126.
+**VOID, not falsified — the next five rows.** Every one was measured on a route that settles on the
+**brightness-calibration** screen (`max_nonblack` 0.1140), not the title screen (0.0069). They are
+correct statements about calibration and say nothing about the title screen, so they are neither
+evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a window that reaches
+0.0069 before quoting any of them. #3126.
+
+- **VOID — "prosper is losing `CB_TARGET_MASK` for the no-effect draws" (the #1946 shape).**
+  `PROSPER_COLORSTATETRACE` reported the presence flag as 1 on 32,649 of 32,649 traced draws — on
+  calibration. #3126.
+- **VOID — "The dropped draws are where the missing picture is."** ~92% of draws carried a non-zero
+  write mask and executed, and the colour-masked-off ones were a single fragment shader
+  (`0x3010660000`) — on calibration. #3126.
+- **VOID — "`no-effect(early)` is discarding content that should render."** One arm said no:
+  `PROSPER_NO_EARLY_NO_EFFECT=1` moves the same draws to the late `no-effect` verdict with
+  `max_nonblack` unchanged at 0.1140, and `PROSPER_FORCE_COLORWRITE=1` makes the composite **worse**
+  (0.1140 → 0.0296). Neither lever admits content. That does not prove the masks were decoded
+  correctly, only that admitting these draws wholesale is not the fix. #3126.
+- **"The `srsrc=s0` failures are a size-0 slot wrongly claimed by the V# path."** Falsified by a
+  built arm: making a guest-declared 8-dword slot decline the V# claim when its eight dwords decode
+  as a valid T# changed nothing — on the draw that recompiles, those eight dwords are **residue**
+  (`degenerate T#`), so the guard correctly falls through and the slot is still claimed. The real
+  shape is #1590's: the T# is absent on the draw that happens to compile the shader. #3126.
+- **"The world renders into an HDR target that the composite then loses."** Falsified: every seeded
+  scene target in the title-screen frame is black at source (brightest channel 0-6 across five HDR
+  targets). #3126.
+- **"A skipped compute dispatch collapses the composite" (the charter's LUT/exposure shape).**
+  Falsified: `PROSPER_COMPUTE_PROGRAM_CENSUS` reports the only program with any skips at
+  **executed=7455, skipped=2**. #3126.
 - **MIMG `SRSRC` is not a user-SGPR index.** It names any SGPR, so a scan that treats every SRSRC as
   a user-data slot reports mostly false positives — scratch registers the shader loaded a descriptor
   into. An earlier list of "bases missing from the table" derived that way is discarded. #3126.

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -268,15 +268,22 @@ contradictory new evidence.
   them as `StorageImage` left both `mimg-unresolved` (5) and `max_nonblack` (0.1097) exactly
   unchanged. That arm may have used a class/provenance the MIMG resolver does not match on, so the
   question is open — but do not assume the fix moves this title. #3128.
-- **"A wall-clock pad route reaches the title screen."** Falsified: 0.1095 once, then 0.0063 / 0.0000
-  / 0.0063 on three unmodified reruns. The single lucky sample was adopted as an A/B baseline and four
-  hypotheses were run against it before the reruns exposed it. Use `reach-title-flip.pad`. #3127.
+- **RETRACTED — "A wall-clock pad route reaches the title screen." (was: *Falsified*.)** The evidence
+  was 0.1095 once, then 0.0063 / 0.0000 / 0.0063 on three unmodified reruns, read at the time as "the
+  timed route works once by luck". Under the corrected number map that reading **inverts**: ~0.11 is
+  the *calibration* screen and ~0.006 is the *title* screen, so the three "failures" are the runs that
+  reached the title and the "lucky" sample is the one that did not. This doc now commits a wall-clock
+  route (`reach-title-hold.pad`, Cross at 150 s/160 s) as the title route for exactly that reason. The
+  row is kept rather than deleted because the mistake it records — adopting a single sample as an A/B
+  baseline — was real even though its conclusion was upside down. #3127.
 - **"The unresolved image ops are what is missing from the title screen."** ~~Falsified by the
   dropped-draw census~~ — **this row was wrong and is retained as a warning.** The census reading (7
   of 1024 discarded draws are `shader-recompile`) is correct, and the inference from it is not: every
   one of those draws is a **full-screen 3840×2160 pass**. Draw *count* is not area, and the failing
   shaders are the composite. #3126.
-**VOID, not falsified — the next five rows.** Every one was measured on a route that settles on the
+
+**VOID, not falsified — the next THREE rows only**, each individually marked. Every one was measured
+on a route that settles on the
 **brightness-calibration** screen (`max_nonblack` 0.1140), not the title screen (0.0069). They are
 correct statements about calibration and say nothing about the title screen, so they are neither
 evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a window that reaches

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -71,11 +71,13 @@ dumped, the resource table is complete and correct — each declared read-only T
 SGPR-resident one under DIRECT (`sgpr_base`) provenance and the EUD-resident ones under INDIRECT
 (`srt_offset = (offset_dw - num_user_sgprs) * 4`) provenance, which is exactly what the table shows.
 
-What is **not** established is which stage the five failures belong to. Every line reports
-`program=0x0`, because `recompile_fragment_impl` hardcodes a zero program address
+What was **not** established at the time of that census is which stage the five failures belong to.
+Every line reported `program=0x0`, because `recompile_fragment_impl` hardcoded a zero program address
 ([#3130](https://github.com/mattias800/prosper/issues/3130)) — so no fragment-shader recompile failure
-on any title can currently be attributed to a shader. Fixing that turns this investigation from an
-inference into a lookup, and is the cheapest next step.
+on any title could be attributed to a shader. **That is fixed** (#3132): fragment diagnostics now carry
+the real guest program address, which turns this from an inference into a lookup. The five failures
+above predate the fix and were never re-attributed, so they remain unassigned to a stage — re-running
+the census is what would assign them.
 
 Separately, four stages declare a *writable* 8-dword T# that reaches no resource table at all
 ([#3128](https://github.com/mattias800/prosper/issues/3128)); one of them has four image ops against a
@@ -92,6 +94,14 @@ completely empty table. Whether that is what its image ops want is untested — 
 
 So the unresolved image ops cost **7 draws, not the picture**. Nearly everything discarded is dropped
 because every colour target's write mask is zero and there is no depth/stencil side effect.
+
+> **VOID as title-screen evidence — measured on the brightness-calibration screen (0.1140), not on
+> the title screen (0.0069).** The whole of this section is kept because its *mechanism* finding
+> stands (no `CB_TARGET_MASK` register is being lost, so this is not the *Oregon Trail* defect
+> #1946), and because the number is cited elsewhere and needs somewhere to point. Its *quantities*
+> describe the wrong screen and are contradicted by the title-screen census below: 8192 draws
+> discarded there against 1024 here. Do not quote the 92% or the 32,649 as facts about the title
+> screen.
 
 **But the dropped draws are not where the missing picture is either.** `PROSPER_COLORSTATETRACE=1`
 over a shorter window traced **32,649** draws, and every single one carries a *decoded*
@@ -191,18 +201,25 @@ quadrant covering the top-left 1920×1080**, i.e. prosper's own seed-miss fill. 
 the seed-miss *gradient*. A brightness metric ranks all three above any real content in this frame,
 which is the recorded hazard: open the image before believing the number.
 
-## Everything else is measured and is not the cause
+## Measured on CALIBRATION, and only one row survives as title-screen evidence
 
-| candidate | measurement |
-| --- | --- |
-| dropped draws | 7 `shader-recompile`, ~30,000 draws executed |
-| skipped compute | `0x300ba70000` executed **7455**, skipped **2** (`PROSPER_COMPUTE_PROGRAM_CENSUS=1`) |
-| lost colour write masks | present and decoded on 32,649 of 32,649 traced draws |
-| composite / tonemap | the HDR sources are black before it runs |
+Every number in this table was read on the 0.1140 calibration screen. The table is kept because it is
+cited, and annotated because three of its four rows were read as ruling out causes on the title
+screen, which they cannot do. **The next section has the title screen's own numbers, and they
+disagree.**
+
+| candidate | measurement (calibration) | title-screen status |
+| --- | --- | --- |
+| dropped draws | 7 `shader-recompile`, ~30,000 draws executed | **FALSIFIED for the title screen** — ~3800 there, see below |
+| skipped compute | `0x300ba70000` executed **7455**, skipped **2** (`PROSPER_COMPUTE_PROGRAM_CENSUS=1`) | not re-measured on the title screen |
+| lost colour write masks | present and decoded on 32,649 of 32,649 traced draws | mechanism holds (no register lost); count is calibration's |
+| composite / tonemap | the HDR sources are black before it runs | holds — established on the title-screen bundle |
 
 ## The title screen's REAL numbers (measured on a 0.0069 frame)
 
-Everything above this section that quotes a live census was measured on calibration. These are the
+Everything above this section that quotes a live census was measured on calibration. Each such
+section now carries that warning at its own head rather than only here — a retraction a hundred lines
+below the number it retracts is one most readers never reach. These are the
 title screen, `PROSPER_NULL_PAGE=1`, census read at the same cumulative total in every arm:
 
 | | calibration (0.1140) | **title screen (0.0069)** |

--- a/prosper/scripts/stray-PPSA02101/README.md
+++ b/prosper/scripts/stray-PPSA02101/README.md
@@ -3,8 +3,29 @@
 `reach-first-map.pad` drives the boot past the **brightness-calibration screen** to the first map
 load.
 
-`reach-title-flip.pad` stops one screen earlier — it reaches the **title screen** and holds there —
-and it is the one to use for anything that has to be reproducible.
+`reach-title-flip.pad` was landed as "reaches the title screen and holds there". **Measured 2026-08-30,
+that is wrong**: over a 320 s run all 16 captured frames are the brightness-calibration screen
+(`max_nonblack` 0.1140). Its single flip-anchored Cross does not accept. Treat it as a deterministic
+way to *hold calibration*, which is still useful — that screen renders correctly and is a stable
+oracle — but not as a title-screen route.
+
+**`reach-title-hold.pad` is the title route**, and it needs `PROSPER_NULL_PAGE=1`. Without that the
+run either faults with a `[nullpage]` report or survives and renders pure black after Accept. With it
+the route lands on the title screen (`max_nonblack` 0.0069, held) in roughly **one run in three**, so
+repeat any measurement rather than trusting one arm.
+
+```bash
+PROSPER_NULL_PAGE=1 \
+PROSPER_PAD_SCRIPT=@prosper/scripts/stray-PPSA02101/reach-title-hold.pad \
+  ./build-linux/screenshot <DUMP_ROOT>/PPSA02101-app0 \
+    --seconds 6 --count 30 --warmup-seconds 140 --timeout 360 \
+    --allow-guest-fault --no-stop-after-guest-fault --out <OUTDIR>
+```
+
+Frames 09-28 settle at 0.0069 when it lands. It presses Cross twice (t=150 and t=160): the first
+accepts calibration, and the second is the margin for a slow boot — on a fast one it lands on the
+title menu's already-selected `START GAME`, which is why a window that runs far past t=160 can catch
+a load instead of the title.
 
 ## Why the title route is anchored on flips, not seconds
 

--- a/prosper/scripts/stray-PPSA02101/README.md
+++ b/prosper/scripts/stray-PPSA02101/README.md
@@ -30,9 +30,10 @@ a load instead of the title.
 ## Why the title route is anchored on flips, not seconds
 
 A wall-clock route cannot hit this title reliably: an earlier 150 s/160 s version fired before
-calibration on slower boots and reached the title only sometimes (`max_nonblack` 0.1095 once, then
-0.0063 / 0.0000 / 0.0063 on three unmodified reruns — a single lucky sample adopted as a baseline is
-how that hour was lost). The flip anchor works because the target is a **steady state** rather than a
+calibration on slower boots and reached the title only sometimes (`max_nonblack` a timed route reached the title only
+sometimes. **That reading was inverted** and is corrected in
+`docs/STRAY_STATUS.md` § Ruled out: ~0.11 is the calibration screen and ~0.006 is the title screen, so
+the samples read as failures were the successes. The flip anchor works because the target is a **steady state** rather than a
 moment: a no-input boot reaches calibration at `present_count` ≈ 1764 and then holds it unchanged
 (identical nonblack 0.1070 from present 1838 through 3205), because that screen waits for input. Any
 anchor after it arrives lands on it however slow the boot was.

--- a/prosper/scripts/stray-PPSA02101/README.md
+++ b/prosper/scripts/stray-PPSA02101/README.md
@@ -42,7 +42,8 @@ stable oracle.
 
 An earlier attempt to read wall-clock timing as unreliable rested on an **inverted number map**:
 ~0.11 was taken for the title screen and ~0.006 for a failure, when it is the other way round
-(`docs/STRAY_STATUS.md` § Ruled out). The samples read as failures were the successes. That is why
+(`docs/STRAY_STATUS.md` § Ruled out). Two of the three samples read as failures were the successes —
+the third was a black frame, which is a failure under either map. That is why
 the wall-clock `reach-title-hold.pad` above is the title route despite this section once arguing no
 wall-clock route could work.
 

--- a/prosper/scripts/stray-PPSA02101/README.md
+++ b/prosper/scripts/stray-PPSA02101/README.md
@@ -27,18 +27,31 @@ accepts calibration, and the second is the margin for a slow boot — on a fast 
 title menu's already-selected `START GAME`, which is why a window that runs far past t=160 can catch
 a load instead of the title.
 
-## Why the title route is anchored on flips, not seconds
+## Why the CALIBRATION route is anchored on flips, not seconds
 
-A wall-clock route cannot hit this title reliably: an earlier 150 s/160 s version fired before
-calibration on slower boots and reached the title only sometimes (`max_nonblack` a timed route reached the title only
-sometimes. **That reading was inverted** and is corrected in
-`docs/STRAY_STATUS.md` § Ruled out: ~0.11 is the calibration screen and ~0.006 is the title screen, so
-the samples read as failures were the successes. The flip anchor works because the target is a **steady state** rather than a
-moment: a no-input boot reaches calibration at `present_count` ≈ 1764 and then holds it unchanged
-(identical nonblack 0.1070 from present 1838 through 3205), because that screen waits for input. Any
-anchor after it arrives lands on it however slow the boot was.
+This section is about `reach-title-flip.pad`, which despite its name reaches **calibration**, not the
+title. The title route is the wall-clock one above; this heading used to claim the opposite and the
+export below used to present this file as the title route, both of which contradicted the top of this
+same README.
+
+The flip anchor is the right shape *for calibration* because that target is a **steady state** rather
+than a moment: a no-input boot reaches calibration at `present_count` ≈ 1764 and then holds it
+unchanged (identical nonblack 0.1070 from present 1838 through 3205), because that screen waits for
+input. Any anchor after it arrives lands on it however slow the boot was — which is what makes it a
+stable oracle.
+
+An earlier attempt to read wall-clock timing as unreliable rested on an **inverted number map**:
+~0.11 was taken for the title screen and ~0.006 for a failure, when it is the other way round
+(`docs/STRAY_STATUS.md` § Ruled out). The samples read as failures were the successes. That is why
+the wall-clock `reach-title-hold.pad` above is the title route despite this section once arguing no
+wall-clock route could work.
+
+Note the unreconciled figure recorded in `reach-title-flip.pad`'s own header: this file's runs
+settle at 0.1140 while an earlier set reported 0.1097 for what should be the same screen. Both are
+calibration; the gap is not explained.
 
 ```bash
+# calibration hold -- NOT the title route
 export PROSPER_PAD_SCRIPT=@prosper/scripts/stray-PPSA02101/reach-title-flip.pad
 ```
 

--- a/prosper/scripts/stray-PPSA02101/reach-title-flip.pad
+++ b/prosper/scripts/stray-PPSA02101/reach-title-flip.pad
@@ -1,3 +1,18 @@
+# Stray (PPSA02101) -- reach the brightness-CALIBRATION screen deterministically and hold there.
+#
+# CORRECTION 2026-08-30: this file was landed as a TITLE-screen route and it is not one. Everything
+# below the correction is the original header, kept because its flip-anchor reasoning is sound and
+# its measurements were real; only the screen it names was wrong.
+#
+# The unresolved part, stated rather than hidden: the original header reports FOUR runs reaching
+# "the title screen" at max_nonblack 0.1097, while a later 16-frame run of this same route settles at
+# 0.1140 on a frame that visibly IS the calibration screen (three cat heads, the Adjust-the-value
+# text, the 16-step slider, the Defaults/Accept prompts). 0.1097 and 0.1140 are close but not equal,
+# and the two measurements have not been reconciled. Whoever picks this up should settle it by
+# LOOKING at a frame from each rather than by comparing the numbers -- that is what exposed the
+# original misreading. See docs/STRAY_STATUS.md and #3126.
+#
+# --- original header follows ---
 # Stray (PPSA02101) -- reach the title screen DETERMINISTICALLY and hold there.
 #
 # Anchored on FLIPS, not seconds. Measured 2026-08-30: a no-input boot reaches the

--- a/prosper/scripts/stray-PPSA02101/reach-title-flip.pad
+++ b/prosper/scripts/stray-PPSA02101/reach-title-flip.pad
@@ -22,9 +22,14 @@
 #
 # That is what makes a single late anchor deterministic: the target state is not a moment,
 # it is a steady state, so any anchor after it arrives lands on it however slow the boot was.
-# A wall-clock route cannot do this -- the earlier 150s/160s version fired before calibration
-# on slower boots and reached the title only sometimes (measured 0.1095 once, then
-# 0.0063/0.0000/0.0063 on three unmodified reruns).
+# The claim that used to sit here -- "a wall-clock route cannot do this", citing an earlier
+# 150s/160s version that "reached the title only sometimes (0.1095 once, then
+# 0.0063/0.0000/0.0063 on three unmodified reruns)" -- is INVERTED and is withdrawn.
+# Under the corrected number map ~0.11 is calibration and ~0.006 is the title screen, so the
+# run read as the success was calibration and two of the three read as failures were the
+# TITLE SCREEN. That route reached the title 2 of 4 times, not 1 of 4, and it is committed as
+# reach-title-hold.pad -- the route this title actually uses. The flip anchor is a good way to
+# hold CALIBRATION; it was never evidence against wall-clock timing.
 #
 # ONE press: Cross accepts calibration (its own prompt bar names it). Nothing after it, so the
 # title screen holds instead of being selected past into the game.

--- a/prosper/scripts/stray-PPSA02101/reach-title-hold.pad
+++ b/prosper/scripts/stray-PPSA02101/reach-title-hold.pad
@@ -2,7 +2,12 @@
 #
 # TIMING MEASURED 2026-08-29, not inherited. A no-input boot settles on the calibration screen at
 # t~140 s (nonblack 0.1097, then constant to t=270 s), NOT the much earlier point the 2026-08-22
-# routes assume. The committed reach-first-map.pad presses Cross every 3 s from t=3, so on today's
+# routes assume.
+#
+# On that 0.1097: reach-title-flip.pad's header records it as UNRECONCILED against the 0.1140 a
+# 16-frame run of the flip route settles at on a frame that visibly is the same calibration screen.
+# Both readings are calibration and the timing above does not depend on which is right, but do not
+# cite 0.1097 as a settled constant for this screen -- the two have not been reconciled. The committed reach-first-map.pad presses Cross every 3 s from t=3, so on today's
 # build every one of those presses lands before there is anything to accept.
 #
 # Cross accepts calibration (its own prompt bar names it). A few spaced presses after the screen is

--- a/prosper/scripts/stray-PPSA02101/reach-title-hold.pad
+++ b/prosper/scripts/stray-PPSA02101/reach-title-hold.pad
@@ -1,0 +1,11 @@
+# Stray (PPSA02101) -- accept the brightness calibration and HOLD on the title screen.
+#
+# TIMING MEASURED 2026-08-29, not inherited. A no-input boot settles on the calibration screen at
+# t~140 s (nonblack 0.1097, then constant to t=270 s), NOT the much earlier point the 2026-08-22
+# routes assume. The committed reach-first-map.pad presses Cross every 3 s from t=3, so on today's
+# build every one of those presses lands before there is anything to accept.
+#
+# Cross accepts calibration (its own prompt bar names it). A few spaced presses after the screen is
+# up, then silence, so the title screen holds for the rest of the run instead of being selected past.
+150-150.5:cross
+160-160.5:cross

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -1653,8 +1653,15 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     return key;
 }
 
+// `program_address` is the guest address of the shader this key was built from. It is DIAGNOSTIC
+// PROVENANCE ONLY and deliberately arrives as a separate argument rather than inside the key: the
+// same program bytes produce the same SPIR-V at every guest address, so folding it into
+// ShaderCompileKey would give each address its own cache entry and quietly defeat the cache. The
+// key's own `code` pointer cannot serve here -- it points into the key's owned COPY of the words,
+// not at guest memory (#3130).
 std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const ShaderCompileKey& key,
-                                              const ShaderResourceTable* resources) {
+                                              const ShaderResourceTable* resources,
+                                              uint64_t program_address) {
     const uint32_t* code = !key.code || key.code->empty() ? nullptr : key.code->data();
     const size_t code_size = key.code ? key.code->size() : 0u;
     if (stage == ShaderProgramStage::Vertex)
@@ -1678,7 +1685,8 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
         return recompile_fragment(code, code_size, resources,
                                   key.has_system_inputs ? &key.system_inputs : nullptr,
                                   key.has_pcrel_dispatch ? key.pcrel_dispatch_target : UINT32_MAX,
-                                  &interpolation, key.fragment_wave32);
+                                  &interpolation, key.fragment_wave32,
+                                  {RecompileDiagnosticStage::Fragment, program_address});
     }
     return {};
 }
@@ -1747,7 +1755,8 @@ void maybe_dump_successful_shader(ShaderProgramStage stage, const ShaderCompileK
 
 SharedShaderWords cache_compiled_graphics_shader(ShaderProgramStage stage, ShaderCompileKey key,
                                                   const ShaderResourceTable* resources,
-                                                  uint64_t* cache_identity) {
+                                                  uint64_t* cache_identity,
+                                                  uint64_t program_address) {
     if (cache_identity) *cache_identity = 0;
     if (getenv("PROSPER_NO_SHADER_CACHE")) {
         auto& cache = shader_cache();
@@ -1756,7 +1765,7 @@ SharedShaderWords cache_compiled_graphics_shader(ShaderProgramStage stage, Shade
             ++cache.stats.bypasses;
         }
         auto spirv = std::make_shared<const std::vector<uint32_t>>(
-            compile_graphics_shader(stage, key, resources));
+            compile_graphics_shader(stage, key, resources, program_address));
         maybe_dump_successful_shader(stage, key, *spirv);
         return spirv;
     }
@@ -1774,7 +1783,7 @@ SharedShaderWords cache_compiled_graphics_shader(ShaderProgramStage stage, Shade
 
     const auto start = std::chrono::steady_clock::now();
     auto spirv = std::make_shared<const std::vector<uint32_t>>(
-        compile_graphics_shader(stage, key, resources));
+        compile_graphics_shader(stage, key, resources, program_address));
     maybe_dump_successful_shader(stage, key, *spirv);
     const auto end = std::chrono::steady_clock::now();
     ++cache.stats.misses;
@@ -1937,7 +1946,21 @@ SharedShaderWords recompile_graphics_shader_cached_shared(
                                                    system_inputs, nullptr, 0,
                                                    vertex_lds_dwords, nullptr,
                                                    fragment_wave32, vertex_capture_position);
-    return cache_compiled_graphics_shader(stage, std::move(key), resources, cache_identity);
+    // Guest memory is 1:1-mapped, so the caller's code pointer IS the guest program address; it must
+    // be captured here because the key owns a copy of the words rather than pointing at them.
+    const uint64_t program_address = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(code));
+    // The trip-bound selector has to be in the key, for exactly the reason the compute path already
+    // mixes it in (`rdna2_cfg_support.hpp`: the cache is keyed on CODE BYTES and never on the
+    // address, so a target and a non-target with the same body collide on one entry, and whichever
+    // compiled first serves the other). Graphics never did this, and it was harmless only because
+    // fragment diagnostics were pinned at address 0 — the selector could not match a program that
+    // had no address. This change gives them their real address, which makes the hazard real for
+    // graphics exactly as it already is for compute, so the guard has to arrive with it.
+    key.trip_bound = compute_trip_bound_settings();
+    if (key.trip_bound.bound) key.trip_bound_program_address = program_address;
+    key.cached_hash = ShaderCompileKeyHash::compute(key);
+    return cache_compiled_graphics_shader(stage, std::move(key), resources, cache_identity,
+                                          program_address);
 }
 
 SharedShaderWords recompile_vertex_chain_cached_shared(
@@ -1953,8 +1976,12 @@ SharedShaderWords recompile_vertex_chain_cached_shared(
         if (cache_identity) *cache_identity = 0;
         return {};
     }
-    return cache_compiled_graphics_shader(ShaderProgramStage::Vertex, std::move(key), resources,
-                                          cache_identity);
+    const uint64_t chain_address = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(prolog));
+    key.trip_bound = compute_trip_bound_settings();
+    if (key.trip_bound.bound) key.trip_bound_program_address = chain_address;
+    key.cached_hash = ShaderCompileKeyHash::compute(key);
+    return cache_compiled_graphics_shader(
+        ShaderProgramStage::Vertex, std::move(key), resources, cache_identity, chain_address);
 }
 
 std::vector<uint32_t> recompile_graphics_shader_cached(

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -6959,9 +6959,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 int ud_origin = 0;
                 const bool has_ud_alias = sreg_range_ud_alias(rs, in.src[1].value, 8, ud_origin);
                 const ShaderResource* pa = has_ud_alias ? rt->by_sgpr_base(ud_origin) : nullptr;
-                fprintf(stderr, "[mimg-unresolved] program=0x%llx pc=%u srsrc=s%d srt_tag=%s0x%x key_res=%s pc_res=%s ud_alias=%s%d alias_res=%s written=%d (%zu res)\n",
+                fprintf(stderr, "[mimg-unresolved] program=0x%llx pc=%u op=0x%02x storage=%d srsrc=s%d srt_tag=%s0x%x key_res=%s pc_res=%s ud_alias=%s%d alias_res=%s written=%d (%zu res)\n",
                         (unsigned long long)b.diagnostic.program_address,
-                        in.pc, in.src[1].value, has_srt_tag ? "" : "NONE ",
+                        in.pc, in.opcode, (int)storage_only_op,
+                        in.src[1].value, has_srt_tag ? "" : "NONE ",
                         has_srt_tag ? srt_tag : 0u,
                         pk ? (pk->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
                         pp ? (pp->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -2928,9 +2928,9 @@ static std::vector<uint32_t> recompile_fragment_impl(
         const PixelSystemInputMapping* system_inputs,
         uint32_t pcrel_dispatch_target,
         const FragmentInterpolationLayout* interpolation,
-        uint32_t wave_size) {
+        uint32_t wave_size,
+        RecompileDiagnosticContext diagnostic) {
     if (wave_size != 32 && wave_size != 64) return {};
-    const RecompileDiagnosticContext diagnostic{RecompileDiagnosticStage::Fragment, 0};
     std::vector<Rdna2Inst> ins;
     const size_t program_dwords = rdna2_walk(code, dwords, ins);
     if (pcrel_dispatch_target != UINT32_MAX) {
@@ -3160,16 +3160,18 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const PixelSystemInputMapping* system_inputs,
                                          uint32_t pcrel_dispatch_target,
                                          const FragmentInterpolationLayout* interpolation,
-                                         bool wave32) {
+                                         bool wave32,
+                                         RecompileDiagnosticContext diagnostic) {
     return recompile_fragment_impl(code, dwords, rt, system_inputs,
                                    pcrel_dispatch_target, interpolation,
-                                   wave32 ? 32u : 64u);
+                                   wave32 ? 32u : 64u, diagnostic);
 }
 
 std::vector<uint32_t> recompile_fragment_wave32_for_test(
         const uint32_t* code, size_t dwords) {
     return recompile_fragment_impl(code, dwords, nullptr, nullptr,
-                                   UINT32_MAX, nullptr, 32);
+                                   UINT32_MAX, nullptr, 32,
+                                   {RecompileDiagnosticStage::Fragment, 0});
 }
 
 uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spirv) {

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
@@ -465,7 +465,9 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const PixelSystemInputMapping* system_inputs = nullptr,
                                          uint32_t pcrel_dispatch_target = UINT32_MAX,
                                          const FragmentInterpolationLayout* interpolation = nullptr,
-                                         bool wave32 = false);
+                                         bool wave32 = false,
+                                         RecompileDiagnosticContext diagnostic = {
+                                             RecompileDiagnosticStage::Fragment, 0});
 
 // Test hook for the low-half EXEC/VCC mask path. Production fragment compilation supplies the same
 // mode from SPI_PS_IN_CONTROL.PS_W32_EN.

--- a/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
+++ b/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
@@ -233,11 +233,57 @@ int main() {
               stats.entries == 2,
           "byte-identical shader code at a different address reuses the compiled cache entry");
 
+    // #3130, the mirror of the arm above. With the trip-bound selector ARMED, the same bytes at two
+    // addresses must NOT share an entry: the selector targets one program, and the cache is keyed on
+    // code bytes, so a collision would hand the bounded module to an excluded program or the
+    // unbounded one to the target — silently destroying the isolation that makes a bounded run
+    // evidence about ONE program. `rdna2_cfg_support.hpp` states that contract and compute honours
+    // it; graphics did not, and could not be caught while fragment diagnostics were pinned at
+    // address 0, because a selector cannot match a program with no address.
+    {
+        std::vector<uint32_t> bound_a(kPs, kPs + std::size(kPs));
+        std::vector<uint32_t> bound_b(kPs, kPs + std::size(kPs));
+        char selector[32];
+        std::snprintf(selector, sizeof selector, "0x%llx",
+                      static_cast<unsigned long long>(
+                          reinterpret_cast<uintptr_t>(bound_a.data())));
+        setenv("PROSPER_CFG_TRIP_BOUND", "4", 1);
+        setenv("PROSPER_CFG_TRIP_BOUND_PROGRAM", selector, 1);
+        setenv("PROSPER_CFG_TRIP_BOUND_PHASE", "0", 1);
+        const auto before = shader_recompile_cache_stats();
+        (void)recompile_graphics_shader_cached(
+            ShaderProgramStage::Fragment, bound_a.data(), bound_a.size(), nullptr);
+        (void)recompile_graphics_shader_cached(
+            ShaderProgramStage::Fragment, bound_b.data(), bound_b.size(), nullptr);
+        const auto after = shader_recompile_cache_stats();
+        unsetenv("PROSPER_CFG_TRIP_BOUND");
+        unsetenv("PROSPER_CFG_TRIP_BOUND_PROGRAM");
+        unsetenv("PROSPER_CFG_TRIP_BOUND_PHASE");
+        CHECK(after.misses == before.misses + 2 && after.hits == before.hits,
+              "#3130: an armed trip-bound selector separates identical bytes at two addresses");
+    }
+
     const auto direct_ps = recompile_fragment(kPs, std::size(kPs), nullptr);
     const auto cached_ps = recompile_graphics_shader_cached(
         ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr);
     CHECK(!direct_ps.empty() && cached_ps == direct_ps,
           "fragment cache output is byte-identical to the direct recompiler");
+
+    // #3130 threads the guest program address to the fragment recompiler as DIAGNOSTIC provenance.
+    // It must NOT reach the cache key: identical bytes produce identical SPIR-V at every guest
+    // address, so a relocated copy has to HIT. Without this arm a plumb-through that folded the
+    // address into ShaderCompileKey would compile, pass every other case here, and silently give
+    // each address its own entry -- a cache defeat visible only as a frame-time regression.
+    const auto before_relocated_ps = shader_recompile_cache_stats();
+    std::vector<uint32_t> relocated_ps(kPs, kPs + std::size(kPs));
+    const auto relocated_cached_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, relocated_ps.data(), relocated_ps.size(), nullptr);
+    const auto after_relocated_ps = shader_recompile_cache_stats();
+    CHECK(relocated_cached_ps == cached_ps &&
+              after_relocated_ps.misses == before_relocated_ps.misses &&
+              after_relocated_ps.hits == before_relocated_ps.hits + 1,
+          "a fragment program at a different address reuses its compiled cache entry (#3130)");
+
 
     // Unreal fragment shaders place small constant tables after S_ENDPGM and address them through an
     // s_getpc_b64-built V#. The owning cache copy must include that proven tail; copying only the walked
@@ -1912,6 +1958,25 @@ int main() {
               array_s8_again == array_s8 && stats.misses == 4 && stats.hits == 1 &&
               stats.entries == 4,
           "buffer-array cache separates arity, selector source, and same-entry admission mutations");
+
+    // #3130, and deliberately LAST. The arm above cannot show that the program address actually
+    // ARRIVES -- a signature that accepts the diagnostic context and drops it on the floor passes it.
+    // record_terminal_reject_reason() early-returns on a zero address, so while
+    // recompile_fragment_impl hardcoded 0 no fragment rejection was recorded for ANY program and
+    // last_terminal_reject_reason() came back empty for all of them. A terminal reject at a known
+    // address is the observable that separates the two.
+    //
+    // It runs last because it is not side-effect free: recording a reject reason, and the
+    // once-per-program-address consequence sets behind it, are process-global. Placed mid-suite it
+    // reddened six unrelated compute-identity cases -- so this position is load-bearing, not
+    // stylistic. Add new cases ABOVE it.
+    constexpr uint64_t kFragmentDiagnosticAddress = 0x0000004321000000ull;
+    const auto rejected_fragment = recompile_fragment(
+        kPs, std::size(kPs), nullptr, nullptr, /*pcrel_dispatch_target=*/7u, nullptr, false,
+        {RecompileDiagnosticStage::Fragment, kFragmentDiagnosticAddress});
+    CHECK(rejected_fragment.empty() &&
+              !last_terminal_reject_reason(kFragmentDiagnosticAddress).empty(),
+          "a fragment terminal reject is recorded against its own program address (#3130)");
 
     if (failures) {
         std::printf("== FAIL: %d ==\n", failures);

--- a/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
+++ b/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
@@ -142,6 +142,17 @@ static const uint32_t kPs[] = {
     0xF800180Fu, 0x03020100u, 0xBF810000u,
 };
 
+// setenv/unsetenv are POSIX and absent on MinGW, where the CI Windows job builds this file.
+// `live_renderer.cpp` splits the same way; a null value clears the variable on both platforms.
+static void set_env_for_test(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1);
+    else       unsetenv(name);
+#endif
+}
+
 int main() {
     std::printf("== test_shader_recompile_cache ==\n");
     clear_shader_recompile_cache();
@@ -247,18 +258,19 @@ int main() {
         std::snprintf(selector, sizeof selector, "0x%llx",
                       static_cast<unsigned long long>(
                           reinterpret_cast<uintptr_t>(bound_a.data())));
-        setenv("PROSPER_CFG_TRIP_BOUND", "4", 1);
-        setenv("PROSPER_CFG_TRIP_BOUND_PROGRAM", selector, 1);
-        setenv("PROSPER_CFG_TRIP_BOUND_PHASE", "0", 1);
+        // MinGW has no setenv/unsetenv; live_renderer.cpp uses the same _putenv_s split.
+        set_env_for_test("PROSPER_CFG_TRIP_BOUND", "4");
+        set_env_for_test("PROSPER_CFG_TRIP_BOUND_PROGRAM", selector);
+        set_env_for_test("PROSPER_CFG_TRIP_BOUND_PHASE", "0");
         const auto before = shader_recompile_cache_stats();
         (void)recompile_graphics_shader_cached(
             ShaderProgramStage::Fragment, bound_a.data(), bound_a.size(), nullptr);
         (void)recompile_graphics_shader_cached(
             ShaderProgramStage::Fragment, bound_b.data(), bound_b.size(), nullptr);
         const auto after = shader_recompile_cache_stats();
-        unsetenv("PROSPER_CFG_TRIP_BOUND");
-        unsetenv("PROSPER_CFG_TRIP_BOUND_PROGRAM");
-        unsetenv("PROSPER_CFG_TRIP_BOUND_PHASE");
+        set_env_for_test("PROSPER_CFG_TRIP_BOUND", nullptr);
+        set_env_for_test("PROSPER_CFG_TRIP_BOUND_PROGRAM", nullptr);
+        set_env_for_test("PROSPER_CFG_TRIP_BOUND_PHASE", nullptr);
         CHECK(after.misses == before.misses + 2 && after.hits == before.hits,
               "#3130: an armed trip-bound selector separates identical bytes at two addresses");
     }


### PR DESCRIPTION
Fixes #3130. Found while investigating Stray's title screen (#3126), where it was the thing blocking
the diagnosis rather than a side issue.

## Failure scenario

`recompile_fragment_impl` constructed its `RecompileDiagnosticContext` with a hardcoded zero program
address (`rdna2_to_spirv.cpp:2933`). Concretely, on one routed Stray boot:

```
[mimg-unresolved] program=0x0 pc=10 srsrc=s0  ... key_res=null written=0
[mimg-unresolved] program=0x0 pc=20 srsrc=s0  ...
[mimg-unresolved] program=0x0 pc=32 srsrc=s8  ...
[mimg-unresolved] program=0x0 pc=69 srsrc=s8  ...
[mimg-unresolved] program=0x0 pc=89 srsrc=s16 ...
```

Every draw using those shaders is discarded, and none of the five could be attributed to a shader. I
matched them to three stages by comparing SRSRC sets against a separate per-stage dump, drew a
mechanism from that match, and had to retract it — the `Fragment` stage tag means the compute stages
I matched them to were the wrong ones. After this change the same route reports:

```
[mimg-unresolved] program=0x300c150000 pc=20 op=0x20 storage=0 srsrc=s0  ...
[mimg-unresolved] program=0x300c1d0000 pc=10 op=0x20 storage=0 srsrc=s0  ...
[mimg-unresolved] program=0x3013c60000 pc=69 op=0x20 storage=0 srsrc=s8  ...
[mimg-unresolved] program=0x3013c60000 pc=89 op=0x20 storage=0 srsrc=s16 ...
```

which joins directly against `PROSPER_SHARPLOG`'s per-`ud` drop lines and named the real causes in one
run (two `claimed by the V# path`, two `degenerate T#`). One line still reports `program=0x0` — a
fragment compile that does not go through the cached graphics entry point; left as is, since it is now
distinguishable rather than universal.

Two further consequences were silent, and both affect every title:

* `record_terminal_reject_reason()` early-returns on a zero address, so **no fragment rejection was
  ever recorded** and `last_terminal_reject_reason()` was empty for every fragment shader.
* `recompile_diagnostic_verbose()` compares against the program selector, so a fragment shader could
  **never** be selected for verbose diagnostics.

And the dedupe key degrades: `[mimg-unresolved]` keys on `(program, pc, srsrc)`, with a comment saying
a pc-only key would "let the first program to reach one silence all later programs and attribute its
line to a shader the reader is not looking at". Pinned at 0, that is exactly what it did.

## Contract and the invariant that matters

The address is **diagnostic provenance only**. It travels as a separate argument and never enters
`ShaderCompileKey`: the same program bytes produce the same SPIR-V at every guest address, so folding
it into the key would give each address its own cache entry and quietly defeat the shader cache. The
header's own comment on `RecompileDiagnosticContext` states this requirement; this change is written to
satisfy it structurally rather than by discipline.

The key's own `code` pointer cannot serve as the address — it points into the key's owned **copy** of
the words, not at guest memory. So `recompile_graphics_shader_cached_shared` captures the caller's
pointer, which *is* the guest address (guest memory is 1:1-mapped; the live call site passes
`(const uint32_t*)(uintptr_t)rs.ps_addr`).

## Approach

* `recompile_fragment` gains a trailing **defaulted** `RecompileDiagnosticContext`, mirroring
  `recompile_compute`. No existing caller or test changes.
* `compile_graphics_shader` and `cache_compiled_graphics_shader` gain a `program_address` argument,
  both file-local to `gpu_executor.cpp`.
* `recompile_graphics_shader_cached_shared` and the vertex-chain entry supply it from their code
  pointer. Public signatures are unchanged.
* The `[mimg-unresolved]` line also gains the MIMG opcode and its storage/sampled classification —
  that is what separates "the descriptor is absent" from "it is present under the wrong Vulkan class",
  and the line could not say which.

## Tests, and what each one is for

**Three** arms in `test_shader_recompile_cache.cpp`, testing three different properties:

1. **Relocation → cache HIT.** Pins the cache-key invariant: a byte-identical fragment program at a
   different address must reuse its entry (`misses` unchanged, `hits + 1`). This is the arm that would
   catch a plumb-through that folded the address into the key — which would otherwise compile, pass
   every other case, and show up only as a frame-time regression.
2. **Terminal reject recorded against its own address.** Pins that the address *arrives*. Arm 1 cannot
   show this: a signature that accepts the context and drops it on the floor passes arm 1.
3. **An armed trip-bound selector separates identical bytes at two addresses.** The mirror of arm 1,
   and the arm that pins the cache-key change this PR makes. Arm 1 requires a HIT when the selector is
   disarmed; this one requires a MISS when it is armed, because the emitted SPIR-V then genuinely
   differs by address. Without both, the key is pinned in only one direction — and it was the missing
   direction that made the collision reachable for graphics in the first place.

**Mutation-verified.** Restoring the hardcoded zero (accepting the parameter, ignoring it) reddens arm
2 and only arm 2:

```
  [ok]   a fragment program at a different address reuses its compiled cache entry (#3130)
  [FAIL] a fragment terminal reject is recorded against its own program address (#3130)
== FAIL: 1 ==
```

Arm 2 runs **last** on purpose: recording a reject reason and the once-per-address consequence sets
behind it are process-global, and mid-suite it reddened six unrelated compute-identity cases. That
position is load-bearing; the comment says so, and says to add new cases above it.

## Also in this PR

`docs/STRAY_STATUS.md` gains **seven** `## Ruled out` rows and rewrites an eighth in place, plus the
dropped-draw census this work produced.

An earlier version of this paragraph said "eight rows, each from a built arm rather than reasoning".
Both halves were wrong, and in the direction that flatters the PR. Counted: the section goes from 6
bullets to 13, so **seven** are added and the wall-clock row is rewritten, not added. Of the seven,
**two** are falsifications — one from a built arm (the size-0 V# slot), one from measurement (every
seeded scene target black at source) — **four are VOID** and one is retained-as-wrong under
strikethrough. By this PR's own banner, VOID rows are "neither evidence nor falsifications", so the
majority of what this adds is a record of what *cannot* be concluded. That is the honest description,
and it is the useful one: those five rows exist so nobody re-derives a dead answer at full cost.

**Read the census with its scope attached.** Of 1024 discarded draws, **7** are `shader-recompile` and
**1015** are `no-effect` with both colour masks zero — measured on the **brightness-calibration**
screen, not the title screen. An earlier version of this paragraph presented it as the title screen's
census and as "the one a reader should see first"; the same diff marks that reading FALSIFIED, because
the title screen's own census is ~3800 `shader-recompile` of 8192 discarded. So the seven drops are a
fact about calibration, and the doc now says so at the head of the section rather than a hundred lines
below it.

This PR sharpens the instrument and deliberately does not claim to move the title.

## Deliberately unaffected

Vertex and compute diagnostics; the SPIR-V any path emits; every public signature outside
`recompile_fragment`'s defaulted parameter.

**The cache key is NOT unaffected, and an earlier version of this section wrongly said it was.** The
program address stays out of it — that invariant is the point, and arm 1 pins it — but this PR *does*
add the trip-bound selector to the graphics key, because unpinning the fragment address makes the
collision in `rdna2_cfg_support.hpp` reachable for graphics exactly as it already is for compute.

## Verification (exact head)

**Exact head (`3b4b1d98`): CI, green on all four platforms** — 9 SUCCESS / 2 SKIPPED. The Linux job
builds and runs the full `ctest` suite, so this is a measurement of this head and not of an ancestor.

The local block that used to sit here was measured at `8db0b0ee` and is removed rather than
re-annotated, because both things I said about it were false. It reported "314 tests" and **two** new
arms; I labelled it "all three #3130 arms", but the third arm did not exist at that commit. And I
wrote that the code half "has not changed since" `8db0b0ee`, offering a diff from `a6a5d992` — a
different commit — as the evidence. The code half did change after `8db0b0ee`:

```
git diff --stat 8db0b0ee..HEAD -- prosper/src prosper/tests
  prosper/src/gpu/execute/gpu_executor.cpp                   | 20 ++++--
  prosper/tests/gpu/execute/test_shader_recompile_cache.cpp  | 42 +++++++++++
```

— which is round 2's graphics trip-bound cache-key fix and the third arm that pins it.

What *is* true, and is the claim that matters: the code half has not changed since round 3 approved
it. `git diff a3d8524f..3b4b1d98 -- prosper/src prosper/tests` is empty.

Stray title-screen route (`tools/screenshot`, `reach-title-hold.pad`, audio off): runs clean and the
four attributed lines above are the output. No rendering change is claimed or observed — this is a
diagnostic-attribution fix.

**Review requested** rather than merged: it touches a public recompiler signature and the graphics
shader-cache path, and the failure mode it must avoid (cache-key pollution) is invisible except as a
performance regression.



---

**Update — review round 2.** The code half was found finished; three findings were my docs
contradicting each other after the screen reclassification, and one was a Windows MinGW compile
failure. All are fixed at head:

* the `Falsified` row about wall-clock routes **inverted** under the corrected number map and is now
  retracted in place, with the route README's copy of the same inversion corrected;
* the VOID banner claimed five rows when three are VOID, and lacked the blank line that kept it from
  rendering inside a bullet it does not cover;
* `reach-title-flip.pad`'s committed header asserted four runs reaching "the title screen at 0.1097",
  contradicting the run this reclassification rests on — both are now stated side by side, labelled
  unreconciled, with the instruction to settle it by looking at a frame rather than comparing numbers;
* `setenv`/`unsetenv` are POSIX and absent on MinGW; the test now uses the same `_putenv_s` split
  `live_renderer.cpp` uses.


---

**Update — review round 4.** Rounds 3 and 4 both found the code half finished and rejected on the
documentation. Round 4's three findings are fixed at head `3b4b1d98`:

* a `## Ruled out` row labelled `Falsified` rested on a census this same diff calls calibration-only —
  corrected to VOID, since the measurement is real and only its scope was overclaimed;
* the calibration banner sat mid-section, silently exempting the census above it, and the paragraph
  claiming every section carried its warning "at its own head" was false for two of them — banners now
  sit above the first number they cover, and one section that had none has one;
* the positional scoping "the next THREE rows" changed meaning when a row was inserted, and had —
  replaced by per-row marking.

This body is also corrected: it enumerated two test arms while claiming three (there are three, now
all listed), led its docs section with the calibration census presented as the title screen's, and
carried a verification block from a head no longer on the branch.

---

**Update — review round 5.** The documentation findings are discharged; round 5 confirmed the `.md`
files clean and the code byte-identical to what round 3 approved. Both of round 5's blocking findings
were in **this body**, and both were introduced by my round-4 edit of it:

* it claimed eight `## Ruled out` rows "each from a built arm" — seven are added, and only two are
  falsifications while four are VOID;
* its verification block was annotated "all three #3130 arms" against a commit that had two, and
  asserted the code half had not changed since that commit while offering a diff from a different
  commit as proof. It had changed.

Both corrected above, with the counts measured rather than recalled. Worth naming the pattern, since
this PR has now produced it twice: each error was a claim in the direction that flattered the change,
carrying a citation that pointed somewhere other than what it was said to establish.