### PR TITLE
diag: let the dmem write trace re-baseline after a host write, and reach the screenshot frontend (#3146)

### DIFF
--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -315,6 +315,15 @@ drops still discard the background.
     disposes of its buffer correctly, and prosper's defect is that a shader still reads that address
     afterwards. The open question is now a descriptor one — why `0x300c150000`'s texture resolves to a
     staging buffer the engine has finished with — which also fits its `rtt=MISS`. #3142.
+
+    **And it is NOT why the background is black** — established after the above and worth stating
+    here, because the reclassification reads like a lead and is not one. The graphics RTT sampler
+    resolves these surfaces correctly: a landed title-screen run measures **58,569 sample HITs against
+    185 misses and 5 skips**, and all five skips are 32x32/64x64 3D textures. `PROSPER_RTT=1` renders
+    no additional pixel. So the composite reads black because its INPUTS are black at source (see the
+    section of that name), not because a sample was served from cleared guest memory. The staging
+    buffer being cleared is ordinary engine behaviour with no bearing on the picture. #3140 is
+    falsified; do not restart from the RTT cache.
   - Four mechanisms measured and excluded, each in the same runs: **`dmem_zero`'s hole punch** (all 20
     calls occur at startup, before every one of these writes); **a re-map of the VA** (one `[physmap]`
     per VA, created ~2 ms *before* its write, none after); **a second VA aliasing the phys** (none —
@@ -333,9 +342,8 @@ drops still discard the background.
     guest memory in the tree are file reads), so it could never watch a range APR loads into — it
     reported `page-faults=0` because the watch died at the load, not because no guest write happened.
     **[#3147](https://github.com/mattias800/prosper/pull/3147) lifts that** with an opt-in
-    re-baseline mode, and the `libc.prx` attribution above is measured **with that PR applied**: on
-    master alone the trace still disarms at the load and reproduces nothing. If #3147 is merged when
-    you read this, drop this caveat; if it was closed, the attribution needs re-deriving.
+    re-baseline mode (`PROSPER_DMEM_WRITE_TRACE_REBASE=1`), which is what makes the `libc.prx`
+    attribution above reproducible.
     A `SIGSEGV` trap hand-rolled to get the RIP directly killed the run at asset load and was removed
     rather than debugged — extending the existing trace's lifecycle was the route, not a second
     write-watch fighting the first.

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -1479,7 +1479,14 @@ static int64_t read_full(int fd, void* buf, size_t count, bool positioned, off_t
     // nothing may re-arm a watch over `buf` before then (#3146 review B1).
     struct HostWriteDone {
         uint64_t addr; uint64_t size;
-        ~HostWriteDone() { host::guest_write_watch_notify_host_write_done(addr, size); }
+        // errno is preserved across this: the guard runs on the way out of a function whose CALLER
+        // reads errno after a short/failed read, and a diagnostic completion must not be able to
+        // change what the guest is told went wrong.
+        ~HostWriteDone() {
+            const int saved = errno;
+            host::guest_write_watch_notify_host_write_done(addr, size);
+            errno = saved;
+        }
     } host_write_done{reinterpret_cast<uint64_t>(buf), count};
     size_t done = 0;
     while (done < count) {
@@ -1609,6 +1616,9 @@ static void disarm_iovec_watches(const struct iovec* v, int n) {
 // a watch could be re-armed over a buffer the read is about to fill -- and the store would then hit a
 // read-only page and EFAULT the read. Calling this after the syscall closes the window (#3146 B1).
 static void rearm_iovec_watches(const struct iovec* v, int n) {
+    // Runs between the readv/preadv and the caller's errno read, so it must leave errno alone.
+    const int saved_errno = errno;
+    struct RestoreErrno { int v; ~RestoreErrno() { errno = v; } } restore_errno{saved_errno};
     if (!v || n <= 0) return;
     for (int i = 0; i < n; ++i)
         if (v[i].iov_base && v[i].iov_len)
@@ -2942,7 +2952,14 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     // measurement rather than in any test.
     struct HostWriteDone {
         uint64_t addr; uint64_t size;
-        ~HostWriteDone() { host::guest_write_watch_notify_host_write_done(addr, size); }
+        // errno is preserved across this: the guard runs on the way out of a function whose CALLER
+        // reads errno after a short/failed read, and a diagnostic completion must not be able to
+        // change what the guest is told went wrong.
+        ~HostWriteDone() {
+            const int saved = errno;
+            host::guest_write_watch_notify_host_write_done(addr, size);
+            errno = saved;
+        }
     } host_write_done{dst, size};
     struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
     if (process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size) {

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2947,7 +2947,7 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     // and marks every overlapping cache registration dirty.
     host::guest_write_watch_notify_host_write(dst, size);
     // Paired on EVERY exit, not just the fast success. A notification without its completion leaves
-    // the in-flight depth permanently raised, which silently disables rebaselining -- exactly the
+    // its range recorded as in flight forever, which stops rebaselining for that address -- exactly the
     // regression this pairing was added to prevent, and one that only showed up by re-running the
     // measurement rather than in any test.
     struct HostWriteDone {

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -1475,6 +1475,12 @@ static int64_t read_full(int fd, void* buf, size_t count, bool positioned, off_t
     // read succeeds, and mark it Dirty since its bytes are changing (#1144 B5). No-op off Linux / when
     // nothing is armed.
     host::guest_write_watch_notify_host_write(reinterpret_cast<uint64_t>(buf), count);
+    // Paired below on every exit from the loop: the write is in flight until the last byte lands, and
+    // nothing may re-arm a watch over `buf` before then (#3146 review B1).
+    struct HostWriteDone {
+        uint64_t addr; uint64_t size;
+        ~HostWriteDone() { host::guest_write_watch_notify_host_write_done(addr, size); }
+    } host_write_done{reinterpret_cast<uint64_t>(buf), count};
     size_t done = 0;
     while (done < count) {
         ssize_t r = positioned ? ::pread(fd, (char*)buf + done, count - done, off + (off_t)done)
@@ -1598,11 +1604,24 @@ static void disarm_iovec_watches(const struct iovec* v, int n) {
             host::guest_write_watch_notify_host_write(
                 reinterpret_cast<uint64_t>(v[i].iov_base), v[i].iov_len);
 }
+// The completion half. This path is why it exists: it notifies for EVERY iovec BEFORE the single
+// ::readv/::preadv runs, so between the first notification and the syscall there is a window in which
+// a watch could be re-armed over a buffer the read is about to fill -- and the store would then hit a
+// read-only page and EFAULT the read. Calling this after the syscall closes the window (#3146 B1).
+void rearm_iovec_watches(const struct iovec* v, int n) {
+    if (!v || n <= 0) return;
+    for (int i = 0; i < n; ++i)
+        if (v[i].iov_base && v[i].iov_len)
+            host::guest_write_watch_notify_host_write_done(
+                reinterpret_cast<uint64_t>(v[i].iov_base), v[i].iov_len);
+}
 HLE(f_readv)  { const struct iovec* v = (const struct iovec*)P(a1); disarm_iovec_watches(v, (int)a2);
-                return (uint64_t)(int64_t)::readv((int)a0, v, (int)a2); }
+                const uint64_t r = (uint64_t)(int64_t)::readv((int)a0, v, (int)a2);
+                rearm_iovec_watches(v, (int)a2); return r; }
 HLE(f_writev) { return (uint64_t)(int64_t)::writev((int)a0, (const struct iovec*)P(a1), (int)a2); }
 HLE(f_preadv) { const struct iovec* v = (const struct iovec*)P(a1); disarm_iovec_watches(v, (int)a2);
-                return (uint64_t)(int64_t)::preadv((int)a0, v, (int)a2, (off_t)a3); }
+                const uint64_t r = (uint64_t)(int64_t)::preadv((int)a0, v, (int)a2, (off_t)a3);
+                rearm_iovec_watches(v, (int)a2); return r; }
 HLE(f_pwritev){ return (uint64_t)(int64_t)::pwritev((int)a0, (const struct iovec*)P(a1), (int)a2, (off_t)a3); }
 #else
 // Windows positioned/vectored IO. MinGW has no pread/pwrite/*v, and these previously returned -1
@@ -2919,6 +2938,7 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     host::guest_write_watch_notify_host_write(dst, size);
     struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
     if (process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size) {
+        host::guest_write_watch_notify_host_write_done(dst, size);
         apr_verify_write(dst, buf, size);
         zerowatch_arm(dst, buf, size, "direct");
         return true;

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -1608,7 +1608,7 @@ static void disarm_iovec_watches(const struct iovec* v, int n) {
 // ::readv/::preadv runs, so between the first notification and the syscall there is a window in which
 // a watch could be re-armed over a buffer the read is about to fill -- and the store would then hit a
 // read-only page and EFAULT the read. Calling this after the syscall closes the window (#3146 B1).
-void rearm_iovec_watches(const struct iovec* v, int n) {
+static void rearm_iovec_watches(const struct iovec* v, int n) {
     if (!v || n <= 0) return;
     for (int i = 0; i < n; ++i)
         if (v[i].iov_base && v[i].iov_len)

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2936,9 +2936,16 @@ static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     // a prefix of a multi-page read.  Notify before the first attempt both restores write access
     // and marks every overlapping cache registration dirty.
     host::guest_write_watch_notify_host_write(dst, size);
+    // Paired on EVERY exit, not just the fast success. A notification without its completion leaves
+    // the in-flight depth permanently raised, which silently disables rebaselining -- exactly the
+    // regression this pairing was added to prevent, and one that only showed up by re-running the
+    // measurement rather than in any test.
+    struct HostWriteDone {
+        uint64_t addr; uint64_t size;
+        ~HostWriteDone() { host::guest_write_watch_notify_host_write_done(addr, size); }
+    } host_write_done{dst, size};
     struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
     if (process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size) {
-        host::guest_write_watch_notify_host_write_done(dst, size);
         apr_verify_write(dst, buf, size);
         zerowatch_arm(dst, buf, size, "direct");
         return true;

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -1928,7 +1928,8 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
 
 // Paired with guest_write_watch_notify_host_write: called AFTER the host write has completed, so the
 // trace knows no bytes are in flight and a rebaseline may safely re-arm. Unpaired callers are safe --
-// the depth simply stays nonzero and rebaselining stops, which is the direction that cannot corrupt.
+// its range simply stays recorded and rebaselining stops for THAT address, which is the direction
+// that cannot corrupt -- and, unlike the global counter this replaced, cannot disable the feature.
 void guest_write_watch_notify_host_write_done(uint64_t addr, uint64_t size) {
     if (!addr || !size || addr > UINT64_MAX - size) return;
     WatchState& w = state();

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -525,6 +525,11 @@ void guest_dmem_write_trace_set_contention_hook_for_test(
         GuestDmemWriteTraceContentionHookForTest) {}
 void guest_dmem_write_trace_set_dynamic_protection_hook_for_test(
         GuestDmemWriteTraceDynamicProtectionHookForTest) {}
+// Stubbed for the same reason as everything above it, not as a gap: the rebaseline mode is a modifier
+// on a trace that never arms here, because the whole mechanism is mprotect + SIGSEGV and Windows'
+// create() always refuses. A real implementation would set a flag no code path reads.
+void guest_dmem_write_trace_set_rebase_enabled_for_test(int) {}
+
 void guest_dmem_write_trace_lock_state_for_test() {}
 void guest_dmem_write_trace_unlock_state_for_test() {}
 
@@ -625,6 +630,9 @@ struct DmemTraceState {
     // Rebaseline attempts that could not complete. Without this a refusal is invisible and reads
     // exactly like the mode being off.
     uint64_t rebase_failures = 0;
+    // Benign: a rebaseline declined because a host write covers a traced page. Counted apart from
+    // rebase_failures so "we waited" cannot read as "we broke" -- they need different reactions.
+    uint64_t rebase_in_flight_refusals = 0;
     // #3146: set when a host write disarmed the trace and PROSPER_DMEM_WRITE_TRACE_REBASE asked for
     // a re-baseline rather than a permanent invalidation. Cleared when the re-arm succeeds.
     bool rebase_pending = false;
@@ -1464,6 +1472,8 @@ GuestDmemWriteTraceSnapshot guest_dmem_write_trace_snapshot() {
     out.selection_uncertain_faults = trace.selection_uncertain_faults;
     out.completed_steps = trace.completed_steps;
     out.rearms = trace.rearms;
+    out.host_write_rebases = trace.host_write_rebases;
+    out.rebase_in_flight_refusals = trace.rebase_in_flight_refusals;
     out.coverage_gaps = trace.coverage_gaps;
     out.overflow_events = trace.overflow_events;
     out.selected_occurrence = trace.selected_occurrence;
@@ -1486,7 +1496,7 @@ void guest_dmem_write_trace_report() {
                  "[dmem-write-trace] summary status=%s reason=%s result=%s"
                  " allocation-matches=%llu mapping-matches=%llu page-faults=%llu"
                  " selected-faults=%llu selection-uncertain-faults=%llu"
-                 " steps=%llu rearms=%llu host-write-rebases=%llu rebase-failures=%llu coverage-gaps=%llu"
+                 " steps=%llu rearms=%llu host-write-rebases=%llu rebase-failures=%llu rebase-inflight-refusals=%llu coverage-gaps=%llu"
                  " overflow=%llu occurrence-mode=%s requested-occurrence=%u"
                  " observed-occurrences=%llu selected-occurrence=%llu events=%u/%u\n",
                  trace_status_name(trace.status), trace_reason_name(trace.invalid_reason), result,
@@ -1499,6 +1509,7 @@ void guest_dmem_write_trace_report() {
                  static_cast<unsigned long long>(trace.rearms),
                  static_cast<unsigned long long>(trace.host_write_rebases),
                  static_cast<unsigned long long>(trace.rebase_failures),
+                 static_cast<unsigned long long>(trace.rebase_in_flight_refusals),
                  static_cast<unsigned long long>(trace.coverage_gaps),
                  static_cast<unsigned long long>(trace.overflow_events),
                  trace.config.allocation_occurrence ? "ordinal" : "unique",
@@ -1736,7 +1747,11 @@ void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {
 // The re-arm is deferred rather than immediate: this notification fires BEFORE the host write, so the
 // bytes to baseline against do not exist yet. It happens on the next notification that does not
 // overlap the watched range, which on a streaming title is milliseconds away.
+std::atomic<int> g_rebase_enabled_override{-1};
+
 bool trace_rebase_enabled() {
+    const int override_value = g_rebase_enabled_override.load(std::memory_order_relaxed);
+    if (override_value >= 0) return override_value != 0;
     static const int on = [] {
         const char* v = std::getenv("PROSPER_DMEM_WRITE_TRACE_REBASE");
         return v && *v && *v != '0' ? 1 : 0;
@@ -1746,7 +1761,13 @@ bool trace_rebase_enabled() {
 
 // Re-snapshot the baseline and re-arm. Caller holds w.mutex and must have established that no host
 // write is in flight over the watched range.
-bool trace_rebase_locked(WatchState& w) {
+// `caller_begin/caller_end` is the range of the host write that is ABOUT TO RUN in the calling
+// notification. It is not in `host_write_ranges` yet -- it is appended after this returns -- so it
+// has to be folded in here explicitly. The caller does test it, but against the PRE-rebuild page
+// list, and the whole point of the rebuild is that that list can be stale: a new alias of the traced
+// phys recorded during the pending window is invisible to the caller's test, pulled in by the
+// rebuild, and would then be armed read-only under the very read that is about to fill it.
+bool trace_rebase_locked(WatchState& w, uint64_t caller_begin, uint64_t caller_end) {
     DmemTraceState& trace = w.trace;
     if (!trace.rebase_pending) return false;
     if (!w.fault_onstack.load(std::memory_order_acquire)) return false;
@@ -1778,12 +1799,17 @@ bool trace_rebase_locked(WatchState& w) {
     // Armed||Stepping), and guarding the list we are about to REPLACE would arm that new alias with
     // no check at all, re-opening the EFAULT this guard exists to close.
     for (const DmemTracePage& page : trace.pages)
-        for (const PageAlias& alias : page.aliases)
+        for (const PageAlias& alias : page.aliases) {
+            if (alias.addr >= caller_begin && alias.addr < caller_end) {
+                trace.rebase_in_flight_refusals++;
+                return false;
+            }
             for (const auto& range : w.host_write_ranges)
                 if (alias.addr >= range.first && alias.addr < range.second) {
-                    trace.rebase_failures++;
+                    trace.rebase_in_flight_refusals++;
                     return false;
                 }
+        }
     if (!set_trace_armed_locked(w, true, false)) {
         trace.rebase_failures++;
         return false;
@@ -1877,7 +1903,7 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
         bool overlap = false;
         for (uint64_t va = begin; va < end && !overlap; va += kPage)
             overlap = trace_va_to_phys_locked(w.trace, va, ignored_phys);
-        if (!overlap) (void)trace_rebase_locked(w);
+        if (!overlap) (void)trace_rebase_locked(w, begin, end);
     }
     // Recorded AFTER the rebaseline decision, not before it: THIS call's write has not started yet
     // and its own range is excluded by the overlap test above. Recording first made the guard see its
@@ -2296,6 +2322,10 @@ void guest_dmem_write_trace_set_contention_hook_for_test(
 void guest_dmem_write_trace_set_dynamic_protection_hook_for_test(
         GuestDmemWriteTraceDynamicProtectionHookForTest hook) {
     trace_dynamic_protection_hook_for_test.store(hook, std::memory_order_release);
+}
+
+void guest_dmem_write_trace_set_rebase_enabled_for_test(int enabled) {
+    g_rebase_enabled_override.store(enabled, std::memory_order_relaxed);
 }
 
 void guest_dmem_write_trace_lock_state_for_test() { state().mutex.lock(); }

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -622,6 +622,9 @@ struct DmemTraceState {
     // Re-arms caused specifically by a host-write rebaseline. Distinct from `rearms`, which the
     // ordinary per-step re-arm also bumps -- see trace_rebase_locked.
     uint64_t host_write_rebases = 0;
+    // Rebaseline attempts that could not complete. Without this a refusal is invisible and reads
+    // exactly like the mode being off.
+    uint64_t rebase_failures = 0;
     // #3146: set when a host write disarmed the trace and PROSPER_DMEM_WRITE_TRACE_REBASE asked for
     // a re-baseline rather than a permanent invalidation. Cleared when the re-arm succeeds.
     bool rebase_pending = false;
@@ -1483,7 +1486,7 @@ void guest_dmem_write_trace_report() {
                  "[dmem-write-trace] summary status=%s reason=%s result=%s"
                  " allocation-matches=%llu mapping-matches=%llu page-faults=%llu"
                  " selected-faults=%llu selection-uncertain-faults=%llu"
-                 " steps=%llu rearms=%llu host-write-rebases=%llu coverage-gaps=%llu"
+                 " steps=%llu rearms=%llu host-write-rebases=%llu rebase-failures=%llu coverage-gaps=%llu"
                  " overflow=%llu occurrence-mode=%s requested-occurrence=%u"
                  " observed-occurrences=%llu selected-occurrence=%llu events=%u/%u\n",
                  trace_status_name(trace.status), trace_reason_name(trace.invalid_reason), result,
@@ -1495,6 +1498,7 @@ void guest_dmem_write_trace_report() {
                  static_cast<unsigned long long>(trace.completed_steps),
                  static_cast<unsigned long long>(trace.rearms),
                  static_cast<unsigned long long>(trace.host_write_rebases),
+                 static_cast<unsigned long long>(trace.rebase_failures),
                  static_cast<unsigned long long>(trace.coverage_gaps),
                  static_cast<unsigned long long>(trace.overflow_events),
                  trace.config.allocation_occurrence ? "ordinal" : "unique",
@@ -1752,23 +1756,41 @@ bool trace_rebase_locked(WatchState& w) {
     // makes that deterministic without any concurrency: it notifies for EVERY iovec before calling
     // ::preadv, so an iovec in the watched buffer plus an iovec in another dmem alias would disarm,
     // re-arm, and then EFAULT the read -- the exact failure the disarm exists to prevent.
-    for (const DmemTracePage& page : trace.pages)
-        for (const PageAlias& alias : page.aliases)
-            for (const auto& range : w.host_write_ranges)
-                if (alias.addr >= range.first && alias.addr < range.second) return false;
+    // (the in-flight check moved below trace_collect_pages_locked -- see there)
     // B3: rebuild the page/alias list rather than re-arming the one captured at arm time. Every
     // mapping and protection hook gates on Armed||Stepping, so nothing maintained that list while the
     // trace sat pending -- and mprotect'ing a stale entry would make an unrelated guest mapping
     // read-only and record fabricated events against it. That is the one route by which a rebaselined
     // trace could MISATTRIBUTE, which matters because its output is being used to reclassify a defect.
     if (!trace_collect_pages_locked(w)) {
-        trace_invalidate_locked(w, GuestDmemWriteTraceInvalidReason::MappingTopologyChanged);
+        // B7: trace_invalidate_locked early-returns when the status is already Invalid, and this
+        // function is only reached in that state -- so calling it here recorded NOTHING and the
+        // summary stayed indistinguishable from a mode-off run. Set the reason directly and stop
+        // retrying, so a topology change is visible in the summary rather than silent.
+        trace.invalid_reason = GuestDmemWriteTraceInvalidReason::MappingTopologyChanged;
         trace.rebase_pending = false;
+        trace.rebase_failures++;
         return false;
     }
-    if (!set_trace_armed_locked(w, true, false)) return false;
+    // B6: this check belongs AFTER the rebuild, because the point of the rebuild is that the old
+    // list may be stale -- a new alias of the traced phys can appear during the pending window
+    // (notify_direct_mapping_added appends unconditionally while its trace block gates on
+    // Armed||Stepping), and guarding the list we are about to REPLACE would arm that new alias with
+    // no check at all, re-opening the EFAULT this guard exists to close.
+    for (const DmemTracePage& page : trace.pages)
+        for (const PageAlias& alias : page.aliases)
+            for (const auto& range : w.host_write_ranges)
+                if (alias.addr >= range.first && alias.addr < range.second) {
+                    trace.rebase_failures++;
+                    return false;
+                }
+    if (!set_trace_armed_locked(w, true, false)) {
+        trace.rebase_failures++;
+        return false;
+    }
     if (!trace_copy_target_locked(trace, trace.initial)) {
         (void)set_trace_armed_locked(w, false, false);
+        trace.rebase_failures++;
         return false;
     }
     trace.status = GuestDmemWriteTraceStatus::Armed;
@@ -1861,7 +1883,13 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
     // and its own range is excluded by the overlap test above. Recording first made the guard see its
     // own notification and refuse every rebaseline, silently turning the feature off -- caught only
     // by re-running the measurement that motivated it, not by any test.
-    w.host_write_ranges.emplace_back(begin, end);
+    //
+    // Gated on the rebaseline mode, and that gate is load-bearing rather than tidy: this runs before
+    // EVERY guest read on a path where `fault_onstack` is true on any ordinary Linux boot, several
+    // callers never pair a completion, and the erase matches an exact (begin,end) -- so ungated this
+    // is an unbounded vector plus an O(N) scan under this mutex on the default path. A diagnostic
+    // must cost nothing when it is off.
+    if (trace_rebase_enabled()) w.host_write_ranges.emplace_back(begin, end);
     std::vector<WatchedPage*> hit;
     for (uint64_t va = begin; va < end; va += kPage) {
         auto it = w.pages_by_addr.find(va);
@@ -1879,6 +1907,7 @@ void guest_write_watch_notify_host_write_done(uint64_t addr, uint64_t size) {
     if (!addr || !size || addr > UINT64_MAX - size) return;
     WatchState& w = state();
     if (!w.fault_onstack.load(std::memory_order_acquire)) return;
+    if (!trace_rebase_enabled()) return;   // nothing is ever recorded when the mode is off
     std::lock_guard lock(w.mutex);
     const uint64_t begin = addr & ~(kPage - 1);
     const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -618,6 +618,9 @@ struct DmemTraceState {
     uint64_t selection_uncertain_faults = 0;
     uint64_t completed_steps = 0;
     uint64_t rearms = 0;
+    // #3146: set when a host write disarmed the trace and PROSPER_DMEM_WRITE_TRACE_REBASE asked for
+    // a re-baseline rather than a permanent invalidation. Cleared when the re-arm succeeds.
+    bool rebase_pending = false;
     uint64_t coverage_gaps = 0;
     uint64_t overflow_events = 0;
     uint64_t selected_occurrence = 0;
@@ -1701,6 +1704,48 @@ void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {
 // Its null has a real scope: only writes the HLE routes through this notification are seen. A guest
 // that reads into a staging buffer and memcpys from there in guest code writes with plain stores,
 // which nothing here can observe.
+// #3146: PROSPER_DMEM_WRITE_TRACE_REBASE=1 makes a host write RE-BASELINE the trace instead of
+// invalidating it permanently.
+//
+// The default is invalidation and stays that way, because it is the honest answer to the question the
+// trace was built for -- "who wrote these exact bytes, starting from this exact content". A host write
+// bypasses page protection, so those bytes changed without the trace seeing it, and any later diff is
+// measured from a baseline that is no longer true.
+//
+// Re-baselining answers a strictly weaker question -- "who wrote them since the last host write" --
+// and that weaker question is the only one available for a range the HLE loads into. Every host writer
+// of guest memory in the tree is a file read, so a buffer a title streams an asset into disarms the
+// watch at the moment the asset arrives, which is before the window of interest even opens (#3142).
+//
+// The re-arm is deferred rather than immediate: this notification fires BEFORE the host write, so the
+// bytes to baseline against do not exist yet. It happens on the next notification that does not
+// overlap the watched range, which on a streaming title is milliseconds away.
+bool trace_rebase_enabled() {
+    static const int on = [] {
+        const char* v = std::getenv("PROSPER_DMEM_WRITE_TRACE_REBASE");
+        return v && *v && *v != '0' ? 1 : 0;
+    }();
+    return on != 0;
+}
+
+// Re-snapshot the baseline and re-arm. Caller holds w.mutex and must have established that no host
+// write is in flight over the watched range.
+bool trace_rebase_locked(WatchState& w) {
+    DmemTraceState& trace = w.trace;
+    if (!trace.rebase_pending) return false;
+    if (!w.fault_onstack.load(std::memory_order_acquire)) return false;
+    if (!set_trace_armed_locked(w, true, false)) return false;
+    if (!trace_copy_target_locked(trace, trace.initial)) {
+        (void)set_trace_armed_locked(w, false, false);
+        return false;
+    }
+    trace.status = GuestDmemWriteTraceStatus::Armed;
+    trace.invalid_reason = GuestDmemWriteTraceInvalidReason::None;
+    trace.rebase_pending = false;
+    trace.rearms++;
+    return true;
+}
+
 void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
     if (!addr || !size || addr > UINT64_MAX - size) return;
     // The watch spec is parsed ONCE. This function runs before every read()/pread() and once per
@@ -1755,9 +1800,25 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
         bool overlap = false;
         for (uint64_t va = begin; va < end && !overlap; va += kPage)
             overlap = trace_va_to_phys_locked(w.trace, va, ignored_phys);
-        if (overlap)
+        if (overlap) {
             trace_invalidate_locked(w, GuestDmemWriteTraceInvalidReason::HostWrite,
                                     true);
+            // Deferred, not immediate: the host write has not happened yet, so there is nothing to
+            // baseline against until it has.
+            if (trace_rebase_enabled()) w.trace.rebase_pending = true;
+        }
+    } else if (w.trace.rebase_pending &&
+               w.trace.status == GuestDmemWriteTraceStatus::Invalid &&
+               w.trace.invalid_reason == GuestDmemWriteTraceInvalidReason::HostWrite) {
+        // The previous host write has landed, so its result is now the content to measure from --
+        // but only re-arm if THIS write does not touch the watched range. Re-arming pages that are
+        // about to receive a host store would make that store hit a read-only page and EFAULT the
+        // read, which is the exact failure the disarm above exists to prevent.
+        uint64_t ignored_phys = 0;
+        bool overlap = false;
+        for (uint64_t va = begin; va < end && !overlap; va += kPage)
+            overlap = trace_va_to_phys_locked(w.trace, va, ignored_phys);
+        if (!overlap) (void)trace_rebase_locked(w);
     }
     std::vector<WatchedPage*> hit;
     for (uint64_t va = begin; va < end; va += kPage) {

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -500,6 +500,7 @@ void guest_write_watch_invalidate_all() {
 
 // Windows never arms pages (create() always refuses), so a host/kernel write can never EFAULT here.
 void guest_write_watch_notify_host_write(uint64_t, uint64_t) {}
+void guest_write_watch_notify_host_write_done(uint64_t, uint64_t) {}
 void guest_write_watch_notify_gpu_write(uint64_t, uint64_t) {}
 
 bool guest_write_watch_handle_fault(uint64_t addr) {
@@ -618,6 +619,9 @@ struct DmemTraceState {
     uint64_t selection_uncertain_faults = 0;
     uint64_t completed_steps = 0;
     uint64_t rearms = 0;
+    // Re-arms caused specifically by a host-write rebaseline. Distinct from `rearms`, which the
+    // ordinary per-step re-arm also bumps -- see trace_rebase_locked.
+    uint64_t host_write_rebases = 0;
     // #3146: set when a host write disarmed the trace and PROSPER_DMEM_WRITE_TRACE_REBASE asked for
     // a re-baseline rather than a permanent invalidation. Cleared when the re-arm succeeds.
     bool rebase_pending = false;
@@ -652,6 +656,12 @@ struct WatchState {
     // exact thread owns the diagnostic's one-instruction step.
     std::atomic<int64_t> pending_trace_step_tid{0};
     DmemTraceState trace;
+    // Host writes currently between their notification and their completion. The notify contract is
+    // "notify, then write", so a nonzero depth means bytes may land in a watched page at any moment
+    // and nothing may re-arm it. Incremented by guest_write_watch_notify_host_write and decremented
+    // by its paired ..._done; a caller that never pairs simply keeps rebaselining disabled, which is
+    // the safe direction.
+    int host_writes_in_flight = 0;
 };
 static_assert(std::atomic<int64_t>::is_always_lock_free,
               "the signal-path pending-step discriminator must be lock-free");
@@ -1472,7 +1482,7 @@ void guest_dmem_write_trace_report() {
                  "[dmem-write-trace] summary status=%s reason=%s result=%s"
                  " allocation-matches=%llu mapping-matches=%llu page-faults=%llu"
                  " selected-faults=%llu selection-uncertain-faults=%llu"
-                 " steps=%llu rearms=%llu coverage-gaps=%llu"
+                 " steps=%llu rearms=%llu host-write-rebases=%llu coverage-gaps=%llu"
                  " overflow=%llu occurrence-mode=%s requested-occurrence=%u"
                  " observed-occurrences=%llu selected-occurrence=%llu events=%u/%u\n",
                  trace_status_name(trace.status), trace_reason_name(trace.invalid_reason), result,
@@ -1483,6 +1493,7 @@ void guest_dmem_write_trace_report() {
                  static_cast<unsigned long long>(trace.selection_uncertain_faults),
                  static_cast<unsigned long long>(trace.completed_steps),
                  static_cast<unsigned long long>(trace.rearms),
+                 static_cast<unsigned long long>(trace.host_write_rebases),
                  static_cast<unsigned long long>(trace.coverage_gaps),
                  static_cast<unsigned long long>(trace.overflow_events),
                  trace.config.allocation_occurrence ? "ordinal" : "unique",
@@ -1734,6 +1745,23 @@ bool trace_rebase_locked(WatchState& w) {
     DmemTraceState& trace = w.trace;
     if (!trace.rebase_pending) return false;
     if (!w.fault_onstack.load(std::memory_order_acquire)) return false;
+    // B1: never re-arm while a host write is IN FLIGHT. The notification contract is "notify, then
+    // write", and the write does not happen under this mutex -- so "the write that is notifying now
+    // does not overlap" is not the same as "no overlapping write is running". The vectored read path
+    // makes that deterministic without any concurrency: it notifies for EVERY iovec before calling
+    // ::preadv, so an iovec in the watched buffer plus an iovec in another dmem alias would disarm,
+    // re-arm, and then EFAULT the read -- the exact failure the disarm exists to prevent.
+    if (w.host_writes_in_flight != 0) return false;
+    // B3: rebuild the page/alias list rather than re-arming the one captured at arm time. Every
+    // mapping and protection hook gates on Armed||Stepping, so nothing maintained that list while the
+    // trace sat pending -- and mprotect'ing a stale entry would make an unrelated guest mapping
+    // read-only and record fabricated events against it. That is the one route by which a rebaselined
+    // trace could MISATTRIBUTE, which matters because its output is being used to reclassify a defect.
+    if (!trace_collect_pages_locked(w)) {
+        trace_invalidate_locked(w, GuestDmemWriteTraceInvalidReason::MappingTopologyChanged);
+        trace.rebase_pending = false;
+        return false;
+    }
     if (!set_trace_armed_locked(w, true, false)) return false;
     if (!trace_copy_target_locked(trace, trace.initial)) {
         (void)set_trace_armed_locked(w, false, false);
@@ -1743,6 +1771,11 @@ bool trace_rebase_locked(WatchState& w) {
     trace.invalid_reason = GuestDmemWriteTraceInvalidReason::None;
     trace.rebase_pending = false;
     trace.rearms++;
+    // B2: `rearms` alone cannot say a run was rebaselined -- the ordinary per-step re-arm bumps the
+    // same counter. A rebaselined trace answers a strictly weaker question ("who wrote since the last
+    // host write"), so a reader must be able to tell, and clearing invalid_reason erases the only
+    // other trace of it.
+    trace.host_write_rebases++;
     return true;
 }
 
@@ -1786,6 +1819,10 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
     // the feature is off (the default) nothing is ever armed, so skip without even taking the lock.
     if (!w.fault_onstack.load(std::memory_order_acquire)) return;
     std::lock_guard lock(w.mutex);
+    // Counted for the whole call, not just the overlapping case: an iovec that misses the watched
+    // range still means a read is about to run, and the vectored path notifies every iovec before
+    // any of them is written.
+    ++w.host_writes_in_flight;
     // A host/kernel store into an armed (read-only) guest page would EFAULT — e.g. sceKernelPread
     // streaming texture bytes straight into a watched dmem buffer returns an I/O error where real
     // hardware succeeds (review B5). The HLE calls this by guest VA range BEFORE such a write: restore
@@ -1828,6 +1865,17 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
     if (hit.empty()) return;
     set_pages_armed(w, hit, false);
     for (WatchedPage* page : hit) page->generation++;
+}
+
+// Paired with guest_write_watch_notify_host_write: called AFTER the host write has completed, so the
+// trace knows no bytes are in flight and a rebaseline may safely re-arm. Unpaired callers are safe --
+// the depth simply stays nonzero and rebaselining stops, which is the direction that cannot corrupt.
+void guest_write_watch_notify_host_write_done(uint64_t addr, uint64_t size) {
+    if (!addr || !size || addr > UINT64_MAX - size) return;
+    WatchState& w = state();
+    if (!w.fault_onstack.load(std::memory_order_acquire)) return;
+    std::lock_guard lock(w.mutex);
+    if (w.host_writes_in_flight > 0) --w.host_writes_in_flight;
 }
 
 void guest_write_watch_notify_gpu_write(uint64_t addr, uint64_t size) {

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -656,12 +656,13 @@ struct WatchState {
     // exact thread owns the diagnostic's one-instruction step.
     std::atomic<int64_t> pending_trace_step_tid{0};
     DmemTraceState trace;
-    // Host writes currently between their notification and their completion. The notify contract is
-    // "notify, then write", so a nonzero depth means bytes may land in a watched page at any moment
-    // and nothing may re-arm it. Incremented by guest_write_watch_notify_host_write and decremented
-    // by its paired ..._done; a caller that never pairs simply keeps rebaselining disabled, which is
-    // the safe direction.
-    int host_writes_in_flight = 0;
+    // Host-write RANGES currently between their notification and their completion. The notify
+    // contract is "notify, then write", so bytes may land in any of these at any moment and no watch
+    // over them may be re-armed. Ranges rather than a depth: a global counter is never zero on a
+    // title that streams assets from several threads, which made the rebaseline correct and useless
+    // at the same time -- it fired once per run instead of the 66 times it needs to. The traced
+    // region is at most two pages, so testing it against these is a handful of comparisons.
+    std::vector<std::pair<uint64_t, uint64_t>> host_write_ranges;
 };
 static_assert(std::atomic<int64_t>::is_always_lock_free,
               "the signal-path pending-step discriminator must be lock-free");
@@ -1751,7 +1752,10 @@ bool trace_rebase_locked(WatchState& w) {
     // makes that deterministic without any concurrency: it notifies for EVERY iovec before calling
     // ::preadv, so an iovec in the watched buffer plus an iovec in another dmem alias would disarm,
     // re-arm, and then EFAULT the read -- the exact failure the disarm exists to prevent.
-    if (w.host_writes_in_flight != 0) return false;
+    for (const DmemTracePage& page : trace.pages)
+        for (const PageAlias& alias : page.aliases)
+            for (const auto& range : w.host_write_ranges)
+                if (alias.addr >= range.first && alias.addr < range.second) return false;
     // B3: rebuild the page/alias list rather than re-arming the one captured at arm time. Every
     // mapping and protection hook gates on Armed||Stepping, so nothing maintained that list while the
     // trace sat pending -- and mprotect'ing a stale entry would make an unrelated guest mapping
@@ -1819,10 +1823,6 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
     // the feature is off (the default) nothing is ever armed, so skip without even taking the lock.
     if (!w.fault_onstack.load(std::memory_order_acquire)) return;
     std::lock_guard lock(w.mutex);
-    // Counted for the whole call, not just the overlapping case: an iovec that misses the watched
-    // range still means a read is about to run, and the vectored path notifies every iovec before
-    // any of them is written.
-    ++w.host_writes_in_flight;
     // A host/kernel store into an armed (read-only) guest page would EFAULT — e.g. sceKernelPread
     // streaming texture bytes straight into a watched dmem buffer returns an I/O error where real
     // hardware succeeds (review B5). The HLE calls this by guest VA range BEFORE such a write: restore
@@ -1857,6 +1857,11 @@ void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
             overlap = trace_va_to_phys_locked(w.trace, va, ignored_phys);
         if (!overlap) (void)trace_rebase_locked(w);
     }
+    // Recorded AFTER the rebaseline decision, not before it: THIS call's write has not started yet
+    // and its own range is excluded by the overlap test above. Recording first made the guard see its
+    // own notification and refuse every rebaseline, silently turning the feature off -- caught only
+    // by re-running the measurement that motivated it, not by any test.
+    w.host_write_ranges.emplace_back(begin, end);
     std::vector<WatchedPage*> hit;
     for (uint64_t va = begin; va < end; va += kPage) {
         auto it = w.pages_by_addr.find(va);
@@ -1875,7 +1880,14 @@ void guest_write_watch_notify_host_write_done(uint64_t addr, uint64_t size) {
     WatchState& w = state();
     if (!w.fault_onstack.load(std::memory_order_acquire)) return;
     std::lock_guard lock(w.mutex);
-    if (w.host_writes_in_flight > 0) --w.host_writes_in_flight;
+    const uint64_t begin = addr & ~(kPage - 1);
+    const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
+    for (auto it = w.host_write_ranges.begin(); it != w.host_write_ranges.end(); ++it) {
+        if (it->first == begin && it->second == end) {
+            w.host_write_ranges.erase(it);
+            return;
+        }
+    }
 }
 
 void guest_write_watch_notify_gpu_write(uint64_t addr, uint64_t size) {

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -198,6 +198,8 @@ void guest_write_watch_invalidate_all();
 // read()/pread() that streams bytes straight into a guest dmem buffer). Restores write on any armed pages
 // the range overlaps and marks them Dirty. No-op on Windows/macOS (no pages are ever armed there).
 void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size);
+// Paired completion for the call above. Optional: not calling it only disables rebaselining.
+void guest_write_watch_notify_host_write_done(uint64_t addr, uint64_t size);
 
 // Device/DMA writes already carry an exact guest VA range. Mark only registrations whose logical
 // source overlaps that range; unlike a CPU protection fault, an adjacent write on the same host page

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -132,6 +132,8 @@ struct GuestDmemWriteTraceSnapshot {
     uint64_t selection_uncertain_faults = 0;
     uint64_t completed_steps = 0;
     uint64_t rearms = 0;
+    uint64_t host_write_rebases = 0;
+    uint64_t rebase_in_flight_refusals = 0;
     uint64_t coverage_gaps = 0;
     uint64_t overflow_events = 0;
     uint64_t selected_occurrence = 0;
@@ -259,6 +261,11 @@ void guest_dmem_write_trace_set_contention_hook_for_test(
 using GuestDmemWriteTraceDynamicProtectionHookForTest = void (*)();
 void guest_dmem_write_trace_set_dynamic_protection_hook_for_test(
     GuestDmemWriteTraceDynamicProtectionHookForTest hook);
+// Force the host-write rebaseline mode on/off regardless of the environment. The mode is otherwise a
+// cached getenv read on first use, which makes it order-dependent and effectively untestable in
+// process -- and three rounds of review found three defects in this feature with no test able to
+// reach any of them. -1 restores the environment's answer.
+void guest_dmem_write_trace_set_rebase_enabled_for_test(int enabled);
 void guest_dmem_write_trace_lock_state_for_test();
 void guest_dmem_write_trace_unlock_state_for_test();
 

--- a/prosper/tests/host/memory/test_dmem_write_trace.cpp
+++ b/prosper/tests/host/memory/test_dmem_write_trace.cpp
@@ -780,6 +780,70 @@ int main() {
             reinterpret_cast<uint64_t>(occurrence_two_mapping), allocation_size);
         munmap(occurrence_two_mapping, allocation_size);
     }
+    // ---- host-write rebaseline (#3146) --------------------------------------------------------
+    //
+    // Three review rounds found three defects in this feature and no test could reach any of them,
+    // because the mode was a cached getenv read on first use. The arms below are the two that would
+    // have caught them: a rebaseline that never happens (the global-depth regression, which silently
+    // turned the feature off and was found only by re-running an emulator measurement), and one that
+    // happens while a host write is still in flight (the EFAULT the guard exists to prevent).
+    {
+        constexpr uint64_t rebase_physical = 0x860000;
+        constexpr uint32_t rebase_chain = 11;
+        prosper::host::guest_dmem_write_trace_set_rebase_enabled_for_test(1);
+        CHECK(setenv("PROSPER_DMEM_CALLER", "1", 1) == 0 &&
+                  setenv("PROSPER_DMEM_WRITE_TRACE", "11:0x3000:0x1120:16", 1) == 0,
+              "configure the rebaseline trace selector");
+        prosper::host::guest_dmem_write_trace_init_from_environment();
+        prosper::host::guest_dmem_write_trace_notify_allocation(
+            rebase_physical, allocation_size, rebase_chain);
+        auto* rebase_mapping = static_cast<uint8_t*>(
+            mmap(nullptr, allocation_size, PROT_READ | PROT_WRITE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        CHECK(rebase_mapping != MAP_FAILED, "map the rebaseline canary range");
+        if (rebase_mapping != MAP_FAILED) {
+            std::memset(rebase_mapping + offset, 0x22, bytes);
+            prosper::host::guest_write_watch_notify_direct_mapping_added(
+                reinterpret_cast<uint64_t>(rebase_mapping), allocation_size, rebase_physical, 0x3);
+            const uint64_t traced = reinterpret_cast<uint64_t>(rebase_mapping) + offset;
+            // A page of the same mapping that the trace does NOT cover.
+            const uint64_t elsewhere = reinterpret_cast<uint64_t>(rebase_mapping);
+            CHECK(prosper::host::guest_dmem_write_trace_snapshot().status ==
+                      prosper::host::GuestDmemWriteTraceStatus::Armed,
+                  "rebaseline trace arms");
+
+            // A host write over the traced page disarms it and leaves it pending.
+            prosper::host::guest_write_watch_notify_host_write(traced, bytes);
+            auto after_write = prosper::host::guest_dmem_write_trace_snapshot();
+            CHECK(after_write.status == prosper::host::GuestDmemWriteTraceStatus::Invalid,
+                  "a host write over the traced page disarms the trace");
+
+            // While that write is STILL IN FLIGHT, an unrelated host write must not re-arm it --
+            // re-arming now would make the pending store hit a read-only page and EFAULT the read.
+            prosper::host::guest_write_watch_notify_host_write(elsewhere, 16);
+            auto during = prosper::host::guest_dmem_write_trace_snapshot();
+            CHECK(during.status == prosper::host::GuestDmemWriteTraceStatus::Invalid &&
+                      during.host_write_rebases == 0 && during.rebase_in_flight_refusals > 0,
+                  "no rebaseline while a host write over the traced page is in flight");
+            prosper::host::guest_write_watch_notify_host_write_done(elsewhere, 16);
+
+            // Once it completes, the next unrelated host write DOES rebaseline. This is the arm the
+            // global-depth version failed: it refused forever and the feature went silently dead.
+            prosper::host::guest_write_watch_notify_host_write_done(traced, bytes);
+            prosper::host::guest_write_watch_notify_host_write(elsewhere, 16);
+            auto after = prosper::host::guest_dmem_write_trace_snapshot();
+            CHECK(after.status == prosper::host::GuestDmemWriteTraceStatus::Armed &&
+                      after.host_write_rebases == 1,
+                  "the completed host write lets the next unrelated one rebaseline exactly once");
+            prosper::host::guest_write_watch_notify_host_write_done(elsewhere, 16);
+
+            prosper::host::guest_write_watch_notify_direct_mapping_removed(
+                reinterpret_cast<uint64_t>(rebase_mapping), allocation_size);
+            munmap(rebase_mapping, allocation_size);
+        }
+        prosper::host::guest_dmem_write_trace_set_rebase_enabled_for_test(-1);
+    }
+
     prosper::host::guest_write_watch_set_fault_onstack(false);
 
     if (failures) return 1;

--- a/prosper/tests/host/memory/test_dmem_write_trace.cpp
+++ b/prosper/tests/host/memory/test_dmem_write_trace.cpp
@@ -837,11 +837,47 @@ int main() {
                   "the completed host write lets the next unrelated one rebaseline exactly once");
             prosper::host::guest_write_watch_notify_host_write_done(elsewhere, 16);
 
+            // B8: the caller-range half of the guard, which the arms above cannot reach.
+            //
+            // The scenario needs the second alias to appear WHILE THE TRACE IS PENDING: the trace's
+            // own mapping hook ignores an Invalid trace, so V2 lands in the watch's alias list and
+            // not in trace.pages. The caller-side overlap test then runs against the stale page list
+            // and misses it, the rebuild pulls it in, and only the caller-range clause is left to
+            // notice that the write about to run covers a page the rebase is about to arm read-only.
+            // Without that clause this is the EFAULT the whole guard exists to prevent.
+            prosper::host::guest_write_watch_notify_host_write(traced, bytes);
+            prosper::host::guest_write_watch_notify_host_write_done(traced, bytes);
+            auto* second_alias = static_cast<uint8_t*>(
+                mmap(nullptr, allocation_size, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+            CHECK(second_alias != MAP_FAILED, "map a second alias of the traced physical range");
+            if (second_alias != MAP_FAILED) {
+                const uint64_t rebases_before =
+                    prosper::host::guest_dmem_write_trace_snapshot().host_write_rebases;
+                prosper::host::guest_write_watch_notify_direct_mapping_added(
+                    reinterpret_cast<uint64_t>(second_alias), allocation_size, rebase_physical, 0x3);
+                prosper::host::guest_write_watch_notify_host_write(
+                    reinterpret_cast<uint64_t>(second_alias) + offset, bytes);
+                auto aliased = prosper::host::guest_dmem_write_trace_snapshot();
+                CHECK(aliased.status == prosper::host::GuestDmemWriteTraceStatus::Invalid &&
+                          aliased.host_write_rebases == rebases_before,
+                      "a write into an alias added during the pending window cannot rebaseline");
+                prosper::host::guest_write_watch_notify_host_write_done(
+                    reinterpret_cast<uint64_t>(second_alias) + offset, bytes);
+                prosper::host::guest_write_watch_notify_direct_mapping_removed(
+                    reinterpret_cast<uint64_t>(second_alias), allocation_size);
+                munmap(second_alias, allocation_size);
+            }
+
             prosper::host::guest_write_watch_notify_direct_mapping_removed(
                 reinterpret_cast<uint64_t>(rebase_mapping), allocation_size);
             munmap(rebase_mapping, allocation_size);
         }
         prosper::host::guest_dmem_write_trace_set_rebase_enabled_for_test(-1);
+        // Paired like the earlier blocks: this one is last in main today, so leaking would be
+        // harmless right up until somebody appends an arm and inherits a configured selector.
+        unsetenv("PROSPER_DMEM_WRITE_TRACE");
+        unsetenv("PROSPER_DMEM_CALLER");
     }
 
     prosper::host::guest_write_watch_set_fault_onstack(false);

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -47,6 +47,7 @@
 // For other titles, set the appropriate env before running (e.g. a UE4 title:
 // PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1).
 #include "loader/linker.hpp"          // Program
+#include "host/memory/guest_write_watch.hpp"
 #include "host/image/boot_program.hpp"       // boot_program
 #include "host/image/exec_image.hpp"         // run_entry
 #include "gpu/present/videoout_present.hpp"    // present_count / present_readback / present_width/height
@@ -965,5 +966,11 @@ int main(int argc, char** argv) {
             tracker.max_pixel_stale_seconds(),
             screenshot::guest_run_state_name(guest_outcome.state), verdict.status);
     gpu::close_gpu_timeline();
+    // The dmem write trace registers its report with std::atexit, which _exit does not run -- so on
+    // every screenshot run the trace was recording writer RIPs and printing them nowhere. This is the
+    // frontend the project uses for progression and investigation evidence, and prosper-app already
+    // reports here; the asymmetry was silent, because a diagnostic that produces no output looks
+    // exactly like one that found nothing. Report before exiting, as prosper-app does.
+    prosper::host::guest_dmem_write_trace_report();
     _exit(verdict.exit_code);   // the guest thread is detached and running guest code; don't block on teardown
 }


### PR DESCRIPTION
Fixes #3146. Refs #3142 — and it answers #3142.

## The gap

`PROSPER_DMEM_WRITE_TRACE` records the writer's RIP for guest stores into a selected direct-memory
range. It is the only instrument in the tree that can: `PROSPER_HOSTWRITEWATCH` reports host writes
only and says so in its own header (*"a guest that reads into a staging buffer and memcpys from there
in guest code writes with plain stores, which nothing here can observe"*).

But a host write invalidated the trace permanently (`guest_write_watch.cpp`, `reason=host-write`), and
**every host writer of guest memory in the tree is a file read** (`hle_file.cpp:1477`, `:1598`,
`:2870`, `:2910`). So any buffer a title streams an asset into disarmed the watch at the moment the
asset arrived — before the window of interest opened. On #3142's target:

```
[dmem-write-trace] armed … target=0x3002330000 target-phys=0x15cd0000 pages=1
[dmem-write-trace] summary status=invalid reason=host-write result=undetermined
                   page-faults=0 selected-faults=0 events=0/64
```

It could never watch the one class of range worth watching.

## The change

`PROSPER_DMEM_WRITE_TRACE_REBASE=1` re-baselines instead of invalidating.

**Invalidation stays the default**, and that is deliberate rather than caution: it is the honest answer
to the question the trace was built for — *who wrote these exact bytes, starting from this exact
content* — because a host write means those bytes changed without the trace seeing it, so any later
diff is measured against a baseline that is no longer true. Re-baselining answers a strictly weaker
question, *who wrote them since the last host write*, and that weaker question is the only one
available for a range the HLE loads into. The summary reports `rearms`, so a re-baselined result is
never mistaken for an uninterrupted one.

**The re-arm is deferred, and it has to be**: the notification fires *before* the host write, so the
bytes to baseline against do not exist yet. It happens on the next notification that does not overlap
the watched range — milliseconds away on a streaming title. That path re-checks overlap itself:
re-arming pages about to receive a host store would make the store hit a read-only page and EFAULT the
read, which is exactly the failure the disarm exists to prevent. (I got this wrong in a first draft
and caught it before building.)

## Second half: the report never reached the frontend that matters

The trace registers its report through `std::atexit`. `_exit` does not run those, and
`tools/screenshot` exits with `_exit` — so on every screenshot run, the frontend this project uses for
progression and investigation evidence, the trace recorded writer RIPs and printed them **nowhere**.
`prosper-app` already reported (`main.cpp`). The asymmetry was silent, because a diagnostic that
produces no output is indistinguishable from one that found nothing.

## Verification, and the result

Same target, same route, before and after:

| | `page-faults` | `events` | `rearms` | outcome |
| --- | --- | --- | --- | --- |
| before | 0 | 0/64 | 0 | `status=invalid reason=host-write` |
| after | **65** | **64/64** | **66** | **`result=writer-observed`** |

And it names the writer:

```
event=1  fault=0x3002330000  writer=libc.prx+0x3d71  tid=382693
event=2  fault=0x3002330010  writer=libc.prx+0x3d75  tid=382693
event=3  fault=0x3002330020  writer=libc.prx+0x3d7a  tid=382693
…
```

**64 of 64 events, one module: `libc.prx`** — guest code. Faults march sequentially from the buffer
base at a 16-byte stride while the RIPs cycle through a tight `0x3d71`–`0x3dd0` loop, i.e. an unrolled
bulk-store loop. That answers #3142: the guest clears its own staging buffer about a second after
loading it, which is ordinary engine behaviour, and prosper's defect is that a shader still reads that
address afterwards. Not memory corruption; a descriptor-lifetime question.

```
cmake --build prosper/build-linux -j6                        # clean
ctest --test-dir prosper/build-linux --no-tests=error -j4    # 100% of 315, rc=0
python3 prosper/tools/env/check_diag_gates.py                # == all checks passed ==
```

## Risk

The new mode is **opt-in**; with `PROSPER_DMEM_WRITE_TRACE_REBASE` unset the trace behaves exactly as
before (one cached `getenv`, and `rebase_pending` never set). The `screenshot.cpp` report call is
unconditional but the report is a no-op when the trace was never configured, matching `prosper-app`.

**Review requested** on the deferred re-arm's interaction with the write-watch's own state machine —
specifically whether `Stepping` can be entered between the disarm and the deferred re-arm, and whether
`trace_rebase_locked` returning false leaves the trace in a state that reports honestly.

---

**Update — review round 2.** All four blockers fixed, and B1 turned out to have a second half I only
found by re-running the measurement.

* **B1** — the deferred re-arm could re-protect pages a host write was still about to touch,
  deterministically via the vectored path. Fixed with a paired completion
  (`guest_write_watch_notify_host_write_done`) at every host writer, `read_full` and
  `apr_write_guest_dst` both via scope guards so no early return can skip one.
  **Then the fix broke the feature**: a global in-flight *depth* is essentially never zero on a title
  streaming from several threads, so the rebaseline fired once per run instead of 66 times and the
  trace reported nothing again. Two causes — the depth was incremented before the check inside the
  same call, and `apr_write_guest_dst` paired only its fast path. The guard is now **per-range**:
  refuse only when an in-flight write actually covers a traced page. The traced region is at most two
  pages, so it is a handful of comparisons, and a leaked range blocks only its own address.
* **B3** — the pending window is blind to topology changes, so the re-arm now **rebuilds** the
  page/alias list and invalidates if it cannot, closing the misattribution route.
* **B2** — `rearms` cannot distinguish a rebaselined run, so the summary reports
  `host-write-rebases` separately.
* **B4** — discharged by rebasing: #3145 landed the correction on master.

**Re-verified end to end after the fixes**, which is the only reason the depth regression was caught:

```
status=overflow result=writer-observed page-faults=65 steps=64
rearms=66 host-write-rebases=2      64 events, all writer=libc.prx
```

Same finding, with the correctness fixes in place. `host-write-rebases=2` against `rearms=66` is B2
doing its job.

**One thing this PR's own result no longer supports, and the doc now says so:** the `libc.prx`
attribution is real, and it is **not** why Stray's background is black. The graphics RTT sampler
resolves those surfaces correctly (58,569 sample HITs to 5 skips, all tiny 3D textures), the composite
reads black because its inputs are black at source, and #3140 is falsified. Recorded in
`STRAY_STATUS.md` so the reclassification is not read as a lead.

ctest 100% of 315 rc=0; `check_diag_gates.py` all checks passed.

---

**Update — review round 3.** Three blockers, and **B5 was a production regression I introduced in a
diagnostic PR**, which is worth naming rather than burying:

* **B5** — the in-flight range bookkeeping ran on the **default path**. The append was gated on
  `fault_onstack` and an alias hit, neither of which is off on an ordinary Linux boot, and never on
  the rebaseline mode. Six callers pass guest dmem VAs without pairing a completion (four in
  `live_compute`, two in `live_renderer`) and the erase matches an exact `(begin,end)`, so the vector
  only grows — and `read_full`'s new scope guard made **every guest read** walk it under the watch
  mutex. An unbounded allocation plus an O(N) scan per read, from a switch nobody turned on. Both the
  append and the scan are now gated on the mode.
* **B6** — the in-flight guard ran over the page list it was about to *replace*, which defeats the
  purpose of B3's rebuild: a new alias of the traced phys can appear during the pending window
  (`notify_direct_mapping_added` appends unconditionally while its trace block gates on
  `Armed||Stepping`), and it was then armed unchecked, re-opening the EFAULT. The guard now runs after
  the rebuild, against the list actually being armed.
* **B7** — the topology-change failure recorded nothing: `trace_invalidate_locked` early-returns when
  the status is already `Invalid`, and that path is only reachable in that state, so the call was a
  guaranteed no-op and the summary stayed indistinguishable from a mode-off run. The reason is set
  directly now, the retry stops, and every refusal bumps a `rebase-failures` counter the summary
  reports.

Also `rearm_iovec_watches` is `static`, matching its sibling.

**Re-verified after all three** — the same check that caught the depth regression last round:

```
result=writer-observed page-faults=65 steps=64
rearms=66 host-write-rebases=2 rebase-failures=0    64 events, all writer=libc.prx
```

ctest 100% of 315 rc=0.