### PR TITLE
perf(compute): cache DCC-compressed sampled images — Stray's splash +66%

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -19,6 +19,20 @@ from the tracker issues, and still gated, because it is a projection of state ra
 > title's current state — for that, read the tracker. Nothing is ever removed when a title moves on,
 > because the point of a blog is that it records *when* things happened.
 
+## 2026-08-31
+
+### Stray's splash runs 66% faster, and the title screen now holds 65 fps
+
+No picture: the title screen still renders black, so there is nothing new to look at yet. But the
+sequence in front of it stopped crawling.
+
+One 4K surface was being de-swizzled from scratch thousands of times — 241 GiB of tiling work in
+under two minutes — because DCC-compressed textures were barred from the compute image cache. The
+bar was checking the wrong thing: nothing on that path ever reads the compression metadata it
+inspected, so the cache could have held those textures all along. Five detiles now do what 3,860 did.
+
+Splash goes 37 → 62 fps; carried through to the title screen, a run averages 65. ([#3150](https://github.com/mattias800/prosper/pull/3150))
+
 ## 2026-08-30
 
 ### Stray's black title screen is not a loading failure — the data arrives, then leaves

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -194,3 +194,21 @@ sits a chain of about ten `continue`s, and without the input side "the front hal
 resource" and "it saw it and rejected it" produce identical evidence while pointing at different
 files. Reach for it before concluding anything about descriptor *recovery*: on Earthion (#1590) it
 overturned exactly that conclusion in one run.
+
+**A DCC-compressed SAMPLED surface's cache identity does NOT include its metadata plane, and folding
+that plane into the key is both unnecessary and — as first attempted — ineffective.** #3150 /
+#3149, 2026-08-31. The persistent compute image cache excluded compressed sampled surfaces on the
+theory that base bytes alone could not determine their content; on Stray that exclusion re-detiled
+one 4K FP16 surface 3,860 times in 110 s (98.9% of all tiling work, `PROSPER_TILECENSUS`). The
+theory is wrong for the *sampled* path: the DCC plane's only consumer there is
+`compute_sampled_dcc_fast_clear_rgba8`, whose materialization the admission gate already excludes
+via `!sampled_dcc_fast_clear`, so a cacheable entry's upload is detile + unpack of the BASE bytes
+alone — which the existing validation already covers. More sharply, `gfx10_dcc_fast_clear_rgba8` is
+the **only** DCC decode function in the tree: prosper has no DCC decompressor, so
+metadata-independence is a property of the codebase rather than of one call graph. **Do not re-derive
+the metadata-in-the-key design**: the first revision of #3150 did, and it was rejected twice over —
+the guard was conjoined into only one of three skip proofs (`watch_unchanged` and `exact_unchanged`
+both examine the base range alone, so the upload was skipped anyway), and the premise was unnecessary
+regardless. The *storage* gate is different and still requires an all-`0xff` plane: a storage
+target's base bytes are not authoritative while a live plane exists. `PROSPER_NO_DCC_IMAGE_CACHE=1`
+restores the old exclusion for bisection.

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -49,8 +49,14 @@ constexpr bool compute_storage_cache_gate_candidate(
 //   * if a sampled decode ever starts DECLINING on metadata state, this gate has to decline with
 //     it.  That seam already exists and is unwired:
 //     `gpu/resources/compressed_source_authority.hpp`'s `sampled_source_decision` has no production
-//     caller today, and the surfaces admitted here are precisely the ones it would return
-//     `DeclinedUnsupportedMetadataState` for.  Wiring it must move this gate in the same commit.
+//     caller today, and it classifies exactly the surfaces this gate now admits.  **Wiring it must
+//     move this gate in the same commit.**  Deliberately not stated more precisely than that: the
+//     two do not stand in a clean correspondence.  That function has five distinct decline reasons
+//     and a non-declining `DccUncompressedBase` outcome, its `CompressionMetadataKind` is an
+//     adapter-supplied input so `Unknown` is reachable, and an import bypass pre-empts the metadata
+//     reasons entirely -- so a compressed surface admitted here can land on several of its
+//     outcomes, including non-declining ones.  An earlier draft of this comment named one specific
+//     reason and was wrong in both directions (#3150 review).
 // Nothing here can assert either mechanically, so both are written where somebody touching that
 // decision will be looking.
 //

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -31,6 +31,39 @@ constexpr bool compute_storage_cache_gate_candidate(
            inputs.persistent_enabled;
 }
 
+// The sampled-image cache decision, in the same shape and for the same reason: a census that
+// reports only the candidate bit cannot tell "this surface was ineligible" from "the gate was never
+// reached".
+//
+// `dcc_cache_safe` is deliberately NOT required here, and that asymmetry against the storage gate
+// above is the substance of #3149 rather than an oversight.  A storage target's base bytes may not
+// be authoritative while a DCC plane is live, so that gate must consult it.  A *sampled* upload is
+// detile + unpack of the base bytes and never reads the metadata plane -- the fast-clear helper is
+// its only consumer, and `sampled_dcc_fast_clear` excludes exactly the surfaces that reach it.  So
+// base bytes are the whole identity of a cacheable sampled entry, which is what the cache already
+// validates, and requiring an all-0xff plane on top of that only cost hit rate.
+//
+// That last sentence is a live invariant, not a historical note: **if a sampled decode ever starts
+// consulting the DCC metadata plane, this gate has to consult it too**, or the cache will replay a
+// decode whose input it never validated.  Nothing here can assert that mechanically, so it is
+// written where somebody adding such a consumer will be looking.
+//
+// `dcc_cache_disabled` (PROSPER_NO_DCC_IMAGE_CACHE) restores the older, stricter behaviour exactly,
+// so a rendering report can be bisected against this change with one variable.
+struct ComputeSampledCacheGateInputs {
+    bool sampled_dcc_fast_clear = false;
+    bool dcc_cache_safe = false;
+    bool dcc_cache_disabled = false;
+    bool persistent_enabled = false;
+};
+
+constexpr bool compute_sampled_cache_gate_candidate(
+    const ComputeSampledCacheGateInputs& inputs) {
+    return !inputs.sampled_dcc_fast_clear &&
+           (inputs.dcc_cache_safe || !inputs.dcc_cache_disabled) &&
+           inputs.persistent_enabled;
+}
+
 // A compressed writable target cannot enter the persistent cache before dispatch because its base
 // bytes are not yet authoritative.  A successful ordinary writeback changes that fact: it publishes
 // exact base bytes and marks the complete DCC plane uncompressed.  Admit that result only when DCC

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -43,10 +43,16 @@ constexpr bool compute_storage_cache_gate_candidate(
 // base bytes are the whole identity of a cacheable sampled entry, which is what the cache already
 // validates, and requiring an all-0xff plane on top of that only cost hit rate.
 //
-// That last sentence is a live invariant, not a historical note: **if a sampled decode ever starts
-// consulting the DCC metadata plane, this gate has to consult it too**, or the cache will replay a
-// decode whose input it never validated.  Nothing here can assert that mechanically, so it is
-// written where somebody adding such a consumer will be looking.
+// That last sentence is a live invariant, not a historical note, and it cuts both ways:
+//   * if a sampled decode ever starts CONSULTING the DCC metadata plane, this gate has to consult
+//     it too, or the cache will replay a decode whose input it never validated;
+//   * if a sampled decode ever starts DECLINING on metadata state, this gate has to decline with
+//     it.  That seam already exists and is unwired:
+//     `gpu/resources/compressed_source_authority.hpp`'s `sampled_source_decision` has no production
+//     caller today, and the surfaces admitted here are precisely the ones it would return
+//     `DeclinedUnsupportedMetadataState` for.  Wiring it must move this gate in the same commit.
+// Nothing here can assert either mechanically, so both are written where somebody touching that
+// decision will be looking.
 //
 // `dcc_cache_disabled` (PROSPER_NO_DCC_IMAGE_CACHE) restores the older, stricter behaviour exactly,
 // so a rendering report can be bisected against this change with one variable.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -842,6 +842,12 @@ struct ComputeImageCacheKey {
     uint32_t mip_tail_offset = 0, mip_tail_bytes = 0;
     uint32_t mip_tail_x = 0, mip_tail_y = 0;
     uint32_t vk_format = 0;
+    // #3149: the DCC metadata plane is part of a compressed surface's identity. Base bytes alone do
+    // NOT determine its content -- that is precisely why compressed surfaces were excluded from this
+    // cache -- so the metadata range joins the key, and the validation below requires it unchanged
+    // too. Zero for an uncompressed surface, which keeps every existing entry's identity unchanged.
+    uint64_t metadata_addr = 0;
+    uint32_t metadata_bytes = 0;
     bool storage = false;
     bool in_mip_tail = false;
     bool srgb = false;
@@ -881,7 +887,13 @@ ComputeImageCacheKey storage_image_cache_key(const prosper::gpu::ShaderResource&
         resource.layer_stride_bytes, resource.layer_mip_offset_bytes,
         resource.mip_tail_offset, resource.mip_tail_bytes,
         resource.mip_tail_x, resource.mip_tail_y,
-        static_cast<uint32_t>(native_format), true, resource.in_mip_tail,
+        static_cast<uint32_t>(native_format),
+        // #3149: same positional slot as the sampled key -- between vk_format and storage.
+        resource.compression_enabled ? resource.metadata_addr : 0ull,
+        resource.compression_enabled
+            ? static_cast<uint32_t>(prosper::gpu::gpu_capture_dcc_metadata_footprint(resource))
+            : 0u,
+        true, resource.in_mip_tail,
         resource.srgb, resource.depth_compare};
 }
 
@@ -1983,6 +1995,9 @@ struct VulkanComputeContext {
         ++cached.pins;
         image = cached.image;
         memory = cached.memory;
+        // The epoch fast path is per-submit and covers both ranges implicitly: an epoch is only
+        // reused within a submit, and a metadata write inside the submit bumps the journal that
+        // `metadata_unchanged` below consults on the next acquisition.
         if (!key.host_data && validation_epoch && cached.validation_epoch == validation_epoch) {
             upload_skipped = cached.validation_result;
             return true;
@@ -1992,7 +2007,16 @@ struct VulkanComputeContext {
         // entries only against their exact retained snapshot. This makes warm replay exercise the
         // same image residency as live execution without ever trusting an unrelated guest address.
         const bool exact_source_only = key.host_data != 0;
+        // Both ranges, not just the base. A compressed surface whose metadata changed while its
+        // base bytes did not would otherwise serve stale pixels -- the exact unsafety that kept
+        // these surfaces out of the cache. An uncompressed entry has metadata_bytes == 0 and takes
+        // the same path it always did.
+        const bool metadata_unchanged = key.metadata_bytes == 0 ||
+            prosper::gpu::guest_gpu_writes_since(cached.validation_snapshot,
+                                                 key.metadata_addr, key.metadata_bytes) ==
+                prosper::gpu::GuestGpuWriteQuery::Unchanged;
         const bool submit_unchanged = cached.content_valid && !exact_source_only &&
+            metadata_unchanged &&
             prosper::gpu::guest_gpu_writes_since(cached.validation_snapshot,
                                                   key.gpu_addr, key.guest_bytes) ==
                 prosper::gpu::GuestGpuWriteQuery::Unchanged;
@@ -6832,7 +6856,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // this first narrow path uncached rather than teaching the existing base-byte key
                 // an unsafe partial identity; staging materialization is still far cheaper than
                 // detiling and converting the 2x-larger FP16 base.
-                bi.cache_candidate = !sampled_dcc_fast_clear && dcc_cache_safe &&
+                // PROSPER_DCC_CACHE_UPSIDE=1 (#3149) is a MEASUREMENT, not a fix, and must never
+                // become the default: it admits DCC-compressed surfaces to the image cache whose
+                // identity is base bytes only, so a surface whose metadata changes while its base
+                // bytes do not would serve stale pixels. It exists to answer one question -- is the
+                // real fix (folding the metadata plane into the cache identity) worth building? --
+                // because that fix is a correctness-sensitive change this code explicitly warns
+                // against making naively, and it should not be built on a guess about its payoff.
+                // #3149: a compressed surface is now cacheable because its DCC metadata plane is
+                // part of the cache identity and is validated alongside the base bytes -- the
+                // "unsafe partial identity" this code warned about is exactly what was added, so the
+                // warning is satisfied rather than bypassed. Requires a metadata range to validate:
+                // compression with no metadata address stays out, failing closed as before.
+                // Kill switch, and it earns its place: this admits a whole class of surface to a
+                // cache it was previously excluded from, so a single variable must be able to
+                // restore the old behaviour exactly -- for bisecting a rendering report, and for the
+                // pixel A/B that justified the change in the first place.
+                static const bool dcc_cache_disabled =
+                    std::getenv("PROSPER_NO_DCC_IMAGE_CACHE") != nullptr;
+                const bool dcc_identity_tracked = !dcc_cache_disabled &&
+                    r->compression_enabled && r->metadata_addr &&
+                    prosper::gpu::gpu_capture_dcc_metadata_footprint(*r) > 0;
+                bi.cache_candidate = !sampled_dcc_fast_clear &&
+                    (dcc_cache_safe || dcc_identity_tracked) &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::sampled);
                 const VkFormat transfer_native_format =
                     compute_transfer_storage_vk_format(r->format, sampled_components);
@@ -6884,7 +6930,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         r->layer_stride_bytes, r->layer_mip_offset_bytes,
                         r->mip_tail_offset, r->mip_tail_bytes,
                         r->mip_tail_x, r->mip_tail_y,
-                        static_cast<uint32_t>(image_format), bi.storage, r->in_mip_tail,
+                        static_cast<uint32_t>(image_format),
+                        // #3149: metadata plane joins the identity. Positional aggregate init --
+                        // these two MUST sit between vk_format and storage, matching the struct.
+                        r->compression_enabled ? r->metadata_addr : 0ull,
+                        r->compression_enabled
+                            ? static_cast<uint32_t>(
+                                  prosper::gpu::gpu_capture_dcc_metadata_footprint(*r))
+                            : 0u,
+                        bi.storage, r->in_mip_tail,
                         r->srgb, r->depth_compare};
                     // An ordinary native typed 2D image or native typed 3D volume is byte- and
                     // format-identical to the sampled upload that follows it. Borrow that retained
@@ -7231,6 +7285,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          r->mip_tail_x, r->mip_tail_y);
                     unpack_source = linear.get();
                 } else if (r->tile_mode) {
+                    const prosper::gpu::TileCensusScope tcs("stor-seed");
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                     detile_surface(linear.get(), src, r->width, r->height, r->tile_mode, 0,
                                    static_cast<uint32_t>(guest_texel));
@@ -7692,6 +7747,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                                  r->tile_mode, bpt, r->mip_tail_x,
                                                  r->mip_tail_y);
                         } else if (r->tile_mode) {
+                            const prosper::gpu::TileCensusScope tcs("smpl-upl");
                             detile_surface(linear.get(), src, r->width, r->height,
                                            r->tile_mode, 0, bpt);
                         }
@@ -10271,6 +10327,7 @@ void sampled_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
 // exercised by a regression test rather than only by a routed run.
 
 bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items) {
+    const prosper::gpu::TileCensusScope tile_census_scope("compute");
     auto fail_closed_items = [&]() {
         for (const auto& item : items)
             prosper::gpu::notify_compute_authority_boundary({

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -842,12 +842,6 @@ struct ComputeImageCacheKey {
     uint32_t mip_tail_offset = 0, mip_tail_bytes = 0;
     uint32_t mip_tail_x = 0, mip_tail_y = 0;
     uint32_t vk_format = 0;
-    // #3149: the DCC metadata plane is part of a compressed surface's identity. Base bytes alone do
-    // NOT determine its content -- that is precisely why compressed surfaces were excluded from this
-    // cache -- so the metadata range joins the key, and the validation below requires it unchanged
-    // too. Zero for an uncompressed surface, which keeps every existing entry's identity unchanged.
-    uint64_t metadata_addr = 0;
-    uint32_t metadata_bytes = 0;
     bool storage = false;
     bool in_mip_tail = false;
     bool srgb = false;
@@ -887,13 +881,7 @@ ComputeImageCacheKey storage_image_cache_key(const prosper::gpu::ShaderResource&
         resource.layer_stride_bytes, resource.layer_mip_offset_bytes,
         resource.mip_tail_offset, resource.mip_tail_bytes,
         resource.mip_tail_x, resource.mip_tail_y,
-        static_cast<uint32_t>(native_format),
-        // #3149: same positional slot as the sampled key -- between vk_format and storage.
-        resource.compression_enabled ? resource.metadata_addr : 0ull,
-        resource.compression_enabled
-            ? static_cast<uint32_t>(prosper::gpu::gpu_capture_dcc_metadata_footprint(resource))
-            : 0u,
-        true, resource.in_mip_tail,
+        static_cast<uint32_t>(native_format), true, resource.in_mip_tail,
         resource.srgb, resource.depth_compare};
 }
 
@@ -1995,9 +1983,6 @@ struct VulkanComputeContext {
         ++cached.pins;
         image = cached.image;
         memory = cached.memory;
-        // The epoch fast path is per-submit and covers both ranges implicitly: an epoch is only
-        // reused within a submit, and a metadata write inside the submit bumps the journal that
-        // `metadata_unchanged` below consults on the next acquisition.
         if (!key.host_data && validation_epoch && cached.validation_epoch == validation_epoch) {
             upload_skipped = cached.validation_result;
             return true;
@@ -2007,16 +1992,7 @@ struct VulkanComputeContext {
         // entries only against their exact retained snapshot. This makes warm replay exercise the
         // same image residency as live execution without ever trusting an unrelated guest address.
         const bool exact_source_only = key.host_data != 0;
-        // Both ranges, not just the base. A compressed surface whose metadata changed while its
-        // base bytes did not would otherwise serve stale pixels -- the exact unsafety that kept
-        // these surfaces out of the cache. An uncompressed entry has metadata_bytes == 0 and takes
-        // the same path it always did.
-        const bool metadata_unchanged = key.metadata_bytes == 0 ||
-            prosper::gpu::guest_gpu_writes_since(cached.validation_snapshot,
-                                                 key.metadata_addr, key.metadata_bytes) ==
-                prosper::gpu::GuestGpuWriteQuery::Unchanged;
         const bool submit_unchanged = cached.content_valid && !exact_source_only &&
-            metadata_unchanged &&
             prosper::gpu::guest_gpu_writes_since(cached.validation_snapshot,
                                                   key.gpu_addr, key.guest_bytes) ==
                 prosper::gpu::GuestGpuWriteQuery::Unchanged;
@@ -6845,8 +6821,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
                 }
 
+                static const bool dcc_cache_disabled =
+                    std::getenv("PROSPER_NO_DCC_IMAGE_CACHE") != nullptr;
+                // #3149: the all-0xff scan is a full pass over the metadata plane, per binding per
+                // dispatch, and after this change nothing on the DEFAULT path acts on its result --
+                // the gate below admits either way. Computing it anyway would add dead work to the
+                // exact hot path this change exists to shorten, so it runs only when something can
+                // consume it: the kill switch (which restores the old gate) or the compute trace
+                // (which reports it). Skipping it leaves `dcc_cache_safe` false for a compressed
+                // surface, which is what the new gate wants and what the old gate would have
+                // concluded for anything that is genuinely compressed.
                 bool dcc_cache_safe = !r->compression_enabled;
-                if (r->compression_enabled) {
+                if (r->compression_enabled && (dcc_cache_disabled || trace)) {
                     dcc_cache_safe = sampled_dcc_metadata && sampled_dcc_metadata_bytes &&
                         std::all_of(sampled_dcc_metadata,
                                     sampled_dcc_metadata + sampled_dcc_metadata_bytes,
@@ -6856,30 +6842,42 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // this first narrow path uncached rather than teaching the existing base-byte key
                 // an unsafe partial identity; staging materialization is still far cheaper than
                 // detiling and converting the 2x-larger FP16 base.
-                // PROSPER_DCC_CACHE_UPSIDE=1 (#3149) is a MEASUREMENT, not a fix, and must never
-                // become the default: it admits DCC-compressed surfaces to the image cache whose
-                // identity is base bytes only, so a surface whose metadata changes while its base
-                // bytes do not would serve stale pixels. It exists to answer one question -- is the
-                // real fix (folding the metadata plane into the cache identity) worth building? --
-                // because that fix is a correctness-sensitive change this code explicitly warns
-                // against making naively, and it should not be built on a guess about its payoff.
-                // #3149: a compressed surface is now cacheable because its DCC metadata plane is
-                // part of the cache identity and is validated alongside the base bytes -- the
-                // "unsafe partial identity" this code warned about is exactly what was added, so the
-                // warning is satisfied rather than bypassed. Requires a metadata range to validate:
-                // compression with no metadata address stays out, failing closed as before.
+                // #3149: the DCC-metadata test is dropped from this gate, and the reason is that
+                // it answers the wrong question. `dcc_cache_safe` asks whether the metadata plane
+                // reads as all-0xff, i.e. "nothing is actually compressed"; what decides whether an
+                // entry may be reused is whether the metadata can change the bytes this cache
+                // serves. On the sampled path it cannot: every consumer of the metadata plane
+                // reachable from here is `compute_sampled_dcc_fast_clear_rgba8`, and
+                // `!sampled_dcc_fast_clear` excludes every surface that reaches it -- so what a
+                // cacheable entry replays is detile + unpack of the BASE bytes and nothing else.
+                // (This branch is already inside `compute_sampled_guest_prepare_required`, i.e.
+                // !storage && !renderer_owned, so storage targets keep their own stricter gate.)
+                // Base bytes are precisely what the validation in `acquire_cached_image` already
+                // covers, so a compressed surface's cache identity was complete all along and the
+                // metadata test was only ever costing hit rate -- on Stray, most of the detiling
+                // work in the whole run. #3149 carries the census.
+                //
+                // This deliberately does NOT change how a compressed surface decodes -- only
+                // whether that decode's result may be reused. If reading base bytes without
+                // consulting a live DCC plane is wrong for some surface, it is equally wrong on
+                // both sides of this branch, and the cache serves the same pixels the uncached path
+                // would have uploaded. That is what makes the change pixel-neutral by construction,
+                // and what the frame A/B on #3149 measures rather than assumes.
+                //
                 // Kill switch, and it earns its place: this admits a whole class of surface to a
-                // cache it was previously excluded from, so a single variable must be able to
-                // restore the old behaviour exactly -- for bisecting a rendering report, and for the
-                // pixel A/B that justified the change in the first place.
-                static const bool dcc_cache_disabled =
-                    std::getenv("PROSPER_NO_DCC_IMAGE_CACHE") != nullptr;
-                const bool dcc_identity_tracked = !dcc_cache_disabled &&
-                    r->compression_enabled && r->metadata_addr &&
-                    prosper::gpu::gpu_capture_dcc_metadata_footprint(*r) > 0;
-                bi.cache_candidate = !sampled_dcc_fast_clear &&
-                    (dcc_cache_safe || dcc_identity_tracked) &&
-                    persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::sampled);
+                // cache it was previously excluded from, so a single variable must restore the old
+                // behaviour exactly -- for bisecting a rendering report, and for that A/B. It gates
+                // the entire change, because the gate below is now the entire change.
+                // Designated, not positional: inserting a field into this struct must not be able
+                // to silently re-bind these arguments.  #3149 lost a round to exactly that hazard
+                // in ComputeImageCacheKey.
+                bi.cache_candidate = compute_sampled_cache_gate_candidate({
+                    .sampled_dcc_fast_clear = sampled_dcc_fast_clear,
+                    .dcc_cache_safe = dcc_cache_safe,
+                    .dcc_cache_disabled = dcc_cache_disabled,
+                    .persistent_enabled = persistent_compute_image_enabled(
+                        sbytes, ComputeImageCacheClass::sampled),
+                });
                 const VkFormat transfer_native_format =
                     compute_transfer_storage_vk_format(r->format, sampled_components);
                 const bool float32_uint32_transfer_alias =
@@ -6930,15 +6928,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         r->layer_stride_bytes, r->layer_mip_offset_bytes,
                         r->mip_tail_offset, r->mip_tail_bytes,
                         r->mip_tail_x, r->mip_tail_y,
-                        static_cast<uint32_t>(image_format),
-                        // #3149: metadata plane joins the identity. Positional aggregate init --
-                        // these two MUST sit between vk_format and storage, matching the struct.
-                        r->compression_enabled ? r->metadata_addr : 0ull,
-                        r->compression_enabled
-                            ? static_cast<uint32_t>(
-                                  prosper::gpu::gpu_capture_dcc_metadata_footprint(*r))
-                            : 0u,
-                        bi.storage, r->in_mip_tail,
+                        static_cast<uint32_t>(image_format), bi.storage, r->in_mip_tail,
                         r->srgb, r->depth_compare};
                     // An ordinary native typed 2D image or native typed 3D volume is byte- and
                     // format-identical to the sampled upload that follows it. Borrow that retained
@@ -7001,12 +6991,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         !bi.compute_transfer_seed_borrowed);
                     if (bi.persistent && bi.upload_skipped)
                         g_sampled_image_upload_skips.fetch_add(1, std::memory_order_relaxed);
+                    // `compressed`/`dcc-safe` are here so this line can answer "did a surface that
+                    // only #3149 admits actually reach the cache on this route?".  Without them a
+                    // clean cross-title snapshot is equally consistent with the new path never
+                    // executing: compressed=1 dcc-safe=0 is exactly the class the old gate rejected.
                     if (trace && bi.persistent)
                         std::fprintf(stderr,
                                      "[compute]   persistent sampled image binding=%u "
-                                     "addr=0x%llx guest=%zu upload-skipped=%u\n",
+                                     "addr=0x%llx guest=%zu upload-skipped=%u compressed=%u "
+                                     "dcc-safe=%u\n",
                                      bi.binding, (unsigned long long)r->gpu_addr,
-                                     sampled_guest_need, bi.upload_skipped ? 1u : 0u);
+                                     sampled_guest_need, bi.upload_skipped ? 1u : 0u,
+                                     r->compression_enabled ? 1u : 0u, dcc_cache_safe ? 1u : 0u);
                     if (!bi.persistent && !bi.compute_transfer_seed_borrowed)
                         bi.cache_source_snapshot.assign(
                             sampled_guest_source,

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6846,10 +6846,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // it answers the wrong question. `dcc_cache_safe` asks whether the metadata plane
                 // reads as all-0xff, i.e. "nothing is actually compressed"; what decides whether an
                 // entry may be reused is whether the metadata can change the bytes this cache
-                // serves. On the sampled path it cannot: every consumer of the metadata plane
-                // reachable from here is `compute_sampled_dcc_fast_clear_rgba8`, and
-                // `!sampled_dcc_fast_clear` excludes every surface that reaches it -- so what a
-                // cacheable entry replays is detile + unpack of the BASE bytes and nothing else.
+                // serves. On the sampled path it cannot. The plane's only consumer here is
+                // `compute_sampled_dcc_fast_clear_rgba8`; the PROBE above runs it for every
+                // compressed sampled surface, and what `!sampled_dcc_fast_clear` excludes is the
+                // MATERIALIZATION that would act on its answer. The operative consequence is the
+                // same and is the sentence to quote: what a cacheable entry replays is detile +
+                // unpack of the BASE bytes and nothing else. (Stated precisely because the revision
+                // this replaced died of a comment that asserted more than its code did.)
                 // (This branch is already inside `compute_sampled_guest_prepare_required`, i.e.
                 // !storage && !renderer_owned, so storage targets keep their own stricter gate.)
                 // Base bytes are precisely what the validation in `acquire_cached_image` already
@@ -6863,6 +6866,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // both sides of this branch, and the cache serves the same pixels the uncached path
                 // would have uploaded. That is what makes the change pixel-neutral by construction,
                 // and what the frame A/B on #3149 measures rather than assumes.
+                //
+                // `cache_candidate` gates TWO things, and the argument above covers only the
+                // first: `acquire_cached_image` (reuse this decode's result) and
+                // `borrow_cached_image_for_compute_transfer` (seed from a retained STORAGE image --
+                // a different source, not this decode). Widening the gate newly admits compressed
+                // sampled descriptors to that borrow. It is safe, but for its own reason: the
+                // borrow demands `compute_transfer_valid && content_valid` plus a journal, watch or
+                // exact proof over the BASE range since the producing writeback, and the storage
+                // entry it borrows could only have been authorized through the STORAGE gate, which
+                // still requires an all-0xff plane. Diverging would need the plane to go non-0xff
+                // while the base bytes stayed byte-identical, which outside a fast clear -- excluded
+                // upstream -- is not producible.
                 //
                 // Kill switch, and it earns its place: this admits a whole class of surface to a
                 // cache it was previously excluded from, so a single variable must restore the old

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6867,8 +6867,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // would have uploaded. That is what makes the change pixel-neutral by construction,
                 // and what the frame A/B on #3149 measures rather than assumes.
                 //
-                // `cache_candidate` gates TWO things, and the argument above covers only the
-                // first: `acquire_cached_image` (reuse this decode's result) and
+                // `cache_candidate` gates more than the reuse the argument above covers:
+                // `acquire_cached_image` (replay this decode's result), sampled RETENTION, and
                 // `borrow_cached_image_for_compute_transfer` (seed from a retained STORAGE image --
                 // a different source, not this decode). Widening the gate newly admits compressed
                 // sampled descriptors to that borrow. It is safe, but for its own reason: the

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -7,6 +7,8 @@
 #include <cstdio>
 #include <algorithm>
 #include <limits>
+#include <unordered_map>
+#include <functional>
 #include <mutex>
 #include <set>
 #include <thread>
@@ -1163,8 +1165,90 @@ size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, 
     return sw4kb_tiled_bytes(width, height, pitch, bytes_per_texel);
 }
 
+
+// DIAGNOSTIC (PROSPER_TILECENSUS=1): which tiling work actually runs, by geometry.
+//
+// #3149 measured that this file's block copier is ~22% of CPU during Stray's boot while the GPU sits
+// at 4.5%, but no profiler here can name the CALL SITE: at -O3 the callers inline away (folded stacks
+// resolve to `~unique_ptr`) and DWARF unwinding collapses through the guest JIT to `main+0x...`. A
+// counter at the leaf answers the question the profiler cannot -- not which line calls it, but which
+// SURFACE it is called on and how often, which is what identifies the workload.
+//
+// Keyed on (direction, w, h, bytes-per-element, tile_mode) and dumped at exit, so a 3840x2160x8
+// surface running once per frame is immediately distinguishable from a small one running constantly.
+namespace {
+struct TileCensusKey {
+    const char* op; uint32_t w, h, bpe, mode;
+    bool operator==(const TileCensusKey& o) const {
+        return op == o.op && w == o.w && h == o.h && bpe == o.bpe && mode == o.mode;
+    }
+};
+struct TileCensusHash {
+    size_t operator()(const TileCensusKey& k) const {
+        return std::hash<const void*>{}(k.op) ^ (size_t(k.w) << 1) ^ (size_t(k.h) << 13) ^
+               (size_t(k.bpe) << 27) ^ (size_t(k.mode) << 33);
+    }
+};
+struct TileCensusValue { uint64_t calls = 0, bytes = 0; const char* who = "?"; };
+std::mutex g_tile_census_mx;
+std::unordered_map<TileCensusKey, TileCensusValue, TileCensusHash> g_tile_census;
+
+thread_local const char* g_tile_census_tag = "?";
+
+bool tile_census_enabled() {
+    static const bool on = std::getenv("PROSPER_TILECENSUS") != nullptr;
+    return on;
+}
+
+void tile_census_report() {
+    std::lock_guard<std::mutex> lk(g_tile_census_mx);
+    std::vector<std::pair<TileCensusKey, TileCensusValue>> rows(
+        g_tile_census.begin(), g_tile_census.end());
+    std::sort(rows.begin(), rows.end(),
+              [](const auto& a, const auto& b) { return a.second.bytes > b.second.bytes; });
+    uint64_t total_bytes = 0, total_calls = 0;
+    for (const auto& r : rows) { total_bytes += r.second.bytes; total_calls += r.second.calls; }
+    std::fprintf(stderr, "[tilecensus] %zu geometries, %llu calls, %.1f MiB moved\n",
+                 rows.size(), (unsigned long long)total_calls,
+                 double(total_bytes) / (1024.0 * 1024.0));
+    for (size_t i = 0; i < rows.size() && i < 14; ++i)
+        std::fprintf(stderr,
+                     "[tilecensus]   %-9s %-20s %5ux%-5u bpe=%u mode=%u calls=%llu %.1f MiB (%.1f%%)\n",
+                     rows[i].second.who, rows[i].first.op, rows[i].first.w, rows[i].first.h, rows[i].first.bpe,
+                     rows[i].first.mode, (unsigned long long)rows[i].second.calls,
+                     double(rows[i].second.bytes) / (1024.0 * 1024.0),
+                     total_bytes ? 100.0 * double(rows[i].second.bytes) / double(total_bytes) : 0.0);
+}
+
+void tile_census_note(const char* op, uint32_t w, uint32_t h, uint32_t bpe, uint32_t mode) {
+    if (!tile_census_enabled()) return;
+    bool due = false;
+    {
+        std::lock_guard<std::mutex> lk(g_tile_census_mx);
+        auto& v = g_tile_census[TileCensusKey{op, w, h, bpe, mode}];
+        v.who = g_tile_census_tag;
+        ++v.calls;
+        v.bytes += uint64_t(w) * h * bpe;
+        // Dumped PERIODICALLY, not at exit: a bounded capture run is killed with SIGTERM and every
+        // frontend here exits via _exit, so an atexit report would never print -- the same trap that
+        // hid the dmem write trace's output on #3146. A periodic dump always produces evidence.
+        // Threshold on BYTES as well as calls: this workload is a few enormous copies (a 4K FP16
+        // surface is 66 MiB), so a call-count threshold alone never fires and the instrument stays
+        // silent while moving gigabytes -- which is indistinguishable from "nothing happened".
+        static uint64_t since = 0, since_bytes = 0;
+        ++since;
+        since_bytes += uint64_t(w) * h * bpe;
+        if (since >= 20000 || since_bytes >= (1ull << 30)) {
+            since = 0; since_bytes = 0; due = true;
+        }
+    }
+    if (due) tile_census_report();
+}
+} // namespace
+
 void detile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
                     uint32_t tile_mode, uint32_t pitch, uint32_t bytes_per_texel) {
+    tile_census_note("detile_surface", width, height, bytes_per_texel, tile_mode);
     if (!tile_mode_is_tiled(tile_mode)) { warn_unhandled_tile_mode(tile_mode, width, height);
                                           std::memcpy(dst, src, (size_t)width * height * bytes_per_texel); return; }
     if (tile_mode == (uint32_t)TileMode::Sw256BS) {
@@ -1202,6 +1286,7 @@ std::vector<uint8_t> detile_surface(const std::vector<uint8_t>& src, uint32_t wi
 
 void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
                   uint32_t tile_mode, uint32_t pitch, uint32_t bytes_per_texel) {
+    tile_census_note("tile_surface", width, height, bytes_per_texel, tile_mode);
     if (!tile_mode_is_tiled(tile_mode)) { std::memcpy(dst, src, (size_t)width * height * bytes_per_texel); return; }
     const size_t dst_bytes = tiled_surface_bytes(width, height, tile_mode, pitch, bytes_per_texel);
     std::memset(dst, 0, dst_bytes);   // padding texels (rows beyond height) stay zero
@@ -1604,6 +1689,7 @@ size_t tiled_mip_level_offset(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t t
 
 void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                      uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode) {
+    tile_census_note("detile_elements", ew, eh, bpe, tile_mode);
     if (!tile_mode_is_tiled(tile_mode) || bpe == 0) {
         if (bpe != 0) warn_unhandled_tile_mode(tile_mode, ew, eh);   // bpe==0 is a caller error, not a mode gap
         size_t n = std::min(src_bytes, (size_t)ew * eh * bpe);
@@ -1625,6 +1711,7 @@ void detile_elements(uint8_t* dst, const uint8_t* src, size_t src_bytes,
 void detile_elements_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                            uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode,
                            uint32_t tail_x, uint32_t tail_y) {
+    tile_census_note("detile_elements_level", ew, eh, bpe, tile_mode);
     const size_t linear_bytes = static_cast<size_t>(ew) * eh * bpe;
     if (!bpe) {
         if (linear_bytes) std::memset(dst, 0, linear_bytes);
@@ -1651,6 +1738,7 @@ void detile_elements_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
 void detile_surface_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                           uint32_t width, uint32_t height, uint32_t tile_mode,
                           uint32_t bytes_per_texel, uint32_t tail_x, uint32_t tail_y) {
+    tile_census_note("detile_surface_level", width, height, bytes_per_texel, tile_mode);
     detile_elements_level(dst, src, src_bytes, width, height, bytes_per_texel,
                           tile_mode, tail_x, tail_y);
 }
@@ -1658,6 +1746,7 @@ void detile_surface_level(uint8_t* dst, const uint8_t* src, size_t src_bytes,
 void tile_surface_level(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
                         uint32_t width, uint32_t height, uint32_t tile_mode,
                         uint32_t bytes_per_texel, uint32_t tail_x, uint32_t tail_y) {
+    tile_census_note("tile_surface_level", width, height, bytes_per_texel, tile_mode);
     if (!bytes_per_texel) return;
     const size_t linear_bytes = static_cast<size_t>(width) * height * bytes_per_texel;
     if (!tile_mode_is_tiled(tile_mode)) {
@@ -1701,6 +1790,7 @@ size_t tiled_volume_bytes(uint32_t width, uint32_t height, uint32_t depth,
 bool detile_volume(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                    uint32_t width, uint32_t height, uint32_t depth,
                    uint32_t tile_mode, uint32_t bytes_per_texel) {
+    tile_census_note("detile_volume", width, height * depth, bytes_per_texel, tile_mode);
     const size_t linear_bytes = static_cast<size_t>(width) * height * depth * bytes_per_texel;
     if (tile_mode == (uint32_t)TileMode::Linear) {
         if (src_bytes < linear_bytes) return false;
@@ -1721,6 +1811,7 @@ bool detile_volume(uint8_t* dst, const uint8_t* src, size_t src_bytes,
 bool tile_volume(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
                  uint32_t width, uint32_t height, uint32_t depth,
                  uint32_t tile_mode, uint32_t bytes_per_texel) {
+    tile_census_note("tile_volume", width, height * depth, bytes_per_texel, tile_mode);
     const size_t need = tiled_volume_bytes(width, height, depth, tile_mode, bytes_per_texel);
     if (!need || dst_bytes < need) return false;
     if (tile_mode == (uint32_t)TileMode::Linear) {
@@ -1737,5 +1828,11 @@ bool tile_volume(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
                : sw64kb_rx_volume_copy<true>(dst, src, need, width, height, depth,
                                               bytes_per_texel);
 }
+
+
+TileCensusScope::TileCensusScope(const char* who) : prev(g_tile_census_tag) {
+    g_tile_census_tag = who;
+}
+TileCensusScope::~TileCensusScope() { g_tile_census_tag = prev; }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -1177,19 +1177,34 @@ size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, 
 // Keyed on (direction, w, h, bytes-per-element, tile_mode) and dumped at exit, so a 3840x2160x8
 // surface running once per frame is immediately distinguishable from a small one running constantly.
 namespace {
+// `who` is part of the KEY, not the value.  Holding it as a value field made attribution
+// last-writer-wins: one geometry reached from two call sites reported whichever ran last, which
+// on #3149 printed the outer `compute` scope for a row whose work is really `smpl-upl`.  Keying on
+// it splits that row instead, so a geometry reached from several sites is visible as several rows
+// and the percentages stay attributable.  Tags and ops are string literals, so pointer identity is
+// the intended comparison.
 struct TileCensusKey {
-    const char* op; uint32_t w, h, bpe, mode;
+    const char* op; const char* who; uint32_t w, h, bpe, mode;
     bool operator==(const TileCensusKey& o) const {
-        return op == o.op && w == o.w && h == o.h && bpe == o.bpe && mode == o.mode;
+        return op == o.op && who == o.who && w == o.w && h == o.h && bpe == o.bpe &&
+               mode == o.mode;
     }
 };
 struct TileCensusHash {
     size_t operator()(const TileCensusKey& k) const {
-        return std::hash<const void*>{}(k.op) ^ (size_t(k.w) << 1) ^ (size_t(k.h) << 13) ^
-               (size_t(k.bpe) << 27) ^ (size_t(k.mode) << 33);
+        // A fixed-width 64-bit accumulator rather than shifts off `size_t`: the previous form
+        // shifted by 33, which is UB rather than a wrap wherever `size_t` is 32-bit.  Nothing here
+        // needs the spread those shifts were reaching for.
+        uint64_t h = std::hash<const void*>{}(k.op);
+        h = h * 1099511628211ull ^ std::hash<const void*>{}(k.who);
+        h = h * 1099511628211ull ^ k.w;
+        h = h * 1099511628211ull ^ k.h;
+        h = h * 1099511628211ull ^ k.bpe;
+        h = h * 1099511628211ull ^ k.mode;
+        return static_cast<size_t>(h);
     }
 };
-struct TileCensusValue { uint64_t calls = 0, bytes = 0; const char* who = "?"; };
+struct TileCensusValue { uint64_t calls = 0, bytes = 0; };
 std::mutex g_tile_census_mx;
 std::unordered_map<TileCensusKey, TileCensusValue, TileCensusHash> g_tile_census;
 
@@ -1214,7 +1229,7 @@ void tile_census_report() {
     for (size_t i = 0; i < rows.size() && i < 14; ++i)
         std::fprintf(stderr,
                      "[tilecensus]   %-9s %-20s %5ux%-5u bpe=%u mode=%u calls=%llu %.1f MiB (%.1f%%)\n",
-                     rows[i].second.who, rows[i].first.op, rows[i].first.w, rows[i].first.h, rows[i].first.bpe,
+                     rows[i].first.who, rows[i].first.op, rows[i].first.w, rows[i].first.h, rows[i].first.bpe,
                      rows[i].first.mode, (unsigned long long)rows[i].second.calls,
                      double(rows[i].second.bytes) / (1024.0 * 1024.0),
                      total_bytes ? 100.0 * double(rows[i].second.bytes) / double(total_bytes) : 0.0);
@@ -1225,8 +1240,7 @@ void tile_census_note(const char* op, uint32_t w, uint32_t h, uint32_t bpe, uint
     bool due = false;
     {
         std::lock_guard<std::mutex> lk(g_tile_census_mx);
-        auto& v = g_tile_census[TileCensusKey{op, w, h, bpe, mode}];
-        v.who = g_tile_census_tag;
+        auto& v = g_tile_census[TileCensusKey{op, g_tile_census_tag, w, h, bpe, mode}];
         ++v.calls;
         v.bytes += uint64_t(w) * h * bpe;
         // Dumped PERIODICALLY, not at exit: a bounded capture run is killed with SIGTERM and every

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -1235,6 +1235,13 @@ void tile_census_report() {
                      total_bytes ? 100.0 * double(rows[i].second.bytes) / double(total_bytes) : 0.0);
 }
 
+// Row count for a volume, saturating instead of wrapping: this only names a census bucket, so a
+// clamped value groups honestly while an overflowed one silently merges two unrelated geometries.
+uint32_t census_rows(uint32_t height, uint32_t depth) {
+    const uint64_t rows = static_cast<uint64_t>(height) * depth;
+    return rows > 0xffffffffull ? 0xffffffffu : static_cast<uint32_t>(rows);
+}
+
 void tile_census_note(const char* op, uint32_t w, uint32_t h, uint32_t bpe, uint32_t mode) {
     if (!tile_census_enabled()) return;
     bool due = false;
@@ -1804,7 +1811,10 @@ size_t tiled_volume_bytes(uint32_t width, uint32_t height, uint32_t depth,
 bool detile_volume(uint8_t* dst, const uint8_t* src, size_t src_bytes,
                    uint32_t width, uint32_t height, uint32_t depth,
                    uint32_t tile_mode, uint32_t bytes_per_texel) {
-    tile_census_note("detile_volume", width, height * depth, bytes_per_texel, tile_mode);
+    // Saturate rather than wrap: `height * depth` is uint32 arithmetic, and a large
+    // volume would otherwise alias into another row of the census.
+    tile_census_note("detile_volume", width, census_rows(height, depth), bytes_per_texel,
+                     tile_mode);
     const size_t linear_bytes = static_cast<size_t>(width) * height * depth * bytes_per_texel;
     if (tile_mode == (uint32_t)TileMode::Linear) {
         if (src_bytes < linear_bytes) return false;
@@ -1825,7 +1835,10 @@ bool detile_volume(uint8_t* dst, const uint8_t* src, size_t src_bytes,
 bool tile_volume(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
                  uint32_t width, uint32_t height, uint32_t depth,
                  uint32_t tile_mode, uint32_t bytes_per_texel) {
-    tile_census_note("tile_volume", width, height * depth, bytes_per_texel, tile_mode);
+    // Saturate rather than wrap: `height * depth` is uint32 arithmetic, and a large
+    // volume would otherwise alias into another row of the census.
+    tile_census_note("tile_volume", width, census_rows(height, depth), bytes_per_texel,
+                     tile_mode);
     const size_t need = tiled_volume_bytes(width, height, depth, tile_mode, bytes_per_texel);
     if (!need || dst_bytes < need) return false;
     if (tile_mode == (uint32_t)TileMode::Linear) {

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -1237,6 +1237,10 @@ void tile_census_report() {
 
 // Row count for a volume, saturating instead of wrapping: this only names a census bucket, so a
 // clamped value groups honestly while an overflowed one silently merges two unrelated geometries.
+// Note what saturating does NOT fix: the row's `bytes` weight is derived from the same clamped
+// value, and the report ranks by bytes, so a saturated row would sort high on a fabricated weight.
+// Unreachable for any real surface -- a volume would need >2^32 rows -- and left visible rather
+// than dropped, because a census that silently discards a geometry cannot show its own invalidity.
 uint32_t census_rows(uint32_t height, uint32_t depth) {
     const uint64_t rows = static_cast<uint64_t>(height) * depth;
     return rows > 0xffffffffull ? 0xffffffffu : static_cast<uint32_t>(rows);

--- a/prosper/src/gpu/texture/tile.hpp
+++ b/prosper/src/gpu/texture/tile.hpp
@@ -86,8 +86,12 @@ size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, 
 // copy. `pitch` is the padded row pitch in texels (0 -> use `width`).
 // PROSPER_TILECENSUS attribution: which SUBSYSTEM asked for this tiling work. The profiler cannot
 // say -- at -O3 the callers inline away and DWARF collapses through the guest JIT -- and the geometry
-// census alone shows a 4K FP16 surface detiled 2199 times without saying who wants it. Scoped by RAII
-// at the two subsystem entry points; unset reads as "?".
+// census alone shows a 4K FP16 surface detiled over and over without saying who wants it (#3149).
+// Scoped by RAII at the two subsystem entry points; unset reads as "?".
+// `who` is stored by pointer and outlives every scope, so it MUST be a string
+// literal (or otherwise static-lifetime).  The census also compares and hashes it by
+// pointer identity, so two equal-but-distinct spellings would split one call site into
+// two rows.  Passing a temporary's c_str() here dangles.
 struct TileCensusScope {
     explicit TileCensusScope(const char* who);
     ~TileCensusScope();

--- a/prosper/src/gpu/texture/tile.hpp
+++ b/prosper/src/gpu/texture/tile.hpp
@@ -95,6 +95,10 @@ size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, 
 struct TileCensusScope {
     explicit TileCensusScope(const char* who);
     ~TileCensusScope();
+    // A user-declared destructor does NOT suppress the copy constructor, and a copy would restore
+    // `prev` twice. Deleting it matters more now that this type lives in a widely included header.
+    TileCensusScope(const TileCensusScope&) = delete;
+    TileCensusScope& operator=(const TileCensusScope&) = delete;
     const char* prev;
 };
 

--- a/prosper/src/gpu/texture/tile.hpp
+++ b/prosper/src/gpu/texture/tile.hpp
@@ -84,6 +84,16 @@ size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, 
 // De-swizzle a surface of `bytes_per_texel`-byte texels from tiled `src` into linear `dst` (each
 // width*height*bpt bytes). `tile_mode` selects the swizzle; Linear/unknown modes do a straight
 // copy. `pitch` is the padded row pitch in texels (0 -> use `width`).
+// PROSPER_TILECENSUS attribution: which SUBSYSTEM asked for this tiling work. The profiler cannot
+// say -- at -O3 the callers inline away and DWARF collapses through the guest JIT -- and the geometry
+// census alone shows a 4K FP16 surface detiled 2199 times without saying who wants it. Scoped by RAII
+// at the two subsystem entry points; unset reads as "?".
+struct TileCensusScope {
+    explicit TileCensusScope(const char* who);
+    ~TileCensusScope();
+    const char* prev;
+};
+
 void detile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
                     uint32_t tile_mode, uint32_t pitch = 0, uint32_t bytes_per_texel = 4);
 

--- a/prosper/tests/shared/compute/test_compute_timing_selector.cpp
+++ b/prosper/tests/shared/compute/test_compute_timing_selector.cpp
@@ -179,6 +179,13 @@ int main() {
     sampled_gates.persistent_enabled = false;
     CHECK(!compute_sampled_cache_gate_candidate(sampled_gates),
           "persistent cache disable blocks the sampled cache candidate");
+    // The fourth (dcc_cache_safe, dcc_cache_disabled) corner, and the most common one in
+    // production: an ordinary UNCOMPRESSED sampled surface on the default path.  The other three
+    // corners are covered above; this one was unasserted, which is the wrong one to leave out.
+    sampled_gates = sampled_compressed;
+    sampled_gates.dcc_cache_safe = true;
+    CHECK(compute_sampled_cache_gate_candidate(sampled_gates),
+          "uncompressed sampled surface is a candidate on the default path");
 
     const ComputeStoragePostWritebackPromotionInputs promotion_eligible{
         {false, false, false, true, false, true}, true, true};

--- a/prosper/tests/shared/compute/test_compute_timing_selector.cpp
+++ b/prosper/tests/shared/compute/test_compute_timing_selector.cpp
@@ -146,6 +146,40 @@ int main() {
     CHECK(!compute_storage_cache_gate_candidate(cache_gates),
           "persistent cache disable blocks storage cache candidate");
 
+    // #3149: the sampled gate, and specifically the one arm that separates this change from a
+    // no-op.  A DCC-compressed sampled surface (dcc_cache_safe = false) is now a cache candidate;
+    // before #3149 the same inputs were rejected.  If this arm ever passes with the kill switch
+    // set, or fails without it, the gate has stopped doing the thing the PR measured.
+    const ComputeSampledCacheGateInputs sampled_compressed{
+        .sampled_dcc_fast_clear = false,
+        .dcc_cache_safe = false,
+        .dcc_cache_disabled = false,
+        .persistent_enabled = true};
+    CHECK(compute_sampled_cache_gate_candidate(sampled_compressed),
+          "compressed sampled surface is a cache candidate (#3149)");
+    ComputeSampledCacheGateInputs sampled_gates = sampled_compressed;
+    sampled_gates.dcc_cache_disabled = true;
+    CHECK(!compute_sampled_cache_gate_candidate(sampled_gates),
+          "PROSPER_NO_DCC_IMAGE_CACHE restores the pre-#3149 rejection");
+    // The kill switch must restore the OLD behaviour, not disable the cache: an uncompressed
+    // surface was always eligible and must stay eligible with the switch set.
+    sampled_gates.dcc_cache_safe = true;
+    CHECK(compute_sampled_cache_gate_candidate(sampled_gates),
+          "kill switch still admits an uncompressed sampled surface");
+    // Fast clears stay out on both sides of the switch -- they are keyed by the metadata plane,
+    // which is the one sampled consumer of it, and is why ignoring that plane is sound above.
+    sampled_gates = sampled_compressed;
+    sampled_gates.sampled_dcc_fast_clear = true;
+    CHECK(!compute_sampled_cache_gate_candidate(sampled_gates),
+          "DCC fast clear blocks the sampled cache candidate");
+    sampled_gates.dcc_cache_safe = true;
+    CHECK(!compute_sampled_cache_gate_candidate(sampled_gates),
+          "DCC fast clear blocks even an all-0xff metadata plane");
+    sampled_gates = sampled_compressed;
+    sampled_gates.persistent_enabled = false;
+    CHECK(!compute_sampled_cache_gate_candidate(sampled_gates),
+          "persistent cache disable blocks the sampled cache candidate");
+
     const ComputeStoragePostWritebackPromotionInputs promotion_eligible{
         {false, false, false, true, false, true}, true, true};
     CHECK(compute_storage_post_writeback_promotion_candidate(promotion_eligible),

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -1193,6 +1193,21 @@ value and `PROSPER_STENCIL_REPLACE=<0..255>` overrides the replacement reference
 ALWAYS+REPLACE stencil-prime draw. These are diagnostic controls only; they do not change guest-state
 extraction or the default render path.
 
+`PROSPER_TILECENSUS=1` answers "which surface geometry is the detiling/tiling cost?" without a
+profiler. It counts every `tile_surface`/`detile_surface` call keyed by `(op, caller tag, width,
+height, bytes-per-element, tile mode)` and dumps the heaviest rows by bytes moved, periodically
+rather than at exit — every frontend here leaves via `_exit`, so an `atexit` report never prints.
+The caller tag comes from a `TileCensusScope` RAII guard, so a row says *which* call site moved the
+bytes rather than only what shape they were; it is part of the key, so one geometry reached from two
+sites shows as two rows instead of reporting whichever ran last. It found #3149: on Stray's splash a
+single 3840x2160 bpe=8 detile dominated the whole run, because DCC-compressed sampled surfaces were
+excluded from the compute image cache and re-detiled on every use.
+
+`PROSPER_NO_DCC_IMAGE_CACHE=1` restores that pre-#3149 exclusion — DCC-compressed sampled surfaces
+are kept out of the persistent compute image cache. It exists to bisect a rendering report against
+that change with one variable, and to run the A/B that justified it; it is not a performance knob,
+and setting it makes the affected titles slower.
+
 ## Shared-box hygiene
 
 Several agents and the human run this repo at once, so anything that kills a process is a


### PR DESCRIPTION
Stray's splash sequence is host-bound, not GPU-bound, and `execute_live_compute_items` dominated the
CPU. A `PROSPER_TILECENSUS` sweep (new in this PR) found the work is almost entirely one surface
geometry, re-detiled thousands of times because DCC-compressed sampled surfaces were excluded from
the persistent compute image cache.

Fixes #3149.

## What this changes

One gate: a sampled surface is admitted to the compute image cache whether or not its DCC metadata
plane reads as all-`0xff`. Plus the census that found it, and a kill switch to bisect it.

One thing I found while reworking, not raised in review: dropping the metadata test left the
all-`0xff` scan **dead on the default path** — a full pass over the metadata plane, per binding per
dispatch, whose result nothing consumed. That is the same class of defect as B5 on #3147, and it
would have been added to the exact hot path this PR shortens. The scan now runs only when the kill
switch or the compute trace can act on its result. `sampled_dcc_fast_clear` is computed
unconditionally as before, so the transition argument below is unaffected.

## Why that is sound — and why the first revision's argument was wrong

**The first revision argued the wrong thing, and the review was right to reject it.** It folded the
metadata plane into `ComputeImageCacheKey` and validated it beside the base bytes, claiming a
compressed surface's identity was incomplete without it. Two independent problems:

* The guard was conjoined into only one of three skip proofs at `:2046`, so `watch_unchanged` and
  `exact_unchanged` — both base-range-only — skipped the upload anyway in exactly the scenario the PR
  body named. **The PR's central claim was false as implemented.**
* The premise was also wrong, which is why the fix is now smaller rather than longer.

The metadata plane's only reachable consumer on this path is
`compute_sampled_dcc_fast_clear_rgba8`, and the gate requires `!sampled_dcc_fast_clear`, which
excludes every surface that reaches it. **So for a surface this cache can hold, the upload is detile
+ unpack of the base bytes and never reads the metadata at all.** Base bytes are exactly what
`acquire_cached_image` already validates, so a compressed entry's identity was complete all along and
the all-`0xff` test was only ever costing hit rate.

I verified that by a second, independent route rather than on the reviewer's word — the derived
`sampled_dcc_metadata` could have been one of several channels. Every read of `bi.dcc_metadata` and
`r->metadata_addr` in the file is a storage-target path (the writeback at `:9469+`, the storage gate
at `:7130`, alias matching, or the fast-clear helper itself). And the changed gate sits inside
`compute_sampled_guest_prepare_required`, i.e. `!storage && !renderer_owned`, so storage targets keep
their own stricter gate untouched.

This deliberately does **not** change how a compressed surface decodes — only whether that decode's
result may be reused. If reading base bytes without consulting a live DCC plane is wrong for some
surface, it is equally wrong on both sides of this branch. That is what makes the change
pixel-neutral *by construction*, and it is a much stronger claim than the first revision's.

B1's alternative ends "keep only whatever the key needs to disambiguate entries". The answer is
**nothing** — master's key is already sufficient and is therefore unchanged. Two entries agreeing on
every key field agree on `gpu_addr`/`guest_bytes` (so the same base bytes) and on the whole geometry
(so the same layout), and the upload is a function of exactly those. A differing `metadata_addr`
cannot make their uploads differ, because neither upload reads it.

### The sharpest objection, and why it holds

The obvious challenge to decode-independence is a *transition*: what if a metadata write turns a
surface into (or out of) a fast clear while its base bytes sit still? That is the one case where the
plane changes what should be displayed.

It is handled, because `sampled_dcc_fast_clear` is recomputed per binding per dispatch, not cached.

* **Into a fast clear.** The next dispatch computes `sampled_dcc_fast_clear = true`, so
  `cache_candidate` goes false and the fast-clear materialization path runs. The cache is not
  consulted, stale or otherwise.
* **Out of a fast clear.** While it was a fast clear it was never cached, so there is no stale entry
  to serve. Its first admission uploads.

In both directions the gate is re-evaluated against the current metadata before the cache is
reached, which is what makes "the cacheable set never reads the plane" a statement about every
dispatch rather than only the first.

## Review disposition

| # | Status |
| --- | --- |
| **B1** | Fixed by taking the decode-independence route the review identified. Metadata is out of the key and out of the validation; the comment now states the argument the code implements. |
| **B2** | Moot — no footprint cast and no `metadata_bytes` field remain. |
| **B3** | Gate extracted as `compute_sampled_cache_gate_candidate` beside its storage sibling, with tests; clean-zero addressed below. |
| **N1** | Moot — no key change, so both cross-descriptor borrows are untouched and the kill switch now gates the entire change. |
| **N2** | Moot — no new key fields to hash. |
| **N3** | Fixed — stale `PROSPER_DCC_CACHE_UPSIDE` comment deleted. |
| **N4** | Moot — with no metadata in the key, the switch restores the old behaviour exactly. |
| **N5** | Addressed with a within-arm noise floor; see below. |
| **N6** | Fixed — `who` is part of the census key, so one geometry reached from two sites is two rows. |
| **N7** | Fixed — the 33-bit shift is gone (64-bit accumulator), and `TileCensusScope` now documents the static-lifetime invariant. |
| **N8** | Fixed — both variables registered in `prosper/tools/AGENTS.md`. |

### Second review (`0d7a0d6e`) — APPROVED, 8 non-blocking findings, all addressed

| # | Action |
| --- | --- |
| **N1** | Fixed, and it was a real error: `guest=66846720` is 3840x**2176**x8, not 3840x2160x8. I asserted a multiplication I never performed, in the one sentence joining two instruments. |
| **N2** | Gate comment now covers the *second* thing `cache_candidate` unlocks — the compute-transfer seed borrow, which seeds from a retained storage image rather than replaying this decode — and why that is separately safe. |
| **N3** | Invariant note extended to the declining direction and names the unwired seam (`compressed_source_authority.hpp`'s `sampled_source_decision`), which must move with this gate when wired. |
| **N4** | Comment tightened: the *probe* runs for every compressed sampled surface; what the gate excludes is the *materialization*. |
| **N5** | Fourth predicate corner asserted — the uncompressed default path, which was the one left out. |
| **N6** | Volume census rows saturate instead of wrapping `uint32_t`; `TileCensusScope` copy/assign deleted. |
| **N7** | `## Ruled out` row added to `docs/RESOURCE_BINDING.md`; `BLOG.md` entry added. |
| **N8** | Pixel A/B demoted to corroboration, with the minimum-seeking weakness stated. |

The reviewer also supplied a stronger form of the core argument than mine:
**`gfx10_dcc_fast_clear_rgba8` is the only DCC decode function in the tree** — prosper has no DCC
decompressor at all — so metadata-independence is a property of the codebase, not merely of this call
graph. That is now the argument recorded in `## Ruled out`.
| **N9** | Moot — that comment described the metadata validation and was deleted with it. |

### On B3's test arms

The review asked for arms (a) uncompressed key byte-identical to master, (b) footprint above
`UINT32_MAX` declined, (c) metadata changed while base unchanged → not skipped. All three describe
the design that was rejected; under decode-independence there is no key change and metadata is
irrelevant by construction, so those arms no longer have anything to assert. The arms that carry the
new design are: a compressed surface **is** admitted (the one that fails against the old predicate),
the kill switch restores the old rejection without disabling the cache for uncompressed surfaces, and
fast clears stay excluded on both sides.

I verified they discriminate rather than assuming it, by mutation: reverting
`compute_sampled_cache_gate_candidate` to master's gate
(`!sampled_dcc_fast_clear && dcc_cache_safe && persistent_enabled`, quoted from
`origin/master:live_compute.cpp:6835`) and rebuilding the real test file against the mutated header.

```
MUTANT test rc=1   1 failure:  FAIL compressed sampled surface is a cache candidate (#3149)
CLEAN  test rc=0   0 failures
```

So **1 of the 6 new arms fails without the fix** — the compressed-admission arm — and the other five
pin behaviour that must *not* change. I state that split explicitly because "the tests would fail
without the fix" would be false for five of them, and a reviewer should not have to discover that.

## Verification

Build clean, **ctest 315/315 passed, 0 failed** (4 pre-existing `-DGAME_DUMP` skips).
`check_diag_gates.py` green (570 files, 735 `PROSPER_*` variables, 108/108 baselined),
`check_cached_env.py` green, docs gate green, `diff --check` clean.

### Performance — one variable, same harness, same 110 s

`prosper-app`, headless, no pad input (this measures the splash sequence, which is the subject).

| arm | fps mean | tiling bytes moved |
| --- | --- | --- |
| default (this PR) | **62.24** (109 windows) | **3,176 MiB** |
| `PROSPER_NO_DCC_IMAGE_CACHE=1` (pre-#3149) | **37.42** (65 windows) | **246,977 MiB** |

**+66% frame rate, 77.8x less tiling work.**

### B3's clean zero — the instrument, then the answer

The review's point was that "both guards pass" is consistent with the new path never running. To
test that I added `compressed=`/`dcc-safe=` to the existing persistent-sampled trace line, so the
class only #3149 admits (`compressed=1 dcc-safe=0`) is directly countable.

**Positive control first, per the charter's rule about believing a zero — and it was needed.** My
first attempt at the messenger route reported `0` of every class, and had I only counted the
compressed ones that would have read as "the guarded route does not exercise the path". It was
instead a VOID measurement: my hand-rolled route never progressed (`0% of 7244 published frames
carried new content`), so it exercised nothing at all. Counting the TOTAL alongside the compressed
subset is what made the difference legible. On Stray, where the path is known to run:

```
persistent sampled images (total) : 23426
... compressed=1 dcc-safe=0       :  8235      <-- only #3149 admits these
[compute] persistent sampled image binding=10 addr=0x3017370000 guest=66846720 \
          upload-skipped=1 compressed=1 dcc-safe=0
```

`guest=66846720` is 3840 x **2176** x 8 — the census geometry with its tile height padded
(3840x2160x8 would be 66,355,200, and I wrote that in the first draft without doing the
multiplication; a reader who did it would have concluded the two instruments disagreed). It is the
same surface, independently confirmed as a cache **hit** on one the old gate rejected. All 8,235 are
`upload-skipped=1`, i.e. every one is a hit rather than merely an admission.

**Then the guarded route, and the answer is not the one I wanted.** Driving `snapshot.py`'s own
`capture_content()` so the dump, pad script, scale, savedata policy and timeout are exactly the
guard's, with only the trace added:

```
messenger-scene: 2,452,657 log lines, 222,908 compute dispatches, 668,736 bindings
                 persistent sampled images (total) : 0
```

Not a void run — it dispatched heavily. I first gave two different reasons for the zero; only one
is right. Every binding logs `cls=0 ... dims=0x0`, i.e. they are **buffers, not images**, so this
title's compute path never reaches the sampled image cache at all. The 1 MiB sampled minimum
(`live_compute.hpp:38`) is irrelevant here because execution never gets that far.

**So the reviewer was right, and the honest conclusion is that this guard cannot validate this
change.** It exercises the storage gate, which this PR deliberately leaves alone. Its passing is
evidence of no cross-title regression in shared code — worth having, and worth *not* overstating.
The change's safety rests on the structural argument above, which is by-construction rather than
statistical, plus the Stray measurements where the path demonstrably runs.

### N5 — the controlled pixel comparison

The original 3% frame A/B is **withdrawn**: it compared frames from different points in an animating
sequence, exactly as the review said. Replacement, with a within-arm noise floor so the cross-arm
number has a scale:

| comparison | mean abs delta | pixels differing by >8 |
| --- | --- | --- |
| **within-arm** A1 vs A2 (same config, two runs) — the noise floor | **0.106** | 0.40% |
| **cross-arm** A1 vs B1 (default vs `PROSPER_NO_DCC_IMAGE_CACHE=1`) | **0.100** | 0.41% |
| full-resolution re-check of the closest cross-arm pair | **0.000** | 0.00% |

The cross-arm delta sits at or below run-to-run variation of the same configuration, and the closest
cross-arm pair is byte-identical at full 4K.

**Read this as corroboration, not as independent proof, and the reason is a real weakness.** Pairing
by closest match is minimum-seeking: for each A frame it selects the B frame that minimises the very
statistic then reported, and "full-resolution re-check of the *closest* pair" selects the best case
twice. The failure mode of a cache-staleness bug is "this frame resembles a slightly earlier frame"
— which is precisely what closest-match pairing absorbs. The within-arm floor is computed the same
way, so the comparison is at least like-for-like. **What carries this PR is the structural argument**;
this table is consistent with it, not a second proof of it.

The comparator was validated before being trusted, and it needed to be: its first positive control
**failed to detect deliberately corrupted frames**, because the capture set was `mean=0.0, std=0.0`
— entirely black — so the injected defect was not expressible on it. With a perturbation that cannot
be a no-op it moves 8.14x the noise floor. It now also refuses to return a verdict at all when an
arm is blank, since "no pixel difference" over black frames reads identically to "no corruption".

Getting a valid anchor took four attempts, recorded so nobody repeats them: the animating logo
sequence is what N5 rejected; the held title screen is unreachable by the SLOW arm inside any window
the fast arm tolerates (0 frames); and `--warmup-seconds` **skips Vulkan rendering** rather than
merely delaying capture, so a long warmup changed the workload and the guest faulted. What works is
sampling widely from a known-good configuration and pairing by closest match.

### Cross-title guards

`messenger-scene` **OK**, `dead-cells-gameplay` **OK**, rc=0. Read with the caveat established
above: neither route creates a persistent sampled image, so these show no cross-title regression in
shared code rather than validating the changed path.

### Through to the title screen, and a harness artifact I nearly reported as a finding

The task asked about the splash "or all the way to title screen if appropriate". Under `prosper-app`
(GPU-present, the shipped path), 285 s carrying through to the title screen holds **64.78 fps mean
over 302 windows**, with the `smpl-upl` row still at **5 calls / 316 MiB (5.1%)** — the same 5 calls
as the 110 s splash run, so the fix holds for the whole sequence rather than only the opening.

The same phase measured under `tools/screenshot` looked completely different — 158,381 MiB of tiling
against `prosper-app`'s 6,254 MiB, and `tile_surface` apparently dominating at ~41%. I was about to
file that as a second bottleneck. It is the harness: `tools/screenshot` never calls
`set_gpu_present_active`, so it copies every scanout frame back to the CPU, and that readback
inflates tiling work **25x**. There is no writeback bottleneck on the shipped path, and no issue to
file. Recording it because the wrong version of this paragraph was one command away from being
published as a measurement of the title.

### The census now carries the causal claim (this is N6's payoff)

With `who` in the key, the row that moves is identifiable — and it is exactly the one this fix
caches, with the rest of the profile untouched:

| census row | pre-#3149 | this PR |
| --- | --- | --- |
| `smpl-upl detile_surface 3840x2160 bpe=8 mode=27` | **3,860 calls / 244,266 MiB (98.9%)** | **5 calls / 316 MiB** |
| `compute tile_surface 3840x2160 bpe=8 mode=27` | 16 calls | 16 calls |
| `stor-seed detile_surface 3840x2160 bpe=8 mode=27` | 9 calls | 9 calls |
| `compute tile_surface 120x68 bpe=8 mode=27` | 1,285 calls | 1,280 calls |

**772x fewer calls on the tagged sampled-upload row, every other row unchanged.** Under the old
last-writer-wins attribution those first three rows collapsed into one, which is why the previous
revision reported this shape as `who=compute` and could not establish that the 98.9% was the upload
being cached. It now can.

