### PR TITLE
diag: catch the moment guest data disappears, and four mechanisms that do not cause it

### DIFF
--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -294,8 +294,8 @@ drops still discard the background.
   read-back (25 of 64 non-zero dwords at texture offset 0). And the range is nonetheless **entirely
   zero when the shader samples it**: base `0x303cd10000`, BC1_SRGB 3840×2160, read by
   `0x300c150000`, `nonzero=0/512` at +65.7 s after its verified write.
-  So this is a **lifetime** defect — something zeroes these ranges between load and use — not a read
-  defect, and the pak reader is not the place to look. #3142.
+  So the pak reader is not the place to look; something zeroes these ranges between load and use, and
+  the row below names it. #3142.
 
 - **"The range is zeroed some time during the ~65 s before the shader reads it."** Falsified, and the
   65 s was an artifact of when the *shader* happened to look rather than of when the data went away.
@@ -306,6 +306,15 @@ drops still discard the background.
   file offset, so it is neither unmapped nor re-pointed. And because that mapping is `MAP_SHARED` on a
   memfd, reading the mapping **is** reading the file — there is no "stale view" case, so the content
   itself was zeroed. #3142, #3145.
+  - **The writer is the guest's own libc, and that reclassifies the whole issue.** With #3147's
+    re-baseline mode the write trace observes the window it previously could not, and attributes
+    **64 of 64 events to `libc.prx`** — guest code — storing sequentially from the buffer base at a
+    16-byte stride through a tight `0x3d71`–`0x3dd0` RIP loop, on one thread. The guest clears its own
+    staging buffer about a second after loading it, which is ordinary engine behaviour. So this is
+    **not** a memory-lifetime defect and never was: the pak reader delivers correctly, the guest
+    disposes of its buffer correctly, and prosper's defect is that a shader still reads that address
+    afterwards. The open question is now a descriptor one — why `0x300c150000`'s texture resolves to a
+    staging buffer the engine has finished with — which also fits its `rtt=MISS`. #3142.
   - Four mechanisms measured and excluded, each in the same runs: **`dmem_zero`'s hole punch** (all 20
     calls occur at startup, before every one of these writes); **a re-map of the VA** (one `[physmap]`
     per VA, created ~2 ms *before* its write, none after); **a second VA aliasing the phys** (none —

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -293,10 +293,31 @@ drops still discard the background.
   `dd`/`od` read of `hk_project-ps5.pak` outside the emulator agrees exactly with the in-memory
   read-back (25 of 64 non-zero dwords at texture offset 0). And the range is nonetheless **entirely
   zero when the shader samples it**: base `0x303cd10000`, BC1_SRGB 3840×2160, read by
-  `0x300c150000`, `nonzero=0/512` at **+65.7 s** after its verified write. A second base,
-  `0x302a300000`, is zero on five samples across 152 s, the earliest only **2.0 s** after its write.
-  So this is a **lifetime** defect — something reclaims, zeroes or remaps these ranges between load
-  and use — not a read defect, and the pak reader is not the place to look. #3142.
+  `0x300c150000`, `nonzero=0/512` at +65.7 s after its verified write.
+  So this is a **lifetime** defect — something zeroes these ranges between load and use — not a read
+  defect, and the pak reader is not the place to look. #3142.
+
+- **"The range is zeroed some time during the ~65 s before the shader reads it."** Falsified, and the
+  65 s was an artifact of when the *shader* happened to look rather than of when the data went away.
+  `PROSPER_ZEROWATCH` polls each armed destination every 50 ms and reports the transition itself: the
+  data is gone **0.5–2.3 s** after its load, and the defect therefore **reproduces in a 2-minute run**
+  rather than the 7-minute title route — it happens during asset load, long before the title screen.
+  At the instant of the flip the mapping is *unchanged*: still `rw-s` on the dmem memfd at the same
+  file offset, so it is neither unmapped nor re-pointed. And because that mapping is `MAP_SHARED` on a
+  memfd, reading the mapping **is** reading the file — there is no "stale view" case, so the content
+  itself was zeroed. #3142, #3145.
+  - Four mechanisms measured and excluded, each in the same runs: **`dmem_zero`'s hole punch** (all 20
+    calls occur at startup, before every one of these writes); **a re-map of the VA** (one `[physmap]`
+    per VA, created ~2 ms *before* its write, none after); **a second VA aliasing the phys** (none —
+    each phys range is mapped exactly once); and **the renderer writing back**
+    (`guest_memory_gpu_write` fires once per run, covering none of the zeroed ranges).
+  - What blocks naming the writer, so nobody re-derives it: `PROSPER_DMEM_WRITE_TRACE` records writer
+    RIPs but is invalidated by a **host** write, and the APR load *is* a host write (all four host
+    writers of guest memory in the tree are file reads), so it can never watch a range APR loads into.
+    It reports `page-faults=0` — no guest write faulted — but the watch died too early for that to be
+    conclusive. A `SIGSEGV` trap hand-rolled to get the RIP directly killed the run at asset load and
+    was removed rather than debugged; extending the existing trace's lifecycle is the route, not a
+    second write-watch fighting the first.
   - Two traps came out of it and are recorded in `GAME_COMPAT_ORCHESTRATION.md`: **235**, log line
     order is not happens-before (the ordering above is a shared monotonic stamp, not line distance);
     **236**, a verifier that compares populations instead of content reports MATCH on entirely

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -310,7 +310,14 @@ drops still discard the background.
     calls occur at startup, before every one of these writes); **a re-map of the VA** (one `[physmap]`
     per VA, created ~2 ms *before* its write, none after); **a second VA aliasing the phys** (none —
     each phys range is mapped exactly once); and **the renderer writing back**
