### PR TITLE
diag(gpu): four instruments for "which shader owns these pixels, and what does it read"

### DIFF
--- a/prosper/src/gpu/agc/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.cpp
@@ -972,12 +972,17 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                     // whatever the FIRST observation saw, which on a long run is the boot-time state,
                     // so a surface filled moments later still reads as empty. That mistake cost three
                     // published corrections before it was caught.
-                    static std::mutex cmx; static std::set<std::pair<uint64_t, int>> cseen;
+                    // Keyed on (shader, base, verdict): the same surface is sampled by several
+                    // stages, and "which shader reads a surface that is empty" is the question this
+                    // answers -- a base-only key reports one sampler and hides the rest.
+                    static std::mutex cmx;
+                    static std::set<std::tuple<const void*, uint64_t, int>> cseen;
                     std::lock_guard<std::mutex> lk(cmx);
-                    if (cseen.insert({d.base, verdict}).second)
+                    if (cseen.insert({shdr.code, d.base, verdict}).second)
                         fprintf(stderr,
-                                "[texcontent] base=0x%llx %ux%u fmt=%u bytes=%llu nonzero=%u/%u %s "
-                                "rtt=%s\n",
+                                "[texcontent] shader=%p base=0x%llx %ux%u fmt=%u bytes=%llu "
+                                "nonzero=%u/%u %s rtt=%s\n",
+                                shdr.code,
                                 (unsigned long long)d.base, d.width, d.height, d.format,
                                 (unsigned long long)span, nonzero, sampled_dwords,
                                 sampled_dwords == 0 ? "UNREADABLE"

--- a/prosper/src/gpu/agc/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.cpp
@@ -963,18 +963,24 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                     // is_live_render_target() is safe to call here only because PROSPER_TEXCONTENT
                     // is in parallel_draw_diagnostic_active()'s list, so draw realization is serial
                     // while this diagnostic is armed. That callback drains and mutates the renderer's
-                    // write queue; calling it from parallel workers is UB and perturbs the very cache
-                    // state this reports.
+                    // write queue, and calling it from parallel workers is UB.
+                    // Serialising fixes the UB and nothing else: the callback still runs once per
+                    // large texture slot per draw, so this diagnostic still shifts the timing of the
+                    // very write queue it reports on. Arming it changes when guest writes land, which
+                    // is why a content verdict from a PROSPER_TEXCONTENT run is evidence about that
+                    // run and not about a default one.
                     const bool cached = prosper::gpu::is_live_render_target(d.base);
                     const int verdict = ((sampled_dwords == 0) ? 0 : (nonzero == 0 ? 1 : 2)) |
                                         (cached ? 4 : 0);
-                    // Deduped on (base, VERDICT), never on base alone. An address-keyed probe reports
-                    // whatever the FIRST observation saw, which on a long run is the boot-time state,
-                    // so a surface filled moments later still reads as empty. That mistake cost three
-                    // published corrections before it was caught.
-                    // Keyed on (shader, base, verdict): the same surface is sampled by several
-                    // stages, and "which shader reads a surface that is empty" is the question this
-                    // answers -- a base-only key reports one sampler and hides the rest.
+                    // Deduped on (SHADER, base, VERDICT), never on base alone, and every part of
+                    // that key earns its place:
+                    //   - verdict, because an address-keyed probe reports whatever the FIRST
+                    //     observation saw, which on a long run is the boot-time state -- a surface
+                    //     filled moments later still reads as empty. That mistake cost three
+                    //     published corrections before it was caught.
+                    //   - shader, because the same surface is sampled by several stages, and "which
+                    //     shader reads a surface that is empty" is the question this answers. A key
+                    //     without it reports one sampler and hides the rest.
                     static std::mutex cmx;
                     static std::set<std::tuple<const void*, uint64_t, int>> cseen;
                     std::lock_guard<std::mutex> lk(cmx);

--- a/prosper/src/gpu/agc/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.cpp
@@ -1,5 +1,6 @@
 // agc_shader_layout.cpp — see agc_shader_layout.hpp. V# decode + the front-half resource-table build.
 #include "gpu/agc/agc_shader_layout.hpp"
+#include "gpu/execute/gpu_execute.hpp"
 #include "gpu/texture/tile.hpp"
 #include <algorithm>
 #include <climits>
@@ -918,6 +919,44 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                     }
                     tseen[key] = done;
                 }
