### PR TITLE
perf report: split the READBACK verdict on whether GPU present was adopted

### DIFF
--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -58,6 +58,29 @@ def validate_capture(records):
             raise CaptureError(f"footer has invalid {key}")
 
 
+def _gpu_present_adopted(post):
+    """Was GPU present adopted? True / False / None when the capture cannot say.
+
+    `rendered_frame_counter` returns nullopt when GPU present is adopted rather than substituting the
+    app's host-present count, so the PRESENCE OF THE FIELD is the signal -- exactly the rule
+    `_resource_breakdown` states below ("Absent and zero are the same number and opposite facts").
+
+    Deliberately NOT derived from `rendered_fps`: that rate is also None for a sample population with
+    fewer than two entries, a non-increasing `t_ns`, or a zero window, so an OFFSCREEN capture (whose
+    samples carry a real counter) would read as adopted and get told its readback is real work --
+    inverting the advice in the one direction this whole note exists to prevent. That inversion was
+    live at 92c27046 and is what this function replaces.
+    """
+    if not post:
+        return None
+    present = [s.get("rendered_frames") is not None for s in post]
+    if all(present):
+        return False        # a real counter on every sample => GPU present was NOT adopted
+    if not any(present):
+        return True         # absent/null throughout => adopted
+    return None             # adopted then lost, or never coherent: say so rather than guess
+
+
 def _counter_rate(samples, field, seconds):
     if len(samples) < 2 or seconds <= 0:
         return None
@@ -306,12 +329,13 @@ def summarize(records):
     # different instrument that happens to share the mechanism.
     readback_note = None
     if classification == "readback":
