### PR TITLE
recompiler: v_ldexp_f32 admits ABS/NEG on src0, its FLOAT operand (#3138)

### DIFF
--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -55,6 +55,12 @@ completely empty table. Whether that is what its image ops want is untested — 
 
 ## Ruled out
 
+- **"The biggest dropped stage is the title-screen background."** Falsified: `0x3011560000` was the
+  largest single loss on this route — one instruction discarding **1536 full-screen 3840×2160 draws
+  per boot** — and fixing it (#3138) left `max_nonblack` unchanged at **0.0069**, a menu-only title
+  screen. Draw-loss rank does not predict which draws carry the picture, so the next candidate should
+  not be chosen by that rank alone. #3138.
+
 One line per falsified hypothesis, the evidence, and the link. Do not restart these without
 contradictory new evidence.
 

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -4574,13 +4574,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // behavior need separate contracts, and silently ignoring either would corrupt
                 // mip/scale reconstruction. ldexp_f32_bits covers the full unmodified i32 exponent
                 // domain without relying on GLSL.std.450 Ldexp's undefined overflow cases.
-                if (in.src_abs[0] || in.src_abs[1] || in.src_abs[2] ||
-                    in.src_neg[0] || in.src_neg[1] || in.src_neg[2] ||
+                // src0 is the FLOAT operand, and ABS/NEG on a float source is the ordinary VOP3
+                // modifier every other float op here already applies through fv() -- hardware order
+                // ABS then NEG. Admitting it is not a new contract (#3138). The original gate
+                // rejected all three sources together, which also refused this well-defined case:
+                // Stray's `0x3011560000` is `v_ldexp_f32 v39, |v35|, -2` (`d7620127,00018523`,
+                // ABS[2:0]=001), and that ONE instruction failed a 3684-dword fragment stage and
+                // discarded 1536 full-screen 3840x2160 draws per routed boot.
+                //
+                // src1 keeps rejecting, and for a reason the gate's own comment gives: it is the
+                // integer EXPONENT, where "absolute value" and "negate" are not float modifiers at
+                // all and silently ignoring either would corrupt mip/scale reconstruction. CLAMP and
+                // OMOD keep rejecting too -- their denormal behaviour needs its own contract.
+                if (in.src_abs[1] || in.src_abs[2] ||
+                    in.src_neg[1] || in.src_neg[2] ||
                     in.clamp || in.omod) {
                     ok = false;
                 } else {
-                    vreg[in.dst.value] = b.ldexp_f32_bits(
-                        val(in.src[0]), val(in.src[1]));
+                    vreg[in.dst.value] = b.ldexp_f32_bits(fv(0), val(in.src[1]));
                 }
             } else if (in.opcode >= 0x144 && in.opcode <= 0x147) {
                 // Cubemap coordinate ops (#273 — DOLL's title post PSes' reflection-probe math):

--- a/prosper/tests/gpu/recompiler/test_recompiled_fragment.cpp
+++ b/prosper/tests/gpu/recompiler/test_recompiled_fragment.cpp
@@ -1142,17 +1142,23 @@ int main() {
         const std::vector<uint32_t> ld_frag = recompile_fragment(ldexp_abs, std::size(ldexp_abs));
         CHECK(!ld_frag.empty(),
               "#3138: v_ldexp_f32 with ABS on its float source recompiles");
-        if (!ld_frag.empty()) {
-            std::vector<uint32_t> ld_vert(kTriVertSpv, kTriVertSpv + std::size(kTriVertSpv));
-            const std::vector<uint8_t> ld_px =
-                prosper::test::render_triangle_rgba(ld_vert, ld_frag, W, H);
-            const uint8_t* c = ld_px.size() == (size_t)W * H * 4
-                ? &ld_px[((size_t)(H / 2) * W + W / 2) * 4] : nullptr;
-            printf("  #3138 centre pixel = %02x %02x %02x\n",
-                   c ? c[0] : 0, c ? c[1] : 0, c ? c[2] : 0);
-            CHECK(c && c[1] > 0x20 && c[0] < 0x20 && c[2] < 0x20,
-                  "#3138: ABS is APPLIED, not dropped (green carries +0.25, not a clamped -0.25)");
-        }
+        // Deliberately NOT nested under the check above: a reverted gate must redden BOTH arms, and
+        // it does only if the value arm still runs and finds no pixel. Nesting it would make the
+        // second arm silently SKIP on exactly the mutation it exists to catch.
+        std::vector<uint32_t> ld_vert(kTriVertSpv, kTriVertSpv + std::size(kTriVertSpv));
+        const std::vector<uint8_t> ld_px =
+            ld_frag.empty() ? std::vector<uint8_t>()
+                            : prosper::test::render_triangle_rgba(ld_vert, ld_frag, W, H);
+        const uint8_t* c = ld_px.size() == (size_t)W * H * 4
+            ? &ld_px[((size_t)(H / 2) * W + W / 2) * 4] : nullptr;
+        printf("  #3138 centre pixel = %02x %02x %02x (want 00 40 00)\n",
+               c ? c[0] : 0, c ? c[1] : 0, c ? c[2] : 0);
+        // A BAND, not a floor. `> 0x20` would also accept 0xff, which is what an
+        // ABS-applied-but-exponent-dropped lowering produces (|-1.0| * 2^0 = 1.0) -- the competing
+        // wrong answer this arm most needs to exclude. |-1.0| * 2^-2 = 0.25 = 0x40 exactly, and this
+        // is the only numeric check of ldexp_f32_bits in the tree.
+        CHECK(c && c[1] > 0x30 && c[1] < 0x50 && c[0] < 0x20 && c[2] < 0x20,
+              "#3138: ABS applied AND the exponent honoured (green is 0.25, not 0 and not 1.0)");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/gpu/recompiler/test_recompiled_fragment.cpp
+++ b/prosper/tests/gpu/recompiler/test_recompiled_fragment.cpp
@@ -1116,6 +1116,45 @@ int main() {
               "#635: MRT3-only export lands on slot 3 and does NOT remap onto color0");
     }
 
+    {
+        // #3138: v_ldexp_f32 with ABS on src0. src0 is the FLOAT operand, where ABS/NEG are the
+        // ordinary VOP3 modifiers every other float op here applies; only the integer EXPONENT
+        // (src1) has no meaning for them. The old gate refused all three sources together, so
+        // Stray's `0x3011560000` -- 3684 dwords with exactly ONE unsupported instruction,
+        // `v_ldexp_f32 v39, |v35|, -2` -- failed entirely and discarded 1536 full-screen draws.
+        //
+        //   v_mov_b32 v4, -1.0 | v_mov_b32 v0, 0 | v_ldexp_f32 v1, |v4|, -2
+        //   v_mov_b32 v2, 0    | v_mov_b32 v3, 1.0 | exp mrt0 v0..v3 | s_endpgm
+        //
+        // GREEN carries |-1.0| * 2^-2 = +0.25, and the sign is the point: without ABS the result is
+        // -0.25, which clamps to zero and reads as black. So the two assertions separate the three
+        // outcomes that matter -- the stage does not compile at all (the old behaviour), it compiles
+        // but silently drops the modifier (green 0), or it compiles and applies it (green > 0).
+        const uint32_t ldexp_abs[] = {
+            0x7E0802F3u,                       // v_mov_b32 v4, -1.0
+            0x7E000280u,                       // v_mov_b32 v0, 0        (red)
+            0xD7620101u, 0x00018504u,          // v_ldexp_f32 v1, |v4|, -2   (green)
+            0x7E040280u,                       // v_mov_b32 v2, 0        (blue)
+            0x7E0602F2u,                       // v_mov_b32 v3, 1.0      (alpha)
+            0xF800180Fu, 0x03020100u,          // exp mrt0, v0..v3
+            0xBF810000u,                       // s_endpgm
+        };
+        const std::vector<uint32_t> ld_frag = recompile_fragment(ldexp_abs, std::size(ldexp_abs));
+        CHECK(!ld_frag.empty(),
+              "#3138: v_ldexp_f32 with ABS on its float source recompiles");
+        if (!ld_frag.empty()) {
+            std::vector<uint32_t> ld_vert(kTriVertSpv, kTriVertSpv + std::size(kTriVertSpv));
+            const std::vector<uint8_t> ld_px =
+                prosper::test::render_triangle_rgba(ld_vert, ld_frag, W, H);
+            const uint8_t* c = ld_px.size() == (size_t)W * H * 4
+                ? &ld_px[((size_t)(H / 2) * W + W / 2) * 4] : nullptr;
+            printf("  #3138 centre pixel = %02x %02x %02x\n",
+                   c ? c[0] : 0, c ? c[1] : 0, c ? c[2] : 0);
+            CHECK(c && c[1] > 0x20 && c[0] < 0x20 && c[2] < 0x20,
+                  "#3138: ABS is APPLIED, not dropped (green carries +0.25, not a clamped -0.25)");
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
@@ -3127,20 +3127,34 @@ int main() {
         printf("  [FAIL] GTA V v_ldexp_f32 did not emit its defined integer-domain SPIR-V\n");
         return 1;
     }
-    // Same-site modifier mutations remain outside this bounded admission. These exact bits exercise
-    // each generic VOP3 modifier field; accepting one would mean the opcode case silently lost it.
+    // Modifier admission, split by OPERAND DOMAIN rather than uniformly (#3138). `D.f = S0.f *
+    // 2**S1.i`: src0 is a FLOAT, so ABS/NEG on it are the ordinary VOP3 float modifiers the emitter
+    // applies through fv() everywhere else, and they now compile. src1 is the INTEGER exponent,
+    // where "absolute value" and "negate" are not float modifiers at all — the original comment's
+    // reason ("silently ignoring either would corrupt mip/scale reconstruction") is a statement
+    // about the exponent, and it still stands. src2 is unused, and CLAMP/OMOD carry denormal
+    // behaviour that needs its own contract.
+    //
+    // The split is not cosmetic: Stray's `0x3011560000` is a 3684-dword fragment stage whose ONLY
+    // unsupported instruction was `v_ldexp_f32 v39, |v35|, -2` (`d7620127`, ABS[2:0]=001), and it
+    // discarded 1536 full-screen 3840x2160 draws per routed boot.
     const uint32_t ldexp_abs0[]  = {0xd7620100u, 0x0002030du, 0xbf810000u};
+    const uint32_t ldexp_neg0[]  = {0xd7620000u, 0x2002030du, 0xbf810000u};
+    if (recompile_valu(ldexp_abs0, std::size(ldexp_abs0), 14, 0).empty() ||
+        recompile_valu(ldexp_neg0, std::size(ldexp_neg0), 14, 0).empty()) {
+        printf("  [FAIL] v_ldexp_f32 rejected a float-source modifier it can express\n");
+        return 1;
+    }
+    // The remaining fields stay outside the admission. These exact bits exercise each one;
+    // accepting any would mean the opcode case silently lost it.
     const uint32_t ldexp_abs1[]  = {0xd7620200u, 0x0002030du, 0xbf810000u};
     const uint32_t ldexp_abs2[]  = {0xd7620400u, 0x0002030du, 0xbf810000u};
-    const uint32_t ldexp_neg0[]  = {0xd7620000u, 0x2002030du, 0xbf810000u};
     const uint32_t ldexp_neg1[]  = {0xd7620000u, 0x4002030du, 0xbf810000u};
     const uint32_t ldexp_neg2[]  = {0xd7620000u, 0x8002030du, 0xbf810000u};
     const uint32_t ldexp_clamp[] = {0xd7628000u, 0x0002030du, 0xbf810000u};
     const uint32_t ldexp_omod[]  = {0xd7620000u, 0x0802030du, 0xbf810000u};
-    if (!recompile_valu(ldexp_abs0, std::size(ldexp_abs0), 14, 0).empty() ||
-        !recompile_valu(ldexp_abs1, std::size(ldexp_abs1), 14, 0).empty() ||
+    if (!recompile_valu(ldexp_abs1, std::size(ldexp_abs1), 14, 0).empty() ||
         !recompile_valu(ldexp_abs2, std::size(ldexp_abs2), 14, 0).empty() ||
-        !recompile_valu(ldexp_neg0, std::size(ldexp_neg0), 14, 0).empty() ||
         !recompile_valu(ldexp_neg1, std::size(ldexp_neg1), 14, 0).empty() ||
         !recompile_valu(ldexp_neg2, std::size(ldexp_neg2), 14, 0).empty() ||
         !recompile_valu(ldexp_clamp, std::size(ldexp_clamp), 14, 0).empty() ||


### PR DESCRIPTION
Fixes #3138. Found by dissecting *Stray*'s title-screen frame offline (#3126).

**This changes a deliberately pinned contract, so it wants a close read.** `test_rdna2_spirv_struct`
enumerated all eight VOP3 modifier mutations on `v_ldexp_f32` and asserted every one rejects. I am
arguing that guard was one operand too broad, not that it was wrong.

## The argument

`D.f = S0.f * 2**S1.i`. **src0 is a float.** ABS/NEG on a float source are the ordinary VOP3 modifiers
this emitter already applies everywhere else through `fv()` (hardware order: ABS then NEG). The gate's
own comment justifies the rejection in terms of the *integer exponent*:

> ABS/NEG on the integer exponent and output-modifier denormal behavior need separate contracts, and
> silently ignoring either would corrupt mip/scale reconstruction.

That is exactly right for `src1`, where "absolute value" and "negate" are not float modifiers at all,
and it does not reach `src0`. `src1`, `src2`, `CLAMP` and `OMOD` keep rejecting.

## What the breadth cost

*Stray*'s `0x3011560000` is a **3684-dword** fragment stage with **exactly one** unsupported
instruction:

```
[recompile-reject] sh=bfa00003/3684 mode=unresolved-operand pc=383
                   words=d7620127,00018523 fmt=9 op=0x362
                   dst=39(kind2) src=35(k2),-2(k3),0(k0) stage=fragment role=terminal
```

`d7620127` has `ABS[2:0] = 001` — abs on src0 only, no neg, no clamp, no omod. So it is
`v_ldexp_f32 v39, |v35|, -2`, and the only thing prosper could not express about it was an absolute
value on a float.

(One correction to the reject line above: its `modifier=0` field prints `in.has_modifier`, the
SDWA/DPP flag, **not** OMOD. OMOD is independently zero here — from word0 bits [60:59] — but do not
read that field as OMOD.)

That one instruction failed the whole stage, and the stage is the **largest single loss on that
title's title screen** — a per-shader drop census puts it at **1536 full-screen 3840×2160 draws
discarded per routed boot**:

```
1536  es=0x30106d0000 ps=0x3011560000 fs_empty=1 target=0x3097110000 3840x2160
```

Offline, `gpu_replay --retry-failed-stage` on the captured frame turns `rejected spirv-dwords=0` into
`recompiled spirv-dwords=84990 contract=accepted`.

## Tests

**The contract test is split by operand domain rather than weakened.** `abs0`/`neg0` must now compile;
`abs1`, `abs2`, `neg1`, `neg2`, `clamp`, `omod` must still reject, with the same exact bits as before.

**A render arm pins the semantics, not just the admission.** `test_recompiled_fragment` runs
`v_ldexp_f32 v1, |v4|, -2` with `v4 = -1.0` and carries the result in the **green** channel. The sign
is the point: without ABS the result is `-0.25`, which clamps to zero and reads as black. So the two
assertions separate all three outcomes that matter — the stage does not compile, it compiles and
silently drops the modifier, or it compiles and applies it. The centre pixel reads back **`0x40`**,
which is exactly 0.25.

**Mutation-verified**: restoring the old gate reddens **both** arms. That was not true when this body
was first written — the value arm sat inside `if (!ld_frag.empty())` and would have *skipped* on
exactly that mutation. It is unnested now, and the claim is checked rather than assumed.

The value assertion is a **band**, not a floor: `> 0x20` also accepted `0xff`, which is what an
ABS-applied-but-exponent-dropped lowering produces (`|-1.0| * 2^0 = 1.0`) — the competing wrong answer
this arm most needs to exclude, and this is the only numeric check of `ldexp_f32_bits` in the tree.

## Effect on the title screen

Dropped-draw census on Stray's title screen, read at the same cumulative total in every arm, two arms
per build:

| build | `shader-recompile` drops @ 4096 discarded |
| --- | --- |
| master | 1026, 989 |
| with #3133 | 866, 886 |
| with #3133 + this | **611, 618** |

Groups do not overlap. **The visible frame does not change** — the title screen is still menu-only at
`max_nonblack` 0.0069, because the remaining ~615 drops still discard the background. This is a
draw-loss reduction, not a rendering claim.

## Deliberately unaffected

`v_ldexp_f32` with any modifier on the integer exponent; CLAMP; OMOD; every other opcode's modifier
gate.

## Verification (exact head)

```
cmake --build prosper/build-linux -j6      # clean
ctest --no-tests=error -j4                 # 100% tests passed out of 314, rc=0
```

`docs/STRAY_STATUS.md` gains the `## Ruled out` row this PR's own result requires: `0x3011560000` was
the largest single draw loss on the route, and fixing it left `max_nonblack` unchanged at 0.0069 — so
draw-loss rank does not predict which draws carry the picture. **#3132 is concurrently editing that
file**; whichever merges second reconciles.

Snapshot guards not yet run on this branch.

Refs #2883, #3126