+            }
+            // PROSPER_TEXCONTENT=1 -- for every large sampled texture, report BOTH sources a
+            // sample can come from: whether its guest memory holds anything, and whether the
+            // renderer's own cache calls it authoritative. Reporting only one is how #3126 produced
+            // a false alarm -- an address the renderer authored is legitimately zero in guest
+            // memory, because its pixels live in the cache.
+            //
+            // Deduped on (base, VERDICT), never on base alone. An address-keyed probe reports
+            // whatever the FIRST decode saw, which on a long run is the boot-time state, so a
+            // surface filled moments later still reads as empty. That mistake cost three published
+            // corrections on #3140 before it was caught; with the verdict in the key a state change
+            // prints and "it was empty" cannot masquerade as "it is empty".
+            if (getenv("PROSPER_TEXCONTENT") && d.width >= 1920u && d.height >= 1080u &&
+                d.base > 0x1000000000ull) {
+                static std::mutex cmx; static std::set<std::pair<uint64_t, int>> cseen;
+                std::lock_guard<std::mutex> lk(cmx);
+                const uint64_t span = (uint64_t)d.width * d.height;
+                uint32_t nonzero = 0, sampled_dwords = 0;
+                for (uint32_t s = 0; s < 8; ++s) {
+                    const uint64_t addr = d.base + (((span / 8u) * s) & ~(uint64_t)3);
+                    if (!guest_readable(addr, 256)) continue;
+                    const uint32_t* words = (const uint32_t*)(uintptr_t)addr;
+                    for (uint32_t k = 0; k < 64; ++k) {
+                        ++sampled_dwords;
+                        if (words[k]) ++nonzero;
+                    }
+                }
+                const bool cached = prosper::gpu::is_live_render_target(d.base);
+                const int verdict = ((sampled_dwords == 0) ? 0 : (nonzero == 0 ? 1 : 2)) |
+                                    (cached ? 4 : 0);
+                if (cseen.insert({d.base, verdict}).second)
+                    fprintf(stderr,
+                            "[texcontent] base=0x%llx %ux%u fmt=%u nonzero=%u/%u %s rtt=%s\n",
+                            (unsigned long long)d.base, d.width, d.height, d.format,
+                            nonzero, sampled_dwords,
+                            sampled_dwords == 0 ? "UNREADABLE"
+                                                : (nonzero == 0 ? "ALL-ZERO" : "has-content"),
+                            cached ? "authoritative" : "MISS");
             }
             if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_TEXLOG")) {
                 const uint32_t* t = tv;   // the fetched T# (SGPR block or EUD spill)

