### PR TITLE
perf(compute): reuse the GPU comparison descriptor pool instead of recreating it per dispatch

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1119,8 +1119,10 @@ struct VulkanComputeContext {
     std::mutex pipeline_cache_mutex;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
     // #3157: the GPU result-comparison pool, owned by the context so it is reset rather than
-    // recreated per dispatch. Measured 853 vkCreateDescriptorPool + 853 vkDestroy per second on
-    // The Plucky Squire before this; the main descriptor pool above already works this way.
+    // recreated per dispatch. It contributed about 144 vkCreateDescriptorPool + 144 vkDestroy per
+    // second on The Plucky Squire (whole-process rate 865/s before, 721/s after); the main
+    // descriptor pool above already works this way. The bulk of the remaining rate is NOT this path
+    // and not prepare_descriptor_pool -- see the note on that helper.
     VkDescriptorPool compare_pool = VK_NULL_HANDLE;
     uint32_t compare_pool_sets = 0;
     uint32_t compare_pool_buffers = 0;
@@ -1357,7 +1359,6 @@ struct VulkanComputeContext {
         if (command_pool) vkDestroyCommandPool(device, command_pool, nullptr);
         if (descriptor_pool) vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
         if (compare_pool) vkDestroyDescriptorPool(device, compare_pool, nullptr);
-        compare_pool = VK_NULL_HANDLE;
         if (compare_pipeline) vkDestroyPipeline(device, compare_pipeline, nullptr);
         if (compare_pipeline_layout)
             vkDestroyPipelineLayout(device, compare_pipeline_layout, nullptr);
@@ -1378,6 +1379,11 @@ struct VulkanComputeContext {
         if (borrowed) return;                       // renderer owns the device/instance
         if (device) vkDestroyDevice(device, nullptr);
         if (instance) vkDestroyInstance(instance, nullptr);
+    }
+
+    static bool compare_pool_reuse_enabled() {   // opt-out for bisection
+        static const bool enabled = std::getenv("PROSPER_NO_COMPARE_POOL_REUSE") == nullptr;
+        return enabled;
     }
 
     static bool descriptor_pool_reuse_enabled() {
@@ -1434,6 +1440,10 @@ struct VulkanComputeContext {
         return true;
     }
 
+    // NOT the source of the ~700 remaining vkCreateDescriptorPool/s: all three capacities below
+    // grow monotonically and the reuse test is <= on each, so this recreates only on a new maximum.
+    // The renderer creates one pool per RENDER PASS (tests/fixtures/render_runner.h, reached via
+    // render_draws_rgba) -- that is where to look next (#3157 review).
     VkDescriptorPool prepare_descriptor_pool(uint32_t buffers, uint32_t sampled,
                                              uint32_t storage) {
         if (!descriptor_pool_reuse_enabled()) return VK_NULL_HANDLE;
@@ -1471,9 +1481,7 @@ struct VulkanComputeContext {
     // Reset-and-reuse the comparison descriptor pool. Same contract as prepare_descriptor_pool:
     // grow capacities monotonically, reset when the request fits, recreate only when it does not.
     VkDescriptorPool prepare_compare_descriptor_pool(uint32_t sets, uint32_t buffers) {
-        static const bool reuse =
-            std::getenv("PROSPER_NO_COMPARE_POOL_REUSE") == nullptr;   // opt-out for bisection
-        if (!reuse || !sets || !buffers) return VK_NULL_HANDLE;
+        if (!compare_pool_reuse_enabled() || !sets || !buffers) return VK_NULL_HANDLE;
         if (compare_pool && sets <= compare_pool_sets && buffers <= compare_pool_buffers) {
             if (vkResetDescriptorPool(device, compare_pool, 0) == VK_SUCCESS) return compare_pool;
             vkDestroyDescriptorPool(device, compare_pool, nullptr);

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1118,6 +1118,12 @@ struct VulkanComputeContext {
     std::filesystem::path pipeline_cache_path;
     std::mutex pipeline_cache_mutex;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
+    // #3157: the GPU result-comparison pool, owned by the context so it is reset rather than
+    // recreated per dispatch. Measured 853 vkCreateDescriptorPool + 853 vkDestroy per second on
+    // The Plucky Squire before this; the main descriptor pool above already works this way.
+    VkDescriptorPool compare_pool = VK_NULL_HANDLE;
+    uint32_t compare_pool_sets = 0;
+    uint32_t compare_pool_buffers = 0;
     VkCommandPool command_pool = VK_NULL_HANDLE;
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
     VkFence dispatch_fence = VK_NULL_HANDLE;
@@ -1350,6 +1356,8 @@ struct VulkanComputeContext {
             vkDestroyQueryPool(device, dispatch_timestamp_pool, nullptr);
         if (command_pool) vkDestroyCommandPool(device, command_pool, nullptr);
         if (descriptor_pool) vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
+        if (compare_pool) vkDestroyDescriptorPool(device, compare_pool, nullptr);
+        compare_pool = VK_NULL_HANDLE;
         if (compare_pipeline) vkDestroyPipeline(device, compare_pipeline, nullptr);
         if (compare_pipeline_layout)
             vkDestroyPipelineLayout(device, compare_pipeline_layout, nullptr);
@@ -1458,6 +1466,32 @@ struct VulkanComputeContext {
         if (!count || vkCreateDescriptorPool(device, &info, nullptr, &descriptor_pool) != VK_SUCCESS)
             descriptor_pool = VK_NULL_HANDLE;
         return descriptor_pool;
+    }
+
+    // Reset-and-reuse the comparison descriptor pool. Same contract as prepare_descriptor_pool:
+    // grow capacities monotonically, reset when the request fits, recreate only when it does not.
+    VkDescriptorPool prepare_compare_descriptor_pool(uint32_t sets, uint32_t buffers) {
+        static const bool reuse =
+            std::getenv("PROSPER_NO_COMPARE_POOL_REUSE") == nullptr;   // opt-out for bisection
+        if (!reuse || !sets || !buffers) return VK_NULL_HANDLE;
+        if (compare_pool && sets <= compare_pool_sets && buffers <= compare_pool_buffers) {
+            if (vkResetDescriptorPool(device, compare_pool, 0) == VK_SUCCESS) return compare_pool;
+            vkDestroyDescriptorPool(device, compare_pool, nullptr);
+            compare_pool = VK_NULL_HANDLE;
+        } else if (compare_pool) {
+            vkDestroyDescriptorPool(device, compare_pool, nullptr);
+            compare_pool = VK_NULL_HANDLE;
+        }
+        compare_pool_sets = std::max(sets, compare_pool_sets);
+        compare_pool_buffers = std::max(buffers, compare_pool_buffers);
+        VkDescriptorPoolSize size{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, compare_pool_buffers};
+        VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+        dpci.maxSets = compare_pool_sets;
+        dpci.poolSizeCount = 1;
+        dpci.pPoolSizes = &size;
+        if (vkCreateDescriptorPool(device, &dpci, nullptr, &compare_pool) != VK_SUCCESS)
+            compare_pool = VK_NULL_HANDLE;
+        return compare_pool;
     }
 
     static bool persistent_mapping_enabled() {
@@ -5314,6 +5348,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     VkBuffer compare_flags = VK_NULL_HANDLE;
     VkDeviceMemory compare_flags_memory = VK_NULL_HANDLE;
     VkDescriptorPool compare_descriptor_pool = VK_NULL_HANDLE;
+    bool compare_pool_owned_by_context = false;
     std::vector<VkDescriptorSet> compare_descriptor_sets;
     VkDescriptorSetLayout descriptor_layout = VK_NULL_HANDLE;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
@@ -5380,7 +5415,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     };
 
     auto cleanup = [&] {
-        if (compare_descriptor_pool)
+        if (compare_descriptor_pool && !compare_pool_owned_by_context)
             vkDestroyDescriptorPool(ctx.device, compare_descriptor_pool, nullptr);
         if (compare_flags) vkDestroyBuffer(ctx.device, compare_flags, nullptr);
         if (compare_flags_memory) ctx.release_memory(compare_flags_memory);
@@ -8253,9 +8288,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 dpci.maxSets = static_cast<uint32_t>(compare_targets.size());
                 dpci.poolSizeCount = 1;
                 dpci.pPoolSizes = &size;
-                compare_ready = vk_soft_ok(vkCreateDescriptorPool(
-                    ctx.device, &dpci, nullptr, &compare_descriptor_pool),
-                    "compare-descriptor-pool");
+                compare_descriptor_pool = ctx.prepare_compare_descriptor_pool(
+                    static_cast<uint32_t>(compare_targets.size()), size.descriptorCount);
+                if (compare_descriptor_pool != VK_NULL_HANDLE) {
+                    compare_pool_owned_by_context = true;   // context resets it; do not destroy here
+                    compare_ready = true;
+                } else {
+                    compare_ready = vk_soft_ok(vkCreateDescriptorPool(
+                        ctx.device, &dpci, nullptr, &compare_descriptor_pool),
+                        "compare-descriptor-pool");
+                }
             }
             if (compare_ready) {
                 compare_descriptor_sets.resize(compare_targets.size());


### PR DESCRIPTION
Refs #3157.

## What

The GPU result-comparison path created **and destroyed** a `VkDescriptorPool` for every dispatch that compares its output. The main descriptor pool a few lines away already avoids this — `prepare_descriptor_pool` resets and reuses, growing capacities monotonically. This applies the same contract to the comparison pool.

## Measured

An `LD_PRELOAD` interposer reporting **rates**, not running totals — a periodic dump of a cumulative total is a *prefix* of the run, and comparing prefixes of different lengths is how I produced a wrong figure earlier on #3155:

| title | baseline | reuse on | baseline is |
| --- | --- | --- | --- |
| *The Plucky Squire* `PPSA15319` | 865 `vkCreateDescriptorPool`/s | **721/s (−17%)** | master |
| *Nikoderiko* `PPSA23760` | 1,212/s | **1,038/s (−14%)** | `PROSPER_NO_COMPARE_POOL_REUSE=1` |
| *Nikoderiko*, earlier run | 784/s | **702/s (−10%)** | master |

Two different baselines, so they are labelled rather than sharing a column. The Plucky Squire also has
an opt-out control arm at **854/s** against master's 865/s.

**The two Nikoderiko rows are kept deliberately, because the discrepancy is informative.** The same
condition measured **702/s** in one run and **1,038/s** in another — ~48% apart — with both arms
shifting together each time. That is the strongest evidence in this PR that the paired design is
doing its job, and that absolute rates from this interposer are **not** comparable across runs. Only
the within-run pair means anything.

`PROSPER_NO_COMPARE_POOL_REUSE=1` restores the old path exactly, and that control arm measures **854/s** against master's 865/s — so the reduction is attributable to the change rather than to run variance.

## What is NOT claimed

**A frame-rate improvement. There is no measurable one.** These titles are dominated by dispatch serialization (#3157) — 27 submits per frame, each awaiting full GPU completion — and trimming per-dispatch driver calls does not move that. This removes real work from the hot path and follows an existing pattern in the same file; it is not the fix for the fundamental problem, and I would rather say so than dress it up.

## Scope — corrected in review

The remaining rate is **not** `prepare_descriptor_pool`: its three capacities grow monotonically and the reuse test is `<=` on each, so it recreates only on a new maximum. The reviewer located the real source — the **renderer creates one `VkDescriptorPool` per render pass** (`tests/fixtures/render_runner.h`, reached via `render_draws_rgba`). Recorded in-code on `prepare_descriptor_pool` so the next reader is not sent to the wrong file, and it is the obvious next target.

## Verification

- **ctest 315/315** — but note this is *not* evidence for this change: nothing under `tests/` names the compare path, so no test demonstrates the reuse branch ran. What does demonstrate it is the control arm above — if the branch never executed, both arms would measure the same.
- The check that would catch a descriptor-lifetime VUID is the **Vulkan validation scan** in the Linux CI job, not ctest.
- Churn figures from matched back-to-back runs, plus an opt-out control arm.
- Ownership: the context now owns and resets the pool; `cleanup` no longer destroys it, and context teardown does.

