### PR TITLE
perf(compute): measure seed/writeback aliasing between dispatches (#3157)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -52,6 +52,24 @@ the render test suite, and the sites are pinned so they cannot quietly grow back
 
 [i3094]: https://github.com/mattias800/prosper/issues/3094
 
+### The compute path waits 19-38% of its wall clock on a fence, and pipelining it cannot help
+
+No picture — this is a negative, and an expensive one to have found the slow way.
+
+Three UE titles spend a fifth to a third of their wall clock inside `vkWaitForFences` on the compute
+path, with `vkQueueSubmit` at about 1% everywhere. That reads as an obvious win: stop waiting on each
+dispatch, overlap them, take the time back. A dispatch ring was built for it and works correctly.
+
+It buys nothing, for a reason no tuning changes. On these routes the guest submits roughly **one
+dispatch per batch** — 23,294 dispatches across ~23,400 batches on *Stray* — and the drain at the end
+of each batch is mandatory, because the guest may read its own memory as soon as the submit returns.
+Every slot is emptied immediately after it is filled, so the ring never overlaps anything. Throughput
+moved 67.5 → 68.5 fps, which is noise; the only real effect was less variance.
+
+The falsification is written down rather than the code being merged, because a default-off switch
+whose own measurement says it can never fire is worse than no switch. What is *not* ruled out is
+deferring across batches — that is where the sized win still lives, and nobody has tried it.
+
 ## 2026-08-31
 
 ### Stray's splash runs 66% faster, and the title screen now holds 65 fps

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1144,6 +1144,27 @@ resource-ownership scheduling rather than reordering by operation type.
   render passes and layouts, so stable application-level pipeline keys/lifetimes are needed first.
 - Reordering compute and graphics by type is not valid. The corrected capture graph proves real
   producer/consumer edges in the representative frame.
+- **A dispatch ring cannot overlap anything WITHIN a batch, because the end-of-batch drain is
+  mandatory** (2026-09-01, [#3157](https://github.com/mattias800/prosper/issues/3157),
+  implementation [#3161](https://github.com/mattias800/prosper/pull/3161), closed unmerged). The
+  hypothesis was well motivated and the sizing was real: an `LD_PRELOAD` interposer put
+  `vkWaitForFences` at **19.6-37.9% of wall** across three UE titles (Stray `PPSA02101` 37.9%,
+  Little Nightmares III `PPSA05143` 33.0%, Dragon Quest VII `PPSA17942` 19.6%), with `vkQueueSubmit`
+  at ~1% everywhere -- so batching *submits* is dead, and ~160 us per dispatch is scheduling latency
+  with the GPU idle. An alias-guarded ring was built and is correct: 315/315 at depths 1, 3 and 8,
+  zero faults across five interleaved 55 s Stray runs.
+  It does not deliver the sized win, and the reason is structural rather than a tuning failure. On
+  this route the guest submits roughly **one dispatch per batch** -- **23,294 dispatches across
+  ~23,400 batches** on Stray -- and the drain at the end of each batch is **mandatory**, because the
+  guest may read its memory as soon as the submit returns. Every slot is therefore drained
+  immediately after it is filled, so the ring never overlaps anything. Measured throughput: medians
+  67.5 -> 68.5 fps, within noise; the only clear effect is **reduced variance**, and what little
+  gain exists comes from per-slot command pools, not from pipelining.
+  **What this does NOT rule out:** deferring **across** batches. That is where the sized win still
+  lives, and it is untried -- it needs a guest-visibility contract the ring does not have. Do not
+  read this row as "pipelining the compute path is dead"; read it as "a within-batch ring is dead,
+  and the dispatches-per-batch ratio is the number to measure before building the next one."
+
 
 ## Windows cross-submit texture write watch
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1164,6 +1164,9 @@ resource-ownership scheduling rather than reordering by operation type.
   lives, and it is untried -- it needs a guest-visibility contract the ring does not have. Do not
   read this row as "pipelining the compute path is dead"; read it as "a within-batch ring is dead,
   and the dispatches-per-batch ratio is the number to measure before building the next one."
+  That ratio comes from `PROSPER_RENDER_TIMING`, which counts dispatches and batches; the alias
+  census (`PROSPER_COMPUTE_ALIAS_CENSUS`) answers a different question -- whether consecutive
+  dispatches alias through guest memory -- and has no call or batch counter at all.
 
 
 ## Windows cross-submit texture write watch

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -210,6 +210,25 @@ struct ComputeGuestRange {
     uint64_t bytes = 0;
 };
 
+// Address 0 is never a guest address, so a range at 0 is never a real one.
+//
+// Extracted and named so the rule is PINNED rather than living as a bare `if (r->gpu_addr)` at two
+// call sites. An explicit null V# entry is bound as a 4-byte zero source backed by a stack-local
+// array, and that synthesis deliberately keeps `gpu_addr == 0` -- its own comment says the point is
+// to bind a null buffer "without inventing a guest address". Feeding it to the census invented one:
+// two dispatches each holding a writable null array entry both produce {0, 4}, which overlaps
+// itself, so the census reported a FABRICATED alias at a non-address.
+//
+// `gpu_addr` rather than `host_data` is the right discriminator, and not only because it is
+// simpler: `resource_bytes_for` returns `host_data` for legitimate MIRRORED guest resources too, so
+// a host_data test would drop real guest ranges. The synthesis sets `host_data` and leaves
+// `gpu_addr` at 0 -- one field separates the cases, and it is this one. It is also the predicate the
+// code that performs the writes already uses, at both
+// `notify_guest_gpu_write_preserving_bytes` call sites, which predate this census.
+constexpr bool compute_guest_range_is_real(const ComputeGuestRange& r) {
+    return r.addr != 0;
+}
+
 // Half-open [addr, addr+bytes) intersection. A zero-length range touches nothing and so can
 // never alias -- that is the `seed_skip`/`renderer_owned` case, where nothing is read from guest
 // memory at all, and counting it as an overlap would overstate the hazard.

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -203,6 +203,10 @@ constexpr bool compute_guest_ranges_overlap(const ComputeGuestRange& a,
     return a.addr < b.addr + b.bytes && b.addr < a.addr + a.bytes;
 }
 
+// Plain (non-atomic) counters, deliberately: the census is read and written only from the thread
+// that runs `execute_live_compute_items`, and making them atomic would put a lock-prefixed RMW on
+// a path whose cost this instrument exists to measure. If a second producer thread is ever added,
+// these need revisiting -- they are not thread-safe and do not claim to be.
 struct ComputeAliasCensusCounters {
     uint64_t dispatches = 0;          // dispatches that declared at least one guest seed source
     uint64_t aliasing_dispatches = 0; // ...of those, ones seeding from the previous writeback set

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -177,4 +177,37 @@ inline bool claim_compute_transfer_gate_selector_summary(
     return true;
 }
 
+// #3157: a guest-memory range, used to measure whether one dispatch's SEED sources overlap the
+// PREVIOUS dispatch's WRITEBACK targets.
+//
+// Why this exists: the per-dispatch `vkWaitForFences` in the live compute path costs ~330 us
+// against ~171 us of GPU execution, so ~160 us per dispatch is scheduling latency. Deferring the
+// waits (pipelining several dispatches before consuming any results) is the obvious fix, but it
+// is only sound where a later dispatch does not seed from guest bytes an earlier one writes
+// back -- both address `r->gpu_addr` for `guest_bytes`, so an overlap is a read-after-write
+// hazard through guest memory that would silently seed from stale bytes.
+//
+// The overlap RATE bounds the achievable win: if consecutive dispatches usually alias, a
+// correctness-preserving pipeline drains constantly and buys nothing. Measure before building.
+struct ComputeGuestRange {
+    uint64_t addr = 0;
+    uint64_t bytes = 0;
+};
+
+// Half-open [addr, addr+bytes) intersection. A zero-length range touches nothing and so can
+// never alias -- that is the `seed_skip`/`renderer_owned` case, where nothing is read from guest
+// memory at all, and counting it as an overlap would overstate the hazard.
+constexpr bool compute_guest_ranges_overlap(const ComputeGuestRange& a,
+                                            const ComputeGuestRange& b) {
+    if (a.bytes == 0 || b.bytes == 0) return false;
+    return a.addr < b.addr + b.bytes && b.addr < a.addr + a.bytes;
+}
+
+struct ComputeAliasCensusCounters {
+    uint64_t dispatches = 0;          // dispatches that declared at least one guest seed source
+    uint64_t aliasing_dispatches = 0; // ...of those, ones seeding from the previous writeback set
+    uint64_t seed_ranges = 0;
+    uint64_t write_ranges = 0;
+};
+
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -189,6 +189,22 @@ inline bool claim_compute_transfer_gate_selector_summary(
 //
 // The overlap RATE bounds the achievable win: if consecutive dispatches usually alias, a
 // correctness-preserving pipeline drains constantly and buys nothing. Measure before building.
+//
+// KNOWN BIASES, stated so a reader can weigh the number instead of trusting it. All four were
+// found by review rather than by the instrument, which is itself the reason to write them down:
+//   * UNDER-counts: the sampled DCC fast-clear path reads guest memory through `metadata_addr`
+//     and its writeback writes the same plane, and neither side is recorded (covering it needs
+//     the metadata range, not `gpu_addr`).
+//   * OVER-counts: `compute_transfer_seed_borrowed` bindings are scored as guest seeds, but they
+//     read a retained GPU image rather than guest memory.
+//   * ASYMMETRIC: `SpirvDescriptorBinding::readable` marks a write-only output that need not be
+//     seeded. The image path consults it; `BoundBuffer` copies `writable` but never `readable`,
+//     so write-only IMAGES are excluded from seeds while write-only BUFFERS are included. That
+//     matches what prosper's buffer upload actually does today -- it does not consult `readable`
+//     either, so those bytes really are read -- but the two paths do not agree, and if the upload
+//     ever starts honouring `readable` this census must change with it.
+//   * DEPTH-1 ONLY: overlap is measured against the immediately preceding dispatch, so the rate
+//     is a lower bound for any ring depth greater than one.
 struct ComputeGuestRange {
     uint64_t addr = 0;
     uint64_t bytes = 0;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -308,6 +308,41 @@ namespace {
 std::atomic<uint64_t> g_buffer_gpu_result_skips{0};
 std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
 std::atomic<uint64_t> g_dcc_post_writeback_promotions{0};
+
+// #3157 alias census (PROSPER_COMPUTE_ALIAS_CENSUS=1, default OFF).
+//
+// Measures how often a dispatch seeds from guest bytes the PREVIOUS dispatch wrote back. That
+// overlap is what makes the obvious fix for the per-dispatch fence wait unsound: deferring
+// writebacks to batch the waits would let the later dispatch seed from stale guest memory.
+// The rate bounds the achievable win -- if consecutive dispatches usually alias, a
+// correctness-preserving pipeline drains every time and gains nothing.
+//
+// Compute submits are serialized (one AGC submit executes at a time), so the previous-writeback
+// set needs no lock; the counters are atomic only so the summary can be read from atexit.
+prosper::frontend::ComputeAliasCensusCounters g_alias_census{};
+std::vector<prosper::frontend::ComputeGuestRange> g_alias_prev_writes;
+
+bool alias_census_enabled() {
+    static const bool on = std::getenv("PROSPER_COMPUTE_ALIAS_CENSUS") != nullptr;
+    return on;
+}
+
+void report_alias_census() {
+    const auto& c = g_alias_census;
+    if (c.dispatches == 0) {
+        std::fprintf(stderr, "[alias-census] no dispatch declared a guest seed source\n");
+        return;
+    }
+    std::fprintf(stderr,
+                 "[alias-census] dispatches_with_seeds=%llu aliasing=%llu (%.1f%%) "
+                 "seed_ranges=%llu write_ranges=%llu\n",
+                 static_cast<unsigned long long>(c.dispatches),
+                 static_cast<unsigned long long>(c.aliasing_dispatches),
+                 100.0 * static_cast<double>(c.aliasing_dispatches) /
+                     static_cast<double>(c.dispatches),
+                 static_cast<unsigned long long>(c.seed_ranges),
+                 static_cast<unsigned long long>(c.write_ranges));
+}
 std::atomic<uint64_t> g_dcc_forced_seed_allocation_reuses{0};
 std::atomic<uint64_t> g_dcc_post_writeback_replacements{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
@@ -5380,6 +5415,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     for (size_t i = 0; i < buffers.size(); ++i)
         buffers[i].descriptor_index = buffer_descriptor_indices[i];
     std::vector<BoundImage> images(image_descriptors.size());
+    // #3157: this dispatch's guest seed sources and writeback targets, collected only when the
+    // alias census is armed so a default run pays nothing.
+    std::vector<prosper::frontend::ComputeGuestRange> alias_seeds, alias_writes;
     std::vector<VkBuffer> staging(image_descriptors.size(), VK_NULL_HANDLE);          // upload/readback
     std::vector<VkDeviceMemory> staging_memory(image_descriptors.size(), VK_NULL_HANDLE);
     std::vector<VkDeviceSize> staging_bytes(image_descriptors.size(), 0);
@@ -7217,6 +7255,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.guest_bytes = guest_bytes;
                 const uint8_t* src = (renderer_owned || bi.seed_skip)
                     ? nullptr : resource_bytes_for(r, guest_bytes);
+                if (alias_census_enabled()) {
+                    // A binding that reads nothing from guest memory cannot alias: `src` is null
+                    // exactly when the seed is skipped or the source is renderer-owned.
+                    if (src) alias_seeds.push_back({r->gpu_addr, guest_bytes});
+                    // The writeback writes up to guest_bytes at r->gpu_addr (see below).
+                    if (bi.storage) alias_writes.push_back({r->gpu_addr, guest_bytes});
+                }
                 // The writeback still writes up to guest_bytes at r->gpu_addr, so a guest-backed
                 // target must be a valid mapped range even when the SEED read is skipped (#1122
                 // review B2): keep the guard for the writeback target, not the seed source.
@@ -8979,6 +9024,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                                 ctx.dispatch_timestamp_pool, 5);
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
+        if (alias_census_enabled() && !alias_seeds.empty()) {
+            g_alias_census.dispatches++;
+            g_alias_census.seed_ranges += alias_seeds.size();
+            g_alias_census.write_ranges += alias_writes.size();
+            bool aliases = false;
+            for (const auto& sd : alias_seeds) {
+                for (const auto& w : g_alias_prev_writes)
+                    if (prosper::frontend::compute_guest_ranges_overlap(sd, w)) { aliases = true; break; }
+                if (aliases) break;
+            }
+            if (aliases) g_alias_census.aliasing_dispatches++;
+            // Report periodically as well as at exit: a bounded run is usually stopped with
+            // SIGTERM, whose default action skips atexit handlers entirely -- so an atexit-only
+            // census yields a clean run and no number.
+            if (g_alias_census.dispatches % 2048 == 0) report_alias_census();
+            static const bool once = [] { std::atexit(report_alias_census); return true; }();
+            (void)once;
+        }
+        if (alias_census_enabled()) g_alias_prev_writes = alias_writes;
         VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         submit.commandBufferCount = 1;
         submit.pCommandBuffers = &command;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -7255,7 +7255,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.guest_bytes = guest_bytes;
                 const uint8_t* src = (renderer_owned || bi.seed_skip)
                     ? nullptr : resource_bytes_for(r, guest_bytes);
-                if (alias_census_enabled() && r->gpu_addr) {
+                if (alias_census_enabled() && compute_guest_range_is_real({r->gpu_addr, guest_bytes})) {
                     // A binding that reads nothing from guest memory cannot alias: `src` is null
                     // exactly when the seed is skipped or the source is renderer-owned. The
                     // `r->gpu_addr` guard is the same rule the buffer loop applies -- address 0 is
@@ -9058,7 +9058,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // a writable null array entry both produce {0, 4}, which overlaps itself, and the
                 // census would report a FABRICATED alias at a non-address. Not a bias -- a false
                 // positive, and a systematic one on descriptor-array titles.
-                if (!b.resource || !b.resource->gpu_addr) continue;
+                if (!b.resource ||
+                    !prosper::frontend::compute_guest_range_is_real({b.resource->gpu_addr, b.guest_bytes}))
+                    continue;
                 if (b.guest_bytes == 0 || b.alias_of != SIZE_MAX) continue;
                 // NOT `!b.upload_skipped`. That flag means "the cached GPU copy still matches
                 // guest memory" (see its assignment: `submit_unchanged || (watches_complete &&

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -7751,6 +7751,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 } else {
                     const size_t need = sampled_guest_need;
                     const uint8_t* src = sampled_guest_source;
+                    if (alias_census_enabled() && src && need) {
+                        // A SAMPLED binding reads guest memory and never writes back, so it
+                        // contributes a seed range and no write range. Omitting these was the
+                        // census's blind spot and it hid the archetypal case: dispatch A writes a
+                        // storage image at X, dispatch B *samples* X. The storage-only census
+                        // could not see B's read at all, so that pair scored as no alias.
+                        alias_seeds.push_back({r->gpu_addr, need});
+                    }
                     const bool needs_sampled_upload = !bi.upload_skipped &&
                         !bi.compute_transfer_seed_borrowed;
                     if (needs_sampled_upload && sampled_dcc_fast_clear) {
@@ -9030,8 +9038,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // `alias_of` entry shares an earlier entry's guest range and would double-count.
             for (const auto& b : buffers) {
                 if (!b.resource || b.guest_bytes == 0 || b.alias_of != SIZE_MAX) continue;
-                if (!b.upload_skipped)
-                    alias_seeds.push_back({b.resource->gpu_addr, b.guest_bytes});
+                // NOT `!b.upload_skipped`. That flag means "the cached GPU copy still matches
+                // guest memory" (see its assignment: `submit_unchanged || (watches_complete &&
+                // dirty_chunks.empty())`), not "this binding does not read guest bytes". A bound
+                // buffer with a guest range reads that range whether or not the copy needed
+                // refreshing -- and under a deferred writeback the watch reports CLEAN precisely
+                // because the writeback has not landed yet, so gating on it would score the exact
+                // hazard being measured as "not a seed" and bias the rate down.
+                alias_seeds.push_back({b.resource->gpu_addr, b.guest_bytes});
                 if (b.writable)
                     alias_writes.push_back({b.resource->gpu_addr, b.guest_bytes});
             }

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -9024,6 +9024,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                                 ctx.dispatch_timestamp_pool, 5);
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
+        if (alias_census_enabled()) {
+            // Storage buffers alias through guest memory exactly as images do, so a guard that
+            // saw only the image path would be a correctness hole rather than a tradeoff. An
+            // `alias_of` entry shares an earlier entry's guest range and would double-count.
+            for (const auto& b : buffers) {
+                if (!b.resource || b.guest_bytes == 0 || b.alias_of != SIZE_MAX) continue;
+                if (!b.upload_skipped)
+                    alias_seeds.push_back({b.resource->gpu_addr, b.guest_bytes});
+                if (b.writable)
+                    alias_writes.push_back({b.resource->gpu_addr, b.guest_bytes});
+            }
+        }
         if (alias_census_enabled() && !alias_seeds.empty()) {
             g_alias_census.dispatches++;
             g_alias_census.seed_ranges += alias_seeds.size();

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -7255,12 +7255,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.guest_bytes = guest_bytes;
                 const uint8_t* src = (renderer_owned || bi.seed_skip)
                     ? nullptr : resource_bytes_for(r, guest_bytes);
-                if (alias_census_enabled()) {
+                if (alias_census_enabled() && r->gpu_addr) {
                     // A binding that reads nothing from guest memory cannot alias: `src` is null
-                    // exactly when the seed is skipped or the source is renderer-owned.
+                    // exactly when the seed is skipped or the source is renderer-owned. The
+                    // `r->gpu_addr` guard is the same rule the buffer loop applies -- address 0 is
+                    // a synthesized null binding, not a guest range.
                     if (src) alias_seeds.push_back({r->gpu_addr, guest_bytes});
-                    // The writeback writes up to guest_bytes at r->gpu_addr (see below).
-                    if (bi.storage) alias_writes.push_back({r->gpu_addr, guest_bytes});
+                    // The writeback writes up to guest_bytes at r->gpu_addr (see below). This arm
+                    // is unconditional inside the `bi.storage` branch that encloses it; the old
+                    // `if (bi.storage)` here was dead and read as if it discriminated something.
+                    alias_writes.push_back({r->gpu_addr, guest_bytes});
                 }
                 // The writeback still writes up to guest_bytes at r->gpu_addr, so a guest-backed
                 // target must be a valid mapped range even when the SEED read is skipped (#1122
@@ -7751,6 +7755,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 } else {
                     const size_t need = sampled_guest_need;
                     const uint8_t* src = sampled_guest_source;
+                    // KNOWN GAP, recorded rather than papered over: the DCC fast-clear path is
+                    // NOT covered, and it is excluded by accident rather than by argument.
+                    // `sampled_guest_source` is assigned only inside `if (!sampled_dcc_fast_clear)`,
+                    // so a fast-clear sample never reaches here -- yet it does read guest memory,
+                    // through `r->metadata_addr`, and materializes the whole surface from it, while
+                    // the writeback writes that same plane. That is a real producer->consumer
+                    // channel missing from BOTH sides of the census, so the rate is a lower bound.
+                    // Covering it needs the metadata range, not `gpu_addr`, which is a larger
+                    // change than this instrument warrants; #3157 carries it.
                     if (alias_census_enabled() && src && need) {
                         // A SAMPLED binding reads guest memory and never writes back, so it
                         // contributes a seed range and no write range. Omitting these was the
@@ -9037,7 +9050,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // saw only the image path would be a correctness hole rather than a tradeoff. An
             // `alias_of` entry shares an earlier entry's guest range and would double-count.
             for (const auto& b : buffers) {
-                if (!b.resource || b.guest_bytes == 0 || b.alias_of != SIZE_MAX) continue;
+                // Address 0 is not a guest address. An explicit null V# entry is bound as a
+                // 4-byte zero source backed by a STACK-LOCAL array (see `null_buffer_seed`), and
+                // that synthesis deliberately keeps `gpu_addr == 0` -- its own comment says the
+                // point is to bind a null buffer "without inventing a guest address". Letting it
+                // through here would invent one anyway: two consecutive dispatches that each hold
+                // a writable null array entry both produce {0, 4}, which overlaps itself, and the
+                // census would report a FABRICATED alias at a non-address. Not a bias -- a false
+                // positive, and a systematic one on descriptor-array titles.
+                if (!b.resource || !b.resource->gpu_addr) continue;
+                if (b.guest_bytes == 0 || b.alias_of != SIZE_MAX) continue;
                 // NOT `!b.upload_skipped`. That flag means "the cached GPU copy still matches
                 // guest memory" (see its assignment: `submit_unchanged || (watches_complete &&
                 // dirty_chunks.empty())`), not "this binding does not read guest bytes". A bound

--- a/prosper/tests/shared/compute/test_compute_timing_selector.cpp
+++ b/prosper/tests/shared/compute/test_compute_timing_selector.cpp
@@ -289,6 +289,14 @@ int main() {
           "adjacent half-open guest ranges do NOT alias");
     CHECK(!compute_guest_ranges_overlap({0x1100, 0x100}, {0x1000, 0x100}),
           "adjacency is symmetric");
+    // INTERIOR zero-length, not a boundary one. A zero-length range that starts where the other
+    // one starts is rejected by half-open arithmetic alone (`b.addr < a.addr + 0` is false), so a
+    // boundary arm passes whether or not the explicit `bytes == 0` guard exists -- it pins nothing.
+    // An address strictly INSIDE the other range is the case that needs the guard: without it,
+    // 0x1080 < 0x1100 and 0x1000 < 0x1080 both hold and the predicate would report an alias.
+    CHECK(!compute_guest_ranges_overlap({0x1080, 0}, {0x1000, 0x100}) &&
+              !compute_guest_ranges_overlap({0x1000, 0x100}, {0x1080, 0}),
+          "an interior zero-length range still never aliases");
     CHECK(!compute_guest_ranges_overlap({0x1000, 0}, {0x1000, 0x100}) &&
               !compute_guest_ranges_overlap({0x1000, 0x100}, {0x1000, 0}),
           "a zero-length range reads nothing and never aliases");

--- a/prosper/tests/shared/compute/test_compute_timing_selector.cpp
+++ b/prosper/tests/shared/compute/test_compute_timing_selector.cpp
@@ -276,6 +276,25 @@ int main() {
               !claim_compute_transfer_gate_selector_summary(missing_consumer),
           "transfer selector summary is claimed exactly once");
 
+    // #3157: the guest-range overlap test that decides whether a dispatch may be pipelined
+    // past the previous one. A false negative here would let a dispatch seed from stale guest
+    // bytes, so the boundary cases are the point.
+    CHECK(compute_guest_ranges_overlap({0x1000, 0x100}, {0x1080, 0x100}),
+          "partially overlapping guest ranges alias");
+    CHECK(compute_guest_ranges_overlap({0x1000, 0x100}, {0x1040, 0x10}),
+          "a contained guest range aliases");
+    CHECK(compute_guest_ranges_overlap({0x1040, 0x10}, {0x1000, 0x100}),
+          "containment aliases in either argument order");
+    CHECK(!compute_guest_ranges_overlap({0x1000, 0x100}, {0x1100, 0x100}),
+          "adjacent half-open guest ranges do NOT alias");
+    CHECK(!compute_guest_ranges_overlap({0x1100, 0x100}, {0x1000, 0x100}),
+          "adjacency is symmetric");
+    CHECK(!compute_guest_ranges_overlap({0x1000, 0}, {0x1000, 0x100}) &&
+              !compute_guest_ranges_overlap({0x1000, 0x100}, {0x1000, 0}),
+          "a zero-length range reads nothing and never aliases");
+    CHECK(compute_guest_ranges_overlap({0x1000, 0x100}, {0x1000, 0x100}),
+          "identical guest ranges alias");
+
     if (failures) {
         std::printf("%d check(s) failed\n", failures);
         return 1;

--- a/prosper/tests/shared/compute/test_compute_timing_selector.cpp
+++ b/prosper/tests/shared/compute/test_compute_timing_selector.cpp
@@ -300,6 +300,19 @@ int main() {
     CHECK(!compute_guest_ranges_overlap({0x1000, 0}, {0x1000, 0x100}) &&
               !compute_guest_ranges_overlap({0x1000, 0x100}, {0x1000, 0}),
           "a zero-length range reads nothing and never aliases");
+    // #3157/C1: a synthesized null binding is not a guest range. The SECOND arm is the point --
+    // it puts the consequence of deleting the guard in the test file, so a reader sees what the
+    // rule prevents rather than only that it exists. Without `compute_guest_range_is_real`, two
+    // dispatches each holding a writable null V# entry both contribute {0, 4}, and {0,4} overlaps
+    // itself, so the census reports an alias where no guest memory is involved at all.
+    CHECK(!compute_guest_range_is_real({0, 4}),
+          "a range at address 0 is a synthesized null binding, not guest memory");
+    CHECK(compute_guest_range_is_real({0x1000, 4}),
+          "an ordinary guest address is a real range");
+    CHECK(compute_guest_ranges_overlap({0, 4}, {0, 4}),
+          "...and {0,4} DOES overlap itself, which is exactly what the guard above prevents "
+          "the census from reporting");
+
     CHECK(compute_guest_ranges_overlap({0x1000, 0x100}, {0x1000, 0x100}),
           "identical guest ranges alias");
 


### PR DESCRIPTION
## Why

`#3157` established that the live compute path's per-dispatch `vkWaitForFences` is the dominant
cost: ~330 us mean against ~171 us of GPU execution, so ~160 us per dispatch is scheduling
latency. At 27 dispatches/frame that is 4.3 ms of a 30 ms frame, and batching the waits sizes at
~13% of frame time.

Starting that implementation showed it is **unsound as usually stated**. A dispatch's writeback
target and the *next* dispatch's seed source are the same guest bytes:

- seed source, `live_compute.cpp:7188`: `resource_bytes_for(r, guest_bytes)`
- and the comment below it: the writeback *"still writes up to `guest_bytes` at `r->gpu_addr`"*

So deferring writebacks to batch the waits lets a later dispatch seed from **stale guest memory** --
silent wrong pixels, not a crash. The per-dispatch wait is load-bearing.

A correct pipeline needs an alias guard that drains on overlap, and whether that is worth building
depends on how often consecutive dispatches actually alias.

## What this adds

`PROSPER_COMPUTE_ALIAS_CENSUS` (default OFF) measures that rate over both binding paths.

**Stray (`PPSA02101`), 90 s offscreen run:**

```
[alias-census] dispatches_with_seeds=43008 aliasing=2653 (6.2%) seed_ranges=87126 write_ranges=61747
```

**~5-6%.** An alias-guarded pipeline drains roughly one dispatch in sixteen, so most of the
~13%-of-frame win survives. That justifies building it.

### Correction: an image-only census understated this 10x

The first version of this branch instrumented only the image path and reported **0.6%**. Covering
storage buffers moved two things:

| | dispatches counted | aliasing |
| --- | --- | --- |
| images only | 2,048 | 12 (0.6%) |
| images + storage buffers | 43,008 | 2,653 (6.2%) |

The rate is ~10x higher, and the population ~20x larger -- buffer-only dispatches declared no seed
range at all and so were not counted. Both numbers support building the pipeline, but they imply
different drain behaviour, and 0.6% is the kind of under-measurement that reads as a green light.
Recorded here rather than silently replaced, because the first figure was briefly published on
#3157.

## Scope and limits

- One title, one route. The rate is a property of the workload, not of prosper; re-measure per
  title before quoting it cross-title.
- The census reports periodically as well as at exit: a bounded run ends in SIGTERM, whose default
  action skips `atexit` handlers entirely, so an atexit-only census yields a clean run and no
  number.

## Verification

- `test_compute_timing_selector`: 52 checks, all pass, exit 0 (7 new -- partial overlap,
  containment in both argument orders, half-open adjacency in both orders, zero-length, identity).
- The overlap predicate is a pure `constexpr` function in the census header, unit-testable away
  from the GPU path.
- Default runs unaffected: every census site is behind `alias_census_enabled()`, and the
  per-dispatch range vectors are only populated when armed.

## Deliberately unaffected

No change to dispatch behaviour, writeback, caching, or submission. This PR measures; it does not
change the wait.

Refs #3157