--- a/prosper/src/gpu/agc/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.cpp
@@ -933,30 +933,57 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // prints and "it was empty" cannot masquerade as "it is empty".
             if (getenv("PROSPER_TEXCONTENT") && d.width >= 1920u && d.height >= 1080u &&
                 d.base > 0x1000000000ull) {
-                static std::mutex cmx; static std::set<std::pair<uint64_t, int>> cseen;
-                std::lock_guard<std::mutex> lk(cmx);
-                const uint64_t span = (uint64_t)d.width * d.height;
-                uint32_t nonzero = 0, sampled_dwords = 0;
-                for (uint32_t s = 0; s < 8; ++s) {
-                    const uint64_t addr = d.base + (((span / 8u) * s) & ~(uint64_t)3);
-                    if (!guest_readable(addr, 256)) continue;
-                    const uint32_t* words = (const uint32_t*)(uintptr_t)addr;
-                    for (uint32_t k = 0; k < 64; ++k) {
-                        ++sampled_dwords;
-                        if (words[k]) ++nonzero;
+                // BYTES, not texels. Offsets computed in texels and applied as byte addresses sample
+                // only the first bytes-per-texel'th of an RGBA8 surface -- reporting a false
+                // ALL-ZERO for anything below that -- and run PAST the end of a BCn one, reporting a
+                // false has-content from unrelated memory. The block arithmetic is the same one
+                // PROSPER_DUMP_TILERAW uses above.
+                Gen5ImageFormatInfo cfi;
+                const bool cfmt = gen5_image_format(d.format, &cfi) && cfi.bytes_per_block &&
+                                  cfi.block_width && cfi.block_height;
+                const uint64_t span =
+                    cfmt ? (uint64_t)((d.width + cfi.block_width - 1) / cfi.block_width) *
+                               ((d.height + cfi.block_height - 1) / cfi.block_height) *
+                               cfi.bytes_per_block
+                         : 0ull;
+                if (cfmt && span >= 256) {
+                    uint32_t nonzero = 0, sampled_dwords = 0;
+                    for (uint32_t s = 0; s < 8; ++s) {
+                        // Every 256-byte window stays inside the footprint: the last one starts at
+                        // span-256 rather than at 7/8 of span plus a read that would overrun.
+                        const uint64_t off = ((span - 256ull) / 7ull) * s;
+                        const uint64_t addr = d.base + (off & ~(uint64_t)3);
+                        if (!guest_readable(addr, 256)) continue;
+                        const uint32_t* words = (const uint32_t*)(uintptr_t)addr;
+                        for (uint32_t k = 0; k < 64; ++k) {
+                            ++sampled_dwords;
+                            if (words[k]) ++nonzero;
+                        }
                     }
+                    // is_live_render_target() is safe to call here only because PROSPER_TEXCONTENT
+                    // is in parallel_draw_diagnostic_active()'s list, so draw realization is serial
+                    // while this diagnostic is armed. That callback drains and mutates the renderer's
+                    // write queue; calling it from parallel workers is UB and perturbs the very cache
+                    // state this reports.
+                    const bool cached = prosper::gpu::is_live_render_target(d.base);
+                    const int verdict = ((sampled_dwords == 0) ? 0 : (nonzero == 0 ? 1 : 2)) |
+                                        (cached ? 4 : 0);
+                    // Deduped on (base, VERDICT), never on base alone. An address-keyed probe reports
+                    // whatever the FIRST observation saw, which on a long run is the boot-time state,
+                    // so a surface filled moments later still reads as empty. That mistake cost three
+                    // published corrections before it was caught.
+                    static std::mutex cmx; static std::set<std::pair<uint64_t, int>> cseen;
+                    std::lock_guard<std::mutex> lk(cmx);
+                    if (cseen.insert({d.base, verdict}).second)
+                        fprintf(stderr,
+                                "[texcontent] base=0x%llx %ux%u fmt=%u bytes=%llu nonzero=%u/%u %s "
+                                "rtt=%s\n",
+                                (unsigned long long)d.base, d.width, d.height, d.format,
+                                (unsigned long long)span, nonzero, sampled_dwords,
+                                sampled_dwords == 0 ? "UNREADABLE"
+                                                    : (nonzero == 0 ? "ALL-ZERO" : "has-content"),
+                                cached ? "authoritative" : "MISS");
                 }
-                const bool cached = prosper::gpu::is_live_render_target(d.base);
-                const int verdict = ((sampled_dwords == 0) ? 0 : (nonzero == 0 ? 1 : 2)) |
-                                    (cached ? 4 : 0);
-                if (cseen.insert({d.base, verdict}).second)
-                    fprintf(stderr,
-                            "[texcontent] base=0x%llx %ux%u fmt=%u nonzero=%u/%u %s rtt=%s\n",
-                            (unsigned long long)d.base, d.width, d.height, d.format,
-                            nonzero, sampled_dwords,
-                            sampled_dwords == 0 ? "UNREADABLE"
-                                                : (nonzero == 0 ? "ALL-ZERO" : "has-content"),
-                            cached ? "authoritative" : "MISS");
             }
             if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_TEXLOG")) {
                 const uint32_t* t = tv;   // the fetched T# (SGPR block or EUD spill)

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -1678,6 +1678,24 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                          (unsigned long long)(draw ? draw->command_order : 0));
         return false;
     }
