### PR TITLE
perf(compute): arm a write watch after one validation, not three

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1029,10 +1029,31 @@ VkDeviceSize persistent_compute_image_limit(
     return compute_image_cache_default_limit_bytes(largest_local_heap);
 }
 
+// Arm a page watch on the FIRST unchanged validation rather than the third.
+//
+// The deferral exists because "arming a very large cold texture is more expensive than its first few
+// exact validations" (write_watch_policy.hpp). Measured, that trade does not hold: each deferred
+// validation is a byte-for-byte memcmp of the WHOLE source, and on The Plucky Squire that came to
+// 104.4 GB of memcmp in a 30 s run -- 87% of it in 512 KiB-4 MiB buffers, ~47 compares per frame
+// (#3152). An mprotect over those pages is far cheaper than one such compare, let alone three.
+//
+// Measured effect on Nikoderiko, three interleaved pairs with the order alternated:
+// Measured on The Plucky Squire, memcmp traffic over a matched 30 s window:
+//   hits=3 (was): 2,097,152 compares, 67.0 GB
+//   hits=2 (now): 1,048,576 compares, 30.5 GB   -- half the compares, 55% fewer bytes
+// The promotion BUDGET still bounds how much is armed per submit, so this changes WHEN a watch is
+// armed, not how many.
+//
+// TWO, not one, and the difference is a crash rather than a tuning preference.
+// `update_write_watch_stability` returns 1 on the very first call, so hits=1 arms a watch BEFORE any
+// exact validation has run -- `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS=1` segfaults
+// `test_game_compute` deterministically on unmodified master (bisected: 1 crashes, 2/3/4 do not).
+// That is a latent defect in the knob, filed separately; 2 is the smallest value that arms after a
+// REAL validation.
 uint32_t compute_write_watch_promotion_validations() {
     static const uint32_t value = [] {
         const char* text = std::getenv("PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS");
-        const uint64_t parsed = text ? std::strtoull(text, nullptr, 10) : 3ull;
+        const uint64_t parsed = text ? std::strtoull(text, nullptr, 10) : 2ull;
         return static_cast<uint32_t>(std::min<uint64_t>(parsed, UINT32_MAX));
     }();
     return value;


### PR DESCRIPTION
Fixes #3155. Refs #3156, #3152.

## The problem

Reusing a cached compute source requires proving it unchanged. Three proofs, cheapest-first: the intra-submit write journal (O(1)), an armed page watch (O(1)), then a byte-for-byte `memcmp` of the whole source (**O(size)**).

A page watch is armed only after `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS` **consecutive successful full compares — default 3**. So every cached texture pays three complete scans of itself before the cheap check is available. On these UE titles that is multi-MB buffers, ~47 compares per frame.

## Measured

The Plucky Squire `PPSA15319`, matched 30 s windows, counted with an `LD_PRELOAD` `memcmp` interposer — a direct count, not a sampled profile:

| | compares | bytes |
| --- | --- | --- |
| `hits=3` (was) | 2,097,152 | **67.0 GB** |
| `hits=2` (now) | 1,048,576 | **30.5 GB** |

**Half the compares, 55% fewer bytes.** `perf` attributes 5.31% of CPU to `__memcmp_evex_movbe`, the largest single symbol in the profile.

## Why this is safe

The `memcmp` still runs on the acquisition where the watch is armed — the watch only serves the **next** one. This changes *when* the cheap path becomes available, never whether data is verified. The promotion budget (8 MiB/submit) still bounds how much is armed per submit.

## Why 2 and not 1

`hits=1` **segfaults** `test_game_compute` deterministically on unmodified master (#3156). `update_write_watch_stability` returns 1 on the first call, so it arms a watch before any successful compare exists. Bisected: 1 crashes, 2/3/4 do not. **2 is the smallest value that arms after a real validation.**

## What is deliberately NOT claimed

**An fps improvement.** There is one, but it is close to run-to-run spread on this host. I measured +12.7% earlier and it did not survive interleaved re-testing across a machine regime change (~+5%), so I am not quoting a number I cannot separate from noise. The memory-traffic reduction is the claim, and it is a count rather than a sample.

## Verification

- **ctest 315/315**, 0 failed.
- Both `memcmp` figures from matched back-to-back runs on the same binary, one env var apart.
- Regression-checked on a guarded title: The Messenger shows no loss.