-    (`guest_memory_gpu_write` fires once per run, covering none of the zeroed ranges).
+    (`guest_memory_gpu_write` fires once per run, covering none of the zeroed ranges). A fifth:
+    **the address being recycled for another asset** — `0x303cd10000` receives exactly one payload
+    and is never written again, though 956 of 6,574 destinations in the run genuinely are reused, so
+    this had to be checked per-address rather than assumed either way.
+  - Corroborated on a second base: `0x302a300000` is sampled by five different shaders across
+    **152 s** and reads zero every time, the earliest only 2.0 s after its byte-verified write. One
+    address going quiet could be a descriptor pointing somewhere stale; two, with one of them read by
+    five separate shaders, is the range.
   - What blocks naming the writer, so nobody re-derives it: `PROSPER_DMEM_WRITE_TRACE` records writer
     RIPs but is invalidated by a **host** write, and the APR load *is* a host write (all four host
     writers of guest memory in the tree are file reads), so it can never watch a range APR loads into.

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -327,13 +327,18 @@ drops still discard the background.
     **152 s** and reads zero every time, the earliest only 2.0 s after its byte-verified write. One
     address going quiet could be a descriptor pointing somewhere stale; two, with one of them read by
     five separate shaders, is the range.
-  - What blocks naming the writer, so nobody re-derives it: `PROSPER_DMEM_WRITE_TRACE` records writer
-    RIPs but is invalidated by a **host** write, and the APR load *is* a host write (all four host
-    writers of guest memory in the tree are file reads), so it can never watch a range APR loads into.
-    It reports `page-faults=0` — no guest write faulted — but the watch died too early for that to be
-    conclusive. A `SIGSEGV` trap hand-rolled to get the RIP directly killed the run at asset load and
-    was removed rather than debugged; extending the existing trace's lifecycle is the route, not a
-    second write-watch fighting the first.
+  - What *used* to block naming the writer, kept because it explains why this took so long and what
+    the attribution above depends on: `PROSPER_DMEM_WRITE_TRACE` records writer RIPs but was
+    invalidated by a **host** write, and the APR load *is* a host write (all four host writers of
+    guest memory in the tree are file reads), so it could never watch a range APR loads into — it
+    reported `page-faults=0` because the watch died at the load, not because no guest write happened.
+    **[#3147](https://github.com/mattias800/prosper/pull/3147) lifts that** with an opt-in
+    re-baseline mode, and the `libc.prx` attribution above is measured **with that PR applied**: on
+    master alone the trace still disarms at the load and reproduces nothing. If #3147 is merged when
+    you read this, drop this caveat; if it was closed, the attribution needs re-deriving.
+    A `SIGSEGV` trap hand-rolled to get the RIP directly killed the run at asset load and was removed
+    rather than debugged — extending the existing trace's lifecycle was the route, not a second
+    write-watch fighting the first.
   - Two traps came out of it and are recorded in `GAME_COMPAT_ORCHESTRATION.md`: **235**, log line
     order is not happens-before (the ordering above is a shared monotonic stamp, not line distance);
     **236**, a verifier that compares populations instead of content reports MATCH on entirely

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2701,6 +2701,10 @@ extern "C" int prosper_apr_dest_scan(uint64_t lo, uint64_t hi, char* out, size_t
 namespace {
 struct ZeroWatchEntry {
     uint64_t dst = 0, size = 0, t_armed = 0;
+    // The offset of the window the SOURCE was found non-zero at. The probe must read this window and
+    // no other: seeding from one window and probing a different one compares two unrelated places,
+    // and reports a flip for a range that never changed.
+    uint64_t seed_off = 0;
     const char* path = "?";
     bool seen_nonzero = false, reported = false;
 };
@@ -2745,7 +2749,7 @@ void zerowatch_poll_forever() {
             for (auto& e : g_zw) {
                 if (e.reported) continue;
                 uint32_t w[64];
-                if (!zw_read256(e.dst, w)) {
+                if (!zw_read256(e.dst + e.seed_off, w)) {
                     e.reported = true;
                     fprintf(stderr,
                             "[zerowatch] t=%llu dst=0x%llx WENT-UNMAPPED after %.3fs  maps=%s\n",
@@ -2758,20 +2762,21 @@ void zerowatch_poll_forever() {
                 uint32_t nz = 0;
                 for (uint32_t k = 0; k < 64; ++k) if (w[k]) ++nz;
                 if (nz) { e.seen_nonzero = true; continue; }
-                // All-zero in the sampled window. Only interesting if this range is KNOWN to have
-                // held data -- otherwise it is a buffer that was never filled, which is not this
-                // defect. That knowledge is seeded at arm time from the source buffer, never from
-                // this window: an all-zero first 256 bytes is common on this data (the source is
-                // ~5.6% non-zero and padding is always zero), so deciding it here would make a
-                // payload with a zero-padded head unreportable -- silently, and exactly for the
-                // class under investigation.
-                if (e.seen_nonzero) {
+                // All-zero at the window the payload was non-zero at, so this range HELD data and
+                // no longer does. `seen_nonzero` is guaranteed true for every entry (arming returns
+                // early otherwise), which is why the probe reading `seed_off` rather than offset 0
+                // is what carries the correctness here: an all-zero first 256 bytes is common on
+                // this data (the source is ~5.6% non-zero and padding is always zero), so probing
+                // offset 0 while seeding elsewhere would report a flip for a range that never
+                // changed -- and would burn the one-shot write-trace report on a non-event.
+                {
                     e.reported = true;
                     fprintf(stderr,
-                            "[zerowatch] t=%llu dst=0x%llx size=%llu sampled=256B@0 armed-via=%s "
+                            "[zerowatch] t=%llu dst=0x%llx size=%llu sampled=256B@0x%llx armed-via=%s "
                             "WENT-ZERO after %.3fs  maps=%s\n",
                             (unsigned long long)prosper::diagnostics::diag_now_us(),
-                            (unsigned long long)e.dst, (unsigned long long)e.size, e.path,
+                            (unsigned long long)e.dst, (unsigned long long)e.size,
+                            (unsigned long long)e.seed_off, e.path,
                             (double)(prosper::diagnostics::diag_now_us() - e.t_armed) / 1e6,
                             zw_mapping_of(e.dst).c_str());
                     // Dump the dmem write trace HERE, at the moment the data disappears. Its own
@@ -2818,11 +2823,14 @@ void zerowatch_arm(uint64_t dst, const void* src, uint64_t size, const char* pat
     // Seed from the SOURCE (see the poll loop): scan a spread of the payload, not just its head.
     const uint8_t* p8 = static_cast<const uint8_t*>(src);
     for (uint32_t w = 0; w < 8 && !e.seen_nonzero; ++w) {
-        const uint64_t off = ((size - 256ull) / 7ull) * w;
+        const uint64_t off = (((size - 256ull) / 7ull) * w) & ~(uint64_t)3;
         for (uint32_t k = 0; k < 256; ++k)
-            if (p8[off + k]) { e.seen_nonzero = true; break; }
+            if (p8[off + k]) { e.seen_nonzero = true; e.seed_off = off; break; }
     }
-    if (!e.seen_nonzero) return;   // the payload itself is all zeros; nothing to lose here
+    // An all-zero payload is skipped, and skipping it is NOT silent-by-omission here: it means the
+    // load itself delivered zeros, which `apr_verify_write` reports on the same write. There is no
+    // disappearance to watch for.
+    if (!e.seen_nonzero) return;
     g_zw.push_back(e);
     if (!g_zw_thread.exchange(true)) std::thread(zerowatch_poll_forever).detach();
 }

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2701,6 +2701,7 @@ extern "C" int prosper_apr_dest_scan(uint64_t lo, uint64_t hi, char* out, size_t
 namespace {
 struct ZeroWatchEntry {
     uint64_t dst = 0, size = 0, t_armed = 0;
+    const char* path = "?";
     bool seen_nonzero = false, reported = false;
 };
 std::mutex g_zw_mx;
@@ -2732,6 +2733,11 @@ bool zw_read256(uint64_t addr, uint32_t* out) {
     return process_vm_readv(getpid(), &l, 1, &r, 1, 0) == 256;
 }
 
+// Runs until the process ends, and is never joined. That is safe here only because every exit path
+// in this project is _Exit -- prosper-app, tools/screenshot, and the guest's own _exit and fatal
+// raise -- so no static this thread touches is ever destroyed under it. A normal `return` from main
+// would make this a use-after-free, so if an exit path ever stops being _Exit, this thread needs a
+// stop flag before that lands.
 void zerowatch_poll_forever() {
     for (;;) {
         {
@@ -2752,14 +2758,20 @@ void zerowatch_poll_forever() {
                 uint32_t nz = 0;
                 for (uint32_t k = 0; k < 64; ++k) if (w[k]) ++nz;
                 if (nz) { e.seen_nonzero = true; continue; }
-                // All-zero. Only interesting if this range was observed holding data first --
-                // otherwise it is a buffer that was never filled, which is not this defect.
+                // All-zero in the sampled window. Only interesting if this range is KNOWN to have
+                // held data -- otherwise it is a buffer that was never filled, which is not this
+                // defect. That knowledge is seeded at arm time from the source buffer, never from
+                // this window: an all-zero first 256 bytes is common on this data (the source is
+                // ~5.6% non-zero and padding is always zero), so deciding it here would make a
+                // payload with a zero-padded head unreportable -- silently, and exactly for the
+                // class under investigation.
                 if (e.seen_nonzero) {
                     e.reported = true;
                     fprintf(stderr,
-                            "[zerowatch] t=%llu dst=0x%llx size=%llu WENT-ZERO after %.3fs  maps=%s\n",
+                            "[zerowatch] t=%llu dst=0x%llx size=%llu sampled=256B@0 armed-via=%s "
+                            "WENT-ZERO after %.3fs  maps=%s\n",
                             (unsigned long long)prosper::diagnostics::diag_now_us(),
-                            (unsigned long long)e.dst, (unsigned long long)e.size,
+                            (unsigned long long)e.dst, (unsigned long long)e.size, e.path,
                             (double)(prosper::diagnostics::diag_now_us() - e.t_armed) / 1e6,
                             zw_mapping_of(e.dst).c_str());
                     // Dump the dmem write trace HERE, at the moment the data disappears. Its own
@@ -2781,13 +2793,36 @@ void zerowatch_poll_forever() {
     }
 }
 
-void zerowatch_arm(uint64_t dst, uint64_t size) {
+// `src` is the buffer just written, so "did this range ever hold data" is answered from the payload
+// rather than from a later poll of the destination. `path` names which write path armed it, because
+// the two are not equivalent: the retry path MAP_FIXEDs anonymous memory over guest pages first, and
+// a range that went through it is the most interesting kind to watch, not one to skip.
+void zerowatch_arm(uint64_t dst, const void* src, uint64_t size, const char* path) {
     if (!zerowatch_enabled() || size < (1u << 20)) return;   // large payloads only: textures, not records
     std::lock_guard<std::mutex> lk(g_zw_mx);
     for (auto& e : g_zw) if (e.dst == dst) return;
-    if (g_zw.size() >= 64) return;
+    if (g_zw.size() >= 64) {
+        // Never drop silently: a capped watch list turns "nothing else went zero" into "nothing else
+        // was looked at", and those read identically in a log.
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            fprintf(stderr, "[zerowatch] watch list FULL at %zu entries -- later destinations are "
+                            "NOT watched; counts below are a floor, not a total\n", g_zw.size());
+        }
+        return;
+    }
     ZeroWatchEntry e;
     e.dst = dst; e.size = size; e.t_armed = prosper::diagnostics::diag_now_us();
+    e.path = path;
+    // Seed from the SOURCE (see the poll loop): scan a spread of the payload, not just its head.
+    const uint8_t* p8 = static_cast<const uint8_t*>(src);
+    for (uint32_t w = 0; w < 8 && !e.seen_nonzero; ++w) {
+        const uint64_t off = ((size - 256ull) / 7ull) * w;
+        for (uint32_t k = 0; k < 256; ++k)
+            if (p8[off + k]) { e.seen_nonzero = true; break; }
+    }
+    if (!e.seen_nonzero) return;   // the payload itself is all zeros; nothing to lose here
     g_zw.push_back(e);
     if (!g_zw_thread.exchange(true)) std::thread(zerowatch_poll_forever).detach();
 }
@@ -2877,7 +2912,7 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
     if (process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size) {
         apr_verify_write(dst, buf, size);
-        zerowatch_arm(dst, size);
+        zerowatch_arm(dst, buf, size, "direct");
         return true;
     }
     bool committed = false;
@@ -2891,7 +2926,12 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     }
     if (!committed) return false;
     const bool retried = process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size;
-    if (retried) apr_verify_write(dst, buf, size);
+    if (retried) {
+        apr_verify_write(dst, buf, size);
+        // The retry path MAP_FIXEDs fresh anonymous pages over the destination first, which makes
+        // it the MOST interesting class to watch, not one to leave uncovered as it was.
+        zerowatch_arm(dst, buf, size, "commit-retry");
+    }
     return retried;
 }
 #endif

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2685,6 +2685,102 @@ extern "C" int prosper_apr_dest_scan(uint64_t lo, uint64_t hi, char* out, size_t
 //
 // PROSPER_APR_VERIFY=1 verifies every write; PROSPER_APR_VERIFY=0xADDR verifies only that
 // destination, which is what keeps the log readable on a title that streams thousands of chunks.
+// DIAGNOSTIC (PROSPER_ZEROWATCH=1): catch the MOMENT guest data disappears, and say what the
+// mapping looked like when it did.
+//
+// #3142 established that APR writes land byte-identically and that the same address reads all-zero
+// seconds later, with no dmem hole-punch, no aliasing mapping and no re-map of the VA in between.
+// Every instrument so far samples at two points and infers what happened between them. This one
+// watches, so the transition itself is the observation rather than something reconstructed from its
+// endpoints -- and it dumps /proc/self/maps for the address at the instant it flips, which is the
+// question the two-point instruments cannot answer: is it still the same mapping?
+//
+// Reads through process_vm_readv, like the write verifier, so a range that becomes unmapped reports
+// that rather than faulting the watchdog thread.
+namespace {
+struct ZeroWatchEntry {
+    uint64_t dst = 0, size = 0, t_armed = 0;
+    bool seen_nonzero = false, reported = false;
+};
+std::mutex g_zw_mx;
+std::vector<ZeroWatchEntry> g_zw;
+std::atomic<bool> g_zw_thread{false};
+
+bool zerowatch_enabled() { static int v = getenv("PROSPER_ZEROWATCH") ? 1 : 0; return v; }
+
+// The covering /proc/self/maps line, so a flip can be attributed to a re-map rather than a write.
+std::string zw_mapping_of(uint64_t addr) {
+    FILE* f = fopen("/proc/self/maps", "r");
+    if (!f) return "<maps-unavailable>";
+    char line[512];
+    std::string hit = "<unmapped>";
+    while (fgets(line, sizeof line, f)) {
+        unsigned long long lo = 0, hi = 0;
+        if (sscanf(line, "%llx-%llx", &lo, &hi) == 2 && addr >= lo && addr < hi) {
+            hit = line;
+            if (!hit.empty() && hit.back() == '\n') hit.pop_back();
+            break;
+        }
+    }
+    fclose(f);
+    return hit;
+}
+
+bool zw_read256(uint64_t addr, uint32_t* out) {
+    struct iovec l { out, 256 }, r { (void*)(uintptr_t)addr, 256 };
+    return process_vm_readv(getpid(), &l, 1, &r, 1, 0) == 256;
+}
+
+void zerowatch_poll_forever() {
+    for (;;) {
+        {
+            std::lock_guard<std::mutex> lk(g_zw_mx);
+            for (auto& e : g_zw) {
+                if (e.reported) continue;
+                uint32_t w[64];
+                if (!zw_read256(e.dst, w)) {
+                    e.reported = true;
+                    fprintf(stderr,
+                            "[zerowatch] t=%llu dst=0x%llx WENT-UNMAPPED after %.3fs  maps=%s\n",
+                            (unsigned long long)prosper::diagnostics::diag_now_us(),
+                            (unsigned long long)e.dst,
+                            (double)(prosper::diagnostics::diag_now_us() - e.t_armed) / 1e6,
+                            zw_mapping_of(e.dst).c_str());
+                    continue;
+                }
+                uint32_t nz = 0;
+                for (uint32_t k = 0; k < 64; ++k) if (w[k]) ++nz;
+                if (nz) { e.seen_nonzero = true; continue; }
+                // All-zero. Only interesting if this range was observed holding data first --
+                // otherwise it is a buffer that was never filled, which is not this defect.
+                if (e.seen_nonzero) {
+                    e.reported = true;
+                    fprintf(stderr,
+                            "[zerowatch] t=%llu dst=0x%llx size=%llu WENT-ZERO after %.3fs  maps=%s\n",
+                            (unsigned long long)prosper::diagnostics::diag_now_us(),
+                            (unsigned long long)e.dst, (unsigned long long)e.size,
+                            (double)(prosper::diagnostics::diag_now_us() - e.t_armed) / 1e6,
+                            zw_mapping_of(e.dst).c_str());
+                }
+            }
+        }
+        struct timespec ts { 0, 50 * 1000 * 1000 };   // 50 ms
+        nanosleep(&ts, nullptr);
+    }
+}
+
+void zerowatch_arm(uint64_t dst, uint64_t size) {
+    if (!zerowatch_enabled() || size < (1u << 20)) return;   // large payloads only: textures, not records
+    std::lock_guard<std::mutex> lk(g_zw_mx);
+    for (auto& e : g_zw) if (e.dst == dst) return;
+    if (g_zw.size() >= 64) return;
+    ZeroWatchEntry e;
+    e.dst = dst; e.size = size; e.t_armed = prosper::diagnostics::diag_now_us();
+    g_zw.push_back(e);
+    if (!g_zw_thread.exchange(true)) std::thread(zerowatch_poll_forever).detach();
+}
+} // namespace
+
 static void apr_verify_write(uint64_t dst, const void* buf, uint64_t size) {
     const char* ev = getenv("PROSPER_APR_VERIFY");
     if (!ev || !*ev || size < 256) return;
@@ -2769,6 +2865,7 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
     if (process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size) {
         apr_verify_write(dst, buf, size);
+        zerowatch_arm(dst, size);
         return true;
     }
     bool committed = false;

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -8,6 +8,7 @@
 #include "hle/fs/save_paths.hpp"
 #include "hle/service/hle_addcontent.hpp"
 #include "hle/dispatch/nid.hpp"
+#include "host/memory/guest_write_watch.hpp"
 #include "diagnostics/diag_clock.hpp"
 #include "hle/kernel/sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "hle/memory/heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
@@ -2761,6 +2762,17 @@ void zerowatch_poll_forever() {
                             (unsigned long long)e.dst, (unsigned long long)e.size,
                             (double)(prosper::diagnostics::diag_now_us() - e.t_armed) / 1e6,
                             zw_mapping_of(e.dst).c_str());
+                    // Dump the dmem write trace HERE, at the moment the data disappears. Its own
+                    // triggers are guest _exit and the fatal raise, neither of which a bounded
+                    // capture run reaches -- so it was recording writer RIPs and printing them
+                    // nowhere. This is the instant at which they answer a question.
+                    //
+                    // No backing-file cross-check accompanies it, and an earlier version tried one:
+                    // the range is MAP_SHARED on a memfd, so reading the mapping IS reading the
+                    // file. There is no "stale view" case for MAP_SHARED to exclude, which makes an
+                    // all-zero read proof that the CONTENT was zeroed rather than proof that this
+                    // view stopped tracking it.
+                    host::guest_dmem_write_trace_report();
                 }
             }
         }

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -13,6 +13,7 @@
 #endif
 #endif
 #include "hle/dispatch/dispatch.hpp"
+#include "diagnostics/diag_clock.hpp"
 #include "hle/memory/dmem_caller_chain.hpp"
 #include "hle/memory/guest_memory_topology.hpp"
 #include "hle/dispatch/nid.hpp"
@@ -1429,9 +1430,27 @@ namespace {
     // range sparse). Called only at ALLOCATION time, so it never disturbs the aliasing contract
     // (which is about mapping an already-allocated phys at a second VA). CONFIDENCE: HIGH (matches
     // the console's fresh-page-zeroed semantics).
+    // DIAGNOSTIC (PROSPER_PHYSLOG): dmem_zero and map_phys_at are the pair that can make guest data
+    // vanish with NO CPU store anywhere -- the signature #3142 is chasing. The VA-level guards
+    // (map_at, map_phys_at_impl) refuse to clobber a committed or untracked mapping, so they are not
+    // the candidate; dmem_zero is, because it punches a hole in the SHARED memfd at a PHYS offset and
+    // every VA aliasing that phys reads zero immediately, with no equivalent guard. dmem_take is
+    // first-fit over released gaps, so a phys range handed to a new tenant may still be mapped and in
+    // use by an old one -- a risk this file already records in prose ("an Ampr map flavor could
+    // already land on an offset a previous tenant wrote") but that nothing measures.
+    //
+    // Logging both sides makes the chain checkable: [physmap] gives VA <-> phys, [dmemzero] gives the
+    // phys ranges that were zeroed and when, and the shared diag_now_us() stamp orders them against
+    // [apr-verify] and [texcontent]. Line order across threads cannot (trap 235).
+    bool physlog() { static int v = getenv("PROSPER_PHYSLOG") ? 1 : 0; return v; }
+
     void dmem_zero(uint64_t phys, uint64_t sz) {
         int fd = dmem_fd();
         if (fd < 0 || phys >= kDmemBase + kDmemTotal || !sz) return;
+        if (physlog())
+            fprintf(stderr, "[dmemzero] t=%llu phys=0x%llx size=0x%llx\n",
+                    (unsigned long long)prosper::diagnostics::diag_now_us(),
+                    (unsigned long long)phys, (unsigned long long)sz);
 #ifdef __linux__
         fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, (off_t)phys, (off_t)sz);
 #else
@@ -1507,10 +1526,19 @@ namespace {
     void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys, uint64_t align = 0,
                       bool fixed = true) {
         void* p = map_phys_at_impl(hint, len, prot, phys, align, fixed);
-        if (p)
+        if (p) {
             host::guest_write_watch_notify_direct_mapping_added(
                 static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p)), len, phys,
                 static_cast<uint32_t>(prot));
+            // Logged HERE rather than at the call sites precisely because this is the documented
+            // single chokepoint for every dmem alias: a per-API log would miss whichever path a
+            // future alias takes, which is the same reason the write-watch was moved here.
+            if (physlog())
+                fprintf(stderr, "[physmap] t=%llu va=0x%llx phys=0x%llx len=0x%llx prot=%d\n",
+                        (unsigned long long)prosper::diagnostics::diag_now_us(),
+                        (unsigned long long)reinterpret_cast<uintptr_t>(p),
+                        (unsigned long long)phys, (unsigned long long)len, prot);
+        }
         return p;
     }
 }
@@ -3253,6 +3281,23 @@ bool guest_memory_gpu_write_supported(uint64_t destination, size_t bytes) {
 
 bool guest_memory_gpu_write(uint64_t destination, const void* source, size_t bytes) {
     if (!source || !guest_memory_gpu_write_supported(destination, bytes)) return false;
+    // PROSPER_PHYSLOG: this is the renderer writing INTO guest direct memory. #3142 is chasing a
+    // range that holds byte-verified loaded data and reads all-zero ~1 s later with its mapping
+    // unchanged -- which a write of zeros through this path produces exactly. Log the destination
+    // and how much of the payload is non-zero: "the renderer wrote here" and "the renderer wrote
+    // ZEROS over loaded data here" are different findings, and only the second is a defect.
+    {
+        static const int physlog_on = getenv("PROSPER_PHYSLOG") ? 1 : 0;
+        if (physlog_on) {
+            const uint8_t* p8 = static_cast<const uint8_t*>(source);
+            size_t probe = bytes < 4096 ? bytes : 4096, nz = 0;
+            for (size_t k = 0; k < probe; ++k) if (p8[k]) ++nz;
+            fprintf(stderr, "[gpuwrite] t=%llu dst=0x%llx bytes=%llu src_nonzero=%llu/%llu\n",
+                    (unsigned long long)prosper::diagnostics::diag_now_us(),
+                    (unsigned long long)destination, (unsigned long long)bytes,
+                    (unsigned long long)nz, (unsigned long long)probe);
+        }
+    }
 
     auto resolve_direct = [](uint64_t address, size_t size, uint64_t& physical) {
         const auto after = std::upper_bound(


### PR DESCRIPTION
Instruments for #3142, and the falsifications they produced. Refs #3142, #3126.

## The state they were built for

#3144 established that Stray's pak reads land **byte-identically** in guest memory (21,499/21,499
`memcmp`-verified) and that the same address reads all-zero when the shader samples it. Every
instrument up to that point sampled two points and inferred the middle. These watch instead.

## `PROSPER_ZEROWATCH`

Polls each large APR destination every 50 ms and reports the non-zero → all-zero transition, dumping
`/proc/self/maps` for the address at that instant.

It fires **at least 11–13 times per run** — a floor, not a total: the watch list's 64-entry cap is
reached on the very first run, which the probe now says out loud instead of dropping silently. The
flip is fast — **0.5–2.3 s** after the load, not the 65 s I had been reasoning about. That 65 s was only the delay until the *shader* sampled; the data was gone
within a second. It also reproduces in a **2-minute** run, not the 7-minute title route, because it
happens during asset load.

The maps line settles the question two-point sampling cannot: at the moment of the flip the mapping is
**unchanged** — still `rw-s` on the dmem memfd at the same offset. Not unmapped, not replaced by an
anonymous mapping, not re-pointed. And because the range is `MAP_SHARED` on a memfd, reading the
mapping *is* reading the file, so there is no "stale view" case to exclude: the **content** was zeroed.

## `PROSPER_PHYSLOG`

Logs the three paths that could plausibly do it — `dmem_zero` (the hole punch), `map_phys_at` (the
documented single chokepoint for every dmem alias) and `guest_memory_gpu_write` (the renderer writing
into guest memory) — each stamped with `diag_now_us()` so they order against `[apr-verify]` and
`[texcontent]` soundly rather than by log position (trap 235).

## What they falsify

| hypothesis | evidence |
| --- | --- |
| `dmem_zero` punches a hole over the range | all **20** calls in the run are at startup, before every one of these writes |
| the VA is re-mapped to a different phys | one `[physmap]` per VA, created ~2 ms *before* its write; none after |
| a second VA aliases the phys and is written | zero aliasing mappings — each phys range is mapped exactly once |
| the renderer writes back over it | `guest_memory_gpu_write` fires **once** per run, covering none of the zeroed ranges |
| the address is recycled for another asset | `0x303cc90000` receives exactly one payload and is never written again |

## The write trace, and the limitation worth carrying forward

`PROSPER_DMEM_WRITE_TRACE` already records writer RIPs, but only prints on guest `_exit` and the fatal
raise — neither of which a bounded capture run reaches, so on every `tools/screenshot` run it was
recording RIPs and printing them nowhere. `PROSPER_ZEROWATCH` now fires its report at the instant a
watched range goes zero.

That run reports `status=invalid reason=host-write`, **`page-faults=0`**: no *guest* write faulted on
the watched page, and a *host* write invalidated the watch. Only four call sites in the tree write
guest memory from the host and all four are file reads, so the invalidation is the APR load itself.
**This instrument therefore cannot watch a range that APR loads into** — that is the blocker for naming
the writer, and it is a property of the trace's lifecycle rather than a result about Stray.

## Verification (exact head)

```
cmake --build prosper/build-linux -j6                        # clean
ctest --test-dir prosper/build-linux --no-tests=error -j4    # 100% of 315, rc=0
python3 prosper/tools/env/check_diag_gates.py                # == all checks passed ==
```

Live: five Stray boots.

## Risk

All three switches are **default-off**. With them unset each site is one cached `getenv` and nothing
else; `PROSPER_ZEROWATCH` starts no thread and arms nothing. No rendering, test or snapshot path
changes.

**Review requested** on one point in particular: `zerowatch_poll_forever` reads the watch vector under
its mutex but the vector is only ever appended to, and I would like a second opinion on the lifetime
argument. An earlier revision of this branch also carried a `SIGSEGV`-based write trap that chained to
prosper's handler; it killed the run at asset load and was **removed rather than debugged**, since
fighting the existing write-watch machinery is exactly the hand-rolled-guard hazard the charter warns
about. It is not in this diff.


---

**Update — review round 2.** Three blocking findings, all fixed at `3008860c`:

* **B1** was the serious one: `WENT-ZERO` printed the full payload size while the poll sampled only
  the first 256 bytes, and `seen_nonzero` was decided from that same window — which
  `apr_verify_write`'s own comment sixty lines below says is *commonly all-zero on this exact data*.
  A payload with a zero-padded head could therefore never report, silently, for precisely the class
  under investigation. `seen_nonzero` is now seeded at arm time from the **source** buffer across
  eight windows, and the line carries `sampled=256B@0` so the verdict states its own basis.
* **B2** — two silent coverage gaps. The 64-entry cap dropped arming with no output, and only the
  fast write path armed, leaving the commit-retry path (which `MAP_FIXED`s fresh anonymous pages over
  the destination first — the most interesting class) unwatched. Both fixed; the line now reports
  `armed-via=`. The cap warning fires immediately, which is what demoted "11–13" to a floor above.
* **B3** — the falsifications and the corrected timing were in issue comments and no `.md` file.
  `docs/STRAY_STATUS.md` gains the `## Ruled out` row, including what blocks naming the writer so
  nobody re-derives it.

Both questions I raised came back clean, and the reviewer sharpened one of them: the in-run access is
safe **because of the mutex**, not because the vector is append-only — my phrasing was the hazard. The
detached thread is safe only because every exit path here is `_Exit`, which is now a comment at the
thread rather than an unstated assumption.

---

**Update — review round 3.** Round 2's B2 and B3 were confirmed fixed; two findings remained and both
are addressed at `f7f1c136`.

* **B1 was a defect I introduced fixing round 1's B1.** Seeding `seen_nonzero` from the source removed
  the silent miss, but the probe still read window 0 of the *destination* — two unrelated places — and
  since arming now returns early when the seed finds nothing, the poll-loop gate became **vacuous**. A
  payload with a zero head and data at window 3 would have printed `WENT-ZERO` for a range that never
  changed, and because `guest_dmem_write_trace_report()` is one-shot, a false first flip burns the
  write trace on a non-event. That is worse than the miss it replaced. The entry now records *which*
  window the source was non-zero at, the probe reads that window, and `sampled=256B@0x<off>` states it.
* **B2 was right to refuse the cap claim as unmeasured**, and it is measured now: the warning fires
  once in the same run that produced the flips.

**Re-measured at `f7f1c136`: 14 flips, every one seeded at offset `0x0`.** So the fix changes no
observation on this title — the earlier numbers stand. It makes the correctness structural rather than
a property of this title's payload layout, which is the reason to make it and worth stating plainly
rather than dressing up as a corrected measurement.

Also restores two things the `STRAY_STATUS.md` row had dropped (round-2 non-blocking): the second base
`0x302a300000`, read zero by five different shaders across 152 s — one address going quiet could be a
descriptor pointing somewhere stale, two cannot — and the fifth falsification, that the address is
recycled for another asset.