+    // PROSPER_DRAWMAP=1 -- one line per distinct (fragment program, colour target, extent, scissor)
+    // with how many draws share it. Answers "which shader owns which pixels" as a static filter over
+    // a whole route in ONE run. Painting one shader at a time answers the same question one
+    // candidate per run; on a title with 66 fragment stages that is the difference between one run
+    // and a bisect. It is what identified Stray's full-screen composite (#3126).
+    if (getenv("PROSPER_DRAWMAP")) {
+        static std::mutex dmx; static std::map<std::string, uint64_t> dseen;
+        char k[192];
+        snprintf(k, sizeof k, "ps=0x%llx target=0x%llx %ux%u scissor=%u,%u..%u,%u tm=0x%x",
+                 (unsigned long long)rs.ps_addr, (unsigned long long)rs.color0_base,
+                 rs.color0_width, rs.color0_height,
+                 (unsigned)rs.scissor_left, (unsigned)rs.scissor_top,
+                 (unsigned)rs.scissor_right, (unsigned)rs.scissor_bottom, rs.cb_target_mask);
+        std::lock_guard<std::mutex> lk(dmx);
+        const uint64_t n = ++dseen[k];
+        if (n == 1 || n % 4096 == 0)
+            fprintf(stderr, "[drawmap] x%llu %s\n", (unsigned long long)n, k);
+    }
     const auto* fused_back = static_cast<const AgcShaderHeader*>(
         prosper_agc_fused_back_header_for_front(rs.es_addr));
     const bool phase_timing = getenv("PROSPER_RENDER_TIMING") != nullptr;

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -9357,6 +9357,12 @@ bool parallel_draw_diagnostic_active(bool log) {
         "PROSPER_SHADER_DUMP_SUCCESS", "PROSPER_DRAWLOG", "PROSPER_DBG",
         "PROSPER_STAGE_FOLD_PROFILE", "PROSPER_DESCRIPTOR_VALIDATE",
         "PROSPER_NO_SHADER_CACHE",
+        // PROSPER_TEXCONTENT queries is_live_render_target(), and that callback is NOT a pure read:
+        // it begins with drain_guest_gpu_writes(), which steals the pending guest-write queue and
+        // mutates an unsynchronised map. Calling it from parallel realization workers is undefined
+        // behaviour AND perturbs the cache state the diagnostic exists to report. Serialising is the
+        // whole reason this list exists.
+        "PROSPER_TEXCONTENT",
     };
     for (const char* name : diagnostics)
         if (std::getenv(name)) return true;

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -8208,6 +8208,20 @@ std::vector<ComputeItem> realize_compute_dispatches(
                          static_cast<int>(cf9200_valid), table->resources.size());
         assign_convention_bindings(*table, 2);
 
+        // PROSPER_COMPUTEMAP=1 -- every storage-image destination a compute dispatch binds. The
+        // graphics-side DRAWMAP cannot see these, so without it a surface written only by compute
+        // looks like a surface nothing writes at all -- which is exactly the wrong turn #3126 took.
+        if (getenv("PROSPER_COMPUTEMAP") && table) {
+            static std::mutex kmx; static std::set<std::pair<uint64_t, uint64_t>> kseen;
+            std::lock_guard<std::mutex> lk(kmx);
+            for (const ShaderResource& r : table->resources) {
+                if (r.cls != ResourceClass::StorageImage) continue;
+                if (!kseen.insert({code_addr, r.gpu_addr}).second) continue;
+                fprintf(stderr, "[computemap] program=0x%llx writes 0x%llx %ux%u binding=%u\n",
+                        (unsigned long long)code_addr, (unsigned long long)r.gpu_addr,
+                        r.width, r.height, r.binding);
+            }
+        }
         ComputeItem item;
         // Fold-time half of the paired read: the descriptors this dispatch will use were just
         // resolved from guest memory, so sample that memory NOW, before anything else runs.

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -6937,6 +6937,41 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // Ungated, and deduped per (pc, srsrc). It fires only when an image op has already
                 // failed to resolve, so its volume is bounded by the defect it reports. Behind
                 // PROSPER_DBG it was unreachable in practice on any routed boot.