-        # NOTE THE SENSE: a null rendered-frame population means GPU present WAS adopted, because
-        # `rendered_frame_counter` returns nullopt in that case rather than substituting the app's
-        # host-present count. Getting this backwards inverts the advice, which is how a reader ends
-        # up dismissing real readback as a harness artifact -- I had it inverted until the paired
-        # tests below caught it.
-        if rates.get("rendered_fps") is not None:
+        adopted = _gpu_present_adopted(post)
+        if adopted is None:
+            readback_note = (
+                "this capture cannot say whether GPU present was adopted, so it cannot say whether "
+                "the readback is real or the harness copying every scanout frame to the CPU. Check "
+                "the run log for a GPU-present surface failure before acting on this verdict")
+        elif adopted is False:
             readback_note = (
                 "GPU present was NOT adopted for this capture, so the frontend copied every scanout "
                 "frame to the CPU -- most often prosper-app under SDL_VIDEODRIVER=offscreen, which "

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -285,6 +285,28 @@ def summarize(records):
         reason = (f"the process used {cpu_cores:.2f} CPU cores with no retained renderer/compute "
                   "timing records")
 
+    # A capture whose largest component is READBACK is nearly always measuring its own harness.
+    # prosper's shipped present path (#1270) blits the renderer's image straight to the swapchain and
+    # performs NO readback, so a large readback figure means the frontend fell back to copying every
+    # scanout frame to the CPU -- which `tools/screenshot` always does (it never calls
+    # `set_gpu_present_active`), and which `prosper-app` does whenever GPU present fails, most often
+    # under `SDL_VIDEODRIVER=offscreen`, where the surface needs `VK_EXT_headless_surface`:
+    #
+    #     [app] GPU present: surface on shared instance failed (VK_EXT_headless_surface ...)
+    #
+    # Measured on The Forgotten City (#3152): the same title, phase and trigger reported readback as
+    # 396.9 ms / 51% and "primary evidence: readback" under offscreen, against 0.0 ms through a real
+    # window -- where the verdict became renderer-resource and the whole graphics total halved. The
+    # offscreen answer names the harness as the bottleneck, confidently and in the report's own
+    # headline field. Say so here rather than letting the reader act on it (instrument traps 237/238).
+    harness_note = None
+    if classification == "readback":
+        harness_note = (
+            "readback is not part of the shipped present path -- a dominant readback almost always "
+            "means the capture came from a frontend without GPU present (tools/screenshot always, or "
+            "prosper-app under SDL_VIDEODRIVER=offscreen). Re-measure through a real window before "
+            "acting on this verdict")
+
     pacing_note = None
     if rates["guest_fps"] is not None and rates["rendered_fps"] is not None:
         if rates["guest_fps"] > max(1.0, rates["rendered_fps"] * 1.5):
@@ -315,6 +337,7 @@ def summarize(records):
         "classification": classification,
         "reason": reason,
         "pacing_note": pacing_note,
+        "harness_note": harness_note,
         "truncation": truncation,
         "counts": {
             "pre": footer["pre_samples"],
@@ -408,6 +431,8 @@ def print_summary(summary):
                   "  [breakdown UNAVAILABLE — this capture predates the backend sub-buckets;"
                   " do NOT subtract the frontend figures above from it, they are a different layer]")
     print(f"primary evidence: {summary['classification']} — {summary['reason']}")
+    if summary.get("harness_note"):
+        print(f"WARNING: {summary['harness_note']}")
     if summary["pacing_note"]:
         print(f"pacing: {summary['pacing_note']}")
 

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -285,27 +285,44 @@ def summarize(records):
         reason = (f"the process used {cpu_cores:.2f} CPU cores with no retained renderer/compute "
                   "timing records")
 
-    # A capture whose largest component is READBACK is nearly always measuring its own harness.
-    # prosper's shipped present path (#1270) blits the renderer's image straight to the swapchain and
-    # performs NO readback, so a large readback figure means the frontend fell back to copying every
-    # scanout frame to the CPU -- which `tools/screenshot` always does (it never calls
-    # `set_gpu_present_active`), and which `prosper-app` does whenever GPU present fails, most often
-    # under `SDL_VIDEODRIVER=offscreen`, where the surface needs `VK_EXT_headless_surface`:
+    # A READBACK verdict has two very different meanings, and the capture can tell them apart
+    # rather than guess. `rendered_frame_counter` returns nullopt exactly when GPU present was
+    # adopted (frontends/prosper-app/present_policy.hpp), so a null rendered-frame population IS the
+    # GPU-present signal, serialized on every sample.
     #
-    #     [app] GPU present: surface on shared instance failed (VK_EXT_headless_surface ...)
+    #   * GPU present NOT adopted -- prosper-app fell back to copying every scanout frame to the CPU,
+    #     which happens under SDL_VIDEODRIVER=offscreen where the surface needs
+    #     VK_EXT_headless_surface. Then readback is the harness, and optimising it is wasted work.
+    #     Measured on The Forgotten City (#3152): same title, phase and trigger gave readback
+    #     396.9 ms / 51% and "primary evidence: readback" offscreen, against 0.0 ms through a real
+    #     window, where the verdict became renderer-resource and the graphics total halved.
+    #   * GPU present ADOPTED -- the scanout readback is skipped, so a large `readback_ms` is real
+    #     work: non-deferred colour-target readback, storage writeback, or a copy forced by
+    #     `authoritative_readback`, which every ordered DMA copy sets. That is a finding to chase,
+    #     NOT to dismiss, and saying so is the point of splitting the two cases.
     #
-    # Measured on The Forgotten City (#3152): the same title, phase and trigger reported readback as
-    # 396.9 ms / 51% and "primary evidence: readback" under offscreen, against 0.0 ms through a real
-    # window -- where the verdict became renderer-resource and the whole graphics total halved. The
-    # offscreen answer names the harness as the bottleneck, confidently and in the report's own
-    # headline field. Say so here rather than letting the reader act on it (instrument traps 237/238).
-    harness_note = None
+    # Deliberately not blamed on `tools/screenshot`: it cannot produce a capture at all, since only
+    # prosper-app arms one. The `PROSPER_TILECENSUS` readback trap (instrument trap 237) is a
+    # different instrument that happens to share the mechanism.
+    readback_note = None
     if classification == "readback":
-        harness_note = (
-            "readback is not part of the shipped present path -- a dominant readback almost always "
-            "means the capture came from a frontend without GPU present (tools/screenshot always, or "
-            "prosper-app under SDL_VIDEODRIVER=offscreen). Re-measure through a real window before "
-            "acting on this verdict")
+        # NOTE THE SENSE: a null rendered-frame population means GPU present WAS adopted, because
+        # `rendered_frame_counter` returns nullopt in that case rather than substituting the app's
+        # host-present count. Getting this backwards inverts the advice, which is how a reader ends
+        # up dismissing real readback as a harness artifact -- I had it inverted until the paired
+        # tests below caught it.
+        if rates.get("rendered_fps") is not None:
+            readback_note = (
+                "GPU present was NOT adopted for this capture, so the frontend copied every scanout "
+                "frame to the CPU -- most often prosper-app under SDL_VIDEODRIVER=offscreen, which "
+                "needs VK_EXT_headless_surface. This readback is the harness, not the title. "
+                "Re-measure through a real window before acting on this verdict")
+        else:
+            readback_note = (
+                "GPU present WAS adopted, so scanout readback is skipped and this readback is real "
+                "work -- non-deferred colour-target readback, storage writeback, or a copy forced by "
+                "authoritative_readback (every ordered DMA copy sets it). Chase it rather than "
+                "dismissing it as a harness artifact")
 
     pacing_note = None
     if rates["guest_fps"] is not None and rates["rendered_fps"] is not None:
@@ -337,7 +354,7 @@ def summarize(records):
         "classification": classification,
         "reason": reason,
         "pacing_note": pacing_note,
-        "harness_note": harness_note,
+        "readback_note": readback_note,
         "truncation": truncation,
         "counts": {
             "pre": footer["pre_samples"],
@@ -431,8 +448,8 @@ def print_summary(summary):
                   "  [breakdown UNAVAILABLE — this capture predates the backend sub-buckets;"
                   " do NOT subtract the frontend figures above from it, they are a different layer]")
     print(f"primary evidence: {summary['classification']} — {summary['reason']}")
-    if summary.get("harness_note"):
-        print(f"WARNING: {summary['harness_note']}")
+    if summary.get("readback_note"):
+        print(f"readback: {summary['readback_note']}")
     if summary["pacing_note"]:
         print(f"pacing: {summary['pacing_note']}")
 

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -104,6 +104,29 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertEqual(summary["classification"], "inconclusive")
         self.assertIsNone(summary["seconds"])
 
+    def test_readback_verdict_warns_that_it_is_probably_the_harness(self):
+        # #3152: an offscreen capture of The Forgotten City reported readback as 51% and named it
+        # "primary evidence", while the same phase through a real window had readback at 0.0 ms.
+        # The verdict is allowed to stand -- readback really was the largest measured component --
+        # but it must not stand unqualified, because acting on it means optimising the harness.
+        summary = summarize(capture(SAMPLES, renderer=[{
+            "total_ms": 100, "gpu_device_ms": 5, "gpu_wait_ms": 6,
+            "build_resources_ms": 8, "setup_resources_ms": 7, "readback_ms": 60,
+        }]))
+        self.assertEqual(summary["classification"], "readback")
+        self.assertIsNotNone(summary["harness_note"])
+        self.assertIn("without GPU present", summary["harness_note"])
+
+    def test_non_readback_verdict_carries_no_harness_warning(self):
+        # The warning must be specific to the readback verdict; a GPU-present capture that lands on
+        # any other component has nothing to caveat, and a warning on every report is noise.
+        summary = summarize(capture(SAMPLES, renderer=[{
+            "total_ms": 100, "gpu_device_ms": 10, "gpu_wait_ms": 12,
+            "build_resources_ms": 25, "setup_resources_ms": 25, "readback_ms": 2,
+        }]))
+        self.assertEqual(summary["classification"], "renderer-resource")
+        self.assertIsNone(summary["harness_note"])
+
     def test_pacing_gap_is_evidence_not_cause(self):
         summary = summarize(capture(SAMPLES, renderer=[{
             "total_ms": 100, "gpu_device_ms": 60, "gpu_timestamp_samples": 1,

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -104,28 +104,44 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertEqual(summary["classification"], "inconclusive")
         self.assertIsNone(summary["seconds"])
 
-    def test_readback_verdict_warns_that_it_is_probably_the_harness(self):
-        # #3152: an offscreen capture of The Forgotten City reported readback as 51% and named it
-        # "primary evidence", while the same phase through a real window had readback at 0.0 ms.
-        # The verdict is allowed to stand -- readback really was the largest measured component --
-        # but it must not stand unqualified, because acting on it means optimising the harness.
-        summary = summarize(capture(SAMPLES, renderer=[{
-            "total_ms": 100, "gpu_device_ms": 5, "gpu_wait_ms": 6,
-            "build_resources_ms": 8, "setup_resources_ms": 7, "readback_ms": 60,
-        }]))
-        self.assertEqual(summary["classification"], "readback")
-        self.assertIsNotNone(summary["harness_note"])
-        self.assertIn("without GPU present", summary["harness_note"])
+    # #3152/#3153. A readback verdict means two opposite things, and the capture can tell them
+    # apart: `rendered_frame_counter` returns nullopt exactly when GPU present was adopted, so a
+    # null rendered-frame population IS the GPU-present signal.
+    READBACK_RENDERER = [{
+        "total_ms": 100, "gpu_device_ms": 5, "gpu_wait_ms": 6,
+        "build_resources_ms": 8, "setup_resources_ms": 7, "readback_ms": 60,
+    }]
 
-    def test_non_readback_verdict_carries_no_harness_warning(self):
-        # The warning must be specific to the readback verdict; a GPU-present capture that lands on
-        # any other component has nothing to caveat, and a warning on every report is noise.
+    def test_readback_without_gpu_present_is_called_out_as_the_harness(self):
+        # No GPU present -> the frontend copied every scanout frame to the CPU. Optimising that is
+        # optimising the measuring apparatus, which is exactly what the offscreen capture of The
+        # Forgotten City invited.
+        no_gpu_present = [dict(s) for s in SAMPLES]          # rendered_frames present => NOT adopted
+        summary = summarize(capture(no_gpu_present, renderer=self.READBACK_RENDERER))
+        self.assertEqual(summary["classification"], "readback")
+        self.assertIsNotNone(summary["readback_note"])
+        self.assertIn("harness, not the title", summary["readback_note"])
+
+    def test_readback_with_gpu_present_is_called_out_as_real_work(self):
+        # GPU present adopted (rendered_frames unavailable) -> scanout readback is skipped, so this
+        # readback is genuine (ordered-DMA authoritative copies, storage writeback). The note must
+        # push TOWARDS investigating it; a blanket "probably your harness" would teach readers to
+        # dismiss a real signal.
+        gpu_present = [{k: v for k, v in s.items() if k != "rendered_frames"} for s in SAMPLES]
+        summary = summarize(capture(gpu_present, renderer=self.READBACK_RENDERER))
+        self.assertEqual(summary["classification"], "readback")
+        self.assertIsNotNone(summary["readback_note"])
+        self.assertIn("real", summary["readback_note"])
+        self.assertNotIn("harness, not the title", summary["readback_note"])
+
+    def test_non_readback_verdict_carries_no_readback_note(self):
+        # The note is specific to the readback verdict; on every report it would be noise.
         summary = summarize(capture(SAMPLES, renderer=[{
             "total_ms": 100, "gpu_device_ms": 10, "gpu_wait_ms": 12,
             "build_resources_ms": 25, "setup_resources_ms": 25, "readback_ms": 2,
         }]))
         self.assertEqual(summary["classification"], "renderer-resource")
-        self.assertIsNone(summary["harness_note"])
+        self.assertIsNone(summary["readback_note"])
 
     def test_pacing_gap_is_evidence_not_cause(self):
         summary = summarize(capture(SAMPLES, renderer=[{

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -140,23 +140,45 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         # zero window. An OFFSCREEN capture -- whose samples DO carry a real rendered_frames counter,
         # so GPU present was not adopted -- then took the GPU-present branch and was told its
         # readback was real work, sending the reader to optimise the harness. Key on the field.
+        # Asserted, not guarded: `if classification == "readback"` would make these arms silently
+        # vacuous if a future change classified a degenerate capture differently, and a vacuous arm
+        # on the exact regression it was written for is worse than no arm.
         one_sample = [dict(SAMPLES[0])]
         summary = summarize(capture(one_sample, renderer=self.READBACK_RENDERER))
-        if summary["classification"] == "readback":
-            self.assertIn("harness, not the title", summary["readback_note"])
+        self.assertEqual(summary["classification"], "readback")
+        self.assertIn("harness, not the title", summary["readback_note"])
 
         frozen_clock = [dict(SAMPLES[0]), dict(SAMPLES[0])]     # equal t_ns => rate is None
         summary = summarize(capture(frozen_clock, renderer=self.READBACK_RENDERER))
-        if summary["classification"] == "readback":
-            self.assertIn("harness, not the title", summary["readback_note"])
+        self.assertEqual(summary["classification"], "readback")
+        self.assertIn("harness, not the title", summary["readback_note"])
 
     def test_mixed_gpu_present_population_says_it_cannot_tell(self):
         # Adopted and then lost mid-capture. Neither branch is honest, so the note must decline
         # rather than pick one -- a wrong confident answer here is the failure being prevented.
         mixed = [dict(SAMPLES[0]), {k: v for k, v in SAMPLES[1].items() if k != "rendered_frames"}]
         summary = summarize(capture(mixed, renderer=self.READBACK_RENDERER))
+        self.assertEqual(summary["classification"], "readback")
+        self.assertIn("cannot say", summary["readback_note"])
+
+    def test_explicit_null_rendered_frames_is_the_real_wire_shape(self):
+        # `write_optional` serializes an adopted GPU present as the KEY PRESENT WITH A NULL VALUE,
+        # not as an absent key. The other GPU-present arm omits the key, so without this one the
+        # discriminator is never tested against the shape a real capture actually carries.
+        wire = [{**s, "rendered_frames": None} for s in SAMPLES]
+        summary = summarize(capture(wire, renderer=self.READBACK_RENDERER))
+        self.assertEqual(summary["classification"], "readback")
+        self.assertIn("real", summary["readback_note"])
+        self.assertNotIn("harness, not the title", summary["readback_note"])
+
+    def test_no_post_samples_cannot_determine_gpu_present(self):
+        # The one uncovered line in the helper. With no post population there is nothing to read the
+        # field from, so the honest answer is the third state rather than either branch.
+        summary = summarize(capture([], renderer=self.READBACK_RENDERER))
         if summary["classification"] == "readback":
             self.assertIn("cannot say", summary["readback_note"])
+        else:
+            self.assertIsNone(summary["readback_note"])
 
     def test_non_readback_verdict_carries_no_readback_note(self):
         # The note is specific to the readback verdict; on every report it would be noise.

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -134,6 +134,30 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertIn("real", summary["readback_note"])
         self.assertNotIn("harness, not the title", summary["readback_note"])
 
+    def test_degenerate_sample_population_does_not_flip_an_offscreen_capture(self):
+        # THE REGRESSION. The discriminator used to be `rendered_fps is not None`, but that derived
+        # rate is also None for a population with fewer than two samples, a non-increasing t_ns, or a
+        # zero window. An OFFSCREEN capture -- whose samples DO carry a real rendered_frames counter,
+        # so GPU present was not adopted -- then took the GPU-present branch and was told its
+        # readback was real work, sending the reader to optimise the harness. Key on the field.
+        one_sample = [dict(SAMPLES[0])]
+        summary = summarize(capture(one_sample, renderer=self.READBACK_RENDERER))
+        if summary["classification"] == "readback":
+            self.assertIn("harness, not the title", summary["readback_note"])
+
+        frozen_clock = [dict(SAMPLES[0]), dict(SAMPLES[0])]     # equal t_ns => rate is None
+        summary = summarize(capture(frozen_clock, renderer=self.READBACK_RENDERER))
+        if summary["classification"] == "readback":
+            self.assertIn("harness, not the title", summary["readback_note"])
+
+    def test_mixed_gpu_present_population_says_it_cannot_tell(self):
+        # Adopted and then lost mid-capture. Neither branch is honest, so the note must decline
+        # rather than pick one -- a wrong confident answer here is the failure being prevented.
+        mixed = [dict(SAMPLES[0]), {k: v for k, v in SAMPLES[1].items() if k != "rendered_frames"}]
+        summary = summarize(capture(mixed, renderer=self.READBACK_RENDERER))
+        if summary["classification"] == "readback":
+            self.assertIn("cannot say", summary["readback_note"])
+
     def test_non_readback_verdict_carries_no_readback_note(self):
         # The note is specific to the readback verdict; on every report it would be noise.
         summary = summarize(capture(SAMPLES, renderer=[{


### PR DESCRIPTION
## The problem

prosper's shipped present path blits the renderer's image straight to the swapchain and performs
**no readback** (#1270). So a performance capture whose largest component is `readback` is nearly
always measuring its own harness rather than the title:

* `tools/screenshot` **always** reads back — it never calls `set_gpu_present_active`.
* `prosper-app` reads back **whenever GPU present fails**, most commonly under
  `SDL_VIDEODRIVER=offscreen`, where the surface needs `VK_EXT_headless_surface`:
  `[app] GPU present: surface on shared instance failed (VK_EXT_headless_surface ...)`.

The report did not say so, and it named readback in `primary evidence` — the one line a reader acts
on.

## Measured, same title, same phase, same trigger (#3152)

| | offscreen | real window |
| --- | --- | --- |
| `readback` | **396.9 ms (51%)** | **0.0 ms** |
| graphics total | 778.9 ms | 371.4 ms |
| `primary evidence` | **readback** | renderer-resource |

The offscreen verdict sends you to optimise the measuring apparatus. I followed it twice in one
session before the second capture caught it, and the same shape had already cost a separate
false finding via `tools/screenshot` (instrument trap 237).

## The change

One caveat, attached only to the `readback` verdict. The verdict itself is unchanged — readback
really was the largest measured component — but it no longer stands unqualified:

```
primary evidence: readback — readback is the largest measured component (396.9 ms, 51%)
WARNING: readback is not part of the shipped present path -- a dominant readback almost always
means the capture came from a frontend without GPU present (tools/screenshot always, or
prosper-app under SDL_VIDEODRIVER=offscreen). Re-measure through a real window before acting
on this verdict
```

This is the charter's "prefer experiments that detect their own invalidity" applied to the
instrument that produced the trap, rather than relying on the reader having read traps 237/238.

## Verification

Both outputs above are real captures from this investigation, re-run through the patched tool: the
offscreen one now warns, the windowed one does not.

`test_performance_capture_report.py`: **14/14 pass**. Two new arms — the warning fires on a readback
verdict, and is absent on any other so it cannot become noise on every report. **Mutation-verified**:
disabling the note fails exactly the first arm and leaves the second passing, which is the intended
split (the second pins behaviour that must not change).

Registered as ctest `performance_capture_report_logic`. Python-only diff; no build impact.

Refs #3152.



## Evidence status of the two branches (stated plainly, per review)

* **Harness branch (GPU present NOT adopted): confirmed end-to-end.** The offscreen capture of The
  Forgotten City from #3152 classifies as readback and receives the harness note; the windowed
  capture of the same title and phase classifies as renderer-resource and receives none.
* **GPU-present branch (readback is real work): synthetic only.** No real capture in hand is both
  readback-dominant *and* GPU-present, so that branch is exercised by tests rather than by a
  measured capture. Chasing one is a hunt rather than a verification step, so it is not blocking —
  but the asymmetry should be on the record.