+            // PROSPER_MIMG_SOFT=1 -- diagnostic only, and deliberately WRONG output.
+            //
+            // Placed BEFORE the reporting dedupe below on purpose. That dedupe fires once per
+            // (program, pc, srsrc); downstream of it, only the FIRST compile of each site would be
+            // softened and every later one -- reachable through ordinary shader-cache eviction --
+            // would take the reject path unchanged. The recorded result would then be
+            // indistinguishable from "nothing was softened", which is exactly the reading this
+            // diagnostic exists to produce. When an image
+            // op cannot resolve its descriptor, write a constant instead of failing the stage, so a
+            // frame can be seen that would otherwise be discarded entirely. It answers one question
+            // nothing else here can: how much of the picture is riding on THIS resolution failure.
+            // On Stray it showed the answer was "none" -- the composite compiled and the frame did
+            // not change -- which is what redirected #3126 away from the recompiler.
+            //
+            // Never acceptable in a run that produces progression evidence: every unresolved sample
+            // reads a flat value.
+            if (!res && getenv("PROSPER_MIMG_SOFT")) {
+                const uint32_t soft = b.uconst(fbits(0.5f));
+                uint32_t comps = 0;
+                for (uint32_t m = 0; m < 4; ++m) if (in.mimg_dmask & (1u << m)) ++comps;
+                if (!comps) comps = 1;
+                for (uint32_t k = 0; k < comps; ++k) {
+                    const int dst = in.dst.value + static_cast<int>(k);
+                    if (dst < 0) break;
+                    const uint32_t old = vreg_old(b, rs, dst);
+                    rs.vreg[dst] = soft;
+                    predicate_write(b, rs, dst, old);
+                }
+                static std::mutex smx; static std::set<uint64_t> sseen;
+                std::lock_guard<std::mutex> lk(smx);
+                if (sseen.insert(((uint64_t)b.diagnostic.program_address << 16) | in.pc).second)
+                    fprintf(stderr, "[mimg-soft] program=0x%llx pc=%u -> constant %u comps\n",
+                            (unsigned long long)b.diagnostic.program_address, in.pc, comps);
+                return true;
+            }
                 static std::mutex mimg_mutex;
                 // Keyed by PROGRAM as well as (pc, srsrc): every shader has a pc 16, so a
                 // pc-only key lets the first program to reach one silence all later programs and
@@ -6996,34 +7031,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     fprintf(stderr, "[mimg-unresolved]   available:%s\n",
                             avail.empty() ? " (none)" : avail.c_str());
                 }
-            }
-            // PROSPER_MIMG_SOFT=1 -- diagnostic only, and deliberately WRONG output. When an image
-            // op cannot resolve its descriptor, write a constant instead of failing the stage, so a
-            // frame can be seen that would otherwise be discarded entirely. It answers one question
-            // nothing else here can: how much of the picture is riding on THIS resolution failure.
-            // On Stray it showed the answer was "none" -- the composite compiled and the frame did
-            // not change -- which is what redirected #3126 away from the recompiler.
-            //
-            // Never acceptable in a run that produces progression evidence: every unresolved sample
-            // reads a flat value.
-            if (!res && getenv("PROSPER_MIMG_SOFT")) {
-                const uint32_t soft = b.uconst(fbits(0.5f));
-                uint32_t comps = 0;
-                for (uint32_t m = 0; m < 4; ++m) if (in.mimg_dmask & (1u << m)) ++comps;
-                if (!comps) comps = 1;
-                for (uint32_t k = 0; k < comps; ++k) {
-                    const int dst = in.dst.value + static_cast<int>(k);
-                    if (dst < 0) break;
-                    const uint32_t old = vreg_old(b, rs, dst);
-                    rs.vreg[dst] = soft;
-                    predicate_write(b, rs, dst, old);
-                }
-                static std::mutex smx; static std::set<uint64_t> sseen;
-                std::lock_guard<std::mutex> lk(smx);
-                if (sseen.insert(((uint64_t)b.diagnostic.program_address << 16) | in.pc).second)
-                    fprintf(stderr, "[mimg-soft] program=0x%llx pc=%u -> constant %u comps\n",
-                            (unsigned long long)b.diagnostic.program_address, in.pc, comps);
-                return true;
             }
             if (!res) { ok = false; return true; }
             const bool uint_texture = res->format == DataFormat::Uint8 ||

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -6997,6 +6997,34 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             avail.empty() ? " (none)" : avail.c_str());
                 }
             }
+            // PROSPER_MIMG_SOFT=1 -- diagnostic only, and deliberately WRONG output. When an image
+            // op cannot resolve its descriptor, write a constant instead of failing the stage, so a
+            // frame can be seen that would otherwise be discarded entirely. It answers one question
+            // nothing else here can: how much of the picture is riding on THIS resolution failure.
+            // On Stray it showed the answer was "none" -- the composite compiled and the frame did
+            // not change -- which is what redirected #3126 away from the recompiler.
+            //
+            // Never acceptable in a run that produces progression evidence: every unresolved sample
+            // reads a flat value.
+            if (!res && getenv("PROSPER_MIMG_SOFT")) {
+                const uint32_t soft = b.uconst(fbits(0.5f));
+                uint32_t comps = 0;
+                for (uint32_t m = 0; m < 4; ++m) if (in.mimg_dmask & (1u << m)) ++comps;
+                if (!comps) comps = 1;
+                for (uint32_t k = 0; k < comps; ++k) {
+                    const int dst = in.dst.value + static_cast<int>(k);
+                    if (dst < 0) break;
+                    const uint32_t old = vreg_old(b, rs, dst);
+                    rs.vreg[dst] = soft;
+                    predicate_write(b, rs, dst, old);
+                }
+                static std::mutex smx; static std::set<uint64_t> sseen;
+                std::lock_guard<std::mutex> lk(smx);
+                if (sseen.insert(((uint64_t)b.diagnostic.program_address << 16) | in.pc).second)
+                    fprintf(stderr, "[mimg-soft] program=0x%llx pc=%u -> constant %u comps\n",
+                            (unsigned long long)b.diagnostic.program_address, in.pc, comps);
+                return true;
+            }
             if (!res) { ok = false; return true; }
             const bool uint_texture = res->format == DataFormat::Uint8 ||
                                       res->format == DataFormat::Uint16 ||


### PR DESCRIPTION
Built while chasing *Stray*'s black title screen (#3126). The existing diagnostics could say which
shaders **failed**; nothing could say which shader **owned the pixels that came out black**. All four
are off by default, additive, and each answers a question none of the others can.

## What each one is for

| variable | question it answers |
| --- | --- |
| `PROSPER_DRAWMAP=1` | which fragment program owns which target, extent and scissor — a static filter over a whole route in **one run** |
| `PROSPER_COMPUTEMAP=1` | which surfaces **compute** writes as storage images (DRAWMAP is graphics-only) |
| `PROSPER_TEXCONTENT=1` | for every large sampled texture: does guest memory hold anything, **and** does the renderer's cache call it authoritative |
| `PROSPER_MIMG_SOFT=1` | how much of the picture rides on one descriptor-resolution failure — writes a constant instead of failing the stage |

## Why they were worth building

**DRAWMAP** identified Stray's full-screen composite in one run. Painting one shader at a time answers
the same question one candidate per run, and that title has 66 fragment stages.

**COMPUTEMAP** exists because DRAWMAP is graphics-only, and a surface written by compute otherwise
looks like a surface nothing writes at all. This investigation took that wrong turn before adding it.

**TEXCONTENT** reports **both** sources a sample can come from. Reporting one alone produces false
alarms: an address the renderer authored is legitimately zero in guest memory, because its pixels live
in the cache — I nearly published exactly that as a defect.

**MIMG_SOFT** produces deliberately wrong output and is never acceptable in a run that yields
progression evidence. Its value is the counterfactual: on Stray it showed the composite compiles and
the frame *still* does not change, which is what redirected #3126 away from the recompiler.

## The dedupe rule, written into the code

`TEXCONTENT` dedupes on **(base, VERDICT)**, never on base alone, and its comment says why: an
address-keyed probe reports whatever the **first** observation saw, which on a long-running renderer
is the boot-time state — so a surface filled moments later still reads as empty. That exact mistake
produced **three published corrections** on #3140 before I caught it. It is called out in the comment
because the shape is easy to repeat and expensive every time.

## Beyond this title

*Grand Theft Auto V* and *Sonic Frontiers* both sit on "a HUD over an absent world" with no way to ask
which shader owns the pixels. DRAWMAP and COMPUTEMAP answer that directly, with no capture and no
per-candidate run.

## Verification

```
cmake --build prosper/build-linux -j6          # clean
ctest --no-tests=error -j4                     # 100% tests passed out of 314, rc=0
python3 tools/env/check_diag_gates.py          # == all checks passed ==
                                               # 108 findings, 108 baselined — no new gate pattern
git diff --check                               # clean
```

No behaviour changes with every variable unset: each is a `getenv` guard around an added block, and
`MIMG_SOFT`'s is placed on the existing `if (!res)` reject path so an unset run takes the original
branch unchanged.

## Not included

`PROSPER_PAINT_PS` (replace one named fragment program with a constant colour) needs the real guest
program address, which #3132 supplies; it belongs on top of that PR rather than this one.

Refs #3126, #3140
