### PR TITLE
perf(compute): alias-guarded dispatch ring, default off (#3157)

### DIFF
--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -177,4 +177,37 @@ inline bool claim_compute_transfer_gate_selector_summary(
     return true;
 }
 
+// #3157: a guest-memory range, used to measure whether one dispatch's SEED sources overlap the
+// PREVIOUS dispatch's WRITEBACK targets.
+//
+// Why this exists: the per-dispatch `vkWaitForFences` in the live compute path costs ~330 us
+// against ~171 us of GPU execution, so ~160 us per dispatch is scheduling latency. Deferring the
+// waits (pipelining several dispatches before consuming any results) is the obvious fix, but it
+// is only sound where a later dispatch does not seed from guest bytes an earlier one writes
+// back -- both address `r->gpu_addr` for `guest_bytes`, so an overlap is a read-after-write
+// hazard through guest memory that would silently seed from stale bytes.
+//
+// The overlap RATE bounds the achievable win: if consecutive dispatches usually alias, a
+// correctness-preserving pipeline drains constantly and buys nothing. Measure before building.
+struct ComputeGuestRange {
+    uint64_t addr = 0;
+    uint64_t bytes = 0;
+};
+
+// Half-open [addr, addr+bytes) intersection. A zero-length range touches nothing and so can
+// never alias -- that is the `seed_skip`/`renderer_owned` case, where nothing is read from guest
+// memory at all, and counting it as an overlap would overstate the hazard.
+constexpr bool compute_guest_ranges_overlap(const ComputeGuestRange& a,
+                                            const ComputeGuestRange& b) {
+    if (a.bytes == 0 || b.bytes == 0) return false;
+    return a.addr < b.addr + b.bytes && b.addr < a.addr + a.bytes;
+}
+
+struct ComputeAliasCensusCounters {
+    uint64_t dispatches = 0;          // dispatches that declared at least one guest seed source
+    uint64_t aliasing_dispatches = 0; // ...of those, ones seeding from the previous writeback set
+    uint64_t seed_ranges = 0;
+    uint64_t write_ranges = 0;
+};
+
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -308,6 +308,41 @@ namespace {
 std::atomic<uint64_t> g_buffer_gpu_result_skips{0};
 std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
 std::atomic<uint64_t> g_dcc_post_writeback_promotions{0};
+
+// #3157 alias census (PROSPER_COMPUTE_ALIAS_CENSUS=1, default OFF).
+//
+// Measures how often a dispatch seeds from guest bytes the PREVIOUS dispatch wrote back. That
+// overlap is what makes the obvious fix for the per-dispatch fence wait unsound: deferring
+// writebacks to batch the waits would let the later dispatch seed from stale guest memory.
+// The rate bounds the achievable win -- if consecutive dispatches usually alias, a
+// correctness-preserving pipeline drains every time and gains nothing.
+//
+// Compute submits are serialized (one AGC submit executes at a time), so the previous-writeback
+// set needs no lock; the counters are atomic only so the summary can be read from atexit.
+prosper::frontend::ComputeAliasCensusCounters g_alias_census{};
+std::vector<prosper::frontend::ComputeGuestRange> g_alias_prev_writes;
+
+bool alias_census_enabled() {
+    static const bool on = std::getenv("PROSPER_COMPUTE_ALIAS_CENSUS") != nullptr;
+    return on;
+}
+
+void report_alias_census() {
+    const auto& c = g_alias_census;
+    if (c.dispatches == 0) {
+        std::fprintf(stderr, "[alias-census] no dispatch declared a guest seed source\n");
+        return;
+    }
+    std::fprintf(stderr,
+                 "[alias-census] dispatches_with_seeds=%llu aliasing=%llu (%.1f%%) "
+                 "seed_ranges=%llu write_ranges=%llu\n",
+                 static_cast<unsigned long long>(c.dispatches),
+                 static_cast<unsigned long long>(c.aliasing_dispatches),
+                 100.0 * static_cast<double>(c.aliasing_dispatches) /
+                     static_cast<double>(c.dispatches),
+                 static_cast<unsigned long long>(c.seed_ranges),
+                 static_cast<unsigned long long>(c.write_ranges));
+}
 std::atomic<uint64_t> g_dcc_forced_seed_allocation_reuses{0};
 std::atomic<uint64_t> g_dcc_post_writeback_replacements{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
@@ -5350,6 +5385,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     for (size_t i = 0; i < buffers.size(); ++i)
         buffers[i].descriptor_index = buffer_descriptor_indices[i];
     std::vector<BoundImage> images(image_descriptors.size());
+    // #3157: this dispatch's guest seed sources and writeback targets, collected only when the
+    // alias census is armed so a default run pays nothing.
+    std::vector<prosper::frontend::ComputeGuestRange> alias_seeds, alias_writes;
     std::vector<VkBuffer> staging(image_descriptors.size(), VK_NULL_HANDLE);          // upload/readback
     std::vector<VkDeviceMemory> staging_memory(image_descriptors.size(), VK_NULL_HANDLE);
     std::vector<VkDeviceSize> staging_bytes(image_descriptors.size(), 0);
@@ -7187,6 +7225,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.guest_bytes = guest_bytes;
                 const uint8_t* src = (renderer_owned || bi.seed_skip)
                     ? nullptr : resource_bytes_for(r, guest_bytes);
+                if (alias_census_enabled()) {
+                    // A binding that reads nothing from guest memory cannot alias: `src` is null
+                    // exactly when the seed is skipped or the source is renderer-owned.
+                    if (src) alias_seeds.push_back({r->gpu_addr, guest_bytes});
+                    // The writeback writes up to guest_bytes at r->gpu_addr (see below).
+                    if (bi.storage) alias_writes.push_back({r->gpu_addr, guest_bytes});
+                }
                 // The writeback still writes up to guest_bytes at r->gpu_addr, so a guest-backed
                 // target must be a valid mapped range even when the SEED read is skipped (#1122
                 // review B2): keep the guard for the writeback target, not the seed source.
@@ -8925,6 +8970,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                                 ctx.dispatch_timestamp_pool, 5);
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
+        if (alias_census_enabled() && !alias_seeds.empty()) {
+            g_alias_census.dispatches++;
+            g_alias_census.seed_ranges += alias_seeds.size();
+            g_alias_census.write_ranges += alias_writes.size();
+            bool aliases = false;
+            for (const auto& sd : alias_seeds) {
+                for (const auto& w : g_alias_prev_writes)
+                    if (prosper::frontend::compute_guest_ranges_overlap(sd, w)) { aliases = true; break; }
+                if (aliases) break;
+            }
+            if (aliases) g_alias_census.aliasing_dispatches++;
+            // Report periodically as well as at exit: a bounded run is usually stopped with
+            // SIGTERM, whose default action skips atexit handlers entirely -- so an atexit-only
+            // census yields a clean run and no number.
+            if (g_alias_census.dispatches % 2048 == 0) report_alias_census();
+            static const bool once = [] { std::atexit(report_alias_census); return true; }();
+            (void)once;
+        }
+        if (alias_census_enabled()) g_alias_prev_writes = alias_writes;
         VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         submit.commandBufferCount = 1;
         submit.pCommandBuffers = &command;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1164,6 +1164,26 @@ struct VulkanComputeContext {
     VkCommandPool command_pool = VK_NULL_HANDLE;
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
     VkFence dispatch_fence = VK_NULL_HANDLE;
+    // #3157 dispatch ring. Each slot owns its own command pool, buffer and fence so a submitted
+    // dispatch can stay in flight while the next one records -- the per-dispatch fence wait costs
+    // ~330us against ~171us of GPU execution, so ~160us per dispatch is pure scheduling latency.
+    // `command_buffer`/`dispatch_fence` above alias the CURRENT slot, so recording code is
+    // unchanged. A separate pool per slot matters: vkResetCommandPool resets every buffer in the
+    // pool, which would clobber a slot still executing.
+    struct DispatchSlot {
+        VkCommandPool pool = VK_NULL_HANDLE;
+        VkCommandBuffer command_buffer = VK_NULL_HANDLE;
+        VkFence fence = VK_NULL_HANDLE;
+        // Set while this slot has been submitted but not yet consumed.
+        std::function<bool()> finish;
+        std::vector<prosper::frontend::ComputeGuestRange> writes;
+    };
+    std::vector<DispatchSlot> dispatch_slots;
+    size_t dispatch_slot_cursor = 0;
+    // Result of every consumed dispatch, folded by the caller.
+    bool pending_all_ok = true;
+    uint64_t ring_drains_on_alias = 0;
+    uint64_t ring_deferred_dispatches = 0;
     VkQueryPool dispatch_timestamp_pool = VK_NULL_HANDLE;
     float timestamp_period_ns = 0.0f;
     uint32_t timestamp_valid_bits = 0;
@@ -1388,6 +1408,23 @@ struct VulkanComputeContext {
         release_cached_buffers();
         release_cached_images();
         release_cached_memory();
+        // Slots must be drained by the caller before teardown; destroying a fence a queued
+        // submit still references is undefined. drain_dispatch_ring() is called at the end of
+        // every batch, so a live slot here means a leak in the caller, not a race to paper over.
+        for (auto& slot : dispatch_slots) {
+            if (slot.fence) vkDestroyFence(device, slot.fence, nullptr);
+            if (slot.pool) vkDestroyCommandPool(device, slot.pool, nullptr);
+        }
+        if (!dispatch_slots.empty()) {
+            // command_buffer/dispatch_fence ALIAS the current slot's handles while the ring is
+            // active -- that is what keeps every recording site unchanged. The slot loop above
+            // has already destroyed them, so the unconditional destroy further down would be a
+            // second destroy of the same handle. It aborts as a heap double free at exit, from
+            // the atexit context teardown rather than from any dispatch.
+            dispatch_fence = VK_NULL_HANDLE;
+            command_buffer = VK_NULL_HANDLE;
+        }
+        dispatch_slots.clear();
         if (dispatch_fence) vkDestroyFence(device, dispatch_fence, nullptr);
         if (dispatch_timestamp_pool)
             vkDestroyQueryPool(device, dispatch_timestamp_pool, nullptr);
@@ -1426,7 +1463,115 @@ struct VulkanComputeContext {
         return enabled;
     }
 
+    // Ring depth. 1 reproduces the historical behaviour exactly (submit, wait, consume), so
+    // the feature is opt-in and a malformed value falls back to it rather than to a guess.
+    size_t dispatch_ring_depth() {
+        static const size_t depth = [] {
+            const char* v = std::getenv("PROSPER_COMPUTE_RING");
+            if (!v || !*v) return size_t{1};
+            char* end = nullptr;
+            const unsigned long parsed = std::strtoul(v, &end, 10);
+            if (!end || *end || parsed < 1 || parsed > 8) return size_t{1};
+            return static_cast<size_t>(parsed);
+        }();
+        return depth;
+    }
+
+    // Free the slot this dispatch will use, BEFORE it acquires any cached resource. The
+    // previous occupant's cleanup releases cached buffers/images by key, so running it later --
+    // once the new dispatch holds the same keys -- frees live resources and double-frees on the
+    // next release. Caught by live_compute_descriptor_array and gpu_capture_render_replay.
+    bool reserve_dispatch_slot() {
+        if (dispatch_ring_depth() <= 1) return true;
+        if (dispatch_slots.size() != dispatch_ring_depth())
+            dispatch_slots.resize(dispatch_ring_depth());
+        return consume_dispatch_slot(dispatch_slots[dispatch_slot_cursor]);
+    }
+
+    // Consume one slot: wait, writeback, cleanup. Safe to call on an empty slot.
+    bool consume_dispatch_slot(DispatchSlot& slot) {
+        if (!slot.finish) return true;
+        auto finish = std::move(slot.finish);
+        slot.finish = nullptr;
+        slot.writes.clear();
+        const bool ok = finish();
+        // execute_item already returned `true` provisionally for this dispatch, so a failure
+        // discovered here has to be recorded somewhere the caller still reads.
+        pending_all_ok = pending_all_ok && ok;
+        return ok;
+    }
+
+    // Drain every in-flight slot, oldest first. Ordering matters: two dispatches may write the
+    // same guest bytes, and the later one must land last.
+    bool drain_dispatch_ring() {
+        bool ok = true;
+        for (size_t i = 0; i < dispatch_slots.size(); i++) {
+            auto& slot = dispatch_slots[(dispatch_slot_cursor + i) % dispatch_slots.size()];
+            ok &= consume_dispatch_slot(slot);
+        }
+        return ok;
+    }
+
+    // The alias guard. A dispatch about to READ guest bytes that an in-flight dispatch still owes
+    // a WRITEBACK to would read stale memory -- the writeback target and the next seed source are
+    // the same address (see the seed site). Measured overlap on Stray is ~6%, so this drains
+    // rarely enough to leave the pipelining win intact.
+    bool drain_ring_if_overlaps(uint64_t addr, uint64_t bytes) {
+        if (bytes == 0) return true;   // reads nothing, cannot alias
+        const prosper::frontend::ComputeGuestRange probe{addr, bytes};
+        for (const auto& slot : dispatch_slots) {
+            if (!slot.finish) continue;
+            for (const auto& w : slot.writes) {
+                if (prosper::frontend::compute_guest_ranges_overlap(probe, w)) {
+                    ring_drains_on_alias++;
+                    return drain_dispatch_ring();
+                }
+            }
+        }
+        return true;
+    }
+
     bool prepare_dispatch_commands() {
+        // Ring path: hand out the cursor's slot and alias command_buffer/dispatch_fence to it, so
+        // every recording site below is unchanged. The slot is consumed first if it is still
+        // holding a previous dispatch -- that is the only place the ring blocks.
+        if (dispatch_ring_depth() > 1) {
+            if (dispatch_slots.size() != dispatch_ring_depth())
+                dispatch_slots.resize(dispatch_ring_depth());
+            auto& slot = dispatch_slots[dispatch_slot_cursor];
+            // The slot must already be free: consuming it here would run the PREVIOUS dispatch's
+            // cleanup after this one has acquired its cached buffers and images, and that cleanup
+            // releases resources by cache key -- it would free them out from under the dispatch
+            // now recording. reserve_dispatch_slot() does it before any acquisition instead.
+            if (slot.finish && !consume_dispatch_slot(slot)) return false;
+            if (!slot.pool) {
+                VkCommandPoolCreateInfo pool_info{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+                pool_info.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+                pool_info.queueFamilyIndex = queue_family;
+                if (vkCreateCommandPool(device, &pool_info, nullptr, &slot.pool) != VK_SUCCESS)
+                    return false;
+                VkCommandBufferAllocateInfo allocate{
+                    VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+                allocate.commandPool = slot.pool;
+                allocate.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+                allocate.commandBufferCount = 1;
+                if (vkAllocateCommandBuffers(device, &allocate, &slot.command_buffer) !=
+                    VK_SUCCESS)
+                    return false;
+            } else if (vkResetCommandPool(device, slot.pool, 0) != VK_SUCCESS) {
+                return false;
+            }
+            if (!slot.fence) {
+                VkFenceCreateInfo fence_info{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+                if (vkCreateFence(device, &fence_info, nullptr, &slot.fence) != VK_SUCCESS)
+                    return false;
+            } else if (vkResetFences(device, 1, &slot.fence) != VK_SUCCESS) {
+                return false;
+            }
+            command_buffer = slot.command_buffer;
+            dispatch_fence = slot.fence;
+            return command_buffer != VK_NULL_HANDLE;
+        }
         if (!command_pool) {
             VkCommandPoolCreateInfo pool_info{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
             pool_info.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
@@ -4924,6 +5069,9 @@ void parent_scan_dump_pair(uint64_t addr, const uint8_t* after, size_t count,
 bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
     using namespace prosper::gpu;
     using ComputeClock = std::chrono::steady_clock;
+    // #3157: free this dispatch's ring slot before touching any cached resource (see the note on
+    // reserve_dispatch_slot). No-op unless the ring is enabled.
+    if (!ctx.reserve_dispatch_slot()) return false;
     auto decline = [&item](const char* reason) {
         report_compute_decline(item, reason);
         return false;
@@ -5388,6 +5536,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // #3157: this dispatch's guest seed sources and writeback targets, collected only when the
     // alias census is armed so a default run pays nothing.
     std::vector<prosper::frontend::ComputeGuestRange> alias_seeds, alias_writes;
+    // The ring needs the same write ranges the census collects, to guard the next dispatch's seed
+    // reads against a writeback this one still owes.
+    const bool collect_alias_ranges =
+        alias_census_enabled() || ctx.dispatch_ring_depth() > 1;
     std::vector<VkBuffer> staging(image_descriptors.size(), VK_NULL_HANDLE);          // upload/readback
     std::vector<VkDeviceMemory> staging_memory(image_descriptors.size(), VK_NULL_HANDLE);
     std::vector<VkDeviceSize> staging_bytes(image_descriptors.size(), 0);
@@ -5605,6 +5757,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 break;
             }
             if (buffers[i].alias_of == SIZE_MAX) {
+                // #3157: an in-flight dispatch may still owe a writeback to exactly these
+                // guest bytes. Reading them now would seed from stale memory, so drain first.
+                // Measured overlap is ~6%, so this is rare enough to leave the pipelining win.
+                (void)ctx.drain_ring_if_overlaps(resource->gpu_addr, buffers[i].guest_bytes);
                 const uint8_t* source = buffers[i].atomic_image
                     ? resource_bytes_for(resource, buffers[i].guest_bytes)
                     : resource_bytes_for(resource, buffers[i].guest_bytes);
@@ -7189,9 +7345,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     skip_image(r, "storage backing size is invalid"); break;
                 }
                 bi.guest_bytes = guest_bytes;
+                // #3157: an in-flight dispatch may still owe a writeback to exactly these
+                // guest bytes. Reading them now would seed from stale memory, so drain first.
+                // Measured overlap is ~6%, so this is rare enough to leave the pipelining win.
+                (void)ctx.drain_ring_if_overlaps(r->gpu_addr, guest_bytes);
                 const uint8_t* src = (renderer_owned || bi.seed_skip)
                     ? nullptr : resource_bytes_for(r, guest_bytes);
-                if (alias_census_enabled()) {
+                if (collect_alias_ranges) {
                     // A binding that reads nothing from guest memory cannot alias: `src` is null
                     // exactly when the seed is skipped or the source is renderer-owned.
                     if (src) alias_seeds.push_back({r->gpu_addr, guest_bytes});
@@ -8927,7 +9087,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                                 ctx.dispatch_timestamp_pool, 5);
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
-        if (alias_census_enabled()) {
+        if (collect_alias_ranges) {
             // Storage buffers alias through guest memory exactly as images do, so a guard that
             // saw only the image path would be a correctness hole rather than a tradeoff. An
             // `alias_of` entry shares an earlier entry's guest range and would double-count.
@@ -10019,6 +10179,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         return ok;
     };
+    // #3157: with a ring, hand the phase to the slot that owns this dispatch's fence and
+    // command buffer instead of blocking on it now. The slot is consumed when it comes round
+    // again, when a later dispatch's seed aliases one of its writeback targets, or at the end of
+    // the batch -- whichever happens first.
+    //
+    // A device loss is never deferred: the caller checks ctx.device_lost to stop the batch, and
+    // that has to be true before it looks.
+    if (submitted_dispatch && ctx.dispatch_ring_depth() > 1 && !ctx.device_lost &&
+        !ctx.dispatch_slots.empty()) {
+        auto& slot = ctx.dispatch_slots[ctx.dispatch_slot_cursor];
+        slot.finish = std::move(finish_dispatch);
+        slot.writes = std::move(alias_writes);
+        ctx.dispatch_slot_cursor =
+            (ctx.dispatch_slot_cursor + 1) % ctx.dispatch_slots.size();
+        ctx.ring_deferred_dispatches++;
+        // Provisional. The real verdict is folded into ctx.pending_all_ok on consume, which the
+        // caller reads after draining -- a deferred failure must not read as success.
+        return true;
+    }
     return finish_dispatch();
 }
 
@@ -10662,6 +10841,17 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
                     item.submit_no, item.command_order, 0, 0, false});
         }
         if (context.device_lost) break;
+    }
+
+    // #3157: every dispatch the ring deferred must be consumed before this call returns. The
+    // guest may read its memory as soon as the submit completes, and the writebacks live in
+    // those slots -- so this drain is what makes deferral invisible to the guest rather than a
+    // visible reordering. It also has to run on the device-lost path, or the slots leak their
+    // Vulkan handles.
+    if (!context.dispatch_slots.empty()) {
+        context.drain_dispatch_ring();
+        all_ok = all_ok && context.pending_all_ok;
+        context.pending_all_ok = true;
     }
     if (timing_enabled) {
         const double elapsed = std::chrono::duration<double, std::milli>(

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5528,6 +5528,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         return reinterpret_cast<uint8_t*>(uintptr_t(resource->gpu_addr));
     };
 
+    // #3157: hoisted out of the do-block so the deferred post-submit phase, which is
+    // constructed after that block, can still see them. `compare_targets` holds raw pointers into
+    // `buffers`/`images`; moving those vectors transfers the allocation rather than relocating
+    // elements, so the pointers stay valid across the move into the deferred phase.
+    struct CompareTarget {
+        VkBuffer current = VK_NULL_HANDLE;
+        VkBuffer baseline = VK_NULL_HANDLE;
+        VkDeviceSize bytes = 0;
+        VkAccessFlags current_src_access = 0;
+        BoundBuffer* buffer = nullptr;
+        BoundImage* image = nullptr;
+    };
+    std::vector<CompareTarget> compare_targets;
+    bool image_timing = false;
     do {
         std::vector<VkDescriptorSetLayoutBinding> layout_bindings(descriptors.size());
         for (size_t descriptor_index = 0; descriptor_index < descriptors.size();
@@ -5885,7 +5899,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             images_ready = false;
         };
-        const bool image_timing =
+        image_timing =
             image_timing_requested && timing_item_selected &&
             (!timing_capture_only || perf_capture_timing) &&
             (!timing_trace_only || trace);
@@ -8291,15 +8305,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // one flag. Exact-width image bytes are canonical; raw-uvec4 image bytes enter this path
         // only for proven-full write-only targets. The optimization is deliberately limited to
         // whole uvec4s; unaligned byte counts retain the collision-free CPU comparison below.
-        struct CompareTarget {
-            VkBuffer current = VK_NULL_HANDLE;
-            VkBuffer baseline = VK_NULL_HANDLE;
-            VkDeviceSize bytes = 0;
-            VkAccessFlags current_src_access = 0;
-            BoundBuffer* buffer = nullptr;
-            BoundImage* image = nullptr;
-        };
-        std::vector<CompareTarget> compare_targets;
         for (BoundBuffer& buffer : buffers) {
             if (buffer.alias_of == SIZE_MAX && buffer.writable && buffer.persistent &&
                 buffer.upload_skipped && buffer.result_baseline && buffer.resource->size &&

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5411,7 +5411,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // Shared failure handling for both the declining and the non-declining helpers below. A
     // VK_ERROR_DEVICE_LOST is fatal wherever it happens, including in optional setup, so it is
     // reported and latched here rather than in either caller.
-    auto vk_note_failure = [&](VkResult result, const char* stage) {
+    // Explicit captures, all copy-safe, so this helper can be carried into a deferred phase:
+    // `ctx` outlives every dispatch, `item` belongs to the caller's batch vector which outlives
+    // the whole submit, and `trace` is a bool. A [&] capture here would dangle the moment
+    // execute_item's frame dies (#3157).
+    auto vk_note_failure = [&ctx, &item, trace](VkResult result, const char* stage) {
         if (result == VK_ERROR_DEVICE_LOST && !ctx.device_lost) {
             ctx.device_lost = true;
             std::fprintf(stderr,
@@ -5430,7 +5434,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // Declining forms: the dispatch cannot proceed, so the census must name the refusal.
     // `stage` is a string literal at every call site, and a Vulkan failure is already identified by
     // the stage that produced it, so the stage name is the reason.
-    auto vk_ok = [&](VkResult result, const char* stage) {
+    auto vk_ok = [vk_note_failure, decline](VkResult result, const char* stage) {
         if (result == VK_SUCCESS) return true;
         vk_note_failure(result, stage);
         return decline(stage);
@@ -5449,7 +5453,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // count — for a dispatch that then executed, which is precisely the class of misread instrument
     // this change exists to end. A census that names non-events is worse than no census, because the
     // count is what invites trust.
-    auto vk_soft_ok = [&](VkResult result, const char* stage) {
+    auto vk_soft_ok = [vk_note_failure](VkResult result, const char* stage) {
         if (result == VK_SUCCESS) return true;
         vk_note_failure(result, stage);
         return false;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5541,6 +5541,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         BoundImage* image = nullptr;
     };
     std::vector<CompareTarget> compare_targets;
+    bool submitted_dispatch = false;
     bool image_timing = false;
     do {
         std::vector<VkDescriptorSetLayoutBinding> layout_bindings(descriptors.size());
@@ -9028,340 +9029,187 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 : vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
         }
         if (!vk_ok(compute_submit_rc, "queue-submit")) break;
-        // #3157 step B1: the whole post-submit phase -- fence wait, its failure handling, GPU
-        // timestamps, and the consume tail -- as ONE callable. Immediately invoked here, so
-        // behaviour is unchanged. This is the unit a dispatch ring defers: cleanup() (run in
-        // the epilogue) destroys the compare-flags buffer the consume reads, so the boundary
-        // has to enclose the wait, not sit after it.
-        auto wait_and_consume = [&]() -> bool {
-            if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
-            const auto fence_wait_start = ComputeClock::now();
-            const VkResult wait_result = vkWaitForFences(
-                ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
-            // Report a LONG wait even when it succeeds.
-            //
-            // A zero timeout count was read as proof that no compute dispatch hangs. That inference has a
-            // hole: an amdgpu context reset SIGNALS pending fences, so a dispatch the kernel watchdog
-            // killed can return VK_SUCCESS here and look indistinguishable from one that finished in
-            // microseconds — with the loss surfacing only at the NEXT submit. Duration is what separates
-            // them: a killed job sits at roughly the kernel's timeout (~10 s), a real one is sub-millisecond.
-            {
-                const double waited_ms = std::chrono::duration<double, std::milli>(
-                    ComputeClock::now() - fence_wait_start).count();
-                if (waited_ms >= 100.0) {
-                    static std::atomic<int> slow{0};
-                    const int n = slow.fetch_add(1);
-                    if (n < 24 || (n & 255) == 0)
+        submitted_dispatch = true;
+    } while (false);
+
+    // #3157 step B1: the whole post-submit phase -- fence wait, its failure handling, GPU
+    // timestamps, and the consume tail -- as ONE callable. Immediately invoked here, so
+    // behaviour is unchanged. This is the unit a dispatch ring defers: cleanup() (run in
+    // the epilogue) destroys the compare-flags buffer the consume reads, so the boundary
+    // has to enclose the wait, not sit after it.
+    auto wait_and_consume = [&]() -> bool {
+        if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
+        const auto fence_wait_start = ComputeClock::now();
+        const VkResult wait_result = vkWaitForFences(
+            ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
+        // Report a LONG wait even when it succeeds.
+        //
+        // A zero timeout count was read as proof that no compute dispatch hangs. That inference has a
+        // hole: an amdgpu context reset SIGNALS pending fences, so a dispatch the kernel watchdog
+        // killed can return VK_SUCCESS here and look indistinguishable from one that finished in
+        // microseconds — with the loss surfacing only at the NEXT submit. Duration is what separates
+        // them: a killed job sits at roughly the kernel's timeout (~10 s), a real one is sub-millisecond.
+        {
+            const double waited_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - fence_wait_start).count();
+            if (waited_ms >= 100.0) {
+                static std::atomic<int> slow{0};
+                const int n = slow.fetch_add(1);
+                if (n < 24 || (n & 255) == 0)
+                    std::fprintf(stderr,
+                                 "[compute] SLOW fence wait %.1f ms result=%d program=0x%llx "
+                                 "submit=%llu dispatch=%llu order=%llu groups=%ux%ux%u\n",
+                                 waited_ms, static_cast<int>(wait_result),
+                                 static_cast<unsigned long long>(item.code_addr),
+                                 static_cast<unsigned long long>(item.submit_no),
+                                 static_cast<unsigned long long>(item.dispatch_index),
+                                 static_cast<unsigned long long>(item.command_order),
+                                 item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
+            }
+        }
+        if (!vk_ok(wait_result, "queue-wait")) {
+            // cleanup() releases resources referenced by the command buffer, including a borrowed
+            // renderer image's pin. With that image bound, in-flight work still references it and
+            // its layout transitions, so drain the queue first rather than freeing it underneath
+            // the GPU.
+            // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
+            // to success; this item stays failed either way, which is the conservative choice for a
+            // dispatch whose results we can no longer trust.
+            if (!ctx.device_lost) {
+                std::unique_lock<std::mutex> qlk(
+                    prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
+                if (prosper::gpu::shared_present_active()) qlk.lock();
+                const VkResult drain_result = vkQueueWaitIdle(ctx.queue);
+                completion_proven = drain_result == VK_SUCCESS;
+                // Soft: this drain runs INSIDE the queue-wait failure path, which has already
+                // declined. Declining again would report one fence timeout as two refusals.
+                if (!vk_soft_ok(drain_result, "queue-drain") && trace)
+                    std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
+            }
+            return false;   // was `break` out of the do/while(false)
+        }
+        completion_proven = true;
+        if (perf_gpu_timing) {
+            uint64_t timestamps[6]{};
+            if (vkGetQueryPoolResults(ctx.device, ctx.dispatch_timestamp_pool, 0, 6,
+                                      sizeof(timestamps), timestamps, sizeof(uint64_t),
+                                      VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
+                const uint64_t mask = ctx.timestamp_valid_bits >= 64
+                    ? UINT64_MAX : ((uint64_t{1} << ctx.timestamp_valid_bits) - 1u);
+                const uint64_t device_ticks = (timestamps[5] - timestamps[0]) & mask;
+                const uint64_t shader_ticks = (timestamps[2] - timestamps[1]) & mask;
+                ++g_perf_compute_gpu_timestamp_samples;
+                g_perf_compute_gpu_device_ms +=
+                    static_cast<double>(device_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_shader_ms +=
+                    static_cast<double>(shader_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_pre_ms += static_cast<double>(
+                    (timestamps[1] - timestamps[0]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_storage_copy_ms += static_cast<double>(
+                    (timestamps[3] - timestamps[2]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_compare_ms += static_cast<double>(
+                    (timestamps[4] - timestamps[3]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_restore_ms += static_cast<double>(
+                    (timestamps[5] - timestamps[4]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+            }
+        }
+        if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
+        phase_dispatch = ComputeClock::now();
+        // #3157 step A: the consume tail as one callable unit. Immediately invoked here, so
+        // behaviour is unchanged -- this only proves the tail is a coherent block with known
+        // escapes before it is deferred behind a dispatch ring.
+        auto consume_dispatch = [&]() -> bool {
+            const auto writeback_prepare_start = phase_dispatch;
+
+            if (!compare_targets.empty()) {
+                void* mapped = nullptr;
+                const VkDeviceSize flag_stride = ctx.compare_flag_stride();
+                if (ctx.map_memory(compare_flags_memory, 0,
+                                   compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
+                    // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
+                    // target would read the padding between flags on any device whose alignment exceeds
+                    // four, reporting every target after the first as unchanged.
+                    const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
+                    for (size_t j = 0; j < compare_targets.size(); ++j) {
+                        CompareTarget& target = compare_targets[j];
+                        uint32_t changed = 0;
+                        std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
+                        if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
+                        if (target.image) target.image->gpu_result_unchanged = changed == 0;
+                    }
+                    ctx.unmap_memory(compare_flags_memory);
+                }
+            }
+
+            // The fence proves every upload is complete and every sampled image is back in GENERAL.
+            // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
+            // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
+            for (BoundImage& image : images) {
+                if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
+                    !image.cache_candidate)
+                    continue;
+                // When this dispatch samples and writes the same guest view through distinct bindings,
+                // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
+                // would occupy the identical key before storage writeback can retain the actual result.
+                const bool replaced_by_storage = std::any_of(
+                    images.begin(), images.end(), [&](const BoundImage& candidate) {
+                        return candidate.storage && candidate.cache_candidate &&
+                               candidate.cache_key == image.cache_key;
+                    });
+                if (replaced_by_storage) continue;
+                if (image.persistent) {
+                    if (!image.upload_skipped) {
+                        if (image.compute_transfer_seed_borrowed)
+                            ctx.validate_cached_image_source_from_compute_transfer(
+                                image.cache_key);
+                        else
+                            ctx.validate_cached_image_source(image.cache_key);
+                    }
+                } else if (image.image && image.memory && image.allocation_bytes &&
+                           (image.cache_source_snapshot.empty()
+                                ? ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                   image.allocation_bytes,
+                                                   static_cast<const uint8_t*>(nullptr))
+                                : ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                   image.allocation_bytes,
+                                                   std::move(image.cache_source_snapshot)))) {
+                    image.persistent = true;
+                    if (trace)
                         std::fprintf(stderr,
-                                     "[compute] SLOW fence wait %.1f ms result=%d program=0x%llx "
-                                     "submit=%llu dispatch=%llu order=%llu groups=%ux%ux%u\n",
-                                     waited_ms, static_cast<int>(wait_result),
-                                     static_cast<unsigned long long>(item.code_addr),
-                                     static_cast<unsigned long long>(item.submit_no),
-                                     static_cast<unsigned long long>(item.dispatch_index),
-                                     static_cast<unsigned long long>(item.command_order),
-                                     item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
+                                     "[compute]   retained sampled image binding=%u addr=0x%llx "
+                                     "allocation=%llu\n",
+                                     image.binding,
+                                     (unsigned long long)image.resource->gpu_addr,
+                                     (unsigned long long)image.allocation_bytes);
                 }
             }
-            if (!vk_ok(wait_result, "queue-wait")) {
-                // cleanup() releases resources referenced by the command buffer, including a borrowed
-                // renderer image's pin. With that image bound, in-flight work still references it and
-                // its layout transitions, so drain the queue first rather than freeing it underneath
-                // the GPU.
-                // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
-                // to success; this item stays failed either way, which is the conservative choice for a
-                // dispatch whose results we can no longer trust.
-                if (!ctx.device_lost) {
-                    std::unique_lock<std::mutex> qlk(
-                        prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
-                    if (prosper::gpu::shared_present_active()) qlk.lock();
-                    const VkResult drain_result = vkQueueWaitIdle(ctx.queue);
-                    completion_proven = drain_result == VK_SUCCESS;
-                    // Soft: this drain runs INSIDE the queue-wait failure path, which has already
-                    // declined. Declining again would report one fence timeout as two refusals.
-                    if (!vk_soft_ok(drain_result, "queue-drain") && trace)
-                        std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
-                }
-                return false;   // was `break` out of the do/while(false)
-            }
-            completion_proven = true;
-            if (perf_gpu_timing) {
-                uint64_t timestamps[6]{};
-                if (vkGetQueryPoolResults(ctx.device, ctx.dispatch_timestamp_pool, 0, 6,
-                                          sizeof(timestamps), timestamps, sizeof(uint64_t),
-                                          VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
-                    const uint64_t mask = ctx.timestamp_valid_bits >= 64
-                        ? UINT64_MAX : ((uint64_t{1} << ctx.timestamp_valid_bits) - 1u);
-                    const uint64_t device_ticks = (timestamps[5] - timestamps[0]) & mask;
-                    const uint64_t shader_ticks = (timestamps[2] - timestamps[1]) & mask;
-                    ++g_perf_compute_gpu_timestamp_samples;
-                    g_perf_compute_gpu_device_ms +=
-                        static_cast<double>(device_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
-                    g_perf_compute_gpu_shader_ms +=
-                        static_cast<double>(shader_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
-                    g_perf_compute_gpu_pre_ms += static_cast<double>(
-                        (timestamps[1] - timestamps[0]) & mask) *
-                        ctx.timestamp_period_ns / 1'000'000.0;
-                    g_perf_compute_gpu_storage_copy_ms += static_cast<double>(
-                        (timestamps[3] - timestamps[2]) & mask) *
-                        ctx.timestamp_period_ns / 1'000'000.0;
-                    g_perf_compute_gpu_compare_ms += static_cast<double>(
-                        (timestamps[4] - timestamps[3]) & mask) *
-                        ctx.timestamp_period_ns / 1'000'000.0;
-                    g_perf_compute_gpu_restore_ms += static_cast<double>(
-                        (timestamps[5] - timestamps[4]) & mask) *
-                        ctx.timestamp_period_ns / 1'000'000.0;
-                }
-            }
-            if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
-            phase_dispatch = ComputeClock::now();
-            // #3157 step A: the consume tail as one callable unit. Immediately invoked here, so
-            // behaviour is unchanged -- this only proves the tail is a coherent block with known
-            // escapes before it is deferred behind a dispatch ring.
-            auto consume_dispatch = [&]() -> bool {
-                const auto writeback_prepare_start = phase_dispatch;
 
-                if (!compare_targets.empty()) {
-                    void* mapped = nullptr;
-                    const VkDeviceSize flag_stride = ctx.compare_flag_stride();
-                    if (ctx.map_memory(compare_flags_memory, 0,
-                                       compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
-                        // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
-                        // target would read the padding between flags on any device whose alignment exceeds
-                        // four, reporting every target after the first as unchanged.
-                        const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
-                        for (size_t j = 0; j < compare_targets.size(); ++j) {
-                            CompareTarget& target = compare_targets[j];
-                            uint32_t changed = 0;
-                            std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
-                            if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
-                            if (target.image) target.image->gpu_result_unchanged = changed == 0;
-                        }
-                        ctx.unmap_memory(compare_flags_memory);
-                    }
-                }
-
-                // The fence proves every upload is complete and every sampled image is back in GENERAL.
-                // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
-                // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
-                for (BoundImage& image : images) {
-                    if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
-                        !image.cache_candidate)
-                        continue;
-                    // When this dispatch samples and writes the same guest view through distinct bindings,
-                    // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
-                    // would occupy the identical key before storage writeback can retain the actual result.
-                    const bool replaced_by_storage = std::any_of(
-                        images.begin(), images.end(), [&](const BoundImage& candidate) {
-                            return candidate.storage && candidate.cache_candidate &&
-                                   candidate.cache_key == image.cache_key;
-                        });
-                    if (replaced_by_storage) continue;
-                    if (image.persistent) {
-                        if (!image.upload_skipped) {
-                            if (image.compute_transfer_seed_borrowed)
-                                ctx.validate_cached_image_source_from_compute_transfer(
-                                    image.cache_key);
-                            else
-                                ctx.validate_cached_image_source(image.cache_key);
-                        }
-                    } else if (image.image && image.memory && image.allocation_bytes &&
-                               (image.cache_source_snapshot.empty()
-                                    ? ctx.retain_image(image.cache_key, image.image, image.memory,
-                                                       image.allocation_bytes,
-                                                       static_cast<const uint8_t*>(nullptr))
-                                    : ctx.retain_image(image.cache_key, image.image, image.memory,
-                                                       image.allocation_bytes,
-                                                       std::move(image.cache_source_snapshot)))) {
-                        image.persistent = true;
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   retained sampled image binding=%u addr=0x%llx "
-                                         "allocation=%llu\n",
-                                         image.binding,
-                                         (unsigned long long)image.resource->gpu_addr,
-                                         (unsigned long long)image.allocation_bytes);
-                    }
-                }
-
-                writeback_prepare_ms = std::chrono::duration<double, std::milli>(
-                    ComputeClock::now() - writeback_prepare_start).count();
-                const auto writeback_buffers_start = ComputeClock::now();
-                bool readback_ok = true;
-                for (auto& buffer : buffers) {
-                    if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
-                    // The exact GPU comparator saw the same bytes as the retained baseline, while source
-                    // validation independently proved that the guest mirror still contains that baseline.
-                    // Preserve architectural write notification, but avoid mapping and scanning the whole
-                    // host-visible buffer merely to rediscover equality.
-                    if (buffer.gpu_result_unchanged) {
-                        g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   skipped GPU-identical buffer writeback binding=%u "
-                                         "addr=0x%llx bytes=%u\n",
-                                         buffer.resource->binding,
-                                         (unsigned long long)buffer.resource->gpu_addr,
-                                         buffer.resource->size);
-                        if (buffer.resource->gpu_addr)
-                            notify_guest_gpu_write_preserving_bytes(
-                                buffer.resource->gpu_addr, buffer.resource->size);
-                        if (buffer.persistent)
-                            ctx.validate_cached_buffer_source(buffer.cache_key);
-                        if (!buffer.resource->host_data && writer_provenance_enabled())
-                            record_guest_write(GuestWriterKind::ComputeBuffer,
-                                               buffer.resource->gpu_addr, buffer.resource->size,
-                                               item.submit_no, item.dispatch_index,
-                                               item.command_order, item.code_addr);
-                        continue;
-                    }
-                    void* mapped = nullptr;
-                    if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
-                        readback_ok = false;
-                        break;
-                    }
-                    uint8_t* destination = buffer.atomic_image
-                        ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
-                        : resource_bytes_for(buffer.resource, buffer.guest_bytes);
-                    const auto* result = static_cast<const uint8_t*>(mapped);
-                    if (buffer.atomic_image) {
-                        if (trace) {
-                            buffer.after_hash = fnv1a(result, buffer.bytes);
-                            for (size_t i = 0; i < buffer.bytes; ++i)
-                                buffer.changed_bytes += buffer.linear_seed[i] != result[i];
-                        }
-                        if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                            prosper::host::guest_write_watch_notify_host_write(
-                                buffer.resource->gpu_addr, buffer.guest_bytes);
-                        // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
-                        const size_t layer_linear_bytes =
-                            static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
-                        for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
-                            uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
-                            const uint8_t* src = result + layer * layer_linear_bytes;
-                            if (buffer.resource->tile_mode) {
-                                tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
-                                             buffer.resource->tile_mode, 0, sizeof(uint32_t));
-                            } else {
-                                const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
-                                const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
-                                    ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
-                                for (uint32_t y = 0; y < buffer.resource->height; ++y)
-                                    std::memcpy(dst + y * destination_pitch,
-                                                src + y * tight_pitch, tight_pitch);
-                            }
-                        }
-                        ctx.unmap_memory(buffer.memory);
-                        if (buffer.resource->gpu_addr) {
-                            set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
-                            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
-                            set_guest_gpu_write_origin(nullptr);
-                        }
-                        if (!buffer.resource->host_data && writer_provenance_enabled())
-                            record_guest_write(GuestWriterKind::ComputeBuffer,
-                                               buffer.resource->gpu_addr, buffer.guest_bytes,
-                                               item.submit_no, item.dispatch_index,
-                                               item.command_order, item.code_addr);
-                        continue;
-                    }
-                    const bool changed = !compute_buffers_equal(
-                        destination, result, buffer.bytes);
-                    if (trace) {
-                        buffer.after_hash = fnv1a(result, buffer.bytes);
-                        for (size_t i = 0; i < buffer.bytes; i++)
-                            buffer.changed_bytes += destination[i] != result[i];
-                        // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
-                        //
-                        // `changed_bytes` says how much moved and nothing about where, which is the only
-                        // question that separates a wrong VALUE from a wrong INDEX. For a structure written
-                        // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
-                        // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
-                        // count or a hash.
-                        // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
-                        // merged and writability is ORed onto the first owner, so the owner's binding is
-                        // NOT evidence that the owner performed the store: a read-only binding followed by
-                        // a writable exact alias reports as though the first wrote, and with several
-                        // writable aliases no single store site can be named at all. The changed indices
-                        // below are allocation-level evidence and stand on their own; the binding is
-                        // reported as `owner-binding` with the alias count beside it so a reader cannot
-                        // mistake it for attribution.
-                        size_t alias_count = 0;
-                        for (const auto& other : buffers)
-                            if (other.alias_of != SIZE_MAX &&
-                                &buffers[other.alias_of] == &buffer) ++alias_count;
-                        if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
-                            char* end = nullptr;
-                            const unsigned long limit = std::strtoul(limit_env, &end, 0);
-                            if (end && !*end && limit) {
-                                // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
-                                // storage and `result` is mapped device memory, and neither contract
-                                // promises uint32_t alignment or a uint32_t object lifetime there. The byte
-                                // bound below deliberately ignores a partial trailing dword.
-                                const size_t dwords = buffer.bytes / sizeof(uint32_t);
-                                const auto load_dword = [](const uint8_t* bytes, size_t index) {
-                                    uint32_t value = 0;
-                                    std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
-                                    return value;
-                                };
-                                unsigned long shown = 0;
-                                for (size_t i = 0; i < dwords && shown < limit; ++i) {
-                                    const uint32_t before_value = load_dword(destination, i);
-                                    const uint32_t after_value = load_dword(result, i);
-                                    if (before_value == after_value) continue;
-                                    // Carry submit/dispatch on EVERY line. Without them the lines from
-                                    // consecutive dispatches concatenate into one stream that looks like a
-                                    // single dispatch's writes -- and a per-dispatch structural claim built
-                                    // on that stream is meaningless. The first analysis run here did exactly
-                                    // that and reported one index changing twice in "one" dispatch.
-                                    std::fprintf(stderr,
-                                                 "[compute]     changed submit=%llu dispatch=%llu "
-                                                 "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
-                                                 "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
-                                                 (unsigned long long)item.submit_no,
-                                                 (unsigned long long)item.dispatch_index,
-                                                 (unsigned long long)(buffer.resource
-                                                     ? buffer.resource->gpu_addr : 0ull),
-                                                 buffer.resource ? buffer.resource->binding : 0u,
-                                                 alias_count, i,
-                                                 before_value, after_value, after_value & 7u,
-                                                 (after_value >> 30) & 1u,
-                                                 (after_value >> 3) & 0x07FFFFFFu);
-                                    ++shown;
-                                }
-                            }
-                        }
-                    }
-                    // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
-                    // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
-                    // after its first dispatch all later readbacks are identical. Avoiding the redundant host
-                    // write removes one full pass over both source and destination. Renderer-alias
-                    // invalidation and writer provenance remain unconditional: renderer-resident state can
-                    // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
-                    if (changed) {
-                        if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                            prosper::host::guest_write_watch_notify_host_write(
-                                buffer.resource->gpu_addr, buffer.resource->size);
-                        copy_compute_buffer(destination, result, buffer.bytes);
-                    }
-                    if (buffer.persistent && !buffer.result_baseline &&
-                        ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
+            writeback_prepare_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_prepare_start).count();
+            const auto writeback_buffers_start = ComputeClock::now();
+            bool readback_ok = true;
+            for (auto& buffer : buffers) {
+                if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
+                // The exact GPU comparator saw the same bytes as the retained baseline, while source
+                // validation independently proved that the guest mirror still contains that baseline.
+                // Preserve architectural write notification, but avoid mapping and scanning the whole
+                // host-visible buffer merely to rediscover equality.
+                if (buffer.gpu_result_unchanged) {
+                    g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
+                    if (trace)
                         std::fprintf(stderr,
-                                     "[compute]   retained exact GPU buffer result baseline binding=%u "
+                                     "[compute]   skipped GPU-identical buffer writeback binding=%u "
                                      "addr=0x%llx bytes=%u\n",
                                      buffer.resource->binding,
                                      (unsigned long long)buffer.resource->gpu_addr,
                                      buffer.resource->size);
-                    ctx.unmap_memory(buffer.memory);
-                    if (buffer.resource->gpu_addr) {
-                        if (changed) {
-                            set_guest_gpu_write_origin("compute-writeback(buffer-full)");
-                            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
-                            set_guest_gpu_write_origin(nullptr);
-                        } else {
-                            notify_guest_gpu_write_preserving_bytes(
-                                buffer.resource->gpu_addr, buffer.resource->size);
-                        }
-                    }
+                    if (buffer.resource->gpu_addr)
+                        notify_guest_gpu_write_preserving_bytes(
+                            buffer.resource->gpu_addr, buffer.resource->size);
                     if (buffer.persistent)
                         ctx.validate_cached_buffer_source(buffer.cache_key);
                     if (!buffer.resource->host_data && writer_provenance_enabled())
@@ -9369,500 +9217,658 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                            buffer.resource->gpu_addr, buffer.resource->size,
                                            item.submit_no, item.dispatch_index,
                                            item.command_order, item.code_addr);
+                    continue;
                 }
-                writeback_buffers_ms = std::chrono::duration<double, std::milli>(
-                    ComputeClock::now() - writeback_buffers_start).count();
-                if (!readback_ok) return false;   // was `break` out of the do-while; the call
-                                                  // site turns a false return back into that break
-                const auto writeback_images_start = ComputeClock::now();
-                // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
-                // into the guest format, then restore its linear or 3D tiled address layout and notify the
-                // render side exactly like the buffer path.
-                for (size_t i = 0; i < images.size() && readback_ok; i++) {
-                    BoundImage& bi = images[i];
-                    if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
-                    const auto image_writeback_start = ComputeClock::now();
-                    const bool image_cache_hit = bi.persistent;
-                    const ShaderResource* r = bi.resource;
-                    const uint32_t cb = data_format_bytes(r->format);
-                    const uint32_t nc = r->num_components ? r->num_components : 1;
-                    const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
-                                                r->format == DataFormat::Unorm2_10_10_10)
-                        ? 4u : (size_t)cb * nc;
-                    const size_t texels = (size_t)r->width * r->height * r->depth;
-                    const size_t linear_bytes = texels * guest_texel;
-                    uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
-                    // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
-                    // independently proved that the guest mirror still contains that baseline. This path
-                    // therefore needs neither a large staging mapping nor a CPU memory pass.
-                    if (bi.gpu_result_unchanged && bi.upload_skipped) {
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   skipped GPU-identical storage writeback binding=%u "
-                                         "addr=0x%llx bytes=%llu\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.exact_result_bytes);
-                        if (r->gpu_addr)
-                            notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                        continue;
-                    }
-                    void* mapped = nullptr;
-                    const auto map_start = ComputeClock::now();
-                    if (g_fail_next_storage_readback_for_test.exchange(
-                            false, std::memory_order_acq_rel)) {
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   injected storage readback failure binding=%u\n",
-                                         bi.binding);
-                        readback_ok = false;
-                        break;
-                    }
-                    if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
-                        readback_ok = false;
-                        break;
-                    }
-                    const auto map_done = ComputeClock::now();
-                    const bool array_image = backend_uses_2d_array(*r);
-                    static const bool direct_tiled_writeback_disabled =
-                        std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
-                    const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
-                        bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
-                        direct_tiled_writeback_disabled);
-                    std::unique_ptr<uint8_t[]> linear;
-                    uint8_t* packed = destination;
-                    if ((r->tile_mode && !tile_mapped_bytes) ||
-                        (!r->tile_mode && array_image && r->depth > 1)) {
-                        linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
-                        packed = linear.get();
-                    }
-                    const uint32_t* channels = static_cast<const uint32_t*>(mapped);
-                    const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
-                    // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
-                    // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
-                    // that guest memory still contains the prior result, and this dispatch reproduced the
-                    // same row-major bytes. If either comparison fails, take the ordinary writeback below.
-                    const bool repeated_output = bi.cache_candidate && bi.persistent &&
-                        bi.upload_skipped && bi.exact_storage_bytes() &&
-                        ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
-                    const auto prepare_done = ComputeClock::now();
-                    if (repeated_output) {
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   skipped identical storage writeback binding=%u "
-                                         "addr=0x%llx bytes=%llu\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.exact_result_bytes);
-                        ctx.unmap_memory(staging_memory[i]);
-                        if (r->gpu_addr)
-                            notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                        continue;
-                    }
-                    // Notify page-based dirty trackers only when bytes will actually be written. Doing this
-                    // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
-                    // even on the no-write path, defeating the validation that made that path safe.
-                    if (!r->host_data && r->gpu_addr)
-                        prosper::host::guest_write_watch_notify_host_write(
-                            r->gpu_addr, bi.guest_bytes);
-                    const auto watch_done = ComputeClock::now();
-                    // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
-                    // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
-                    // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
-                    // and, for a partial write, restore the un-stored texels from the clean seed after packing.
-                    std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
-                    if (bi.poison_verify) {
-                        size_t survived = 0;
-                        poison_texel.assign(texels, 0);
-                        for (size_t t = 0; t < texels; ++t) {
-                            bool all = true;
-                            if (bi.exact_storage_bytes()) {
-                                const uint8_t* texel = native_texels + t * guest_texel;
-                                for (size_t b = 0; b < guest_texel; ++b)
-                                    if (texel[b] != 0x5a) all = false;
-                            } else {
-                                for (uint32_t c = 0; c < 4; ++c)
-                                    if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
-                            }
-                            if (all) { ++survived; poison_texel[t] = 1; }
-                        }
-                        {
-                            const SeedCoverageKey proof_key{item.code_addr, bi.binding,
-                                                            r->width, r->height, r->depth};
-                            std::lock_guard<std::mutex> lk(seed_coverage_mu);
-                            // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                            seed_coverage_proof[proof_key] =
-                                SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
-                        }
-                        std::fprintf(stderr,
-                                     "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
-                                     (unsigned long long)item.code_addr, bi.binding, texels, survived,
-                                     survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
-                    }
+                void* mapped = nullptr;
+                if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
+                    readback_ok = false;
+                    break;
+                }
+                uint8_t* destination = buffer.atomic_image
+                    ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
+                    : resource_bytes_for(buffer.resource, buffer.guest_bytes);
+                const auto* result = static_cast<const uint8_t*>(mapped);
+                if (buffer.atomic_image) {
                     if (trace) {
-                        if (bi.exact_storage_bytes()) {
-                            for (size_t t = 0; t < texels; ++t) {
-                                const uint8_t* texel = native_texels + t * guest_texel;
-                                for (size_t b = 0; b < guest_texel; ++b)
-                                    bi.nonzero_channels += texel[b] != 0;
-                            }
+                        buffer.after_hash = fnv1a(result, buffer.bytes);
+                        for (size_t i = 0; i < buffer.bytes; ++i)
+                            buffer.changed_bytes += buffer.linear_seed[i] != result[i];
+                    }
+                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                        prosper::host::guest_write_watch_notify_host_write(
+                            buffer.resource->gpu_addr, buffer.guest_bytes);
+                    // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
+                    const size_t layer_linear_bytes =
+                        static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
+                    for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
+                        uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
+                        const uint8_t* src = result + layer * layer_linear_bytes;
+                        if (buffer.resource->tile_mode) {
+                            tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
+                                         buffer.resource->tile_mode, 0, sizeof(uint32_t));
                         } else {
-                            for (size_t t = 0; t < texels; t++)
-                                for (uint32_t c = 0; c < 4; c++)
-                                    bi.nonzero_channels += channels[t * 4 + c] != 0;
+                            const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
+                            const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
+                                ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
+                            for (uint32_t y = 0; y < buffer.resource->height; ++y)
+                                std::memcpy(dst + y * destination_pitch,
+                                            src + y * tight_pitch, tight_pitch);
                         }
                     }
-                    const auto pack_start = ComputeClock::now();
-                    static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
-                    if (bi.exact_storage_bytes()) {
-                        // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
-                        // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
-                        // non-proving write can feed those bytes straight to the tiler, avoiding a second
-                        // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
-                        if (!tile_mapped_bytes)
-                            parallel_compute_texels(texels, linear_bytes * 2,
-                                [&](size_t begin, size_t end) {
-                                    std::memcpy(packed + begin * guest_texel,
-                                                native_texels + begin * guest_texel,
-                                                (end - begin) * guest_texel);
-                                });
-                    } else if (pack_range_enabled) {
-                        storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
-                    } else {
-                        for (size_t t = 0; t < texels; t++)
-                            storage_pack_texel(channels + t * 4, r->format, nc,
-                                               packed + t * guest_texel);
+                    ctx.unmap_memory(buffer.memory);
+                    if (buffer.resource->gpu_addr) {
+                        set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
+                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
+                        set_guest_gpu_write_origin(nullptr);
                     }
-                    // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
-                    // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
-                    // content (exactly a partial write's contract). Full-coverage proving frames have no
-                    // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
-                    if (bi.poison_verify && !poison_texel.empty() &&
-                        bi.seed_linear.size() == linear_bytes) {
-                        for (size_t t = 0; t < texels; ++t) {
-                            if (poison_texel[t])
-                                std::memcpy(packed + t * guest_texel,
-                                            bi.seed_linear.data() + t * guest_texel, guest_texel);
-                        }
-                    }
-                    const auto pack_done = ComputeClock::now();
-                    static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
-                    if (verify_pack && !bi.exact_storage_bytes()) {
-                        // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
-                        // be bit-identical to the per-texel path it replaces, verified against the real
-                        // workload's texels. Logs the clean case too, so a verified run is self-proving.
-                        std::vector<uint8_t> expect(guest_texel);
-                        size_t bad = 0, first_bad = 0;
-                        for (size_t t = 0; t < texels; ++t) {
-                            std::memset(expect.data(), 0, expect.size());
-                            storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
-                            if (std::memcmp(expect.data(), packed + t * guest_texel,
-                                            guest_texel) != 0) {
-                                if (!bad) first_bad = t;
-                                ++bad;
-                            }
-                        }
-                        std::fprintf(stderr,
-                                     "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
-                                     "texels=%zu mismatches=%zu%s\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
-                                     nc, texels, bad, bad ? " MISMATCH" : "");
-                        if (bad)
-                            std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
-                                         first_bad);
-                    }
-                    const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
-                    if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
-                        if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
-                                         r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
-                            readback_ok = false;
-                            ctx.unmap_memory(staging_memory[i]);
-                            break;
-                        }
-                    } else if (array_image && r->depth > 1) {
-                        const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
-                        const size_t selected_slice = r->in_mip_tail
-                            ? r->mip_tail_bytes
-                            : (r->tile_mode
-                                   ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
-                                                         static_cast<uint32_t>(guest_texel))
-                                   : (r->layer_stride_bytes
-                                          ? linear_array_surface_bytes(
-                                                *r, static_cast<uint32_t>(guest_texel))
-                                          : linear_slice));
-                        const size_t layer_stride = r->layer_stride_bytes
-                            ? r->layer_stride_bytes : selected_slice;
-                        for (uint32_t layer = 0; layer < r->depth; ++layer) {
-                            uint8_t* layer_base = destination + layer_stride * layer;
-                            if (!r->tile_mode) {
-                                const size_t row_pitch = r->layer_stride_bytes
-                                    ? linear_array_row_pitch(
-                                          *r, static_cast<uint32_t>(guest_texel))
-                                    : static_cast<size_t>(r->width) * guest_texel;
-                                for (uint32_t y = 0; y < r->height; ++y)
-                                    std::memcpy(
-                                        layer_base + r->layer_mip_offset_bytes + y * row_pitch,
-                                        layout_source + linear_slice * layer +
-                                            static_cast<size_t>(y) * r->width * guest_texel,
-                                        static_cast<size_t>(r->width) * guest_texel);
-                            } else if (r->in_mip_tail) {
-                                tile_surface_level(
-                                    layer_base, r->mip_tail_bytes,
-                                    layout_source + linear_slice * layer,
-                                    r->width, r->height, r->tile_mode,
-                                    static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
-                            } else {
-                                tile_surface(
-                                    layer_base + r->layer_mip_offset_bytes,
-                                    layout_source + linear_slice * layer,
-                                    r->width, r->height, r->tile_mode, 0,
-                                    static_cast<uint32_t>(guest_texel));
-                            }
-                        }
-                    } else if (r->tile_mode && r->in_mip_tail) {
-                        tile_surface_level(destination, bi.guest_bytes, layout_source,
-                                           r->width, r->height, r->tile_mode,
-                                           static_cast<uint32_t>(guest_texel),
-                                           r->mip_tail_x, r->mip_tail_y);
-                    } else if (r->tile_mode) {
-                        tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
-                                     static_cast<uint32_t>(guest_texel));
-                    }
-                    const auto layout_done = ComputeClock::now();
-                    pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
-                    layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
-                    if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
-                    const auto notify_start = ComputeClock::now();
-                    // Name the writer. "a guest write covers this surface" and "prosper's own compute
-                    // writeback covers this surface" are different facts, and only the second says the
-                    // emulator is invalidating its own caches. Everything reaching the DS invalidation path
-                    // used to report the default `gpu`, which cannot distinguish them.
-                    set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
-                    notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
-                    set_guest_gpu_write_origin(nullptr);
-                    if (!r->host_data && writer_provenance_enabled())
+                    if (!buffer.resource->host_data && writer_provenance_enabled())
                         record_guest_write(GuestWriterKind::ComputeBuffer,
-                                           r->gpu_addr, bi.guest_bytes,
+                                           buffer.resource->gpu_addr, buffer.guest_bytes,
                                            item.submit_no, item.dispatch_index,
                                            item.command_order, item.code_addr);
-                    if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
-                        const bool leave_compressed_for_test =
-                            g_leave_next_dcc_metadata_compressed_for_test.exchange(
-                                false, std::memory_order_acq_rel);
-                        if (!leave_compressed_for_test) {
-                            std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
-                            // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
-                            // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
-                            // aspects" and invalidates depth as well as stencil. So this reset can discard a
-                            // retained depth image. Tagged so that consequence is attributable rather than
-                            // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
-                            // separate question that needs the operation's real HTILE semantics proven.
-                            set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
-                            notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
-                            set_guest_gpu_write_origin(nullptr);
-                            if (!r->dcc_metadata_host_data && writer_provenance_enabled())
-                                record_guest_write(GuestWriterKind::ComputeBuffer,
-                                                   r->metadata_addr, bi.dcc_metadata_bytes,
-                                                   item.submit_no, item.dispatch_index,
-                                                   item.command_order, item.code_addr);
-                            if (trace)
+                    continue;
+                }
+                const bool changed = !compute_buffers_equal(
+                    destination, result, buffer.bytes);
+                if (trace) {
+                    buffer.after_hash = fnv1a(result, buffer.bytes);
+                    for (size_t i = 0; i < buffer.bytes; i++)
+                        buffer.changed_bytes += destination[i] != result[i];
+                    // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
+                    //
+                    // `changed_bytes` says how much moved and nothing about where, which is the only
+                    // question that separates a wrong VALUE from a wrong INDEX. For a structure written
+                    // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
+                    // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
+                    // count or a hash.
+                    // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
+                    // merged and writability is ORed onto the first owner, so the owner's binding is
+                    // NOT evidence that the owner performed the store: a read-only binding followed by
+                    // a writable exact alias reports as though the first wrote, and with several
+                    // writable aliases no single store site can be named at all. The changed indices
+                    // below are allocation-level evidence and stand on their own; the binding is
+                    // reported as `owner-binding` with the alias count beside it so a reader cannot
+                    // mistake it for attribution.
+                    size_t alias_count = 0;
+                    for (const auto& other : buffers)
+                        if (other.alias_of != SIZE_MAX &&
+                            &buffers[other.alias_of] == &buffer) ++alias_count;
+                    if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
+                        char* end = nullptr;
+                        const unsigned long limit = std::strtoul(limit_env, &end, 0);
+                        if (end && !*end && limit) {
+                            // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
+                            // storage and `result` is mapped device memory, and neither contract
+                            // promises uint32_t alignment or a uint32_t object lifetime there. The byte
+                            // bound below deliberately ignores a partial trailing dword.
+                            const size_t dwords = buffer.bytes / sizeof(uint32_t);
+                            const auto load_dword = [](const uint8_t* bytes, size_t index) {
+                                uint32_t value = 0;
+                                std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
+                                return value;
+                            };
+                            unsigned long shown = 0;
+                            for (size_t i = 0; i < dwords && shown < limit; ++i) {
+                                const uint32_t before_value = load_dword(destination, i);
+                                const uint32_t after_value = load_dword(result, i);
+                                if (before_value == after_value) continue;
+                                // Carry submit/dispatch on EVERY line. Without them the lines from
+                                // consecutive dispatches concatenate into one stream that looks like a
+                                // single dispatch's writes -- and a per-dispatch structural claim built
+                                // on that stream is meaningless. The first analysis run here did exactly
+                                // that and reported one index changing twice in "one" dispatch.
                                 std::fprintf(stderr,
-                                             "[compute]   DCC uncompressed binding=%u meta=0x%llx "
-                                             "bytes=%zu code=0xff\n",
-                                             bi.binding, (unsigned long long)r->metadata_addr,
-                                             bi.dcc_metadata_bytes);
-                        } else if (trace) {
-                            std::fprintf(stderr,
-                                         "[compute]   injected unresolved DCC writeback binding=%u\n",
-                                         bi.binding);
+                                             "[compute]     changed submit=%llu dispatch=%llu "
+                                             "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
+                                             "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
+                                             (unsigned long long)item.submit_no,
+                                             (unsigned long long)item.dispatch_index,
+                                             (unsigned long long)(buffer.resource
+                                                 ? buffer.resource->gpu_addr : 0ull),
+                                             buffer.resource ? buffer.resource->binding : 0u,
+                                             alias_count, i,
+                                             before_value, after_value, after_value & 7u,
+                                             (after_value >> 30) & 1u,
+                                             (after_value >> 3) & 0x07FFFFFFu);
+                                ++shown;
+                            }
                         }
                     }
-                    if (bi.mirror_result_to_imported) {
-                        const BoundImage& mirror = images[bi.seed_from_imported];
-                        notify_live_render_target_image_written({
-                            r->gpu_addr, mirror.imported_width, mirror.imported_height,
-                            mirror.imported_pixel_format});
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   mirrored storage result into renderer RTT "
-                                         "binding=%u addr=0x%llx extent=%ux%u\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         mirror.imported_width, mirror.imported_height);
+                }
+                // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
+                // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
+                // after its first dispatch all later readbacks are identical. Avoiding the redundant host
+                // write removes one full pass over both source and destination. Renderer-alias
+                // invalidation and writer provenance remain unconditional: renderer-resident state can
+                // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
+                if (changed) {
+                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                        prosper::host::guest_write_watch_notify_host_write(
+                            buffer.resource->gpu_addr, buffer.resource->size);
+                    copy_compute_buffer(destination, result, buffer.bytes);
+                }
+                if (buffer.persistent && !buffer.result_baseline &&
+                    ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
+                    std::fprintf(stderr,
+                                 "[compute]   retained exact GPU buffer result baseline binding=%u "
+                                 "addr=0x%llx bytes=%u\n",
+                                 buffer.resource->binding,
+                                 (unsigned long long)buffer.resource->gpu_addr,
+                                 buffer.resource->size);
+                ctx.unmap_memory(buffer.memory);
+                if (buffer.resource->gpu_addr) {
+                    if (changed) {
+                        set_guest_gpu_write_origin("compute-writeback(buffer-full)");
+                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+                        set_guest_gpu_write_origin(nullptr);
+                    } else {
+                        notify_guest_gpu_write_preserving_bytes(
+                            buffer.resource->gpu_addr, buffer.resource->size);
                     }
-                    const auto notify_done = ComputeClock::now();
-                    bool retain_gpu_result_baseline = false;
-                    bool promoted_after_writeback = false;
-                    const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
-                        std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
-                                    [](uint8_t value) { return value == 0xff; });
-                    if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
-                        const uint8_t* retained_source =
-                            (adaptive_storage_result_validation_enabled() &&
-                             cold_storage_result_snapshot_can_defer(
-                                 r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
-                                 cold_storage_result_snapshot_defer_min_bytes()))
-                            ? nullptr : destination;
-                        if (bi.forced_seed_allocation_reused) {
-                            // The exact cache entry was already pinned and forcibly reseeded before this
-                            // dispatch. Successful writeback plus the final all-uncompressed metadata scan
-                            // may now restore source/transfer authority without replacing its allocation.
-                            bi.cache_candidate = true;
-                            g_dcc_post_writeback_promotions.fetch_add(
-                                1, std::memory_order_relaxed);
-                            if (trace)
-                                std::fprintf(stderr,
-                                             "[compute]   promoted reused post-writeback DCC storage "
-                                             "image binding=%u addr=0x%llx allocation=%llu\n",
-                                             bi.binding, (unsigned long long)r->gpu_addr,
-                                             (unsigned long long)bi.allocation_bytes);
-                        } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                            ctx.replace_or_retain_image(
-                                bi.cache_key, bi.image, bi.memory,
-                                bi.allocation_bytes, retained_source)) {
-                            bi.cache_candidate = true;
-                            bi.persistent = true;
-                            promoted_after_writeback = true;
-                            g_dcc_post_writeback_promotions.fetch_add(
-                                1, std::memory_order_relaxed);
-                            if (trace)
-                                std::fprintf(stderr,
-                                             "[compute]   promoted post-writeback DCC storage image "
-                                             "binding=%u addr=0x%llx allocation=%llu\n",
-                                             bi.binding, (unsigned long long)r->gpu_addr,
-                                             (unsigned long long)bi.allocation_bytes);
-                        }
-                    }
-                    if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
-                        ctx.invalidate_cached_image_source(bi.cache_key);
-                    if (bi.cache_candidate) {
-                        if (bi.persistent && !promoted_after_writeback) {
-                            // Guest bytes now mirror the retained image again. A changing full-overwrite
-                            // target needs no source snapshot; the first repeated result retains one exact
-                            // baseline, and subsequent identical GPU skips do not recopy it.
-                            ctx.validate_cached_image_source(
-                                bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
-                                bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
-                                    native_3d_transfer_enabled());
-                        } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                                   ctx.retain_image(bi.cache_key, bi.image, bi.memory,
-                                                    bi.allocation_bytes,
-                                                    (adaptive_storage_result_validation_enabled() &&
-                                                     cold_storage_result_snapshot_can_defer(
-                                                         r->host_data != nullptr, bi.seed_skip,
-                                                         bi.guest_bytes,
-                                                         cold_storage_result_snapshot_defer_min_bytes()))
-                                                        ? nullptr : destination)) {
-                            bi.persistent = true;
-                            if (trace)
-                                std::fprintf(stderr,
-                                             "[compute]   retained storage image binding=%u "
-                                             "addr=0x%llx allocation=%llu\n",
-                                             bi.binding, (unsigned long long)r->gpu_addr,
-                                             (unsigned long long)bi.allocation_bytes);
-                        }
-                        // An aligned exact result is retained as the staging buffer immediately below.
-                        // Copying it into a host vector first only to clear that vector after ownership
-                        // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
-                        // setup keeps the exact current host fallback; a failed ownership attempt invalidates
-                        // any older fallback so the next dispatch takes the ordinary writeback path.
-                        const bool force_host_result_fallback =
-                            bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
-                            !(bi.exact_result_bytes & 15u) &&
-                            g_force_next_image_result_host_fallback_for_test.exchange(
-                                false, std::memory_order_acq_rel);
-                        retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
-                            bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
-                            !force_host_result_fallback && ctx.prepare_compare_pipeline();
-                        if (bi.persistent && !retain_gpu_result_baseline)
-                            ctx.remember_cached_image_result(
-                                bi.cache_key, native_texels,
-                                static_cast<size_t>(bi.exact_result_bytes));
-                    }
-                    const auto cache_done = ComputeClock::now();
-                    ctx.unmap_memory(staging_memory[i]);
-                    const VkBuffer retained_result = staging[i];
-                    if (retain_gpu_result_baseline &&
-                        ctx.retain_cached_image_result_buffer(
-                            bi.cache_key, staging[i], staging_memory[i],
-                            bi.staging_allocation_bytes, bi.exact_result_bytes)) {
-                        bi.result_baseline = retained_result;
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   retained exact GPU result baseline binding=%u "
-                                         "addr=0x%llx bytes=%zu\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
-                    }
-                    const auto image_writeback_done = ComputeClock::now();
-                    const auto image_milliseconds = [](auto begin, auto end) {
-                        return std::chrono::duration<double, std::milli>(end - begin).count();
-                    };
-                    image_map_ms += image_milliseconds(map_start, map_done);
-                    image_prepare_ms += image_milliseconds(map_done, prepare_done);
-                    image_watch_ms += image_milliseconds(prepare_done, watch_done);
-                    image_notify_ms += image_milliseconds(notify_start, notify_done);
-                    image_cache_ms += image_milliseconds(notify_done, cache_done);
-                    if (image_timing)
+                }
+                if (buffer.persistent)
+                    ctx.validate_cached_buffer_source(buffer.cache_key);
+                if (!buffer.resource->host_data && writer_provenance_enabled())
+                    record_guest_write(GuestWriterKind::ComputeBuffer,
+                                       buffer.resource->gpu_addr, buffer.resource->size,
+                                       item.submit_no, item.dispatch_index,
+                                       item.command_order, item.code_addr);
+            }
+            writeback_buffers_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_buffers_start).count();
+            if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                              // site turns a false return back into that break
+            const auto writeback_images_start = ComputeClock::now();
+            // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
+            // into the guest format, then restore its linear or 3D tiled address layout and notify the
+            // render side exactly like the buffer path.
+            for (size_t i = 0; i < images.size() && readback_ok; i++) {
+                BoundImage& bi = images[i];
+                if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
+                const auto image_writeback_start = ComputeClock::now();
+                const bool image_cache_hit = bi.persistent;
+                const ShaderResource* r = bi.resource;
+                const uint32_t cb = data_format_bytes(r->format);
+                const uint32_t nc = r->num_components ? r->num_components : 1;
+                const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
+                                            r->format == DataFormat::Unorm2_10_10_10)
+                    ? 4u : (size_t)cb * nc;
+                const size_t texels = (size_t)r->width * r->height * r->depth;
+                const size_t linear_bytes = texels * guest_texel;
+                uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
+                // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
+                // independently proved that the guest mirror still contains that baseline. This path
+                // therefore needs neither a large staging mapping nor a CPU memory pass.
+                if (bi.gpu_result_unchanged && bi.upload_skipped) {
+                    if (trace)
                         std::fprintf(stderr,
-                                     "[compute-image-writeback] code=0x%llx hash=0x%016llx "
-                                     "binding=%u addr=0x%llx "
-                                     "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
-                                     "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
-                                     "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
-                                     "total_ms=%.3f\n",
-                                     (unsigned long long)item.code_addr,
-                                     (unsigned long long)timing_program_hash, bi.binding,
-                                     (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
-                                     r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
-                                     bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
-                                     image_milliseconds(map_start, map_done),
-                                     image_milliseconds(map_done, prepare_done),
-                                     image_milliseconds(prepare_done, watch_done),
-                                     image_milliseconds(pack_start, pack_done),
-                                     image_milliseconds(pack_done, layout_done),
-                                     image_milliseconds(notify_start, notify_done),
-                                     image_milliseconds(notify_done, cache_done),
-                                     image_milliseconds(image_writeback_start, image_writeback_done));
+                                     "[compute]   skipped GPU-identical storage writeback binding=%u "
+                                     "addr=0x%llx bytes=%llu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)bi.exact_result_bytes);
+                    if (r->gpu_addr)
+                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                    continue;
                 }
-                writeback_images_ms = std::chrono::duration<double, std::milli>(
-                    ComputeClock::now() - writeback_images_start).count();
-                if (!readback_ok) return false;   // was `break` out of the do-while; the call
-                                                  // site turns a false return back into that break
-                const auto writeback_publish_start = ComputeClock::now();
-                // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
-                // completed, and a failed dispatch cannot reach here. Native results may seed a later
-                // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
-                // also be exported directly to graphics. Raw interchange images are compatible with neither.
-                for (const BoundImage& image : images) {
-                    if (!image.storage) continue;
-                    const bool unique = image.alias_of == SIZE_MAX;
-                    const bool native_exact_storage = image.native_float_storage ||
-                        image.native_uint_storage || image.packed_r11_storage;
-                    const bool publish_eligible = native_exact_storage && unique &&
-                        image.cache_candidate && image.persistent;
-                    const bool authorized = publish_eligible &&
-                        ctx.authorize_cached_image_compute_transfer(image.cache_key);
-                    transfer_gate_census.record_storage_publish(
-                        transfer_gate_observation.role, native_exact_storage, unique,
-                        image.cache_candidate, image.persistent, authorized);
-                    if (authority_observation.selected && unique && image.resource) {
-                        authority_census.record_selected_storage_output(
-                            item, image.binding,
-                            ShadowComputeAuthorityRange::from(
-                                image.resource->gpu_addr, image.guest_bytes),
-                            authorized);
+                void* mapped = nullptr;
+                const auto map_start = ComputeClock::now();
+                if (g_fail_next_storage_readback_for_test.exchange(
+                        false, std::memory_order_acq_rel)) {
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   injected storage readback failure binding=%u\n",
+                                     bi.binding);
+                    readback_ok = false;
+                    break;
+                }
+                if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
+                    readback_ok = false;
+                    break;
+                }
+                const auto map_done = ComputeClock::now();
+                const bool array_image = backend_uses_2d_array(*r);
+                static const bool direct_tiled_writeback_disabled =
+                    std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
+                const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
+                    bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
+                    direct_tiled_writeback_disabled);
+                std::unique_ptr<uint8_t[]> linear;
+                uint8_t* packed = destination;
+                if ((r->tile_mode && !tile_mapped_bytes) ||
+                    (!r->tile_mode && array_image && r->depth > 1)) {
+                    linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
+                    packed = linear.get();
+                }
+                const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+                const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
+                // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
+                // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
+                // that guest memory still contains the prior result, and this dispatch reproduced the
+                // same row-major bytes. If either comparison fails, take the ordinary writeback below.
+                const bool repeated_output = bi.cache_candidate && bi.persistent &&
+                    bi.upload_skipped && bi.exact_storage_bytes() &&
+                    ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
+                const auto prepare_done = ComputeClock::now();
+                if (repeated_output) {
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   skipped identical storage writeback binding=%u "
+                                     "addr=0x%llx bytes=%llu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)bi.exact_result_bytes);
+                    ctx.unmap_memory(staging_memory[i]);
+                    if (r->gpu_addr)
+                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                    continue;
+                }
+                // Notify page-based dirty trackers only when bytes will actually be written. Doing this
+                // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
+                // even on the no-write path, defeating the validation that made that path safe.
+                if (!r->host_data && r->gpu_addr)
+                    prosper::host::guest_write_watch_notify_host_write(
+                        r->gpu_addr, bi.guest_bytes);
+                const auto watch_done = ComputeClock::now();
+                // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
+                // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
+                // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
+                // and, for a partial write, restore the un-stored texels from the clean seed after packing.
+                std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
+                if (bi.poison_verify) {
+                    size_t survived = 0;
+                    poison_texel.assign(texels, 0);
+                    for (size_t t = 0; t < texels; ++t) {
+                        bool all = true;
+                        if (bi.exact_storage_bytes()) {
+                            const uint8_t* texel = native_texels + t * guest_texel;
+                            for (size_t b = 0; b < guest_texel; ++b)
+                                if (texel[b] != 0x5a) all = false;
+                        } else {
+                            for (uint32_t c = 0; c < 4; ++c)
+                                if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
+                        }
+                        if (all) { ++survived; poison_texel[t] = 1; }
                     }
-                    if (publish_eligible && image.graphics_sampled_usage)
-                        ctx.authorize_cached_image_export(image.cache_key, item.command_order);
+                    {
+                        const SeedCoverageKey proof_key{item.code_addr, bi.binding,
+                                                        r->width, r->height, r->depth};
+                        std::lock_guard<std::mutex> lk(seed_coverage_mu);
+                        // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
+                        seed_coverage_proof[proof_key] =
+                            SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
+                    }
+                    std::fprintf(stderr,
+                                 "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
+                                 (unsigned long long)item.code_addr, bi.binding, texels, survived,
+                                 survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
                 }
-                writeback_publish_ms = std::chrono::duration<double, std::milli>(
-                    ComputeClock::now() - writeback_publish_start).count();
-                ok = true;
-                phase_writeback = ComputeClock::now();
-                return true;
-            };
-            if (!consume_dispatch()) return false;
+                if (trace) {
+                    if (bi.exact_storage_bytes()) {
+                        for (size_t t = 0; t < texels; ++t) {
+                            const uint8_t* texel = native_texels + t * guest_texel;
+                            for (size_t b = 0; b < guest_texel; ++b)
+                                bi.nonzero_channels += texel[b] != 0;
+                        }
+                    } else {
+                        for (size_t t = 0; t < texels; t++)
+                            for (uint32_t c = 0; c < 4; c++)
+                                bi.nonzero_channels += channels[t * 4 + c] != 0;
+                    }
+                }
+                const auto pack_start = ComputeClock::now();
+                static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
+                if (bi.exact_storage_bytes()) {
+                    // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
+                    // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
+                    // non-proving write can feed those bytes straight to the tiler, avoiding a second
+                    // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
+                    if (!tile_mapped_bytes)
+                        parallel_compute_texels(texels, linear_bytes * 2,
+                            [&](size_t begin, size_t end) {
+                                std::memcpy(packed + begin * guest_texel,
+                                            native_texels + begin * guest_texel,
+                                            (end - begin) * guest_texel);
+                            });
+                } else if (pack_range_enabled) {
+                    storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
+                } else {
+                    for (size_t t = 0; t < texels; t++)
+                        storage_pack_texel(channels + t * 4, r->format, nc,
+                                           packed + t * guest_texel);
+                }
+                // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
+                // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
+                // content (exactly a partial write's contract). Full-coverage proving frames have no
+                // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
+                if (bi.poison_verify && !poison_texel.empty() &&
+                    bi.seed_linear.size() == linear_bytes) {
+                    for (size_t t = 0; t < texels; ++t) {
+                        if (poison_texel[t])
+                            std::memcpy(packed + t * guest_texel,
+                                        bi.seed_linear.data() + t * guest_texel, guest_texel);
+                    }
+                }
+                const auto pack_done = ComputeClock::now();
+                static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
+                if (verify_pack && !bi.exact_storage_bytes()) {
+                    // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
+                    // be bit-identical to the per-texel path it replaces, verified against the real
+                    // workload's texels. Logs the clean case too, so a verified run is self-proving.
+                    std::vector<uint8_t> expect(guest_texel);
+                    size_t bad = 0, first_bad = 0;
+                    for (size_t t = 0; t < texels; ++t) {
+                        std::memset(expect.data(), 0, expect.size());
+                        storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
+                        if (std::memcmp(expect.data(), packed + t * guest_texel,
+                                        guest_texel) != 0) {
+                            if (!bad) first_bad = t;
+                            ++bad;
+                        }
+                    }
+                    std::fprintf(stderr,
+                                 "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
+                                 "texels=%zu mismatches=%zu%s\n",
+                                 bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
+                                 nc, texels, bad, bad ? " MISMATCH" : "");
+                    if (bad)
+                        std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
+                                     first_bad);
+                }
+                const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
+                if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
+                    if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
+                                     r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                        readback_ok = false;
+                        ctx.unmap_memory(staging_memory[i]);
+                        break;
+                    }
+                } else if (array_image && r->depth > 1) {
+                    const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
+                    const size_t selected_slice = r->in_mip_tail
+                        ? r->mip_tail_bytes
+                        : (r->tile_mode
+                               ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
+                                                     static_cast<uint32_t>(guest_texel))
+                               : (r->layer_stride_bytes
+                                      ? linear_array_surface_bytes(
+                                            *r, static_cast<uint32_t>(guest_texel))
+                                      : linear_slice));
+                    const size_t layer_stride = r->layer_stride_bytes
+                        ? r->layer_stride_bytes : selected_slice;
+                    for (uint32_t layer = 0; layer < r->depth; ++layer) {
+                        uint8_t* layer_base = destination + layer_stride * layer;
+                        if (!r->tile_mode) {
+                            const size_t row_pitch = r->layer_stride_bytes
+                                ? linear_array_row_pitch(
+                                      *r, static_cast<uint32_t>(guest_texel))
+                                : static_cast<size_t>(r->width) * guest_texel;
+                            for (uint32_t y = 0; y < r->height; ++y)
+                                std::memcpy(
+                                    layer_base + r->layer_mip_offset_bytes + y * row_pitch,
+                                    layout_source + linear_slice * layer +
+                                        static_cast<size_t>(y) * r->width * guest_texel,
+                                    static_cast<size_t>(r->width) * guest_texel);
+                        } else if (r->in_mip_tail) {
+                            tile_surface_level(
+                                layer_base, r->mip_tail_bytes,
+                                layout_source + linear_slice * layer,
+                                r->width, r->height, r->tile_mode,
+                                static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
+                        } else {
+                            tile_surface(
+                                layer_base + r->layer_mip_offset_bytes,
+                                layout_source + linear_slice * layer,
+                                r->width, r->height, r->tile_mode, 0,
+                                static_cast<uint32_t>(guest_texel));
+                        }
+                    }
+                } else if (r->tile_mode && r->in_mip_tail) {
+                    tile_surface_level(destination, bi.guest_bytes, layout_source,
+                                       r->width, r->height, r->tile_mode,
+                                       static_cast<uint32_t>(guest_texel),
+                                       r->mip_tail_x, r->mip_tail_y);
+                } else if (r->tile_mode) {
+                    tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
+                                 static_cast<uint32_t>(guest_texel));
+                }
+                const auto layout_done = ComputeClock::now();
+                pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
+                layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
+                if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
+                const auto notify_start = ComputeClock::now();
+                // Name the writer. "a guest write covers this surface" and "prosper's own compute
+                // writeback covers this surface" are different facts, and only the second says the
+                // emulator is invalidating its own caches. Everything reaching the DS invalidation path
+                // used to report the default `gpu`, which cannot distinguish them.
+                set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
+                notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+                set_guest_gpu_write_origin(nullptr);
+                if (!r->host_data && writer_provenance_enabled())
+                    record_guest_write(GuestWriterKind::ComputeBuffer,
+                                       r->gpu_addr, bi.guest_bytes,
+                                       item.submit_no, item.dispatch_index,
+                                       item.command_order, item.code_addr);
+                if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
+                    const bool leave_compressed_for_test =
+                        g_leave_next_dcc_metadata_compressed_for_test.exchange(
+                            false, std::memory_order_acq_rel);
+                    if (!leave_compressed_for_test) {
+                        std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                        // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
+                        // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
+                        // aspects" and invalidates depth as well as stencil. So this reset can discard a
+                        // retained depth image. Tagged so that consequence is attributable rather than
+                        // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
+                        // separate question that needs the operation's real HTILE semantics proven.
+                        set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
+                        notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                        set_guest_gpu_write_origin(nullptr);
+                        if (!r->dcc_metadata_host_data && writer_provenance_enabled())
+                            record_guest_write(GuestWriterKind::ComputeBuffer,
+                                               r->metadata_addr, bi.dcc_metadata_bytes,
+                                               item.submit_no, item.dispatch_index,
+                                               item.command_order, item.code_addr);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   DCC uncompressed binding=%u meta=0x%llx "
+                                         "bytes=%zu code=0xff\n",
+                                         bi.binding, (unsigned long long)r->metadata_addr,
+                                         bi.dcc_metadata_bytes);
+                    } else if (trace) {
+                        std::fprintf(stderr,
+                                     "[compute]   injected unresolved DCC writeback binding=%u\n",
+                                     bi.binding);
+                    }
+                }
+                if (bi.mirror_result_to_imported) {
+                    const BoundImage& mirror = images[bi.seed_from_imported];
+                    notify_live_render_target_image_written({
+                        r->gpu_addr, mirror.imported_width, mirror.imported_height,
+                        mirror.imported_pixel_format});
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   mirrored storage result into renderer RTT "
+                                     "binding=%u addr=0x%llx extent=%ux%u\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     mirror.imported_width, mirror.imported_height);
+                }
+                const auto notify_done = ComputeClock::now();
+                bool retain_gpu_result_baseline = false;
+                bool promoted_after_writeback = false;
+                const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
+                    std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
+                                [](uint8_t value) { return value == 0xff; });
+                if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
+                    const uint8_t* retained_source =
+                        (adaptive_storage_result_validation_enabled() &&
+                         cold_storage_result_snapshot_can_defer(
+                             r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
+                             cold_storage_result_snapshot_defer_min_bytes()))
+                        ? nullptr : destination;
+                    if (bi.forced_seed_allocation_reused) {
+                        // The exact cache entry was already pinned and forcibly reseeded before this
+                        // dispatch. Successful writeback plus the final all-uncompressed metadata scan
+                        // may now restore source/transfer authority without replacing its allocation.
+                        bi.cache_candidate = true;
+                        g_dcc_post_writeback_promotions.fetch_add(
+                            1, std::memory_order_relaxed);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   promoted reused post-writeback DCC storage "
+                                         "image binding=%u addr=0x%llx allocation=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.allocation_bytes);
+                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                        ctx.replace_or_retain_image(
+                            bi.cache_key, bi.image, bi.memory,
+                            bi.allocation_bytes, retained_source)) {
+                        bi.cache_candidate = true;
+                        bi.persistent = true;
+                        promoted_after_writeback = true;
+                        g_dcc_post_writeback_promotions.fetch_add(
+                            1, std::memory_order_relaxed);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   promoted post-writeback DCC storage image "
+                                         "binding=%u addr=0x%llx allocation=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.allocation_bytes);
+                    }
+                }
+                if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
+                    ctx.invalidate_cached_image_source(bi.cache_key);
+                if (bi.cache_candidate) {
+                    if (bi.persistent && !promoted_after_writeback) {
+                        // Guest bytes now mirror the retained image again. A changing full-overwrite
+                        // target needs no source snapshot; the first repeated result retains one exact
+                        // baseline, and subsequent identical GPU skips do not recopy it.
+                        ctx.validate_cached_image_source(
+                            bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
+                            bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
+                                native_3d_transfer_enabled());
+                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                               ctx.retain_image(bi.cache_key, bi.image, bi.memory,
+                                                bi.allocation_bytes,
+                                                (adaptive_storage_result_validation_enabled() &&
+                                                 cold_storage_result_snapshot_can_defer(
+                                                     r->host_data != nullptr, bi.seed_skip,
+                                                     bi.guest_bytes,
+                                                     cold_storage_result_snapshot_defer_min_bytes()))
+                                                    ? nullptr : destination)) {
+                        bi.persistent = true;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   retained storage image binding=%u "
+                                         "addr=0x%llx allocation=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.allocation_bytes);
+                    }
+                    // An aligned exact result is retained as the staging buffer immediately below.
+                    // Copying it into a host vector first only to clear that vector after ownership
+                    // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
+                    // setup keeps the exact current host fallback; a failed ownership attempt invalidates
+                    // any older fallback so the next dispatch takes the ordinary writeback path.
+                    const bool force_host_result_fallback =
+                        bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
+                        !(bi.exact_result_bytes & 15u) &&
+                        g_force_next_image_result_host_fallback_for_test.exchange(
+                            false, std::memory_order_acq_rel);
+                    retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
+                        bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
+                        !force_host_result_fallback && ctx.prepare_compare_pipeline();
+                    if (bi.persistent && !retain_gpu_result_baseline)
+                        ctx.remember_cached_image_result(
+                            bi.cache_key, native_texels,
+                            static_cast<size_t>(bi.exact_result_bytes));
+                }
+                const auto cache_done = ComputeClock::now();
+                ctx.unmap_memory(staging_memory[i]);
+                const VkBuffer retained_result = staging[i];
+                if (retain_gpu_result_baseline &&
+                    ctx.retain_cached_image_result_buffer(
+                        bi.cache_key, staging[i], staging_memory[i],
+                        bi.staging_allocation_bytes, bi.exact_result_bytes)) {
+                    bi.result_baseline = retained_result;
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   retained exact GPU result baseline binding=%u "
+                                     "addr=0x%llx bytes=%zu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
+                }
+                const auto image_writeback_done = ComputeClock::now();
+                const auto image_milliseconds = [](auto begin, auto end) {
+                    return std::chrono::duration<double, std::milli>(end - begin).count();
+                };
+                image_map_ms += image_milliseconds(map_start, map_done);
+                image_prepare_ms += image_milliseconds(map_done, prepare_done);
+                image_watch_ms += image_milliseconds(prepare_done, watch_done);
+                image_notify_ms += image_milliseconds(notify_start, notify_done);
+                image_cache_ms += image_milliseconds(notify_done, cache_done);
+                if (image_timing)
+                    std::fprintf(stderr,
+                                 "[compute-image-writeback] code=0x%llx hash=0x%016llx "
+                                 "binding=%u addr=0x%llx "
+                                 "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
+                                 "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
+                                 "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
+                                 "total_ms=%.3f\n",
+                                 (unsigned long long)item.code_addr,
+                                 (unsigned long long)timing_program_hash, bi.binding,
+                                 (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
+                                 r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
+                                 bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
+                                 image_milliseconds(map_start, map_done),
+                                 image_milliseconds(map_done, prepare_done),
+                                 image_milliseconds(prepare_done, watch_done),
+                                 image_milliseconds(pack_start, pack_done),
+                                 image_milliseconds(pack_done, layout_done),
+                                 image_milliseconds(notify_start, notify_done),
+                                 image_milliseconds(notify_done, cache_done),
+                                 image_milliseconds(image_writeback_start, image_writeback_done));
+            }
+            writeback_images_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_images_start).count();
+            if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                              // site turns a false return back into that break
+            const auto writeback_publish_start = ComputeClock::now();
+            // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
+            // completed, and a failed dispatch cannot reach here. Native results may seed a later
+            // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
+            // also be exported directly to graphics. Raw interchange images are compatible with neither.
+            for (const BoundImage& image : images) {
+                if (!image.storage) continue;
+                const bool unique = image.alias_of == SIZE_MAX;
+                const bool native_exact_storage = image.native_float_storage ||
+                    image.native_uint_storage || image.packed_r11_storage;
+                const bool publish_eligible = native_exact_storage && unique &&
+                    image.cache_candidate && image.persistent;
+                const bool authorized = publish_eligible &&
+                    ctx.authorize_cached_image_compute_transfer(image.cache_key);
+                transfer_gate_census.record_storage_publish(
+                    transfer_gate_observation.role, native_exact_storage, unique,
+                    image.cache_candidate, image.persistent, authorized);
+                if (authority_observation.selected && unique && image.resource) {
+                    authority_census.record_selected_storage_output(
+                        item, image.binding,
+                        ShadowComputeAuthorityRange::from(
+                            image.resource->gpu_addr, image.guest_bytes),
+                        authorized);
+                }
+                if (publish_eligible && image.graphics_sampled_usage)
+                    ctx.authorize_cached_image_export(image.cache_key, item.command_order);
+            }
+            writeback_publish_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_publish_start).count();
+            ok = true;
+            phase_writeback = ComputeClock::now();
             return true;
         };
-        if (!wait_and_consume()) break;
-    } while (false);
+        if (!consume_dispatch()) return false;
+        return true;
+    };
+    // Run it inline for now; a dispatch ring will store it in a slot instead. `ok`
+    // carries the outcome, which is why the result is not re-tested here -- the old
+    // `break` on failure simply left the do-block, which had nothing after it.
+    if (submitted_dispatch) wait_and_consume();
 
     if (trace)
         std::fprintf(stderr, "[compute] execute submit=%llu dispatch=%llu code=0x%llx "

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1184,6 +1184,7 @@ struct VulkanComputeContext {
     bool pending_all_ok = true;
     uint64_t ring_drains_on_alias = 0;
     uint64_t ring_deferred_dispatches = 0;
+    uint64_t ring_consumed_dispatches = 0;
     VkQueryPool dispatch_timestamp_pool = VK_NULL_HANDLE;
     float timestamp_period_ns = 0.0f;
     uint32_t timestamp_valid_bits = 0;
@@ -1494,6 +1495,7 @@ struct VulkanComputeContext {
         auto finish = std::move(slot.finish);
         slot.finish = nullptr;
         slot.writes.clear();
+        ring_consumed_dispatches++;
         const bool ok = finish();
         // execute_item already returned `true` provisionally for this dispatch, so a failure
         // discovered here has to be recorded somewhere the caller still reads.
@@ -9166,7 +9168,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // the BoundBuffer*/BoundImage* inside compare_targets stay valid. Everything else is a
     // handle, a scalar, or a lambda already made copy-safe (#3157).
     auto finish_dispatch = [&authority_census, &ctx, &item, &spirv, &transfer_gate_census, 
-        buffers = std::move(buffers), compare_targets = std::move(compare_targets), dispatch_fence, 
+        buffers = std::move(buffers), compare_targets = std::move(compare_targets), dispatch_fence, buffer_resources = std::move(buffer_resources), 
         images = std::move(images), staging = std::move(staging), 
         staging_bytes = std::move(staging_bytes), staging_memory = std::move(staging_memory), 
         authority_observation, compare_descriptor_pool, compare_flags, compare_flags_memory, 

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1185,6 +1185,7 @@ struct VulkanComputeContext {
     uint64_t ring_drains_on_alias = 0;
     uint64_t ring_deferred_dispatches = 0;
     uint64_t ring_consumed_dispatches = 0;
+    uint64_t ring_batches = 0;
     VkQueryPool dispatch_timestamp_pool = VK_NULL_HANDLE;
     float timestamp_period_ns = 0.0f;
     uint32_t timestamp_valid_bits = 0;
@@ -10874,6 +10875,22 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     // Vulkan handles.
     if (!context.dispatch_slots.empty()) {
         context.drain_dispatch_ring();
+        // PROSPER_COMPUTE_RING_STATS=1. Dispatches-per-batch is what decides whether the ring can
+        // help at all on a given title: the end-of-batch drain is mandatory (the guest may read
+        // its memory once the submit returns), so a workload that submits one dispatch per batch
+        // drains every slot immediately after filling it and never overlaps anything. Stray
+        // measures ~1.0, which is why the ring buys it almost nothing.
+        context.ring_batches++;
+        static const bool ring_stats = std::getenv("PROSPER_COMPUTE_RING_STATS") != nullptr;
+        if (ring_stats && context.ring_batches % 256 == 0)
+            std::fprintf(stderr,
+                "[ring] batches=%llu dispatches=%llu per_batch=%.2f consumed=%llu alias_drains=%llu\n",
+                (unsigned long long)context.ring_batches,
+                (unsigned long long)context.ring_deferred_dispatches,
+                static_cast<double>(context.ring_deferred_dispatches) /
+                    static_cast<double>(context.ring_batches),
+                (unsigned long long)context.ring_consumed_dispatches,
+                (unsigned long long)context.ring_drains_on_alias);
         all_ok = all_ok && context.pending_all_ok;
         context.pending_all_ok = true;
     }

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -9100,93 +9100,253 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
         phase_dispatch = ComputeClock::now();
-        const auto writeback_prepare_start = phase_dispatch;
+        // #3157 step A: the consume tail as one callable unit. Immediately invoked here, so
+        // behaviour is unchanged -- this only proves the tail is a coherent block with known
+        // escapes before it is deferred behind a dispatch ring.
+        auto consume_dispatch = [&]() -> bool {
+            const auto writeback_prepare_start = phase_dispatch;
 
-        if (!compare_targets.empty()) {
-            void* mapped = nullptr;
-            const VkDeviceSize flag_stride = ctx.compare_flag_stride();
-            if (ctx.map_memory(compare_flags_memory, 0,
-                               compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
-                // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
-                // target would read the padding between flags on any device whose alignment exceeds
-                // four, reporting every target after the first as unchanged.
-                const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
-                for (size_t j = 0; j < compare_targets.size(); ++j) {
-                    CompareTarget& target = compare_targets[j];
-                    uint32_t changed = 0;
-                    std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
-                    if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
-                    if (target.image) target.image->gpu_result_unchanged = changed == 0;
+            if (!compare_targets.empty()) {
+                void* mapped = nullptr;
+                const VkDeviceSize flag_stride = ctx.compare_flag_stride();
+                if (ctx.map_memory(compare_flags_memory, 0,
+                                   compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
+                    // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
+                    // target would read the padding between flags on any device whose alignment exceeds
+                    // four, reporting every target after the first as unchanged.
+                    const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
+                    for (size_t j = 0; j < compare_targets.size(); ++j) {
+                        CompareTarget& target = compare_targets[j];
+                        uint32_t changed = 0;
+                        std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
+                        if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
+                        if (target.image) target.image->gpu_result_unchanged = changed == 0;
+                    }
+                    ctx.unmap_memory(compare_flags_memory);
                 }
-                ctx.unmap_memory(compare_flags_memory);
             }
-        }
 
-        // The fence proves every upload is complete and every sampled image is back in GENERAL.
-        // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
-        // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
-        for (BoundImage& image : images) {
-            if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
-                !image.cache_candidate)
-                continue;
-            // When this dispatch samples and writes the same guest view through distinct bindings,
-            // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
-            // would occupy the identical key before storage writeback can retain the actual result.
-            const bool replaced_by_storage = std::any_of(
-                images.begin(), images.end(), [&](const BoundImage& candidate) {
-                    return candidate.storage && candidate.cache_candidate &&
-                           candidate.cache_key == image.cache_key;
-                });
-            if (replaced_by_storage) continue;
-            if (image.persistent) {
-                if (!image.upload_skipped) {
-                    if (image.compute_transfer_seed_borrowed)
-                        ctx.validate_cached_image_source_from_compute_transfer(
-                            image.cache_key);
-                    else
-                        ctx.validate_cached_image_source(image.cache_key);
+            // The fence proves every upload is complete and every sampled image is back in GENERAL.
+            // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
+            // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
+            for (BoundImage& image : images) {
+                if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
+                    !image.cache_candidate)
+                    continue;
+                // When this dispatch samples and writes the same guest view through distinct bindings,
+                // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
+                // would occupy the identical key before storage writeback can retain the actual result.
+                const bool replaced_by_storage = std::any_of(
+                    images.begin(), images.end(), [&](const BoundImage& candidate) {
+                        return candidate.storage && candidate.cache_candidate &&
+                               candidate.cache_key == image.cache_key;
+                    });
+                if (replaced_by_storage) continue;
+                if (image.persistent) {
+                    if (!image.upload_skipped) {
+                        if (image.compute_transfer_seed_borrowed)
+                            ctx.validate_cached_image_source_from_compute_transfer(
+                                image.cache_key);
+                        else
+                            ctx.validate_cached_image_source(image.cache_key);
+                    }
+                } else if (image.image && image.memory && image.allocation_bytes &&
+                           (image.cache_source_snapshot.empty()
+                                ? ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                   image.allocation_bytes,
+                                                   static_cast<const uint8_t*>(nullptr))
+                                : ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                   image.allocation_bytes,
+                                                   std::move(image.cache_source_snapshot)))) {
+                    image.persistent = true;
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   retained sampled image binding=%u addr=0x%llx "
+                                     "allocation=%llu\n",
+                                     image.binding,
+                                     (unsigned long long)image.resource->gpu_addr,
+                                     (unsigned long long)image.allocation_bytes);
                 }
-            } else if (image.image && image.memory && image.allocation_bytes &&
-                       (image.cache_source_snapshot.empty()
-                            ? ctx.retain_image(image.cache_key, image.image, image.memory,
-                                               image.allocation_bytes,
-                                               static_cast<const uint8_t*>(nullptr))
-                            : ctx.retain_image(image.cache_key, image.image, image.memory,
-                                               image.allocation_bytes,
-                                               std::move(image.cache_source_snapshot)))) {
-                image.persistent = true;
-                if (trace)
-                    std::fprintf(stderr,
-                                 "[compute]   retained sampled image binding=%u addr=0x%llx "
-                                 "allocation=%llu\n",
-                                 image.binding,
-                                 (unsigned long long)image.resource->gpu_addr,
-                                 (unsigned long long)image.allocation_bytes);
             }
-        }
 
-        writeback_prepare_ms = std::chrono::duration<double, std::milli>(
-            ComputeClock::now() - writeback_prepare_start).count();
-        const auto writeback_buffers_start = ComputeClock::now();
-        bool readback_ok = true;
-        for (auto& buffer : buffers) {
-            if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
-            // The exact GPU comparator saw the same bytes as the retained baseline, while source
-            // validation independently proved that the guest mirror still contains that baseline.
-            // Preserve architectural write notification, but avoid mapping and scanning the whole
-            // host-visible buffer merely to rediscover equality.
-            if (buffer.gpu_result_unchanged) {
-                g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
-                if (trace)
+            writeback_prepare_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_prepare_start).count();
+            const auto writeback_buffers_start = ComputeClock::now();
+            bool readback_ok = true;
+            for (auto& buffer : buffers) {
+                if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
+                // The exact GPU comparator saw the same bytes as the retained baseline, while source
+                // validation independently proved that the guest mirror still contains that baseline.
+                // Preserve architectural write notification, but avoid mapping and scanning the whole
+                // host-visible buffer merely to rediscover equality.
+                if (buffer.gpu_result_unchanged) {
+                    g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   skipped GPU-identical buffer writeback binding=%u "
+                                     "addr=0x%llx bytes=%u\n",
+                                     buffer.resource->binding,
+                                     (unsigned long long)buffer.resource->gpu_addr,
+                                     buffer.resource->size);
+                    if (buffer.resource->gpu_addr)
+                        notify_guest_gpu_write_preserving_bytes(
+                            buffer.resource->gpu_addr, buffer.resource->size);
+                    if (buffer.persistent)
+                        ctx.validate_cached_buffer_source(buffer.cache_key);
+                    if (!buffer.resource->host_data && writer_provenance_enabled())
+                        record_guest_write(GuestWriterKind::ComputeBuffer,
+                                           buffer.resource->gpu_addr, buffer.resource->size,
+                                           item.submit_no, item.dispatch_index,
+                                           item.command_order, item.code_addr);
+                    continue;
+                }
+                void* mapped = nullptr;
+                if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
+                    readback_ok = false;
+                    break;
+                }
+                uint8_t* destination = buffer.atomic_image
+                    ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
+                    : resource_bytes_for(buffer.resource, buffer.guest_bytes);
+                const auto* result = static_cast<const uint8_t*>(mapped);
+                if (buffer.atomic_image) {
+                    if (trace) {
+                        buffer.after_hash = fnv1a(result, buffer.bytes);
+                        for (size_t i = 0; i < buffer.bytes; ++i)
+                            buffer.changed_bytes += buffer.linear_seed[i] != result[i];
+                    }
+                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                        prosper::host::guest_write_watch_notify_host_write(
+                            buffer.resource->gpu_addr, buffer.guest_bytes);
+                    // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
+                    const size_t layer_linear_bytes =
+                        static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
+                    for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
+                        uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
+                        const uint8_t* src = result + layer * layer_linear_bytes;
+                        if (buffer.resource->tile_mode) {
+                            tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
+                                         buffer.resource->tile_mode, 0, sizeof(uint32_t));
+                        } else {
+                            const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
+                            const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
+                                ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
+                            for (uint32_t y = 0; y < buffer.resource->height; ++y)
+                                std::memcpy(dst + y * destination_pitch,
+                                            src + y * tight_pitch, tight_pitch);
+                        }
+                    }
+                    ctx.unmap_memory(buffer.memory);
+                    if (buffer.resource->gpu_addr) {
+                        set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
+                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
+                        set_guest_gpu_write_origin(nullptr);
+                    }
+                    if (!buffer.resource->host_data && writer_provenance_enabled())
+                        record_guest_write(GuestWriterKind::ComputeBuffer,
+                                           buffer.resource->gpu_addr, buffer.guest_bytes,
+                                           item.submit_no, item.dispatch_index,
+                                           item.command_order, item.code_addr);
+                    continue;
+                }
+                const bool changed = !compute_buffers_equal(
+                    destination, result, buffer.bytes);
+                if (trace) {
+                    buffer.after_hash = fnv1a(result, buffer.bytes);
+                    for (size_t i = 0; i < buffer.bytes; i++)
+                        buffer.changed_bytes += destination[i] != result[i];
+                    // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
+                    //
+                    // `changed_bytes` says how much moved and nothing about where, which is the only
+                    // question that separates a wrong VALUE from a wrong INDEX. For a structure written
+                    // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
+                    // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
+                    // count or a hash.
+                    // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
+                    // merged and writability is ORed onto the first owner, so the owner's binding is
+                    // NOT evidence that the owner performed the store: a read-only binding followed by
+                    // a writable exact alias reports as though the first wrote, and with several
+                    // writable aliases no single store site can be named at all. The changed indices
+                    // below are allocation-level evidence and stand on their own; the binding is
+                    // reported as `owner-binding` with the alias count beside it so a reader cannot
+                    // mistake it for attribution.
+                    size_t alias_count = 0;
+                    for (const auto& other : buffers)
+                        if (other.alias_of != SIZE_MAX &&
+                            &buffers[other.alias_of] == &buffer) ++alias_count;
+                    if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
+                        char* end = nullptr;
+                        const unsigned long limit = std::strtoul(limit_env, &end, 0);
+                        if (end && !*end && limit) {
+                            // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
+                            // storage and `result` is mapped device memory, and neither contract
+                            // promises uint32_t alignment or a uint32_t object lifetime there. The byte
+                            // bound below deliberately ignores a partial trailing dword.
+                            const size_t dwords = buffer.bytes / sizeof(uint32_t);
+                            const auto load_dword = [](const uint8_t* bytes, size_t index) {
+                                uint32_t value = 0;
+                                std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
+                                return value;
+                            };
+                            unsigned long shown = 0;
+                            for (size_t i = 0; i < dwords && shown < limit; ++i) {
+                                const uint32_t before_value = load_dword(destination, i);
+                                const uint32_t after_value = load_dword(result, i);
+                                if (before_value == after_value) continue;
+                                // Carry submit/dispatch on EVERY line. Without them the lines from
+                                // consecutive dispatches concatenate into one stream that looks like a
+                                // single dispatch's writes -- and a per-dispatch structural claim built
+                                // on that stream is meaningless. The first analysis run here did exactly
+                                // that and reported one index changing twice in "one" dispatch.
+                                std::fprintf(stderr,
+                                             "[compute]     changed submit=%llu dispatch=%llu "
+                                             "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
+                                             "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
+                                             (unsigned long long)item.submit_no,
+                                             (unsigned long long)item.dispatch_index,
+                                             (unsigned long long)(buffer.resource
+                                                 ? buffer.resource->gpu_addr : 0ull),
+                                             buffer.resource ? buffer.resource->binding : 0u,
+                                             alias_count, i,
+                                             before_value, after_value, after_value & 7u,
+                                             (after_value >> 30) & 1u,
+                                             (after_value >> 3) & 0x07FFFFFFu);
+                                ++shown;
+                            }
+                        }
+                    }
+                }
+                // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
+                // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
+                // after its first dispatch all later readbacks are identical. Avoiding the redundant host
+                // write removes one full pass over both source and destination. Renderer-alias
+                // invalidation and writer provenance remain unconditional: renderer-resident state can
+                // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
+                if (changed) {
+                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                        prosper::host::guest_write_watch_notify_host_write(
+                            buffer.resource->gpu_addr, buffer.resource->size);
+                    copy_compute_buffer(destination, result, buffer.bytes);
+                }
+                if (buffer.persistent && !buffer.result_baseline &&
+                    ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
                     std::fprintf(stderr,
-                                 "[compute]   skipped GPU-identical buffer writeback binding=%u "
+                                 "[compute]   retained exact GPU buffer result baseline binding=%u "
                                  "addr=0x%llx bytes=%u\n",
                                  buffer.resource->binding,
                                  (unsigned long long)buffer.resource->gpu_addr,
                                  buffer.resource->size);
-                if (buffer.resource->gpu_addr)
-                    notify_guest_gpu_write_preserving_bytes(
-                        buffer.resource->gpu_addr, buffer.resource->size);
+                ctx.unmap_memory(buffer.memory);
+                if (buffer.resource->gpu_addr) {
+                    if (changed) {
+                        set_guest_gpu_write_origin("compute-writeback(buffer-full)");
+                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+                        set_guest_gpu_write_origin(nullptr);
+                    } else {
+                        notify_guest_gpu_write_preserving_bytes(
+                            buffer.resource->gpu_addr, buffer.resource->size);
+                    }
+                }
                 if (buffer.persistent)
                     ctx.validate_cached_buffer_source(buffer.cache_key);
                 if (!buffer.resource->host_data && writer_provenance_enabled())
@@ -9194,647 +9354,496 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                        buffer.resource->gpu_addr, buffer.resource->size,
                                        item.submit_no, item.dispatch_index,
                                        item.command_order, item.code_addr);
-                continue;
             }
-            void* mapped = nullptr;
-            if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
-                readback_ok = false;
-                break;
-            }
-            uint8_t* destination = buffer.atomic_image
-                ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
-                : resource_bytes_for(buffer.resource, buffer.guest_bytes);
-            const auto* result = static_cast<const uint8_t*>(mapped);
-            if (buffer.atomic_image) {
-                if (trace) {
-                    buffer.after_hash = fnv1a(result, buffer.bytes);
-                    for (size_t i = 0; i < buffer.bytes; ++i)
-                        buffer.changed_bytes += buffer.linear_seed[i] != result[i];
+            writeback_buffers_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_buffers_start).count();
+            if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                              // site turns a false return back into that break
+            const auto writeback_images_start = ComputeClock::now();
+            // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
+            // into the guest format, then restore its linear or 3D tiled address layout and notify the
+            // render side exactly like the buffer path.
+            for (size_t i = 0; i < images.size() && readback_ok; i++) {
+                BoundImage& bi = images[i];
+                if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
+                const auto image_writeback_start = ComputeClock::now();
+                const bool image_cache_hit = bi.persistent;
+                const ShaderResource* r = bi.resource;
+                const uint32_t cb = data_format_bytes(r->format);
+                const uint32_t nc = r->num_components ? r->num_components : 1;
+                const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
+                                            r->format == DataFormat::Unorm2_10_10_10)
+                    ? 4u : (size_t)cb * nc;
+                const size_t texels = (size_t)r->width * r->height * r->depth;
+                const size_t linear_bytes = texels * guest_texel;
+                uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
+                // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
+                // independently proved that the guest mirror still contains that baseline. This path
+                // therefore needs neither a large staging mapping nor a CPU memory pass.
+                if (bi.gpu_result_unchanged && bi.upload_skipped) {
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   skipped GPU-identical storage writeback binding=%u "
+                                     "addr=0x%llx bytes=%llu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)bi.exact_result_bytes);
+                    if (r->gpu_addr)
+                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                    continue;
                 }
-                if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                    prosper::host::guest_write_watch_notify_host_write(
-                        buffer.resource->gpu_addr, buffer.guest_bytes);
-                // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
-                const size_t layer_linear_bytes =
-                    static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
-                for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
-                    uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
-                    const uint8_t* src = result + layer * layer_linear_bytes;
-                    if (buffer.resource->tile_mode) {
-                        tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
-                                     buffer.resource->tile_mode, 0, sizeof(uint32_t));
-                    } else {
-                        const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
-                        const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
-                            ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
-                        for (uint32_t y = 0; y < buffer.resource->height; ++y)
-                            std::memcpy(dst + y * destination_pitch,
-                                        src + y * tight_pitch, tight_pitch);
-                    }
-                }
-                ctx.unmap_memory(buffer.memory);
-                if (buffer.resource->gpu_addr) {
-                    set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
-                    notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
-                    set_guest_gpu_write_origin(nullptr);
-                }
-                if (!buffer.resource->host_data && writer_provenance_enabled())
-                    record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       buffer.resource->gpu_addr, buffer.guest_bytes,
-                                       item.submit_no, item.dispatch_index,
-                                       item.command_order, item.code_addr);
-                continue;
-            }
-            const bool changed = !compute_buffers_equal(
-                destination, result, buffer.bytes);
-            if (trace) {
-                buffer.after_hash = fnv1a(result, buffer.bytes);
-                for (size_t i = 0; i < buffer.bytes; i++)
-                    buffer.changed_bytes += destination[i] != result[i];
-                // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
-                //
-                // `changed_bytes` says how much moved and nothing about where, which is the only
-                // question that separates a wrong VALUE from a wrong INDEX. For a structure written
-                // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
-                // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
-                // count or a hash.
-                // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
-                // merged and writability is ORed onto the first owner, so the owner's binding is
-                // NOT evidence that the owner performed the store: a read-only binding followed by
-                // a writable exact alias reports as though the first wrote, and with several
-                // writable aliases no single store site can be named at all. The changed indices
-                // below are allocation-level evidence and stand on their own; the binding is
-                // reported as `owner-binding` with the alias count beside it so a reader cannot
-                // mistake it for attribution.
-                size_t alias_count = 0;
-                for (const auto& other : buffers)
-                    if (other.alias_of != SIZE_MAX &&
-                        &buffers[other.alias_of] == &buffer) ++alias_count;
-                if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
-                    char* end = nullptr;
-                    const unsigned long limit = std::strtoul(limit_env, &end, 0);
-                    if (end && !*end && limit) {
-                        // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
-                        // storage and `result` is mapped device memory, and neither contract
-                        // promises uint32_t alignment or a uint32_t object lifetime there. The byte
-                        // bound below deliberately ignores a partial trailing dword.
-                        const size_t dwords = buffer.bytes / sizeof(uint32_t);
-                        const auto load_dword = [](const uint8_t* bytes, size_t index) {
-                            uint32_t value = 0;
-                            std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
-                            return value;
-                        };
-                        unsigned long shown = 0;
-                        for (size_t i = 0; i < dwords && shown < limit; ++i) {
-                            const uint32_t before_value = load_dword(destination, i);
-                            const uint32_t after_value = load_dword(result, i);
-                            if (before_value == after_value) continue;
-                            // Carry submit/dispatch on EVERY line. Without them the lines from
-                            // consecutive dispatches concatenate into one stream that looks like a
-                            // single dispatch's writes -- and a per-dispatch structural claim built
-                            // on that stream is meaningless. The first analysis run here did exactly
-                            // that and reported one index changing twice in "one" dispatch.
-                            std::fprintf(stderr,
-                                         "[compute]     changed submit=%llu dispatch=%llu "
-                                         "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
-                                         "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
-                                         (unsigned long long)item.submit_no,
-                                         (unsigned long long)item.dispatch_index,
-                                         (unsigned long long)(buffer.resource
-                                             ? buffer.resource->gpu_addr : 0ull),
-                                         buffer.resource ? buffer.resource->binding : 0u,
-                                         alias_count, i,
-                                         before_value, after_value, after_value & 7u,
-                                         (after_value >> 30) & 1u,
-                                         (after_value >> 3) & 0x07FFFFFFu);
-                            ++shown;
-                        }
-                    }
-                }
-            }
-            // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
-            // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
-            // after its first dispatch all later readbacks are identical. Avoiding the redundant host
-            // write removes one full pass over both source and destination. Renderer-alias
-            // invalidation and writer provenance remain unconditional: renderer-resident state can
-            // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
-            if (changed) {
-                if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                    prosper::host::guest_write_watch_notify_host_write(
-                        buffer.resource->gpu_addr, buffer.resource->size);
-                copy_compute_buffer(destination, result, buffer.bytes);
-            }
-            if (buffer.persistent && !buffer.result_baseline &&
-                ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
-                std::fprintf(stderr,
-                             "[compute]   retained exact GPU buffer result baseline binding=%u "
-                             "addr=0x%llx bytes=%u\n",
-                             buffer.resource->binding,
-                             (unsigned long long)buffer.resource->gpu_addr,
-                             buffer.resource->size);
-            ctx.unmap_memory(buffer.memory);
-            if (buffer.resource->gpu_addr) {
-                if (changed) {
-                    set_guest_gpu_write_origin("compute-writeback(buffer-full)");
-                    notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
-                    set_guest_gpu_write_origin(nullptr);
-                } else {
-                    notify_guest_gpu_write_preserving_bytes(
-                        buffer.resource->gpu_addr, buffer.resource->size);
-                }
-            }
-            if (buffer.persistent)
-                ctx.validate_cached_buffer_source(buffer.cache_key);
-            if (!buffer.resource->host_data && writer_provenance_enabled())
-                record_guest_write(GuestWriterKind::ComputeBuffer,
-                                   buffer.resource->gpu_addr, buffer.resource->size,
-                                   item.submit_no, item.dispatch_index,
-                                   item.command_order, item.code_addr);
-        }
-        writeback_buffers_ms = std::chrono::duration<double, std::milli>(
-            ComputeClock::now() - writeback_buffers_start).count();
-        if (!readback_ok) break;
-        const auto writeback_images_start = ComputeClock::now();
-        // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
-        // into the guest format, then restore its linear or 3D tiled address layout and notify the
-        // render side exactly like the buffer path.
-        for (size_t i = 0; i < images.size() && readback_ok; i++) {
-            BoundImage& bi = images[i];
-            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
-            const auto image_writeback_start = ComputeClock::now();
-            const bool image_cache_hit = bi.persistent;
-            const ShaderResource* r = bi.resource;
-            const uint32_t cb = data_format_bytes(r->format);
-            const uint32_t nc = r->num_components ? r->num_components : 1;
-            const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
-                                        r->format == DataFormat::Unorm2_10_10_10)
-                ? 4u : (size_t)cb * nc;
-            const size_t texels = (size_t)r->width * r->height * r->depth;
-            const size_t linear_bytes = texels * guest_texel;
-            uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
-            // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
-            // independently proved that the guest mirror still contains that baseline. This path
-            // therefore needs neither a large staging mapping nor a CPU memory pass.
-            if (bi.gpu_result_unchanged && bi.upload_skipped) {
-                if (trace)
-                    std::fprintf(stderr,
-                                 "[compute]   skipped GPU-identical storage writeback binding=%u "
-                                 "addr=0x%llx bytes=%llu\n",
-                                 bi.binding, (unsigned long long)r->gpu_addr,
-                                 (unsigned long long)bi.exact_result_bytes);
-                if (r->gpu_addr)
-                    notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                continue;
-            }
-            void* mapped = nullptr;
-            const auto map_start = ComputeClock::now();
-            if (g_fail_next_storage_readback_for_test.exchange(
-                    false, std::memory_order_acq_rel)) {
-                if (trace)
-                    std::fprintf(stderr,
-                                 "[compute]   injected storage readback failure binding=%u\n",
-                                 bi.binding);
-                readback_ok = false;
-                break;
-            }
-            if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
-                readback_ok = false;
-                break;
-            }
-            const auto map_done = ComputeClock::now();
-            const bool array_image = backend_uses_2d_array(*r);
-            static const bool direct_tiled_writeback_disabled =
-                std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
-            const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
-                bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
-                direct_tiled_writeback_disabled);
-            std::unique_ptr<uint8_t[]> linear;
-            uint8_t* packed = destination;
-            if ((r->tile_mode && !tile_mapped_bytes) ||
-                (!r->tile_mode && array_image && r->depth > 1)) {
-                linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
-                packed = linear.get();
-            }
-            const uint32_t* channels = static_cast<const uint32_t*>(mapped);
-            const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
-            // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
-            // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
-            // that guest memory still contains the prior result, and this dispatch reproduced the
-            // same row-major bytes. If either comparison fails, take the ordinary writeback below.
-            const bool repeated_output = bi.cache_candidate && bi.persistent &&
-                bi.upload_skipped && bi.exact_storage_bytes() &&
-                ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
-            const auto prepare_done = ComputeClock::now();
-            if (repeated_output) {
-                if (trace)
-                    std::fprintf(stderr,
-                                 "[compute]   skipped identical storage writeback binding=%u "
-                                 "addr=0x%llx bytes=%llu\n",
-                                 bi.binding, (unsigned long long)r->gpu_addr,
-                                 (unsigned long long)bi.exact_result_bytes);
-                ctx.unmap_memory(staging_memory[i]);
-                if (r->gpu_addr)
-                    notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                continue;
-            }
-            // Notify page-based dirty trackers only when bytes will actually be written. Doing this
-            // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
-            // even on the no-write path, defeating the validation that made that path safe.
-            if (!r->host_data && r->gpu_addr)
-                prosper::host::guest_write_watch_notify_host_write(
-                    r->gpu_addr, bi.guest_bytes);
-            const auto watch_done = ComputeClock::now();
-            // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
-            // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
-            // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
-            // and, for a partial write, restore the un-stored texels from the clean seed after packing.
-            std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
-            if (bi.poison_verify) {
-                size_t survived = 0;
-                poison_texel.assign(texels, 0);
-                for (size_t t = 0; t < texels; ++t) {
-                    bool all = true;
-                    if (bi.exact_storage_bytes()) {
-                        const uint8_t* texel = native_texels + t * guest_texel;
-                        for (size_t b = 0; b < guest_texel; ++b)
-                            if (texel[b] != 0x5a) all = false;
-                    } else {
-                        for (uint32_t c = 0; c < 4; ++c)
-                            if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
-                    }
-                    if (all) { ++survived; poison_texel[t] = 1; }
-                }
-                {
-                    const SeedCoverageKey proof_key{item.code_addr, bi.binding,
-                                                    r->width, r->height, r->depth};
-                    std::lock_guard<std::mutex> lk(seed_coverage_mu);
-                    // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                    seed_coverage_proof[proof_key] =
-                        SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
-                }
-                std::fprintf(stderr,
-                             "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
-                             (unsigned long long)item.code_addr, bi.binding, texels, survived,
-                             survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
-            }
-            if (trace) {
-                if (bi.exact_storage_bytes()) {
-                    for (size_t t = 0; t < texels; ++t) {
-                        const uint8_t* texel = native_texels + t * guest_texel;
-                        for (size_t b = 0; b < guest_texel; ++b)
-                            bi.nonzero_channels += texel[b] != 0;
-                    }
-                } else {
-                    for (size_t t = 0; t < texels; t++)
-                        for (uint32_t c = 0; c < 4; c++)
-                            bi.nonzero_channels += channels[t * 4 + c] != 0;
-                }
-            }
-            const auto pack_start = ComputeClock::now();
-            static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
-            if (bi.exact_storage_bytes()) {
-                // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
-                // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
-                // non-proving write can feed those bytes straight to the tiler, avoiding a second
-                // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
-                if (!tile_mapped_bytes)
-                    parallel_compute_texels(texels, linear_bytes * 2,
-                        [&](size_t begin, size_t end) {
-                            std::memcpy(packed + begin * guest_texel,
-                                        native_texels + begin * guest_texel,
-                                        (end - begin) * guest_texel);
-                        });
-            } else if (pack_range_enabled) {
-                storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
-            } else {
-                for (size_t t = 0; t < texels; t++)
-                    storage_pack_texel(channels + t * 4, r->format, nc,
-                                       packed + t * guest_texel);
-            }
-            // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
-            // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
-            // content (exactly a partial write's contract). Full-coverage proving frames have no
-            // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
-            if (bi.poison_verify && !poison_texel.empty() &&
-                bi.seed_linear.size() == linear_bytes) {
-                for (size_t t = 0; t < texels; ++t) {
-                    if (poison_texel[t])
-                        std::memcpy(packed + t * guest_texel,
-                                    bi.seed_linear.data() + t * guest_texel, guest_texel);
-                }
-            }
-            const auto pack_done = ComputeClock::now();
-            static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
-            if (verify_pack && !bi.exact_storage_bytes()) {
-                // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
-                // be bit-identical to the per-texel path it replaces, verified against the real
-                // workload's texels. Logs the clean case too, so a verified run is self-proving.
-                std::vector<uint8_t> expect(guest_texel);
-                size_t bad = 0, first_bad = 0;
-                for (size_t t = 0; t < texels; ++t) {
-                    std::memset(expect.data(), 0, expect.size());
-                    storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
-                    if (std::memcmp(expect.data(), packed + t * guest_texel,
-                                    guest_texel) != 0) {
-                        if (!bad) first_bad = t;
-                        ++bad;
-                    }
-                }
-                std::fprintf(stderr,
-                             "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
-                             "texels=%zu mismatches=%zu%s\n",
-                             bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
-                             nc, texels, bad, bad ? " MISMATCH" : "");
-                if (bad)
-                    std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
-                                 first_bad);
-            }
-            const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
-            if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
-                if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
-                                 r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                void* mapped = nullptr;
+                const auto map_start = ComputeClock::now();
+                if (g_fail_next_storage_readback_for_test.exchange(
+                        false, std::memory_order_acq_rel)) {
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   injected storage readback failure binding=%u\n",
+                                     bi.binding);
                     readback_ok = false;
-                    ctx.unmap_memory(staging_memory[i]);
                     break;
                 }
-            } else if (array_image && r->depth > 1) {
-                const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
-                const size_t selected_slice = r->in_mip_tail
-                    ? r->mip_tail_bytes
-                    : (r->tile_mode
-                           ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
-                                                 static_cast<uint32_t>(guest_texel))
-                           : (r->layer_stride_bytes
-                                  ? linear_array_surface_bytes(
-                                        *r, static_cast<uint32_t>(guest_texel))
-                                  : linear_slice));
-                const size_t layer_stride = r->layer_stride_bytes
-                    ? r->layer_stride_bytes : selected_slice;
-                for (uint32_t layer = 0; layer < r->depth; ++layer) {
-                    uint8_t* layer_base = destination + layer_stride * layer;
-                    if (!r->tile_mode) {
-                        const size_t row_pitch = r->layer_stride_bytes
-                            ? linear_array_row_pitch(
-                                  *r, static_cast<uint32_t>(guest_texel))
-                            : static_cast<size_t>(r->width) * guest_texel;
-                        for (uint32_t y = 0; y < r->height; ++y)
-                            std::memcpy(
-                                layer_base + r->layer_mip_offset_bytes + y * row_pitch,
-                                layout_source + linear_slice * layer +
-                                    static_cast<size_t>(y) * r->width * guest_texel,
-                                static_cast<size_t>(r->width) * guest_texel);
-                    } else if (r->in_mip_tail) {
-                        tile_surface_level(
-                            layer_base, r->mip_tail_bytes,
-                            layout_source + linear_slice * layer,
-                            r->width, r->height, r->tile_mode,
-                            static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
+                if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
+                    readback_ok = false;
+                    break;
+                }
+                const auto map_done = ComputeClock::now();
+                const bool array_image = backend_uses_2d_array(*r);
+                static const bool direct_tiled_writeback_disabled =
+                    std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
+                const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
+                    bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
+                    direct_tiled_writeback_disabled);
+                std::unique_ptr<uint8_t[]> linear;
+                uint8_t* packed = destination;
+                if ((r->tile_mode && !tile_mapped_bytes) ||
+                    (!r->tile_mode && array_image && r->depth > 1)) {
+                    linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
+                    packed = linear.get();
+                }
+                const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+                const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
+                // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
+                // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
+                // that guest memory still contains the prior result, and this dispatch reproduced the
+                // same row-major bytes. If either comparison fails, take the ordinary writeback below.
+                const bool repeated_output = bi.cache_candidate && bi.persistent &&
+                    bi.upload_skipped && bi.exact_storage_bytes() &&
+                    ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
+                const auto prepare_done = ComputeClock::now();
+                if (repeated_output) {
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   skipped identical storage writeback binding=%u "
+                                     "addr=0x%llx bytes=%llu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)bi.exact_result_bytes);
+                    ctx.unmap_memory(staging_memory[i]);
+                    if (r->gpu_addr)
+                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                    continue;
+                }
+                // Notify page-based dirty trackers only when bytes will actually be written. Doing this
+                // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
+                // even on the no-write path, defeating the validation that made that path safe.
+                if (!r->host_data && r->gpu_addr)
+                    prosper::host::guest_write_watch_notify_host_write(
+                        r->gpu_addr, bi.guest_bytes);
+                const auto watch_done = ComputeClock::now();
+                // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
+                // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
+                // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
+                // and, for a partial write, restore the un-stored texels from the clean seed after packing.
+                std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
+                if (bi.poison_verify) {
+                    size_t survived = 0;
+                    poison_texel.assign(texels, 0);
+                    for (size_t t = 0; t < texels; ++t) {
+                        bool all = true;
+                        if (bi.exact_storage_bytes()) {
+                            const uint8_t* texel = native_texels + t * guest_texel;
+                            for (size_t b = 0; b < guest_texel; ++b)
+                                if (texel[b] != 0x5a) all = false;
+                        } else {
+                            for (uint32_t c = 0; c < 4; ++c)
+                                if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
+                        }
+                        if (all) { ++survived; poison_texel[t] = 1; }
+                    }
+                    {
+                        const SeedCoverageKey proof_key{item.code_addr, bi.binding,
+                                                        r->width, r->height, r->depth};
+                        std::lock_guard<std::mutex> lk(seed_coverage_mu);
+                        // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
+                        seed_coverage_proof[proof_key] =
+                            SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
+                    }
+                    std::fprintf(stderr,
+                                 "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
+                                 (unsigned long long)item.code_addr, bi.binding, texels, survived,
+                                 survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
+                }
+                if (trace) {
+                    if (bi.exact_storage_bytes()) {
+                        for (size_t t = 0; t < texels; ++t) {
+                            const uint8_t* texel = native_texels + t * guest_texel;
+                            for (size_t b = 0; b < guest_texel; ++b)
+                                bi.nonzero_channels += texel[b] != 0;
+                        }
                     } else {
-                        tile_surface(
-                            layer_base + r->layer_mip_offset_bytes,
-                            layout_source + linear_slice * layer,
-                            r->width, r->height, r->tile_mode, 0,
-                            static_cast<uint32_t>(guest_texel));
+                        for (size_t t = 0; t < texels; t++)
+                            for (uint32_t c = 0; c < 4; c++)
+                                bi.nonzero_channels += channels[t * 4 + c] != 0;
                     }
                 }
-            } else if (r->tile_mode && r->in_mip_tail) {
-                tile_surface_level(destination, bi.guest_bytes, layout_source,
-                                   r->width, r->height, r->tile_mode,
-                                   static_cast<uint32_t>(guest_texel),
-                                   r->mip_tail_x, r->mip_tail_y);
-            } else if (r->tile_mode) {
-                tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
-                             static_cast<uint32_t>(guest_texel));
-            }
-            const auto layout_done = ComputeClock::now();
-            pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
-            layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
-            if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
-            const auto notify_start = ComputeClock::now();
-            // Name the writer. "a guest write covers this surface" and "prosper's own compute
-            // writeback covers this surface" are different facts, and only the second says the
-            // emulator is invalidating its own caches. Everything reaching the DS invalidation path
-            // used to report the default `gpu`, which cannot distinguish them.
-            set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
-            notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
-            set_guest_gpu_write_origin(nullptr);
-            if (!r->host_data && writer_provenance_enabled())
-                record_guest_write(GuestWriterKind::ComputeBuffer,
-                                   r->gpu_addr, bi.guest_bytes,
-                                   item.submit_no, item.dispatch_index,
-                                   item.command_order, item.code_addr);
-            if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
-                const bool leave_compressed_for_test =
-                    g_leave_next_dcc_metadata_compressed_for_test.exchange(
-                        false, std::memory_order_acq_rel);
-                if (!leave_compressed_for_test) {
-                    std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
-                    // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
-                    // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
-                    // aspects" and invalidates depth as well as stencil. So this reset can discard a
-                    // retained depth image. Tagged so that consequence is attributable rather than
-                    // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
-                    // separate question that needs the operation's real HTILE semantics proven.
-                    set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
-                    notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
-                    set_guest_gpu_write_origin(nullptr);
-                    if (!r->dcc_metadata_host_data && writer_provenance_enabled())
-                        record_guest_write(GuestWriterKind::ComputeBuffer,
-                                           r->metadata_addr, bi.dcc_metadata_bytes,
-                                           item.submit_no, item.dispatch_index,
-                                           item.command_order, item.code_addr);
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   DCC uncompressed binding=%u meta=0x%llx "
-                                     "bytes=%zu code=0xff\n",
-                                     bi.binding, (unsigned long long)r->metadata_addr,
-                                     bi.dcc_metadata_bytes);
-                } else if (trace) {
-                    std::fprintf(stderr,
-                                 "[compute]   injected unresolved DCC writeback binding=%u\n",
-                                 bi.binding);
+                const auto pack_start = ComputeClock::now();
+                static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
+                if (bi.exact_storage_bytes()) {
+                    // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
+                    // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
+                    // non-proving write can feed those bytes straight to the tiler, avoiding a second
+                    // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
+                    if (!tile_mapped_bytes)
+                        parallel_compute_texels(texels, linear_bytes * 2,
+                            [&](size_t begin, size_t end) {
+                                std::memcpy(packed + begin * guest_texel,
+                                            native_texels + begin * guest_texel,
+                                            (end - begin) * guest_texel);
+                            });
+                } else if (pack_range_enabled) {
+                    storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
+                } else {
+                    for (size_t t = 0; t < texels; t++)
+                        storage_pack_texel(channels + t * 4, r->format, nc,
+                                           packed + t * guest_texel);
                 }
-            }
-            if (bi.mirror_result_to_imported) {
-                const BoundImage& mirror = images[bi.seed_from_imported];
-                notify_live_render_target_image_written({
-                    r->gpu_addr, mirror.imported_width, mirror.imported_height,
-                    mirror.imported_pixel_format});
-                if (trace)
-                    std::fprintf(stderr,
-                                 "[compute]   mirrored storage result into renderer RTT "
-                                 "binding=%u addr=0x%llx extent=%ux%u\n",
-                                 bi.binding, (unsigned long long)r->gpu_addr,
-                                 mirror.imported_width, mirror.imported_height);
-            }
-            const auto notify_done = ComputeClock::now();
-            bool retain_gpu_result_baseline = false;
-            bool promoted_after_writeback = false;
-            const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
-                std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
-                            [](uint8_t value) { return value == 0xff; });
-            if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
-                const uint8_t* retained_source =
-                    (adaptive_storage_result_validation_enabled() &&
-                     cold_storage_result_snapshot_can_defer(
-                         r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
-                         cold_storage_result_snapshot_defer_min_bytes()))
-                    ? nullptr : destination;
-                if (bi.forced_seed_allocation_reused) {
-                    // The exact cache entry was already pinned and forcibly reseeded before this
-                    // dispatch. Successful writeback plus the final all-uncompressed metadata scan
-                    // may now restore source/transfer authority without replacing its allocation.
-                    bi.cache_candidate = true;
-                    g_dcc_post_writeback_promotions.fetch_add(
-                        1, std::memory_order_relaxed);
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   promoted reused post-writeback DCC storage "
-                                     "image binding=%u addr=0x%llx allocation=%llu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     (unsigned long long)bi.allocation_bytes);
-                } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                    ctx.replace_or_retain_image(
-                        bi.cache_key, bi.image, bi.memory,
-                        bi.allocation_bytes, retained_source)) {
-                    bi.cache_candidate = true;
-                    bi.persistent = true;
-                    promoted_after_writeback = true;
-                    g_dcc_post_writeback_promotions.fetch_add(
-                        1, std::memory_order_relaxed);
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   promoted post-writeback DCC storage image "
-                                     "binding=%u addr=0x%llx allocation=%llu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     (unsigned long long)bi.allocation_bytes);
+                // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
+                // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
+                // content (exactly a partial write's contract). Full-coverage proving frames have no
+                // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
+                if (bi.poison_verify && !poison_texel.empty() &&
+                    bi.seed_linear.size() == linear_bytes) {
+                    for (size_t t = 0; t < texels; ++t) {
+                        if (poison_texel[t])
+                            std::memcpy(packed + t * guest_texel,
+                                        bi.seed_linear.data() + t * guest_texel, guest_texel);
+                    }
                 }
-            }
-            if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
-                ctx.invalidate_cached_image_source(bi.cache_key);
-            if (bi.cache_candidate) {
-                if (bi.persistent && !promoted_after_writeback) {
-                    // Guest bytes now mirror the retained image again. A changing full-overwrite
-                    // target needs no source snapshot; the first repeated result retains one exact
-                    // baseline, and subsequent identical GPU skips do not recopy it.
-                    ctx.validate_cached_image_source(
-                        bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
-                        bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
-                            native_3d_transfer_enabled());
-                } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                           ctx.retain_image(bi.cache_key, bi.image, bi.memory,
-                                            bi.allocation_bytes,
-                                            (adaptive_storage_result_validation_enabled() &&
-                                             cold_storage_result_snapshot_can_defer(
-                                                 r->host_data != nullptr, bi.seed_skip,
-                                                 bi.guest_bytes,
-                                                 cold_storage_result_snapshot_defer_min_bytes()))
-                                                ? nullptr : destination)) {
-                    bi.persistent = true;
+                const auto pack_done = ComputeClock::now();
+                static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
+                if (verify_pack && !bi.exact_storage_bytes()) {
+                    // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
+                    // be bit-identical to the per-texel path it replaces, verified against the real
+                    // workload's texels. Logs the clean case too, so a verified run is self-proving.
+                    std::vector<uint8_t> expect(guest_texel);
+                    size_t bad = 0, first_bad = 0;
+                    for (size_t t = 0; t < texels; ++t) {
+                        std::memset(expect.data(), 0, expect.size());
+                        storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
+                        if (std::memcmp(expect.data(), packed + t * guest_texel,
+                                        guest_texel) != 0) {
+                            if (!bad) first_bad = t;
+                            ++bad;
+                        }
+                    }
+                    std::fprintf(stderr,
+                                 "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
+                                 "texels=%zu mismatches=%zu%s\n",
+                                 bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
+                                 nc, texels, bad, bad ? " MISMATCH" : "");
+                    if (bad)
+                        std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
+                                     first_bad);
+                }
+                const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
+                if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
+                    if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
+                                     r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                        readback_ok = false;
+                        ctx.unmap_memory(staging_memory[i]);
+                        break;
+                    }
+                } else if (array_image && r->depth > 1) {
+                    const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
+                    const size_t selected_slice = r->in_mip_tail
+                        ? r->mip_tail_bytes
+                        : (r->tile_mode
+                               ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
+                                                     static_cast<uint32_t>(guest_texel))
+                               : (r->layer_stride_bytes
+                                      ? linear_array_surface_bytes(
+                                            *r, static_cast<uint32_t>(guest_texel))
+                                      : linear_slice));
+                    const size_t layer_stride = r->layer_stride_bytes
+                        ? r->layer_stride_bytes : selected_slice;
+                    for (uint32_t layer = 0; layer < r->depth; ++layer) {
+                        uint8_t* layer_base = destination + layer_stride * layer;
+                        if (!r->tile_mode) {
+                            const size_t row_pitch = r->layer_stride_bytes
+                                ? linear_array_row_pitch(
+                                      *r, static_cast<uint32_t>(guest_texel))
+                                : static_cast<size_t>(r->width) * guest_texel;
+                            for (uint32_t y = 0; y < r->height; ++y)
+                                std::memcpy(
+                                    layer_base + r->layer_mip_offset_bytes + y * row_pitch,
+                                    layout_source + linear_slice * layer +
+                                        static_cast<size_t>(y) * r->width * guest_texel,
+                                    static_cast<size_t>(r->width) * guest_texel);
+                        } else if (r->in_mip_tail) {
+                            tile_surface_level(
+                                layer_base, r->mip_tail_bytes,
+                                layout_source + linear_slice * layer,
+                                r->width, r->height, r->tile_mode,
+                                static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
+                        } else {
+                            tile_surface(
+                                layer_base + r->layer_mip_offset_bytes,
+                                layout_source + linear_slice * layer,
+                                r->width, r->height, r->tile_mode, 0,
+                                static_cast<uint32_t>(guest_texel));
+                        }
+                    }
+                } else if (r->tile_mode && r->in_mip_tail) {
+                    tile_surface_level(destination, bi.guest_bytes, layout_source,
+                                       r->width, r->height, r->tile_mode,
+                                       static_cast<uint32_t>(guest_texel),
+                                       r->mip_tail_x, r->mip_tail_y);
+                } else if (r->tile_mode) {
+                    tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
+                                 static_cast<uint32_t>(guest_texel));
+                }
+                const auto layout_done = ComputeClock::now();
+                pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
+                layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
+                if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
+                const auto notify_start = ComputeClock::now();
+                // Name the writer. "a guest write covers this surface" and "prosper's own compute
+                // writeback covers this surface" are different facts, and only the second says the
+                // emulator is invalidating its own caches. Everything reaching the DS invalidation path
+                // used to report the default `gpu`, which cannot distinguish them.
+                set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
+                notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+                set_guest_gpu_write_origin(nullptr);
+                if (!r->host_data && writer_provenance_enabled())
+                    record_guest_write(GuestWriterKind::ComputeBuffer,
+                                       r->gpu_addr, bi.guest_bytes,
+                                       item.submit_no, item.dispatch_index,
+                                       item.command_order, item.code_addr);
+                if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
+                    const bool leave_compressed_for_test =
+                        g_leave_next_dcc_metadata_compressed_for_test.exchange(
+                            false, std::memory_order_acq_rel);
+                    if (!leave_compressed_for_test) {
+                        std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                        // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
+                        // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
+                        // aspects" and invalidates depth as well as stencil. So this reset can discard a
+                        // retained depth image. Tagged so that consequence is attributable rather than
+                        // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
+                        // separate question that needs the operation's real HTILE semantics proven.
+                        set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
+                        notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                        set_guest_gpu_write_origin(nullptr);
+                        if (!r->dcc_metadata_host_data && writer_provenance_enabled())
+                            record_guest_write(GuestWriterKind::ComputeBuffer,
+                                               r->metadata_addr, bi.dcc_metadata_bytes,
+                                               item.submit_no, item.dispatch_index,
+                                               item.command_order, item.code_addr);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   DCC uncompressed binding=%u meta=0x%llx "
+                                         "bytes=%zu code=0xff\n",
+                                         bi.binding, (unsigned long long)r->metadata_addr,
+                                         bi.dcc_metadata_bytes);
+                    } else if (trace) {
+                        std::fprintf(stderr,
+                                     "[compute]   injected unresolved DCC writeback binding=%u\n",
+                                     bi.binding);
+                    }
+                }
+                if (bi.mirror_result_to_imported) {
+                    const BoundImage& mirror = images[bi.seed_from_imported];
+                    notify_live_render_target_image_written({
+                        r->gpu_addr, mirror.imported_width, mirror.imported_height,
+                        mirror.imported_pixel_format});
                     if (trace)
                         std::fprintf(stderr,
-                                     "[compute]   retained storage image binding=%u "
-                                     "addr=0x%llx allocation=%llu\n",
+                                     "[compute]   mirrored storage result into renderer RTT "
+                                     "binding=%u addr=0x%llx extent=%ux%u\n",
                                      bi.binding, (unsigned long long)r->gpu_addr,
-                                     (unsigned long long)bi.allocation_bytes);
+                                     mirror.imported_width, mirror.imported_height);
                 }
-                // An aligned exact result is retained as the staging buffer immediately below.
-                // Copying it into a host vector first only to clear that vector after ownership
-                // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
-                // setup keeps the exact current host fallback; a failed ownership attempt invalidates
-                // any older fallback so the next dispatch takes the ordinary writeback path.
-                const bool force_host_result_fallback =
-                    bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
-                    !(bi.exact_result_bytes & 15u) &&
-                    g_force_next_image_result_host_fallback_for_test.exchange(
-                        false, std::memory_order_acq_rel);
-                retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
-                    bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
-                    !force_host_result_fallback && ctx.prepare_compare_pipeline();
-                if (bi.persistent && !retain_gpu_result_baseline)
-                    ctx.remember_cached_image_result(
-                        bi.cache_key, native_texels,
-                        static_cast<size_t>(bi.exact_result_bytes));
-            }
-            const auto cache_done = ComputeClock::now();
-            ctx.unmap_memory(staging_memory[i]);
-            const VkBuffer retained_result = staging[i];
-            if (retain_gpu_result_baseline &&
-                ctx.retain_cached_image_result_buffer(
-                    bi.cache_key, staging[i], staging_memory[i],
-                    bi.staging_allocation_bytes, bi.exact_result_bytes)) {
-                bi.result_baseline = retained_result;
-                if (trace)
+                const auto notify_done = ComputeClock::now();
+                bool retain_gpu_result_baseline = false;
+                bool promoted_after_writeback = false;
+                const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
+                    std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
+                                [](uint8_t value) { return value == 0xff; });
+                if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
+                    const uint8_t* retained_source =
+                        (adaptive_storage_result_validation_enabled() &&
+                         cold_storage_result_snapshot_can_defer(
+                             r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
+                             cold_storage_result_snapshot_defer_min_bytes()))
+                        ? nullptr : destination;
+                    if (bi.forced_seed_allocation_reused) {
+                        // The exact cache entry was already pinned and forcibly reseeded before this
+                        // dispatch. Successful writeback plus the final all-uncompressed metadata scan
+                        // may now restore source/transfer authority without replacing its allocation.
+                        bi.cache_candidate = true;
+                        g_dcc_post_writeback_promotions.fetch_add(
+                            1, std::memory_order_relaxed);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   promoted reused post-writeback DCC storage "
+                                         "image binding=%u addr=0x%llx allocation=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.allocation_bytes);
+                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                        ctx.replace_or_retain_image(
+                            bi.cache_key, bi.image, bi.memory,
+                            bi.allocation_bytes, retained_source)) {
+                        bi.cache_candidate = true;
+                        bi.persistent = true;
+                        promoted_after_writeback = true;
+                        g_dcc_post_writeback_promotions.fetch_add(
+                            1, std::memory_order_relaxed);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   promoted post-writeback DCC storage image "
+                                         "binding=%u addr=0x%llx allocation=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.allocation_bytes);
+                    }
+                }
+                if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
+                    ctx.invalidate_cached_image_source(bi.cache_key);
+                if (bi.cache_candidate) {
+                    if (bi.persistent && !promoted_after_writeback) {
+                        // Guest bytes now mirror the retained image again. A changing full-overwrite
+                        // target needs no source snapshot; the first repeated result retains one exact
+                        // baseline, and subsequent identical GPU skips do not recopy it.
+                        ctx.validate_cached_image_source(
+                            bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
+                            bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
+                                native_3d_transfer_enabled());
+                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                               ctx.retain_image(bi.cache_key, bi.image, bi.memory,
+                                                bi.allocation_bytes,
+                                                (adaptive_storage_result_validation_enabled() &&
+                                                 cold_storage_result_snapshot_can_defer(
+                                                     r->host_data != nullptr, bi.seed_skip,
+                                                     bi.guest_bytes,
+                                                     cold_storage_result_snapshot_defer_min_bytes()))
+                                                    ? nullptr : destination)) {
+                        bi.persistent = true;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   retained storage image binding=%u "
+                                         "addr=0x%llx allocation=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.allocation_bytes);
+                    }
+                    // An aligned exact result is retained as the staging buffer immediately below.
+                    // Copying it into a host vector first only to clear that vector after ownership
+                    // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
+                    // setup keeps the exact current host fallback; a failed ownership attempt invalidates
+                    // any older fallback so the next dispatch takes the ordinary writeback path.
+                    const bool force_host_result_fallback =
+                        bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
+                        !(bi.exact_result_bytes & 15u) &&
+                        g_force_next_image_result_host_fallback_for_test.exchange(
+                            false, std::memory_order_acq_rel);
+                    retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
+                        bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
+                        !force_host_result_fallback && ctx.prepare_compare_pipeline();
+                    if (bi.persistent && !retain_gpu_result_baseline)
+                        ctx.remember_cached_image_result(
+                            bi.cache_key, native_texels,
+                            static_cast<size_t>(bi.exact_result_bytes));
+                }
+                const auto cache_done = ComputeClock::now();
+                ctx.unmap_memory(staging_memory[i]);
+                const VkBuffer retained_result = staging[i];
+                if (retain_gpu_result_baseline &&
+                    ctx.retain_cached_image_result_buffer(
+                        bi.cache_key, staging[i], staging_memory[i],
+                        bi.staging_allocation_bytes, bi.exact_result_bytes)) {
+                    bi.result_baseline = retained_result;
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   retained exact GPU result baseline binding=%u "
+                                     "addr=0x%llx bytes=%zu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
+                }
+                const auto image_writeback_done = ComputeClock::now();
+                const auto image_milliseconds = [](auto begin, auto end) {
+                    return std::chrono::duration<double, std::milli>(end - begin).count();
+                };
+                image_map_ms += image_milliseconds(map_start, map_done);
+                image_prepare_ms += image_milliseconds(map_done, prepare_done);
+                image_watch_ms += image_milliseconds(prepare_done, watch_done);
+                image_notify_ms += image_milliseconds(notify_start, notify_done);
+                image_cache_ms += image_milliseconds(notify_done, cache_done);
+                if (image_timing)
                     std::fprintf(stderr,
-                                 "[compute]   retained exact GPU result baseline binding=%u "
-                                 "addr=0x%llx bytes=%zu\n",
-                                 bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
+                                 "[compute-image-writeback] code=0x%llx hash=0x%016llx "
+                                 "binding=%u addr=0x%llx "
+                                 "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
+                                 "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
+                                 "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
+                                 "total_ms=%.3f\n",
+                                 (unsigned long long)item.code_addr,
+                                 (unsigned long long)timing_program_hash, bi.binding,
+                                 (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
+                                 r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
+                                 bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
+                                 image_milliseconds(map_start, map_done),
+                                 image_milliseconds(map_done, prepare_done),
+                                 image_milliseconds(prepare_done, watch_done),
+                                 image_milliseconds(pack_start, pack_done),
+                                 image_milliseconds(pack_done, layout_done),
+                                 image_milliseconds(notify_start, notify_done),
+                                 image_milliseconds(notify_done, cache_done),
+                                 image_milliseconds(image_writeback_start, image_writeback_done));
             }
-            const auto image_writeback_done = ComputeClock::now();
-            const auto image_milliseconds = [](auto begin, auto end) {
-                return std::chrono::duration<double, std::milli>(end - begin).count();
-            };
-            image_map_ms += image_milliseconds(map_start, map_done);
-            image_prepare_ms += image_milliseconds(map_done, prepare_done);
-            image_watch_ms += image_milliseconds(prepare_done, watch_done);
-            image_notify_ms += image_milliseconds(notify_start, notify_done);
-            image_cache_ms += image_milliseconds(notify_done, cache_done);
-            if (image_timing)
-                std::fprintf(stderr,
-                             "[compute-image-writeback] code=0x%llx hash=0x%016llx "
-                             "binding=%u addr=0x%llx "
-                             "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
-                             "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
-                             "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
-                             "total_ms=%.3f\n",
-                             (unsigned long long)item.code_addr,
-                             (unsigned long long)timing_program_hash, bi.binding,
-                             (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
-                             r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
-                             bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
-                             image_milliseconds(map_start, map_done),
-                             image_milliseconds(map_done, prepare_done),
-                             image_milliseconds(prepare_done, watch_done),
-                             image_milliseconds(pack_start, pack_done),
-                             image_milliseconds(pack_done, layout_done),
-                             image_milliseconds(notify_start, notify_done),
-                             image_milliseconds(notify_done, cache_done),
-                             image_milliseconds(image_writeback_start, image_writeback_done));
-        }
-        writeback_images_ms = std::chrono::duration<double, std::milli>(
-            ComputeClock::now() - writeback_images_start).count();
-        if (!readback_ok) break;
-        const auto writeback_publish_start = ComputeClock::now();
-        // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
-        // completed, and a failed dispatch cannot reach here. Native results may seed a later
-        // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
-        // also be exported directly to graphics. Raw interchange images are compatible with neither.
-        for (const BoundImage& image : images) {
-            if (!image.storage) continue;
-            const bool unique = image.alias_of == SIZE_MAX;
-            const bool native_exact_storage = image.native_float_storage ||
-                image.native_uint_storage || image.packed_r11_storage;
-            const bool publish_eligible = native_exact_storage && unique &&
-                image.cache_candidate && image.persistent;
-            const bool authorized = publish_eligible &&
-                ctx.authorize_cached_image_compute_transfer(image.cache_key);
-            transfer_gate_census.record_storage_publish(
-                transfer_gate_observation.role, native_exact_storage, unique,
-                image.cache_candidate, image.persistent, authorized);
-            if (authority_observation.selected && unique && image.resource) {
-                authority_census.record_selected_storage_output(
-                    item, image.binding,
-                    ShadowComputeAuthorityRange::from(
-                        image.resource->gpu_addr, image.guest_bytes),
-                    authorized);
+            writeback_images_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_images_start).count();
+            if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                              // site turns a false return back into that break
+            const auto writeback_publish_start = ComputeClock::now();
+            // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
+            // completed, and a failed dispatch cannot reach here. Native results may seed a later
+            // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
+            // also be exported directly to graphics. Raw interchange images are compatible with neither.
+            for (const BoundImage& image : images) {
+                if (!image.storage) continue;
+                const bool unique = image.alias_of == SIZE_MAX;
+                const bool native_exact_storage = image.native_float_storage ||
+                    image.native_uint_storage || image.packed_r11_storage;
+                const bool publish_eligible = native_exact_storage && unique &&
+                    image.cache_candidate && image.persistent;
+                const bool authorized = publish_eligible &&
+                    ctx.authorize_cached_image_compute_transfer(image.cache_key);
+                transfer_gate_census.record_storage_publish(
+                    transfer_gate_observation.role, native_exact_storage, unique,
+                    image.cache_candidate, image.persistent, authorized);
+                if (authority_observation.selected && unique && image.resource) {
+                    authority_census.record_selected_storage_output(
+                        item, image.binding,
+                        ShadowComputeAuthorityRange::from(
+                            image.resource->gpu_addr, image.guest_bytes),
+                        authorized);
+                }
+                if (publish_eligible && image.graphics_sampled_usage)
+                    ctx.authorize_cached_image_export(image.cache_key, item.command_order);
             }
-            if (publish_eligible && image.graphics_sampled_usage)
-                ctx.authorize_cached_image_export(image.cache_key, item.command_order);
-        }
-        writeback_publish_ms = std::chrono::duration<double, std::milli>(
-            ComputeClock::now() - writeback_publish_start).count();
-        ok = true;
-        phase_writeback = ComputeClock::now();
+            writeback_publish_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - writeback_publish_start).count();
+            ok = true;
+            phase_writeback = ComputeClock::now();
+            return true;
+        };
+        if (!consume_dispatch()) break;
     } while (false);
 
     if (trace)

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -9019,178 +9019,340 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 : vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
         }
         if (!vk_ok(compute_submit_rc, "queue-submit")) break;
-        if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
-        const auto fence_wait_start = ComputeClock::now();
-        const VkResult wait_result = vkWaitForFences(
-            ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
-        // Report a LONG wait even when it succeeds.
-        //
-        // A zero timeout count was read as proof that no compute dispatch hangs. That inference has a
-        // hole: an amdgpu context reset SIGNALS pending fences, so a dispatch the kernel watchdog
-        // killed can return VK_SUCCESS here and look indistinguishable from one that finished in
-        // microseconds — with the loss surfacing only at the NEXT submit. Duration is what separates
-        // them: a killed job sits at roughly the kernel's timeout (~10 s), a real one is sub-millisecond.
-        {
-            const double waited_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - fence_wait_start).count();
-            if (waited_ms >= 100.0) {
-                static std::atomic<int> slow{0};
-                const int n = slow.fetch_add(1);
-                if (n < 24 || (n & 255) == 0)
-                    std::fprintf(stderr,
-                                 "[compute] SLOW fence wait %.1f ms result=%d program=0x%llx "
-                                 "submit=%llu dispatch=%llu order=%llu groups=%ux%ux%u\n",
-                                 waited_ms, static_cast<int>(wait_result),
-                                 static_cast<unsigned long long>(item.code_addr),
-                                 static_cast<unsigned long long>(item.submit_no),
-                                 static_cast<unsigned long long>(item.dispatch_index),
-                                 static_cast<unsigned long long>(item.command_order),
-                                 item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
-            }
-        }
-        if (!vk_ok(wait_result, "queue-wait")) {
-            // cleanup() releases resources referenced by the command buffer, including a borrowed
-            // renderer image's pin. With that image bound, in-flight work still references it and
-            // its layout transitions, so drain the queue first rather than freeing it underneath
-            // the GPU.
-            // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
-            // to success; this item stays failed either way, which is the conservative choice for a
-            // dispatch whose results we can no longer trust.
-            if (!ctx.device_lost) {
-                std::unique_lock<std::mutex> qlk(
-                    prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
-                if (prosper::gpu::shared_present_active()) qlk.lock();
-                const VkResult drain_result = vkQueueWaitIdle(ctx.queue);
-                completion_proven = drain_result == VK_SUCCESS;
-                // Soft: this drain runs INSIDE the queue-wait failure path, which has already
-                // declined. Declining again would report one fence timeout as two refusals.
-                if (!vk_soft_ok(drain_result, "queue-drain") && trace)
-                    std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
-            }
-            break;
-        }
-        completion_proven = true;
-        if (perf_gpu_timing) {
-            uint64_t timestamps[6]{};
-            if (vkGetQueryPoolResults(ctx.device, ctx.dispatch_timestamp_pool, 0, 6,
-                                      sizeof(timestamps), timestamps, sizeof(uint64_t),
-                                      VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
-                const uint64_t mask = ctx.timestamp_valid_bits >= 64
-                    ? UINT64_MAX : ((uint64_t{1} << ctx.timestamp_valid_bits) - 1u);
-                const uint64_t device_ticks = (timestamps[5] - timestamps[0]) & mask;
-                const uint64_t shader_ticks = (timestamps[2] - timestamps[1]) & mask;
-                ++g_perf_compute_gpu_timestamp_samples;
-                g_perf_compute_gpu_device_ms +=
-                    static_cast<double>(device_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_shader_ms +=
-                    static_cast<double>(shader_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_pre_ms += static_cast<double>(
-                    (timestamps[1] - timestamps[0]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_storage_copy_ms += static_cast<double>(
-                    (timestamps[3] - timestamps[2]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_compare_ms += static_cast<double>(
-                    (timestamps[4] - timestamps[3]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_restore_ms += static_cast<double>(
-                    (timestamps[5] - timestamps[4]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-            }
-        }
-        if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
-        phase_dispatch = ComputeClock::now();
-        // #3157 step A: the consume tail as one callable unit. Immediately invoked here, so
-        // behaviour is unchanged -- this only proves the tail is a coherent block with known
-        // escapes before it is deferred behind a dispatch ring.
-        auto consume_dispatch = [&]() -> bool {
-            const auto writeback_prepare_start = phase_dispatch;
-
-            if (!compare_targets.empty()) {
-                void* mapped = nullptr;
-                const VkDeviceSize flag_stride = ctx.compare_flag_stride();
-                if (ctx.map_memory(compare_flags_memory, 0,
-                                   compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
-                    // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
-                    // target would read the padding between flags on any device whose alignment exceeds
-                    // four, reporting every target after the first as unchanged.
-                    const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
-                    for (size_t j = 0; j < compare_targets.size(); ++j) {
-                        CompareTarget& target = compare_targets[j];
-                        uint32_t changed = 0;
-                        std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
-                        if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
-                        if (target.image) target.image->gpu_result_unchanged = changed == 0;
-                    }
-                    ctx.unmap_memory(compare_flags_memory);
+        // #3157 step B1: the whole post-submit phase -- fence wait, its failure handling, GPU
+        // timestamps, and the consume tail -- as ONE callable. Immediately invoked here, so
+        // behaviour is unchanged. This is the unit a dispatch ring defers: cleanup() (run in
+        // the epilogue) destroys the compare-flags buffer the consume reads, so the boundary
+        // has to enclose the wait, not sit after it.
+        auto wait_and_consume = [&]() -> bool {
+            if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
+            const auto fence_wait_start = ComputeClock::now();
+            const VkResult wait_result = vkWaitForFences(
+                ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
+            // Report a LONG wait even when it succeeds.
+            //
+            // A zero timeout count was read as proof that no compute dispatch hangs. That inference has a
+            // hole: an amdgpu context reset SIGNALS pending fences, so a dispatch the kernel watchdog
+            // killed can return VK_SUCCESS here and look indistinguishable from one that finished in
+            // microseconds — with the loss surfacing only at the NEXT submit. Duration is what separates
+            // them: a killed job sits at roughly the kernel's timeout (~10 s), a real one is sub-millisecond.
+            {
+                const double waited_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - fence_wait_start).count();
+                if (waited_ms >= 100.0) {
+                    static std::atomic<int> slow{0};
+                    const int n = slow.fetch_add(1);
+                    if (n < 24 || (n & 255) == 0)
+                        std::fprintf(stderr,
+                                     "[compute] SLOW fence wait %.1f ms result=%d program=0x%llx "
+                                     "submit=%llu dispatch=%llu order=%llu groups=%ux%ux%u\n",
+                                     waited_ms, static_cast<int>(wait_result),
+                                     static_cast<unsigned long long>(item.code_addr),
+                                     static_cast<unsigned long long>(item.submit_no),
+                                     static_cast<unsigned long long>(item.dispatch_index),
+                                     static_cast<unsigned long long>(item.command_order),
+                                     item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
                 }
             }
-
-            // The fence proves every upload is complete and every sampled image is back in GENERAL.
-            // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
-            // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
-            for (BoundImage& image : images) {
-                if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
-                    !image.cache_candidate)
-                    continue;
-                // When this dispatch samples and writes the same guest view through distinct bindings,
-                // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
-                // would occupy the identical key before storage writeback can retain the actual result.
-                const bool replaced_by_storage = std::any_of(
-                    images.begin(), images.end(), [&](const BoundImage& candidate) {
-                        return candidate.storage && candidate.cache_candidate &&
-                               candidate.cache_key == image.cache_key;
-                    });
-                if (replaced_by_storage) continue;
-                if (image.persistent) {
-                    if (!image.upload_skipped) {
-                        if (image.compute_transfer_seed_borrowed)
-                            ctx.validate_cached_image_source_from_compute_transfer(
-                                image.cache_key);
-                        else
-                            ctx.validate_cached_image_source(image.cache_key);
-                    }
-                } else if (image.image && image.memory && image.allocation_bytes &&
-                           (image.cache_source_snapshot.empty()
-                                ? ctx.retain_image(image.cache_key, image.image, image.memory,
-                                                   image.allocation_bytes,
-                                                   static_cast<const uint8_t*>(nullptr))
-                                : ctx.retain_image(image.cache_key, image.image, image.memory,
-                                                   image.allocation_bytes,
-                                                   std::move(image.cache_source_snapshot)))) {
-                    image.persistent = true;
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   retained sampled image binding=%u addr=0x%llx "
-                                     "allocation=%llu\n",
-                                     image.binding,
-                                     (unsigned long long)image.resource->gpu_addr,
-                                     (unsigned long long)image.allocation_bytes);
+            if (!vk_ok(wait_result, "queue-wait")) {
+                // cleanup() releases resources referenced by the command buffer, including a borrowed
+                // renderer image's pin. With that image bound, in-flight work still references it and
+                // its layout transitions, so drain the queue first rather than freeing it underneath
+                // the GPU.
+                // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
+                // to success; this item stays failed either way, which is the conservative choice for a
+                // dispatch whose results we can no longer trust.
+                if (!ctx.device_lost) {
+                    std::unique_lock<std::mutex> qlk(
+                        prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
+                    if (prosper::gpu::shared_present_active()) qlk.lock();
+                    const VkResult drain_result = vkQueueWaitIdle(ctx.queue);
+                    completion_proven = drain_result == VK_SUCCESS;
+                    // Soft: this drain runs INSIDE the queue-wait failure path, which has already
+                    // declined. Declining again would report one fence timeout as two refusals.
+                    if (!vk_soft_ok(drain_result, "queue-drain") && trace)
+                        std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
+                }
+                return false;   // was `break` out of the do/while(false)
+            }
+            completion_proven = true;
+            if (perf_gpu_timing) {
+                uint64_t timestamps[6]{};
+                if (vkGetQueryPoolResults(ctx.device, ctx.dispatch_timestamp_pool, 0, 6,
+                                          sizeof(timestamps), timestamps, sizeof(uint64_t),
+                                          VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
+                    const uint64_t mask = ctx.timestamp_valid_bits >= 64
+                        ? UINT64_MAX : ((uint64_t{1} << ctx.timestamp_valid_bits) - 1u);
+                    const uint64_t device_ticks = (timestamps[5] - timestamps[0]) & mask;
+                    const uint64_t shader_ticks = (timestamps[2] - timestamps[1]) & mask;
+                    ++g_perf_compute_gpu_timestamp_samples;
+                    g_perf_compute_gpu_device_ms +=
+                        static_cast<double>(device_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_shader_ms +=
+                        static_cast<double>(shader_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_pre_ms += static_cast<double>(
+                        (timestamps[1] - timestamps[0]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_storage_copy_ms += static_cast<double>(
+                        (timestamps[3] - timestamps[2]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_compare_ms += static_cast<double>(
+                        (timestamps[4] - timestamps[3]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_restore_ms += static_cast<double>(
+                        (timestamps[5] - timestamps[4]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
                 }
             }
+            if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
+            phase_dispatch = ComputeClock::now();
+            // #3157 step A: the consume tail as one callable unit. Immediately invoked here, so
+            // behaviour is unchanged -- this only proves the tail is a coherent block with known
+            // escapes before it is deferred behind a dispatch ring.
+            auto consume_dispatch = [&]() -> bool {
+                const auto writeback_prepare_start = phase_dispatch;
 
-            writeback_prepare_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_prepare_start).count();
-            const auto writeback_buffers_start = ComputeClock::now();
-            bool readback_ok = true;
-            for (auto& buffer : buffers) {
-                if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
-                // The exact GPU comparator saw the same bytes as the retained baseline, while source
-                // validation independently proved that the guest mirror still contains that baseline.
-                // Preserve architectural write notification, but avoid mapping and scanning the whole
-                // host-visible buffer merely to rediscover equality.
-                if (buffer.gpu_result_unchanged) {
-                    g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
-                    if (trace)
+                if (!compare_targets.empty()) {
+                    void* mapped = nullptr;
+                    const VkDeviceSize flag_stride = ctx.compare_flag_stride();
+                    if (ctx.map_memory(compare_flags_memory, 0,
+                                       compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
+                        // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
+                        // target would read the padding between flags on any device whose alignment exceeds
+                        // four, reporting every target after the first as unchanged.
+                        const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
+                        for (size_t j = 0; j < compare_targets.size(); ++j) {
+                            CompareTarget& target = compare_targets[j];
+                            uint32_t changed = 0;
+                            std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
+                            if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
+                            if (target.image) target.image->gpu_result_unchanged = changed == 0;
+                        }
+                        ctx.unmap_memory(compare_flags_memory);
+                    }
+                }
+
+                // The fence proves every upload is complete and every sampled image is back in GENERAL.
+                // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
+                // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
+                for (BoundImage& image : images) {
+                    if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
+                        !image.cache_candidate)
+                        continue;
+                    // When this dispatch samples and writes the same guest view through distinct bindings,
+                    // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
+                    // would occupy the identical key before storage writeback can retain the actual result.
+                    const bool replaced_by_storage = std::any_of(
+                        images.begin(), images.end(), [&](const BoundImage& candidate) {
+                            return candidate.storage && candidate.cache_candidate &&
+                                   candidate.cache_key == image.cache_key;
+                        });
+                    if (replaced_by_storage) continue;
+                    if (image.persistent) {
+                        if (!image.upload_skipped) {
+                            if (image.compute_transfer_seed_borrowed)
+                                ctx.validate_cached_image_source_from_compute_transfer(
+                                    image.cache_key);
+                            else
+                                ctx.validate_cached_image_source(image.cache_key);
+                        }
+                    } else if (image.image && image.memory && image.allocation_bytes &&
+                               (image.cache_source_snapshot.empty()
+                                    ? ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                       image.allocation_bytes,
+                                                       static_cast<const uint8_t*>(nullptr))
+                                    : ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                       image.allocation_bytes,
+                                                       std::move(image.cache_source_snapshot)))) {
+                        image.persistent = true;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   retained sampled image binding=%u addr=0x%llx "
+                                         "allocation=%llu\n",
+                                         image.binding,
+                                         (unsigned long long)image.resource->gpu_addr,
+                                         (unsigned long long)image.allocation_bytes);
+                    }
+                }
+
+                writeback_prepare_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_prepare_start).count();
+                const auto writeback_buffers_start = ComputeClock::now();
+                bool readback_ok = true;
+                for (auto& buffer : buffers) {
+                    if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
+                    // The exact GPU comparator saw the same bytes as the retained baseline, while source
+                    // validation independently proved that the guest mirror still contains that baseline.
+                    // Preserve architectural write notification, but avoid mapping and scanning the whole
+                    // host-visible buffer merely to rediscover equality.
+                    if (buffer.gpu_result_unchanged) {
+                        g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   skipped GPU-identical buffer writeback binding=%u "
+                                         "addr=0x%llx bytes=%u\n",
+                                         buffer.resource->binding,
+                                         (unsigned long long)buffer.resource->gpu_addr,
+                                         buffer.resource->size);
+                        if (buffer.resource->gpu_addr)
+                            notify_guest_gpu_write_preserving_bytes(
+                                buffer.resource->gpu_addr, buffer.resource->size);
+                        if (buffer.persistent)
+                            ctx.validate_cached_buffer_source(buffer.cache_key);
+                        if (!buffer.resource->host_data && writer_provenance_enabled())
+                            record_guest_write(GuestWriterKind::ComputeBuffer,
+                                               buffer.resource->gpu_addr, buffer.resource->size,
+                                               item.submit_no, item.dispatch_index,
+                                               item.command_order, item.code_addr);
+                        continue;
+                    }
+                    void* mapped = nullptr;
+                    if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
+                        readback_ok = false;
+                        break;
+                    }
+                    uint8_t* destination = buffer.atomic_image
+                        ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
+                        : resource_bytes_for(buffer.resource, buffer.guest_bytes);
+                    const auto* result = static_cast<const uint8_t*>(mapped);
+                    if (buffer.atomic_image) {
+                        if (trace) {
+                            buffer.after_hash = fnv1a(result, buffer.bytes);
+                            for (size_t i = 0; i < buffer.bytes; ++i)
+                                buffer.changed_bytes += buffer.linear_seed[i] != result[i];
+                        }
+                        if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                            prosper::host::guest_write_watch_notify_host_write(
+                                buffer.resource->gpu_addr, buffer.guest_bytes);
+                        // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
+                        const size_t layer_linear_bytes =
+                            static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
+                        for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
+                            uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
+                            const uint8_t* src = result + layer * layer_linear_bytes;
+                            if (buffer.resource->tile_mode) {
+                                tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
+                                             buffer.resource->tile_mode, 0, sizeof(uint32_t));
+                            } else {
+                                const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
+                                const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
+                                    ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
+                                for (uint32_t y = 0; y < buffer.resource->height; ++y)
+                                    std::memcpy(dst + y * destination_pitch,
+                                                src + y * tight_pitch, tight_pitch);
+                            }
+                        }
+                        ctx.unmap_memory(buffer.memory);
+                        if (buffer.resource->gpu_addr) {
+                            set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
+                            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
+                            set_guest_gpu_write_origin(nullptr);
+                        }
+                        if (!buffer.resource->host_data && writer_provenance_enabled())
+                            record_guest_write(GuestWriterKind::ComputeBuffer,
+                                               buffer.resource->gpu_addr, buffer.guest_bytes,
+                                               item.submit_no, item.dispatch_index,
+                                               item.command_order, item.code_addr);
+                        continue;
+                    }
+                    const bool changed = !compute_buffers_equal(
+                        destination, result, buffer.bytes);
+                    if (trace) {
+                        buffer.after_hash = fnv1a(result, buffer.bytes);
+                        for (size_t i = 0; i < buffer.bytes; i++)
+                            buffer.changed_bytes += destination[i] != result[i];
+                        // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
+                        //
+                        // `changed_bytes` says how much moved and nothing about where, which is the only
+                        // question that separates a wrong VALUE from a wrong INDEX. For a structure written
+                        // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
+                        // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
+                        // count or a hash.
+                        // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
+                        // merged and writability is ORed onto the first owner, so the owner's binding is
+                        // NOT evidence that the owner performed the store: a read-only binding followed by
+                        // a writable exact alias reports as though the first wrote, and with several
+                        // writable aliases no single store site can be named at all. The changed indices
+                        // below are allocation-level evidence and stand on their own; the binding is
+                        // reported as `owner-binding` with the alias count beside it so a reader cannot
+                        // mistake it for attribution.
+                        size_t alias_count = 0;
+                        for (const auto& other : buffers)
+                            if (other.alias_of != SIZE_MAX &&
+                                &buffers[other.alias_of] == &buffer) ++alias_count;
+                        if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
+                            char* end = nullptr;
+                            const unsigned long limit = std::strtoul(limit_env, &end, 0);
+                            if (end && !*end && limit) {
+                                // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
+                                // storage and `result` is mapped device memory, and neither contract
+                                // promises uint32_t alignment or a uint32_t object lifetime there. The byte
+                                // bound below deliberately ignores a partial trailing dword.
+                                const size_t dwords = buffer.bytes / sizeof(uint32_t);
+                                const auto load_dword = [](const uint8_t* bytes, size_t index) {
+                                    uint32_t value = 0;
+                                    std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
+                                    return value;
+                                };
+                                unsigned long shown = 0;
+                                for (size_t i = 0; i < dwords && shown < limit; ++i) {
+                                    const uint32_t before_value = load_dword(destination, i);
+                                    const uint32_t after_value = load_dword(result, i);
+                                    if (before_value == after_value) continue;
+                                    // Carry submit/dispatch on EVERY line. Without them the lines from
+                                    // consecutive dispatches concatenate into one stream that looks like a
+                                    // single dispatch's writes -- and a per-dispatch structural claim built
+                                    // on that stream is meaningless. The first analysis run here did exactly
+                                    // that and reported one index changing twice in "one" dispatch.
+                                    std::fprintf(stderr,
+                                                 "[compute]     changed submit=%llu dispatch=%llu "
+                                                 "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
+                                                 "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
+                                                 (unsigned long long)item.submit_no,
+                                                 (unsigned long long)item.dispatch_index,
+                                                 (unsigned long long)(buffer.resource
+                                                     ? buffer.resource->gpu_addr : 0ull),
+                                                 buffer.resource ? buffer.resource->binding : 0u,
+                                                 alias_count, i,
+                                                 before_value, after_value, after_value & 7u,
+                                                 (after_value >> 30) & 1u,
+                                                 (after_value >> 3) & 0x07FFFFFFu);
+                                    ++shown;
+                                }
+                            }
+                        }
+                    }
+                    // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
+                    // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
+                    // after its first dispatch all later readbacks are identical. Avoiding the redundant host
+                    // write removes one full pass over both source and destination. Renderer-alias
+                    // invalidation and writer provenance remain unconditional: renderer-resident state can
+                    // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
+                    if (changed) {
+                        if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                            prosper::host::guest_write_watch_notify_host_write(
+                                buffer.resource->gpu_addr, buffer.resource->size);
+                        copy_compute_buffer(destination, result, buffer.bytes);
+                    }
+                    if (buffer.persistent && !buffer.result_baseline &&
+                        ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
                         std::fprintf(stderr,
-                                     "[compute]   skipped GPU-identical buffer writeback binding=%u "
+                                     "[compute]   retained exact GPU buffer result baseline binding=%u "
                                      "addr=0x%llx bytes=%u\n",
                                      buffer.resource->binding,
                                      (unsigned long long)buffer.resource->gpu_addr,
                                      buffer.resource->size);
-                    if (buffer.resource->gpu_addr)
-                        notify_guest_gpu_write_preserving_bytes(
-                            buffer.resource->gpu_addr, buffer.resource->size);
+                    ctx.unmap_memory(buffer.memory);
+                    if (buffer.resource->gpu_addr) {
+                        if (changed) {
+                            set_guest_gpu_write_origin("compute-writeback(buffer-full)");
+                            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+                            set_guest_gpu_write_origin(nullptr);
+                        } else {
+                            notify_guest_gpu_write_preserving_bytes(
+                                buffer.resource->gpu_addr, buffer.resource->size);
+                        }
+                    }
                     if (buffer.persistent)
                         ctx.validate_cached_buffer_source(buffer.cache_key);
                     if (!buffer.resource->host_data && writer_provenance_enabled())
@@ -9198,652 +9360,499 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                            buffer.resource->gpu_addr, buffer.resource->size,
                                            item.submit_no, item.dispatch_index,
                                            item.command_order, item.code_addr);
-                    continue;
                 }
-                void* mapped = nullptr;
-                if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
-                    readback_ok = false;
-                    break;
-                }
-                uint8_t* destination = buffer.atomic_image
-                    ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
-                    : resource_bytes_for(buffer.resource, buffer.guest_bytes);
-                const auto* result = static_cast<const uint8_t*>(mapped);
-                if (buffer.atomic_image) {
-                    if (trace) {
-                        buffer.after_hash = fnv1a(result, buffer.bytes);
-                        for (size_t i = 0; i < buffer.bytes; ++i)
-                            buffer.changed_bytes += buffer.linear_seed[i] != result[i];
+                writeback_buffers_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_buffers_start).count();
+                if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                                  // site turns a false return back into that break
+                const auto writeback_images_start = ComputeClock::now();
+                // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
+                // into the guest format, then restore its linear or 3D tiled address layout and notify the
+                // render side exactly like the buffer path.
+                for (size_t i = 0; i < images.size() && readback_ok; i++) {
+                    BoundImage& bi = images[i];
+                    if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
+                    const auto image_writeback_start = ComputeClock::now();
+                    const bool image_cache_hit = bi.persistent;
+                    const ShaderResource* r = bi.resource;
+                    const uint32_t cb = data_format_bytes(r->format);
+                    const uint32_t nc = r->num_components ? r->num_components : 1;
+                    const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
+                                                r->format == DataFormat::Unorm2_10_10_10)
+                        ? 4u : (size_t)cb * nc;
+                    const size_t texels = (size_t)r->width * r->height * r->depth;
+                    const size_t linear_bytes = texels * guest_texel;
+                    uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
+                    // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
+                    // independently proved that the guest mirror still contains that baseline. This path
+                    // therefore needs neither a large staging mapping nor a CPU memory pass.
+                    if (bi.gpu_result_unchanged && bi.upload_skipped) {
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   skipped GPU-identical storage writeback binding=%u "
+                                         "addr=0x%llx bytes=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.exact_result_bytes);
+                        if (r->gpu_addr)
+                            notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                        continue;
                     }
-                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                        prosper::host::guest_write_watch_notify_host_write(
-                            buffer.resource->gpu_addr, buffer.guest_bytes);
-                    // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
-                    const size_t layer_linear_bytes =
-                        static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
-                    for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
-                        uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
-                        const uint8_t* src = result + layer * layer_linear_bytes;
-                        if (buffer.resource->tile_mode) {
-                            tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
-                                         buffer.resource->tile_mode, 0, sizeof(uint32_t));
-                        } else {
-                            const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
-                            const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
-                                ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
-                            for (uint32_t y = 0; y < buffer.resource->height; ++y)
-                                std::memcpy(dst + y * destination_pitch,
-                                            src + y * tight_pitch, tight_pitch);
-                        }
-                    }
-                    ctx.unmap_memory(buffer.memory);
-                    if (buffer.resource->gpu_addr) {
-                        set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
-                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
-                        set_guest_gpu_write_origin(nullptr);
-                    }
-                    if (!buffer.resource->host_data && writer_provenance_enabled())
-                        record_guest_write(GuestWriterKind::ComputeBuffer,
-                                           buffer.resource->gpu_addr, buffer.guest_bytes,
-                                           item.submit_no, item.dispatch_index,
-                                           item.command_order, item.code_addr);
-                    continue;
-                }
-                const bool changed = !compute_buffers_equal(
-                    destination, result, buffer.bytes);
-                if (trace) {
-                    buffer.after_hash = fnv1a(result, buffer.bytes);
-                    for (size_t i = 0; i < buffer.bytes; i++)
-                        buffer.changed_bytes += destination[i] != result[i];
-                    // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
-                    //
-                    // `changed_bytes` says how much moved and nothing about where, which is the only
-                    // question that separates a wrong VALUE from a wrong INDEX. For a structure written
-                    // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
-                    // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
-                    // count or a hash.
-                    // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
-                    // merged and writability is ORed onto the first owner, so the owner's binding is
-                    // NOT evidence that the owner performed the store: a read-only binding followed by
-                    // a writable exact alias reports as though the first wrote, and with several
-                    // writable aliases no single store site can be named at all. The changed indices
-                    // below are allocation-level evidence and stand on their own; the binding is
-                    // reported as `owner-binding` with the alias count beside it so a reader cannot
-                    // mistake it for attribution.
-                    size_t alias_count = 0;
-                    for (const auto& other : buffers)
-                        if (other.alias_of != SIZE_MAX &&
-                            &buffers[other.alias_of] == &buffer) ++alias_count;
-                    if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
-                        char* end = nullptr;
-                        const unsigned long limit = std::strtoul(limit_env, &end, 0);
-                        if (end && !*end && limit) {
-                            // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
-                            // storage and `result` is mapped device memory, and neither contract
-                            // promises uint32_t alignment or a uint32_t object lifetime there. The byte
-                            // bound below deliberately ignores a partial trailing dword.
-                            const size_t dwords = buffer.bytes / sizeof(uint32_t);
-                            const auto load_dword = [](const uint8_t* bytes, size_t index) {
-                                uint32_t value = 0;
-                                std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
-                                return value;
-                            };
-                            unsigned long shown = 0;
-                            for (size_t i = 0; i < dwords && shown < limit; ++i) {
-                                const uint32_t before_value = load_dword(destination, i);
-                                const uint32_t after_value = load_dword(result, i);
-                                if (before_value == after_value) continue;
-                                // Carry submit/dispatch on EVERY line. Without them the lines from
-                                // consecutive dispatches concatenate into one stream that looks like a
-                                // single dispatch's writes -- and a per-dispatch structural claim built
-                                // on that stream is meaningless. The first analysis run here did exactly
-                                // that and reported one index changing twice in "one" dispatch.
-                                std::fprintf(stderr,
-                                             "[compute]     changed submit=%llu dispatch=%llu "
-                                             "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
-                                             "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
-                                             (unsigned long long)item.submit_no,
-                                             (unsigned long long)item.dispatch_index,
-                                             (unsigned long long)(buffer.resource
-                                                 ? buffer.resource->gpu_addr : 0ull),
-                                             buffer.resource ? buffer.resource->binding : 0u,
-                                             alias_count, i,
-                                             before_value, after_value, after_value & 7u,
-                                             (after_value >> 30) & 1u,
-                                             (after_value >> 3) & 0x07FFFFFFu);
-                                ++shown;
-                            }
-                        }
-                    }
-                }
-                // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
-                // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
-                // after its first dispatch all later readbacks are identical. Avoiding the redundant host
-                // write removes one full pass over both source and destination. Renderer-alias
-                // invalidation and writer provenance remain unconditional: renderer-resident state can
-                // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
-                if (changed) {
-                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                        prosper::host::guest_write_watch_notify_host_write(
-                            buffer.resource->gpu_addr, buffer.resource->size);
-                    copy_compute_buffer(destination, result, buffer.bytes);
-                }
-                if (buffer.persistent && !buffer.result_baseline &&
-                    ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
-                    std::fprintf(stderr,
-                                 "[compute]   retained exact GPU buffer result baseline binding=%u "
-                                 "addr=0x%llx bytes=%u\n",
-                                 buffer.resource->binding,
-                                 (unsigned long long)buffer.resource->gpu_addr,
-                                 buffer.resource->size);
-                ctx.unmap_memory(buffer.memory);
-                if (buffer.resource->gpu_addr) {
-                    if (changed) {
-                        set_guest_gpu_write_origin("compute-writeback(buffer-full)");
-                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
-                        set_guest_gpu_write_origin(nullptr);
-                    } else {
-                        notify_guest_gpu_write_preserving_bytes(
-                            buffer.resource->gpu_addr, buffer.resource->size);
-                    }
-                }
-                if (buffer.persistent)
-                    ctx.validate_cached_buffer_source(buffer.cache_key);
-                if (!buffer.resource->host_data && writer_provenance_enabled())
-                    record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       buffer.resource->gpu_addr, buffer.resource->size,
-                                       item.submit_no, item.dispatch_index,
-                                       item.command_order, item.code_addr);
-            }
-            writeback_buffers_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_buffers_start).count();
-            if (!readback_ok) return false;   // was `break` out of the do-while; the call
-                                              // site turns a false return back into that break
-            const auto writeback_images_start = ComputeClock::now();
-            // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
-            // into the guest format, then restore its linear or 3D tiled address layout and notify the
-            // render side exactly like the buffer path.
-            for (size_t i = 0; i < images.size() && readback_ok; i++) {
-                BoundImage& bi = images[i];
-                if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
-                const auto image_writeback_start = ComputeClock::now();
-                const bool image_cache_hit = bi.persistent;
-                const ShaderResource* r = bi.resource;
-                const uint32_t cb = data_format_bytes(r->format);
-                const uint32_t nc = r->num_components ? r->num_components : 1;
-                const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
-                                            r->format == DataFormat::Unorm2_10_10_10)
-                    ? 4u : (size_t)cb * nc;
-                const size_t texels = (size_t)r->width * r->height * r->depth;
-                const size_t linear_bytes = texels * guest_texel;
-                uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
-                // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
-                // independently proved that the guest mirror still contains that baseline. This path
-                // therefore needs neither a large staging mapping nor a CPU memory pass.
-                if (bi.gpu_result_unchanged && bi.upload_skipped) {
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   skipped GPU-identical storage writeback binding=%u "
-                                     "addr=0x%llx bytes=%llu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     (unsigned long long)bi.exact_result_bytes);
-                    if (r->gpu_addr)
-                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                    continue;
-                }
-                void* mapped = nullptr;
-                const auto map_start = ComputeClock::now();
-                if (g_fail_next_storage_readback_for_test.exchange(
-                        false, std::memory_order_acq_rel)) {
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   injected storage readback failure binding=%u\n",
-                                     bi.binding);
-                    readback_ok = false;
-                    break;
-                }
-                if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
-                    readback_ok = false;
-                    break;
-                }
-                const auto map_done = ComputeClock::now();
-                const bool array_image = backend_uses_2d_array(*r);
-                static const bool direct_tiled_writeback_disabled =
-                    std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
-                const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
-                    bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
-                    direct_tiled_writeback_disabled);
-                std::unique_ptr<uint8_t[]> linear;
-                uint8_t* packed = destination;
-                if ((r->tile_mode && !tile_mapped_bytes) ||
-                    (!r->tile_mode && array_image && r->depth > 1)) {
-                    linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
-                    packed = linear.get();
-                }
-                const uint32_t* channels = static_cast<const uint32_t*>(mapped);
-                const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
-                // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
-                // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
-                // that guest memory still contains the prior result, and this dispatch reproduced the
-                // same row-major bytes. If either comparison fails, take the ordinary writeback below.
-                const bool repeated_output = bi.cache_candidate && bi.persistent &&
-                    bi.upload_skipped && bi.exact_storage_bytes() &&
-                    ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
-                const auto prepare_done = ComputeClock::now();
-                if (repeated_output) {
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   skipped identical storage writeback binding=%u "
-                                     "addr=0x%llx bytes=%llu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     (unsigned long long)bi.exact_result_bytes);
-                    ctx.unmap_memory(staging_memory[i]);
-                    if (r->gpu_addr)
-                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                    continue;
-                }
-                // Notify page-based dirty trackers only when bytes will actually be written. Doing this
-                // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
-                // even on the no-write path, defeating the validation that made that path safe.
-                if (!r->host_data && r->gpu_addr)
-                    prosper::host::guest_write_watch_notify_host_write(
-                        r->gpu_addr, bi.guest_bytes);
-                const auto watch_done = ComputeClock::now();
-                // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
-                // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
-                // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
-                // and, for a partial write, restore the un-stored texels from the clean seed after packing.
-                std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
-                if (bi.poison_verify) {
-                    size_t survived = 0;
-                    poison_texel.assign(texels, 0);
-                    for (size_t t = 0; t < texels; ++t) {
-                        bool all = true;
-                        if (bi.exact_storage_bytes()) {
-                            const uint8_t* texel = native_texels + t * guest_texel;
-                            for (size_t b = 0; b < guest_texel; ++b)
-                                if (texel[b] != 0x5a) all = false;
-                        } else {
-                            for (uint32_t c = 0; c < 4; ++c)
-                                if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
-                        }
-                        if (all) { ++survived; poison_texel[t] = 1; }
-                    }
-                    {
-                        const SeedCoverageKey proof_key{item.code_addr, bi.binding,
-                                                        r->width, r->height, r->depth};
-                        std::lock_guard<std::mutex> lk(seed_coverage_mu);
-                        // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                        seed_coverage_proof[proof_key] =
-                            SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
-                    }
-                    std::fprintf(stderr,
-                                 "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
-                                 (unsigned long long)item.code_addr, bi.binding, texels, survived,
-                                 survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
-                }
-                if (trace) {
-                    if (bi.exact_storage_bytes()) {
-                        for (size_t t = 0; t < texels; ++t) {
-                            const uint8_t* texel = native_texels + t * guest_texel;
-                            for (size_t b = 0; b < guest_texel; ++b)
-                                bi.nonzero_channels += texel[b] != 0;
-                        }
-                    } else {
-                        for (size_t t = 0; t < texels; t++)
-                            for (uint32_t c = 0; c < 4; c++)
-                                bi.nonzero_channels += channels[t * 4 + c] != 0;
-                    }
-                }
-                const auto pack_start = ComputeClock::now();
-                static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
-                if (bi.exact_storage_bytes()) {
-                    // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
-                    // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
-                    // non-proving write can feed those bytes straight to the tiler, avoiding a second
-                    // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
-                    if (!tile_mapped_bytes)
-                        parallel_compute_texels(texels, linear_bytes * 2,
-                            [&](size_t begin, size_t end) {
-                                std::memcpy(packed + begin * guest_texel,
-                                            native_texels + begin * guest_texel,
-                                            (end - begin) * guest_texel);
-                            });
-                } else if (pack_range_enabled) {
-                    storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
-                } else {
-                    for (size_t t = 0; t < texels; t++)
-                        storage_pack_texel(channels + t * 4, r->format, nc,
-                                           packed + t * guest_texel);
-                }
-                // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
-                // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
-                // content (exactly a partial write's contract). Full-coverage proving frames have no
-                // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
-                if (bi.poison_verify && !poison_texel.empty() &&
-                    bi.seed_linear.size() == linear_bytes) {
-                    for (size_t t = 0; t < texels; ++t) {
-                        if (poison_texel[t])
-                            std::memcpy(packed + t * guest_texel,
-                                        bi.seed_linear.data() + t * guest_texel, guest_texel);
-                    }
-                }
-                const auto pack_done = ComputeClock::now();
-                static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
-                if (verify_pack && !bi.exact_storage_bytes()) {
-                    // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
-                    // be bit-identical to the per-texel path it replaces, verified against the real
-                    // workload's texels. Logs the clean case too, so a verified run is self-proving.
-                    std::vector<uint8_t> expect(guest_texel);
-                    size_t bad = 0, first_bad = 0;
-                    for (size_t t = 0; t < texels; ++t) {
-                        std::memset(expect.data(), 0, expect.size());
-                        storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
-                        if (std::memcmp(expect.data(), packed + t * guest_texel,
-                                        guest_texel) != 0) {
-                            if (!bad) first_bad = t;
-                            ++bad;
-                        }
-                    }
-                    std::fprintf(stderr,
-                                 "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
-                                 "texels=%zu mismatches=%zu%s\n",
-                                 bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
-                                 nc, texels, bad, bad ? " MISMATCH" : "");
-                    if (bad)
-                        std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
-                                     first_bad);
-                }
-                const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
-                if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
-                    if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
-                                     r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                    void* mapped = nullptr;
+                    const auto map_start = ComputeClock::now();
+                    if (g_fail_next_storage_readback_for_test.exchange(
+                            false, std::memory_order_acq_rel)) {
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   injected storage readback failure binding=%u\n",
+                                         bi.binding);
                         readback_ok = false;
-                        ctx.unmap_memory(staging_memory[i]);
                         break;
                     }
-                } else if (array_image && r->depth > 1) {
-                    const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
-                    const size_t selected_slice = r->in_mip_tail
-                        ? r->mip_tail_bytes
-                        : (r->tile_mode
-                               ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
-                                                     static_cast<uint32_t>(guest_texel))
-                               : (r->layer_stride_bytes
-                                      ? linear_array_surface_bytes(
-                                            *r, static_cast<uint32_t>(guest_texel))
-                                      : linear_slice));
-                    const size_t layer_stride = r->layer_stride_bytes
-                        ? r->layer_stride_bytes : selected_slice;
-                    for (uint32_t layer = 0; layer < r->depth; ++layer) {
-                        uint8_t* layer_base = destination + layer_stride * layer;
-                        if (!r->tile_mode) {
-                            const size_t row_pitch = r->layer_stride_bytes
-                                ? linear_array_row_pitch(
-                                      *r, static_cast<uint32_t>(guest_texel))
-                                : static_cast<size_t>(r->width) * guest_texel;
-                            for (uint32_t y = 0; y < r->height; ++y)
-                                std::memcpy(
-                                    layer_base + r->layer_mip_offset_bytes + y * row_pitch,
-                                    layout_source + linear_slice * layer +
-                                        static_cast<size_t>(y) * r->width * guest_texel,
-                                    static_cast<size_t>(r->width) * guest_texel);
-                        } else if (r->in_mip_tail) {
-                            tile_surface_level(
-                                layer_base, r->mip_tail_bytes,
-                                layout_source + linear_slice * layer,
-                                r->width, r->height, r->tile_mode,
-                                static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
+                    if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
+                        readback_ok = false;
+                        break;
+                    }
+                    const auto map_done = ComputeClock::now();
+                    const bool array_image = backend_uses_2d_array(*r);
+                    static const bool direct_tiled_writeback_disabled =
+                        std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
+                    const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
+                        bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
+                        direct_tiled_writeback_disabled);
+                    std::unique_ptr<uint8_t[]> linear;
+                    uint8_t* packed = destination;
+                    if ((r->tile_mode && !tile_mapped_bytes) ||
+                        (!r->tile_mode && array_image && r->depth > 1)) {
+                        linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
+                        packed = linear.get();
+                    }
+                    const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+                    const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
+                    // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
+                    // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
+                    // that guest memory still contains the prior result, and this dispatch reproduced the
+                    // same row-major bytes. If either comparison fails, take the ordinary writeback below.
+                    const bool repeated_output = bi.cache_candidate && bi.persistent &&
+                        bi.upload_skipped && bi.exact_storage_bytes() &&
+                        ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
+                    const auto prepare_done = ComputeClock::now();
+                    if (repeated_output) {
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   skipped identical storage writeback binding=%u "
+                                         "addr=0x%llx bytes=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.exact_result_bytes);
+                        ctx.unmap_memory(staging_memory[i]);
+                        if (r->gpu_addr)
+                            notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                        continue;
+                    }
+                    // Notify page-based dirty trackers only when bytes will actually be written. Doing this
+                    // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
+                    // even on the no-write path, defeating the validation that made that path safe.
+                    if (!r->host_data && r->gpu_addr)
+                        prosper::host::guest_write_watch_notify_host_write(
+                            r->gpu_addr, bi.guest_bytes);
+                    const auto watch_done = ComputeClock::now();
+                    // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
+                    // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
+                    // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
+                    // and, for a partial write, restore the un-stored texels from the clean seed after packing.
+                    std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
+                    if (bi.poison_verify) {
+                        size_t survived = 0;
+                        poison_texel.assign(texels, 0);
+                        for (size_t t = 0; t < texels; ++t) {
+                            bool all = true;
+                            if (bi.exact_storage_bytes()) {
+                                const uint8_t* texel = native_texels + t * guest_texel;
+                                for (size_t b = 0; b < guest_texel; ++b)
+                                    if (texel[b] != 0x5a) all = false;
+                            } else {
+                                for (uint32_t c = 0; c < 4; ++c)
+                                    if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
+                            }
+                            if (all) { ++survived; poison_texel[t] = 1; }
+                        }
+                        {
+                            const SeedCoverageKey proof_key{item.code_addr, bi.binding,
+                                                            r->width, r->height, r->depth};
+                            std::lock_guard<std::mutex> lk(seed_coverage_mu);
+                            // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
+                            seed_coverage_proof[proof_key] =
+                                SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
+                        }
+                        std::fprintf(stderr,
+                                     "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
+                                     (unsigned long long)item.code_addr, bi.binding, texels, survived,
+                                     survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
+                    }
+                    if (trace) {
+                        if (bi.exact_storage_bytes()) {
+                            for (size_t t = 0; t < texels; ++t) {
+                                const uint8_t* texel = native_texels + t * guest_texel;
+                                for (size_t b = 0; b < guest_texel; ++b)
+                                    bi.nonzero_channels += texel[b] != 0;
+                            }
                         } else {
-                            tile_surface(
-                                layer_base + r->layer_mip_offset_bytes,
-                                layout_source + linear_slice * layer,
-                                r->width, r->height, r->tile_mode, 0,
-                                static_cast<uint32_t>(guest_texel));
+                            for (size_t t = 0; t < texels; t++)
+                                for (uint32_t c = 0; c < 4; c++)
+                                    bi.nonzero_channels += channels[t * 4 + c] != 0;
                         }
                     }
-                } else if (r->tile_mode && r->in_mip_tail) {
-                    tile_surface_level(destination, bi.guest_bytes, layout_source,
-                                       r->width, r->height, r->tile_mode,
-                                       static_cast<uint32_t>(guest_texel),
-                                       r->mip_tail_x, r->mip_tail_y);
-                } else if (r->tile_mode) {
-                    tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
-                                 static_cast<uint32_t>(guest_texel));
-                }
-                const auto layout_done = ComputeClock::now();
-                pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
-                layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
-                if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
-                const auto notify_start = ComputeClock::now();
-                // Name the writer. "a guest write covers this surface" and "prosper's own compute
-                // writeback covers this surface" are different facts, and only the second says the
-                // emulator is invalidating its own caches. Everything reaching the DS invalidation path
-                // used to report the default `gpu`, which cannot distinguish them.
-                set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
-                notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
-                set_guest_gpu_write_origin(nullptr);
-                if (!r->host_data && writer_provenance_enabled())
-                    record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       r->gpu_addr, bi.guest_bytes,
-                                       item.submit_no, item.dispatch_index,
-                                       item.command_order, item.code_addr);
-                if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
-                    const bool leave_compressed_for_test =
-                        g_leave_next_dcc_metadata_compressed_for_test.exchange(
-                            false, std::memory_order_acq_rel);
-                    if (!leave_compressed_for_test) {
-                        std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
-                        // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
-                        // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
-                        // aspects" and invalidates depth as well as stencil. So this reset can discard a
-                        // retained depth image. Tagged so that consequence is attributable rather than
-                        // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
-                        // separate question that needs the operation's real HTILE semantics proven.
-                        set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
-                        notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
-                        set_guest_gpu_write_origin(nullptr);
-                        if (!r->dcc_metadata_host_data && writer_provenance_enabled())
-                            record_guest_write(GuestWriterKind::ComputeBuffer,
-                                               r->metadata_addr, bi.dcc_metadata_bytes,
-                                               item.submit_no, item.dispatch_index,
-                                               item.command_order, item.code_addr);
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   DCC uncompressed binding=%u meta=0x%llx "
-                                         "bytes=%zu code=0xff\n",
-                                         bi.binding, (unsigned long long)r->metadata_addr,
-                                         bi.dcc_metadata_bytes);
-                    } else if (trace) {
-                        std::fprintf(stderr,
-                                     "[compute]   injected unresolved DCC writeback binding=%u\n",
-                                     bi.binding);
+                    const auto pack_start = ComputeClock::now();
+                    static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
+                    if (bi.exact_storage_bytes()) {
+                        // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
+                        // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
+                        // non-proving write can feed those bytes straight to the tiler, avoiding a second
+                        // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
+                        if (!tile_mapped_bytes)
+                            parallel_compute_texels(texels, linear_bytes * 2,
+                                [&](size_t begin, size_t end) {
+                                    std::memcpy(packed + begin * guest_texel,
+                                                native_texels + begin * guest_texel,
+                                                (end - begin) * guest_texel);
+                                });
+                    } else if (pack_range_enabled) {
+                        storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
+                    } else {
+                        for (size_t t = 0; t < texels; t++)
+                            storage_pack_texel(channels + t * 4, r->format, nc,
+                                               packed + t * guest_texel);
                     }
-                }
-                if (bi.mirror_result_to_imported) {
-                    const BoundImage& mirror = images[bi.seed_from_imported];
-                    notify_live_render_target_image_written({
-                        r->gpu_addr, mirror.imported_width, mirror.imported_height,
-                        mirror.imported_pixel_format});
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   mirrored storage result into renderer RTT "
-                                     "binding=%u addr=0x%llx extent=%ux%u\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     mirror.imported_width, mirror.imported_height);
-                }
-                const auto notify_done = ComputeClock::now();
-                bool retain_gpu_result_baseline = false;
-                bool promoted_after_writeback = false;
-                const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
-                    std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
-                                [](uint8_t value) { return value == 0xff; });
-                if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
-                    const uint8_t* retained_source =
-                        (adaptive_storage_result_validation_enabled() &&
-                         cold_storage_result_snapshot_can_defer(
-                             r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
-                             cold_storage_result_snapshot_defer_min_bytes()))
-                        ? nullptr : destination;
-                    if (bi.forced_seed_allocation_reused) {
-                        // The exact cache entry was already pinned and forcibly reseeded before this
-                        // dispatch. Successful writeback plus the final all-uncompressed metadata scan
-                        // may now restore source/transfer authority without replacing its allocation.
-                        bi.cache_candidate = true;
-                        g_dcc_post_writeback_promotions.fetch_add(
-                            1, std::memory_order_relaxed);
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   promoted reused post-writeback DCC storage "
-                                         "image binding=%u addr=0x%llx allocation=%llu\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.allocation_bytes);
-                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                        ctx.replace_or_retain_image(
-                            bi.cache_key, bi.image, bi.memory,
-                            bi.allocation_bytes, retained_source)) {
-                        bi.cache_candidate = true;
-                        bi.persistent = true;
-                        promoted_after_writeback = true;
-                        g_dcc_post_writeback_promotions.fetch_add(
-                            1, std::memory_order_relaxed);
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   promoted post-writeback DCC storage image "
-                                         "binding=%u addr=0x%llx allocation=%llu\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.allocation_bytes);
+                    // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
+                    // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
+                    // content (exactly a partial write's contract). Full-coverage proving frames have no
+                    // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
+                    if (bi.poison_verify && !poison_texel.empty() &&
+                        bi.seed_linear.size() == linear_bytes) {
+                        for (size_t t = 0; t < texels; ++t) {
+                            if (poison_texel[t])
+                                std::memcpy(packed + t * guest_texel,
+                                            bi.seed_linear.data() + t * guest_texel, guest_texel);
+                        }
                     }
-                }
-                if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
-                    ctx.invalidate_cached_image_source(bi.cache_key);
-                if (bi.cache_candidate) {
-                    if (bi.persistent && !promoted_after_writeback) {
-                        // Guest bytes now mirror the retained image again. A changing full-overwrite
-                        // target needs no source snapshot; the first repeated result retains one exact
-                        // baseline, and subsequent identical GPU skips do not recopy it.
-                        ctx.validate_cached_image_source(
-                            bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
-                            bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
-                                native_3d_transfer_enabled());
-                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                               ctx.retain_image(bi.cache_key, bi.image, bi.memory,
-                                                bi.allocation_bytes,
-                                                (adaptive_storage_result_validation_enabled() &&
-                                                 cold_storage_result_snapshot_can_defer(
-                                                     r->host_data != nullptr, bi.seed_skip,
-                                                     bi.guest_bytes,
-                                                     cold_storage_result_snapshot_defer_min_bytes()))
-                                                    ? nullptr : destination)) {
-                        bi.persistent = true;
+                    const auto pack_done = ComputeClock::now();
+                    static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
+                    if (verify_pack && !bi.exact_storage_bytes()) {
+                        // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
+                        // be bit-identical to the per-texel path it replaces, verified against the real
+                        // workload's texels. Logs the clean case too, so a verified run is self-proving.
+                        std::vector<uint8_t> expect(guest_texel);
+                        size_t bad = 0, first_bad = 0;
+                        for (size_t t = 0; t < texels; ++t) {
+                            std::memset(expect.data(), 0, expect.size());
+                            storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
+                            if (std::memcmp(expect.data(), packed + t * guest_texel,
+                                            guest_texel) != 0) {
+                                if (!bad) first_bad = t;
+                                ++bad;
+                            }
+                        }
+                        std::fprintf(stderr,
+                                     "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
+                                     "texels=%zu mismatches=%zu%s\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
+                                     nc, texels, bad, bad ? " MISMATCH" : "");
+                        if (bad)
+                            std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
+                                         first_bad);
+                    }
+                    const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
+                    if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
+                        if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
+                                         r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                            readback_ok = false;
+                            ctx.unmap_memory(staging_memory[i]);
+                            break;
+                        }
+                    } else if (array_image && r->depth > 1) {
+                        const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
+                        const size_t selected_slice = r->in_mip_tail
+                            ? r->mip_tail_bytes
+                            : (r->tile_mode
+                                   ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
+                                                         static_cast<uint32_t>(guest_texel))
+                                   : (r->layer_stride_bytes
+                                          ? linear_array_surface_bytes(
+                                                *r, static_cast<uint32_t>(guest_texel))
+                                          : linear_slice));
+                        const size_t layer_stride = r->layer_stride_bytes
+                            ? r->layer_stride_bytes : selected_slice;
+                        for (uint32_t layer = 0; layer < r->depth; ++layer) {
+                            uint8_t* layer_base = destination + layer_stride * layer;
+                            if (!r->tile_mode) {
+                                const size_t row_pitch = r->layer_stride_bytes
+                                    ? linear_array_row_pitch(
+                                          *r, static_cast<uint32_t>(guest_texel))
+                                    : static_cast<size_t>(r->width) * guest_texel;
+                                for (uint32_t y = 0; y < r->height; ++y)
+                                    std::memcpy(
+                                        layer_base + r->layer_mip_offset_bytes + y * row_pitch,
+                                        layout_source + linear_slice * layer +
+                                            static_cast<size_t>(y) * r->width * guest_texel,
+                                        static_cast<size_t>(r->width) * guest_texel);
+                            } else if (r->in_mip_tail) {
+                                tile_surface_level(
+                                    layer_base, r->mip_tail_bytes,
+                                    layout_source + linear_slice * layer,
+                                    r->width, r->height, r->tile_mode,
+                                    static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
+                            } else {
+                                tile_surface(
+                                    layer_base + r->layer_mip_offset_bytes,
+                                    layout_source + linear_slice * layer,
+                                    r->width, r->height, r->tile_mode, 0,
+                                    static_cast<uint32_t>(guest_texel));
+                            }
+                        }
+                    } else if (r->tile_mode && r->in_mip_tail) {
+                        tile_surface_level(destination, bi.guest_bytes, layout_source,
+                                           r->width, r->height, r->tile_mode,
+                                           static_cast<uint32_t>(guest_texel),
+                                           r->mip_tail_x, r->mip_tail_y);
+                    } else if (r->tile_mode) {
+                        tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
+                                     static_cast<uint32_t>(guest_texel));
+                    }
+                    const auto layout_done = ComputeClock::now();
+                    pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
+                    layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
+                    if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
+                    const auto notify_start = ComputeClock::now();
+                    // Name the writer. "a guest write covers this surface" and "prosper's own compute
+                    // writeback covers this surface" are different facts, and only the second says the
+                    // emulator is invalidating its own caches. Everything reaching the DS invalidation path
+                    // used to report the default `gpu`, which cannot distinguish them.
+                    set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
+                    notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+                    set_guest_gpu_write_origin(nullptr);
+                    if (!r->host_data && writer_provenance_enabled())
+                        record_guest_write(GuestWriterKind::ComputeBuffer,
+                                           r->gpu_addr, bi.guest_bytes,
+                                           item.submit_no, item.dispatch_index,
+                                           item.command_order, item.code_addr);
+                    if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
+                        const bool leave_compressed_for_test =
+                            g_leave_next_dcc_metadata_compressed_for_test.exchange(
+                                false, std::memory_order_acq_rel);
+                        if (!leave_compressed_for_test) {
+                            std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                            // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
+                            // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
+                            // aspects" and invalidates depth as well as stencil. So this reset can discard a
+                            // retained depth image. Tagged so that consequence is attributable rather than
+                            // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
+                            // separate question that needs the operation's real HTILE semantics proven.
+                            set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
+                            notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                            set_guest_gpu_write_origin(nullptr);
+                            if (!r->dcc_metadata_host_data && writer_provenance_enabled())
+                                record_guest_write(GuestWriterKind::ComputeBuffer,
+                                                   r->metadata_addr, bi.dcc_metadata_bytes,
+                                                   item.submit_no, item.dispatch_index,
+                                                   item.command_order, item.code_addr);
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   DCC uncompressed binding=%u meta=0x%llx "
+                                             "bytes=%zu code=0xff\n",
+                                             bi.binding, (unsigned long long)r->metadata_addr,
+                                             bi.dcc_metadata_bytes);
+                        } else if (trace) {
+                            std::fprintf(stderr,
+                                         "[compute]   injected unresolved DCC writeback binding=%u\n",
+                                         bi.binding);
+                        }
+                    }
+                    if (bi.mirror_result_to_imported) {
+                        const BoundImage& mirror = images[bi.seed_from_imported];
+                        notify_live_render_target_image_written({
+                            r->gpu_addr, mirror.imported_width, mirror.imported_height,
+                            mirror.imported_pixel_format});
                         if (trace)
                             std::fprintf(stderr,
-                                         "[compute]   retained storage image binding=%u "
-                                         "addr=0x%llx allocation=%llu\n",
+                                         "[compute]   mirrored storage result into renderer RTT "
+                                         "binding=%u addr=0x%llx extent=%ux%u\n",
                                          bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.allocation_bytes);
+                                         mirror.imported_width, mirror.imported_height);
                     }
-                    // An aligned exact result is retained as the staging buffer immediately below.
-                    // Copying it into a host vector first only to clear that vector after ownership
-                    // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
-                    // setup keeps the exact current host fallback; a failed ownership attempt invalidates
-                    // any older fallback so the next dispatch takes the ordinary writeback path.
-                    const bool force_host_result_fallback =
-                        bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
-                        !(bi.exact_result_bytes & 15u) &&
-                        g_force_next_image_result_host_fallback_for_test.exchange(
-                            false, std::memory_order_acq_rel);
-                    retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
-                        bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
-                        !force_host_result_fallback && ctx.prepare_compare_pipeline();
-                    if (bi.persistent && !retain_gpu_result_baseline)
-                        ctx.remember_cached_image_result(
-                            bi.cache_key, native_texels,
-                            static_cast<size_t>(bi.exact_result_bytes));
-                }
-                const auto cache_done = ComputeClock::now();
-                ctx.unmap_memory(staging_memory[i]);
-                const VkBuffer retained_result = staging[i];
-                if (retain_gpu_result_baseline &&
-                    ctx.retain_cached_image_result_buffer(
-                        bi.cache_key, staging[i], staging_memory[i],
-                        bi.staging_allocation_bytes, bi.exact_result_bytes)) {
-                    bi.result_baseline = retained_result;
-                    if (trace)
+                    const auto notify_done = ComputeClock::now();
+                    bool retain_gpu_result_baseline = false;
+                    bool promoted_after_writeback = false;
+                    const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
+                        std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
+                                    [](uint8_t value) { return value == 0xff; });
+                    if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
+                        const uint8_t* retained_source =
+                            (adaptive_storage_result_validation_enabled() &&
+                             cold_storage_result_snapshot_can_defer(
+                                 r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
+                                 cold_storage_result_snapshot_defer_min_bytes()))
+                            ? nullptr : destination;
+                        if (bi.forced_seed_allocation_reused) {
+                            // The exact cache entry was already pinned and forcibly reseeded before this
+                            // dispatch. Successful writeback plus the final all-uncompressed metadata scan
+                            // may now restore source/transfer authority without replacing its allocation.
+                            bi.cache_candidate = true;
+                            g_dcc_post_writeback_promotions.fetch_add(
+                                1, std::memory_order_relaxed);
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   promoted reused post-writeback DCC storage "
+                                             "image binding=%u addr=0x%llx allocation=%llu\n",
+                                             bi.binding, (unsigned long long)r->gpu_addr,
+                                             (unsigned long long)bi.allocation_bytes);
+                        } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                            ctx.replace_or_retain_image(
+                                bi.cache_key, bi.image, bi.memory,
+                                bi.allocation_bytes, retained_source)) {
+                            bi.cache_candidate = true;
+                            bi.persistent = true;
+                            promoted_after_writeback = true;
+                            g_dcc_post_writeback_promotions.fetch_add(
+                                1, std::memory_order_relaxed);
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   promoted post-writeback DCC storage image "
+                                             "binding=%u addr=0x%llx allocation=%llu\n",
+                                             bi.binding, (unsigned long long)r->gpu_addr,
+                                             (unsigned long long)bi.allocation_bytes);
+                        }
+                    }
+                    if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
+                        ctx.invalidate_cached_image_source(bi.cache_key);
+                    if (bi.cache_candidate) {
+                        if (bi.persistent && !promoted_after_writeback) {
+                            // Guest bytes now mirror the retained image again. A changing full-overwrite
+                            // target needs no source snapshot; the first repeated result retains one exact
+                            // baseline, and subsequent identical GPU skips do not recopy it.
+                            ctx.validate_cached_image_source(
+                                bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
+                                bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
+                                    native_3d_transfer_enabled());
+                        } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                                   ctx.retain_image(bi.cache_key, bi.image, bi.memory,
+                                                    bi.allocation_bytes,
+                                                    (adaptive_storage_result_validation_enabled() &&
+                                                     cold_storage_result_snapshot_can_defer(
+                                                         r->host_data != nullptr, bi.seed_skip,
+                                                         bi.guest_bytes,
+                                                         cold_storage_result_snapshot_defer_min_bytes()))
+                                                        ? nullptr : destination)) {
+                            bi.persistent = true;
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   retained storage image binding=%u "
+                                             "addr=0x%llx allocation=%llu\n",
+                                             bi.binding, (unsigned long long)r->gpu_addr,
+                                             (unsigned long long)bi.allocation_bytes);
+                        }
+                        // An aligned exact result is retained as the staging buffer immediately below.
+                        // Copying it into a host vector first only to clear that vector after ownership
+                        // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
+                        // setup keeps the exact current host fallback; a failed ownership attempt invalidates
+                        // any older fallback so the next dispatch takes the ordinary writeback path.
+                        const bool force_host_result_fallback =
+                            bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
+                            !(bi.exact_result_bytes & 15u) &&
+                            g_force_next_image_result_host_fallback_for_test.exchange(
+                                false, std::memory_order_acq_rel);
+                        retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
+                            bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
+                            !force_host_result_fallback && ctx.prepare_compare_pipeline();
+                        if (bi.persistent && !retain_gpu_result_baseline)
+                            ctx.remember_cached_image_result(
+                                bi.cache_key, native_texels,
+                                static_cast<size_t>(bi.exact_result_bytes));
+                    }
+                    const auto cache_done = ComputeClock::now();
+                    ctx.unmap_memory(staging_memory[i]);
+                    const VkBuffer retained_result = staging[i];
+                    if (retain_gpu_result_baseline &&
+                        ctx.retain_cached_image_result_buffer(
+                            bi.cache_key, staging[i], staging_memory[i],
+                            bi.staging_allocation_bytes, bi.exact_result_bytes)) {
+                        bi.result_baseline = retained_result;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   retained exact GPU result baseline binding=%u "
+                                         "addr=0x%llx bytes=%zu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
+                    }
+                    const auto image_writeback_done = ComputeClock::now();
+                    const auto image_milliseconds = [](auto begin, auto end) {
+                        return std::chrono::duration<double, std::milli>(end - begin).count();
+                    };
+                    image_map_ms += image_milliseconds(map_start, map_done);
+                    image_prepare_ms += image_milliseconds(map_done, prepare_done);
+                    image_watch_ms += image_milliseconds(prepare_done, watch_done);
+                    image_notify_ms += image_milliseconds(notify_start, notify_done);
+                    image_cache_ms += image_milliseconds(notify_done, cache_done);
+                    if (image_timing)
                         std::fprintf(stderr,
-                                     "[compute]   retained exact GPU result baseline binding=%u "
-                                     "addr=0x%llx bytes=%zu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
+                                     "[compute-image-writeback] code=0x%llx hash=0x%016llx "
+                                     "binding=%u addr=0x%llx "
+                                     "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
+                                     "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
+                                     "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
+                                     "total_ms=%.3f\n",
+                                     (unsigned long long)item.code_addr,
+                                     (unsigned long long)timing_program_hash, bi.binding,
+                                     (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
+                                     r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
+                                     bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
+                                     image_milliseconds(map_start, map_done),
+                                     image_milliseconds(map_done, prepare_done),
+                                     image_milliseconds(prepare_done, watch_done),
+                                     image_milliseconds(pack_start, pack_done),
+                                     image_milliseconds(pack_done, layout_done),
+                                     image_milliseconds(notify_start, notify_done),
+                                     image_milliseconds(notify_done, cache_done),
+                                     image_milliseconds(image_writeback_start, image_writeback_done));
                 }
-                const auto image_writeback_done = ComputeClock::now();
-                const auto image_milliseconds = [](auto begin, auto end) {
-                    return std::chrono::duration<double, std::milli>(end - begin).count();
-                };
-                image_map_ms += image_milliseconds(map_start, map_done);
-                image_prepare_ms += image_milliseconds(map_done, prepare_done);
-                image_watch_ms += image_milliseconds(prepare_done, watch_done);
-                image_notify_ms += image_milliseconds(notify_start, notify_done);
-                image_cache_ms += image_milliseconds(notify_done, cache_done);
-                if (image_timing)
-                    std::fprintf(stderr,
-                                 "[compute-image-writeback] code=0x%llx hash=0x%016llx "
-                                 "binding=%u addr=0x%llx "
-                                 "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
-                                 "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
-                                 "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
-                                 "total_ms=%.3f\n",
-                                 (unsigned long long)item.code_addr,
-                                 (unsigned long long)timing_program_hash, bi.binding,
-                                 (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
-                                 r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
-                                 bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
-                                 image_milliseconds(map_start, map_done),
-                                 image_milliseconds(map_done, prepare_done),
-                                 image_milliseconds(prepare_done, watch_done),
-                                 image_milliseconds(pack_start, pack_done),
-                                 image_milliseconds(pack_done, layout_done),
-                                 image_milliseconds(notify_start, notify_done),
-                                 image_milliseconds(notify_done, cache_done),
-                                 image_milliseconds(image_writeback_start, image_writeback_done));
-            }
-            writeback_images_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_images_start).count();
-            if (!readback_ok) return false;   // was `break` out of the do-while; the call
-                                              // site turns a false return back into that break
-            const auto writeback_publish_start = ComputeClock::now();
-            // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
-            // completed, and a failed dispatch cannot reach here. Native results may seed a later
-            // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
-            // also be exported directly to graphics. Raw interchange images are compatible with neither.
-            for (const BoundImage& image : images) {
-                if (!image.storage) continue;
-                const bool unique = image.alias_of == SIZE_MAX;
-                const bool native_exact_storage = image.native_float_storage ||
-                    image.native_uint_storage || image.packed_r11_storage;
-                const bool publish_eligible = native_exact_storage && unique &&
-                    image.cache_candidate && image.persistent;
-                const bool authorized = publish_eligible &&
-                    ctx.authorize_cached_image_compute_transfer(image.cache_key);
-                transfer_gate_census.record_storage_publish(
-                    transfer_gate_observation.role, native_exact_storage, unique,
-                    image.cache_candidate, image.persistent, authorized);
-                if (authority_observation.selected && unique && image.resource) {
-                    authority_census.record_selected_storage_output(
-                        item, image.binding,
-                        ShadowComputeAuthorityRange::from(
-                            image.resource->gpu_addr, image.guest_bytes),
-                        authorized);
+                writeback_images_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_images_start).count();
+                if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                                  // site turns a false return back into that break
+                const auto writeback_publish_start = ComputeClock::now();
+                // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
+                // completed, and a failed dispatch cannot reach here. Native results may seed a later
+                // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
+                // also be exported directly to graphics. Raw interchange images are compatible with neither.
+                for (const BoundImage& image : images) {
+                    if (!image.storage) continue;
+                    const bool unique = image.alias_of == SIZE_MAX;
+                    const bool native_exact_storage = image.native_float_storage ||
+                        image.native_uint_storage || image.packed_r11_storage;
+                    const bool publish_eligible = native_exact_storage && unique &&
+                        image.cache_candidate && image.persistent;
+                    const bool authorized = publish_eligible &&
+                        ctx.authorize_cached_image_compute_transfer(image.cache_key);
+                    transfer_gate_census.record_storage_publish(
+                        transfer_gate_observation.role, native_exact_storage, unique,
+                        image.cache_candidate, image.persistent, authorized);
+                    if (authority_observation.selected && unique && image.resource) {
+                        authority_census.record_selected_storage_output(
+                            item, image.binding,
+                            ShadowComputeAuthorityRange::from(
+                                image.resource->gpu_addr, image.guest_bytes),
+                            authorized);
+                    }
+                    if (publish_eligible && image.graphics_sampled_usage)
+                        ctx.authorize_cached_image_export(image.cache_key, item.command_order);
                 }
-                if (publish_eligible && image.graphics_sampled_usage)
-                    ctx.authorize_cached_image_export(image.cache_key, item.command_order);
-            }
-            writeback_publish_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_publish_start).count();
-            ok = true;
-            phase_writeback = ComputeClock::now();
+                writeback_publish_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_publish_start).count();
+                ok = true;
+                phase_writeback = ComputeClock::now();
+                return true;
+            };
+            if (!consume_dispatch()) return false;
             return true;
         };
-        if (!consume_dispatch()) break;
+        if (!wait_and_consume()) break;
     } while (false);
 
     if (trace)

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -9032,184 +9032,345 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         submitted_dispatch = true;
     } while (false);
 
-    // #3157 step B1: the whole post-submit phase -- fence wait, its failure handling, GPU
-    // timestamps, and the consume tail -- as ONE callable. Immediately invoked here, so
-    // behaviour is unchanged. This is the unit a dispatch ring defers: cleanup() (run in
-    // the epilogue) destroys the compare-flags buffer the consume reads, so the boundary
-    // has to enclose the wait, not sit after it.
-    auto wait_and_consume = [&]() -> bool {
-        if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
-        const auto fence_wait_start = ComputeClock::now();
-        const VkResult wait_result = vkWaitForFences(
-            ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
-        // Report a LONG wait even when it succeeds.
-        //
-        // A zero timeout count was read as proof that no compute dispatch hangs. That inference has a
-        // hole: an amdgpu context reset SIGNALS pending fences, so a dispatch the kernel watchdog
-        // killed can return VK_SUCCESS here and look indistinguishable from one that finished in
-        // microseconds — with the loss surfacing only at the NEXT submit. Duration is what separates
-        // them: a killed job sits at roughly the kernel's timeout (~10 s), a real one is sub-millisecond.
-        {
-            const double waited_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - fence_wait_start).count();
-            if (waited_ms >= 100.0) {
-                static std::atomic<int> slow{0};
-                const int n = slow.fetch_add(1);
-                if (n < 24 || (n & 255) == 0)
-                    std::fprintf(stderr,
-                                 "[compute] SLOW fence wait %.1f ms result=%d program=0x%llx "
-                                 "submit=%llu dispatch=%llu order=%llu groups=%ux%ux%u\n",
-                                 waited_ms, static_cast<int>(wait_result),
-                                 static_cast<unsigned long long>(item.code_addr),
-                                 static_cast<unsigned long long>(item.submit_no),
-                                 static_cast<unsigned long long>(item.dispatch_index),
-                                 static_cast<unsigned long long>(item.command_order),
-                                 item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
-            }
-        }
-        if (!vk_ok(wait_result, "queue-wait")) {
-            // cleanup() releases resources referenced by the command buffer, including a borrowed
-            // renderer image's pin. With that image bound, in-flight work still references it and
-            // its layout transitions, so drain the queue first rather than freeing it underneath
-            // the GPU.
-            // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
-            // to success; this item stays failed either way, which is the conservative choice for a
-            // dispatch whose results we can no longer trust.
-            if (!ctx.device_lost) {
-                std::unique_lock<std::mutex> qlk(
-                    prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
-                if (prosper::gpu::shared_present_active()) qlk.lock();
-                const VkResult drain_result = vkQueueWaitIdle(ctx.queue);
-                completion_proven = drain_result == VK_SUCCESS;
-                // Soft: this drain runs INSIDE the queue-wait failure path, which has already
-                // declined. Declining again would report one fence timeout as two refusals.
-                if (!vk_soft_ok(drain_result, "queue-drain") && trace)
-                    std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
-            }
-            return false;   // was `break` out of the do/while(false)
-        }
-        completion_proven = true;
-        if (perf_gpu_timing) {
-            uint64_t timestamps[6]{};
-            if (vkGetQueryPoolResults(ctx.device, ctx.dispatch_timestamp_pool, 0, 6,
-                                      sizeof(timestamps), timestamps, sizeof(uint64_t),
-                                      VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
-                const uint64_t mask = ctx.timestamp_valid_bits >= 64
-                    ? UINT64_MAX : ((uint64_t{1} << ctx.timestamp_valid_bits) - 1u);
-                const uint64_t device_ticks = (timestamps[5] - timestamps[0]) & mask;
-                const uint64_t shader_ticks = (timestamps[2] - timestamps[1]) & mask;
-                ++g_perf_compute_gpu_timestamp_samples;
-                g_perf_compute_gpu_device_ms +=
-                    static_cast<double>(device_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_shader_ms +=
-                    static_cast<double>(shader_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_pre_ms += static_cast<double>(
-                    (timestamps[1] - timestamps[0]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_storage_copy_ms += static_cast<double>(
-                    (timestamps[3] - timestamps[2]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_compare_ms += static_cast<double>(
-                    (timestamps[4] - timestamps[3]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-                g_perf_compute_gpu_restore_ms += static_cast<double>(
-                    (timestamps[5] - timestamps[4]) & mask) *
-                    ctx.timestamp_period_ns / 1'000'000.0;
-            }
-        }
-        if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
-        phase_dispatch = ComputeClock::now();
-        // #3157 step A: the consume tail as one callable unit. Immediately invoked here, so
-        // behaviour is unchanged -- this only proves the tail is a coherent block with known
-        // escapes before it is deferred behind a dispatch ring.
-        auto consume_dispatch = [&]() -> bool {
-            const auto writeback_prepare_start = phase_dispatch;
-
-            if (!compare_targets.empty()) {
-                void* mapped = nullptr;
-                const VkDeviceSize flag_stride = ctx.compare_flag_stride();
-                if (ctx.map_memory(compare_flags_memory, 0,
-                                   compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
-                    // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
-                    // target would read the padding between flags on any device whose alignment exceeds
-                    // four, reporting every target after the first as unchanged.
-                    const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
-                    for (size_t j = 0; j < compare_targets.size(); ++j) {
-                        CompareTarget& target = compare_targets[j];
-                        uint32_t changed = 0;
-                        std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
-                        if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
-                        if (target.image) target.image->gpu_result_unchanged = changed == 0;
-                    }
-                    ctx.unmap_memory(compare_flags_memory);
+    // #3157 step B2d: the entire deferrable unit -- fence wait, consume, and the epilogue that
+    // must follow it. cleanup(), inside the epilogue, destroys the compare-flags buffer the
+    // consume reads, so the two cannot be separated. wait_and_consume stays a nested lambda so
+    // its failure returns skip the remaining consume work WITHOUT skipping the epilogue.
+    auto finish_dispatch = [&]() -> bool {
+        // #3157 step B1: the whole post-submit phase -- fence wait, its failure handling, GPU
+        // timestamps, and the consume tail -- as ONE callable. Immediately invoked here, so
+        // behaviour is unchanged. This is the unit a dispatch ring defers: cleanup() (run in
+        // the epilogue) destroys the compare-flags buffer the consume reads, so the boundary
+        // has to enclose the wait, not sit after it.
+        auto wait_and_consume = [&]() -> bool {
+            if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
+            const auto fence_wait_start = ComputeClock::now();
+            const VkResult wait_result = vkWaitForFences(
+                ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
+            // Report a LONG wait even when it succeeds.
+            //
+            // A zero timeout count was read as proof that no compute dispatch hangs. That inference has a
+            // hole: an amdgpu context reset SIGNALS pending fences, so a dispatch the kernel watchdog
+            // killed can return VK_SUCCESS here and look indistinguishable from one that finished in
+            // microseconds — with the loss surfacing only at the NEXT submit. Duration is what separates
+            // them: a killed job sits at roughly the kernel's timeout (~10 s), a real one is sub-millisecond.
+            {
+                const double waited_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - fence_wait_start).count();
+                if (waited_ms >= 100.0) {
+                    static std::atomic<int> slow{0};
+                    const int n = slow.fetch_add(1);
+                    if (n < 24 || (n & 255) == 0)
+                        std::fprintf(stderr,
+                                     "[compute] SLOW fence wait %.1f ms result=%d program=0x%llx "
+                                     "submit=%llu dispatch=%llu order=%llu groups=%ux%ux%u\n",
+                                     waited_ms, static_cast<int>(wait_result),
+                                     static_cast<unsigned long long>(item.code_addr),
+                                     static_cast<unsigned long long>(item.submit_no),
+                                     static_cast<unsigned long long>(item.dispatch_index),
+                                     static_cast<unsigned long long>(item.command_order),
+                                     item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
                 }
             }
-
-            // The fence proves every upload is complete and every sampled image is back in GENERAL.
-            // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
-            // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
-            for (BoundImage& image : images) {
-                if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
-                    !image.cache_candidate)
-                    continue;
-                // When this dispatch samples and writes the same guest view through distinct bindings,
-                // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
-                // would occupy the identical key before storage writeback can retain the actual result.
-                const bool replaced_by_storage = std::any_of(
-                    images.begin(), images.end(), [&](const BoundImage& candidate) {
-                        return candidate.storage && candidate.cache_candidate &&
-                               candidate.cache_key == image.cache_key;
-                    });
-                if (replaced_by_storage) continue;
-                if (image.persistent) {
-                    if (!image.upload_skipped) {
-                        if (image.compute_transfer_seed_borrowed)
-                            ctx.validate_cached_image_source_from_compute_transfer(
-                                image.cache_key);
-                        else
-                            ctx.validate_cached_image_source(image.cache_key);
-                    }
-                } else if (image.image && image.memory && image.allocation_bytes &&
-                           (image.cache_source_snapshot.empty()
-                                ? ctx.retain_image(image.cache_key, image.image, image.memory,
-                                                   image.allocation_bytes,
-                                                   static_cast<const uint8_t*>(nullptr))
-                                : ctx.retain_image(image.cache_key, image.image, image.memory,
-                                                   image.allocation_bytes,
-                                                   std::move(image.cache_source_snapshot)))) {
-                    image.persistent = true;
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   retained sampled image binding=%u addr=0x%llx "
-                                     "allocation=%llu\n",
-                                     image.binding,
-                                     (unsigned long long)image.resource->gpu_addr,
-                                     (unsigned long long)image.allocation_bytes);
+            if (!vk_ok(wait_result, "queue-wait")) {
+                // cleanup() releases resources referenced by the command buffer, including a borrowed
+                // renderer image's pin. With that image bound, in-flight work still references it and
+                // its layout transitions, so drain the queue first rather than freeing it underneath
+                // the GPU.
+                // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
+                // to success; this item stays failed either way, which is the conservative choice for a
+                // dispatch whose results we can no longer trust.
+                if (!ctx.device_lost) {
+                    std::unique_lock<std::mutex> qlk(
+                        prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
+                    if (prosper::gpu::shared_present_active()) qlk.lock();
+                    const VkResult drain_result = vkQueueWaitIdle(ctx.queue);
+                    completion_proven = drain_result == VK_SUCCESS;
+                    // Soft: this drain runs INSIDE the queue-wait failure path, which has already
+                    // declined. Declining again would report one fence timeout as two refusals.
+                    if (!vk_soft_ok(drain_result, "queue-drain") && trace)
+                        std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
+                }
+                return false;   // was `break` out of the do/while(false)
+            }
+            completion_proven = true;
+            if (perf_gpu_timing) {
+                uint64_t timestamps[6]{};
+                if (vkGetQueryPoolResults(ctx.device, ctx.dispatch_timestamp_pool, 0, 6,
+                                          sizeof(timestamps), timestamps, sizeof(uint64_t),
+                                          VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
+                    const uint64_t mask = ctx.timestamp_valid_bits >= 64
+                        ? UINT64_MAX : ((uint64_t{1} << ctx.timestamp_valid_bits) - 1u);
+                    const uint64_t device_ticks = (timestamps[5] - timestamps[0]) & mask;
+                    const uint64_t shader_ticks = (timestamps[2] - timestamps[1]) & mask;
+                    ++g_perf_compute_gpu_timestamp_samples;
+                    g_perf_compute_gpu_device_ms +=
+                        static_cast<double>(device_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_shader_ms +=
+                        static_cast<double>(shader_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_pre_ms += static_cast<double>(
+                        (timestamps[1] - timestamps[0]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_storage_copy_ms += static_cast<double>(
+                        (timestamps[3] - timestamps[2]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_compare_ms += static_cast<double>(
+                        (timestamps[4] - timestamps[3]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
+                    g_perf_compute_gpu_restore_ms += static_cast<double>(
+                        (timestamps[5] - timestamps[4]) & mask) *
+                        ctx.timestamp_period_ns / 1'000'000.0;
                 }
             }
+            if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
+            phase_dispatch = ComputeClock::now();
+            // #3157 step A: the consume tail as one callable unit. Immediately invoked here, so
+            // behaviour is unchanged -- this only proves the tail is a coherent block with known
+            // escapes before it is deferred behind a dispatch ring.
+            auto consume_dispatch = [&]() -> bool {
+                const auto writeback_prepare_start = phase_dispatch;
 
-            writeback_prepare_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_prepare_start).count();
-            const auto writeback_buffers_start = ComputeClock::now();
-            bool readback_ok = true;
-            for (auto& buffer : buffers) {
-                if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
-                // The exact GPU comparator saw the same bytes as the retained baseline, while source
-                // validation independently proved that the guest mirror still contains that baseline.
-                // Preserve architectural write notification, but avoid mapping and scanning the whole
-                // host-visible buffer merely to rediscover equality.
-                if (buffer.gpu_result_unchanged) {
-                    g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
-                    if (trace)
+                if (!compare_targets.empty()) {
+                    void* mapped = nullptr;
+                    const VkDeviceSize flag_stride = ctx.compare_flag_stride();
+                    if (ctx.map_memory(compare_flags_memory, 0,
+                                       compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
+                        // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
+                        // target would read the padding between flags on any device whose alignment exceeds
+                        // four, reporting every target after the first as unchanged.
+                        const auto* flag_bytes = static_cast<const uint8_t*>(mapped);
+                        for (size_t j = 0; j < compare_targets.size(); ++j) {
+                            CompareTarget& target = compare_targets[j];
+                            uint32_t changed = 0;
+                            std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
+                            if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
+                            if (target.image) target.image->gpu_result_unchanged = changed == 0;
+                        }
+                        ctx.unmap_memory(compare_flags_memory);
+                    }
+                }
+
+                // The fence proves every upload is complete and every sampled image is back in GENERAL.
+                // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
+                // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
+                for (BoundImage& image : images) {
+                    if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
+                        !image.cache_candidate)
+                        continue;
+                    // When this dispatch samples and writes the same guest view through distinct bindings,
+                    // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
+                    // would occupy the identical key before storage writeback can retain the actual result.
+                    const bool replaced_by_storage = std::any_of(
+                        images.begin(), images.end(), [&](const BoundImage& candidate) {
+                            return candidate.storage && candidate.cache_candidate &&
+                                   candidate.cache_key == image.cache_key;
+                        });
+                    if (replaced_by_storage) continue;
+                    if (image.persistent) {
+                        if (!image.upload_skipped) {
+                            if (image.compute_transfer_seed_borrowed)
+                                ctx.validate_cached_image_source_from_compute_transfer(
+                                    image.cache_key);
+                            else
+                                ctx.validate_cached_image_source(image.cache_key);
+                        }
+                    } else if (image.image && image.memory && image.allocation_bytes &&
+                               (image.cache_source_snapshot.empty()
+                                    ? ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                       image.allocation_bytes,
+                                                       static_cast<const uint8_t*>(nullptr))
+                                    : ctx.retain_image(image.cache_key, image.image, image.memory,
+                                                       image.allocation_bytes,
+                                                       std::move(image.cache_source_snapshot)))) {
+                        image.persistent = true;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   retained sampled image binding=%u addr=0x%llx "
+                                         "allocation=%llu\n",
+                                         image.binding,
+                                         (unsigned long long)image.resource->gpu_addr,
+                                         (unsigned long long)image.allocation_bytes);
+                    }
+                }
+
+                writeback_prepare_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_prepare_start).count();
+                const auto writeback_buffers_start = ComputeClock::now();
+                bool readback_ok = true;
+                for (auto& buffer : buffers) {
+                    if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
+                    // The exact GPU comparator saw the same bytes as the retained baseline, while source
+                    // validation independently proved that the guest mirror still contains that baseline.
+                    // Preserve architectural write notification, but avoid mapping and scanning the whole
+                    // host-visible buffer merely to rediscover equality.
+                    if (buffer.gpu_result_unchanged) {
+                        g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   skipped GPU-identical buffer writeback binding=%u "
+                                         "addr=0x%llx bytes=%u\n",
+                                         buffer.resource->binding,
+                                         (unsigned long long)buffer.resource->gpu_addr,
+                                         buffer.resource->size);
+                        if (buffer.resource->gpu_addr)
+                            notify_guest_gpu_write_preserving_bytes(
+                                buffer.resource->gpu_addr, buffer.resource->size);
+                        if (buffer.persistent)
+                            ctx.validate_cached_buffer_source(buffer.cache_key);
+                        if (!buffer.resource->host_data && writer_provenance_enabled())
+                            record_guest_write(GuestWriterKind::ComputeBuffer,
+                                               buffer.resource->gpu_addr, buffer.resource->size,
+                                               item.submit_no, item.dispatch_index,
+                                               item.command_order, item.code_addr);
+                        continue;
+                    }
+                    void* mapped = nullptr;
+                    if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
+                        readback_ok = false;
+                        break;
+                    }
+                    uint8_t* destination = buffer.atomic_image
+                        ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
+                        : resource_bytes_for(buffer.resource, buffer.guest_bytes);
+                    const auto* result = static_cast<const uint8_t*>(mapped);
+                    if (buffer.atomic_image) {
+                        if (trace) {
+                            buffer.after_hash = fnv1a(result, buffer.bytes);
+                            for (size_t i = 0; i < buffer.bytes; ++i)
+                                buffer.changed_bytes += buffer.linear_seed[i] != result[i];
+                        }
+                        if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                            prosper::host::guest_write_watch_notify_host_write(
+                                buffer.resource->gpu_addr, buffer.guest_bytes);
+                        // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
+                        const size_t layer_linear_bytes =
+                            static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
+                        for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
+                            uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
+                            const uint8_t* src = result + layer * layer_linear_bytes;
+                            if (buffer.resource->tile_mode) {
+                                tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
+                                             buffer.resource->tile_mode, 0, sizeof(uint32_t));
+                            } else {
+                                const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
+                                const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
+                                    ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
+                                for (uint32_t y = 0; y < buffer.resource->height; ++y)
+                                    std::memcpy(dst + y * destination_pitch,
+                                                src + y * tight_pitch, tight_pitch);
+                            }
+                        }
+                        ctx.unmap_memory(buffer.memory);
+                        if (buffer.resource->gpu_addr) {
+                            set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
+                            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
+                            set_guest_gpu_write_origin(nullptr);
+                        }
+                        if (!buffer.resource->host_data && writer_provenance_enabled())
+                            record_guest_write(GuestWriterKind::ComputeBuffer,
+                                               buffer.resource->gpu_addr, buffer.guest_bytes,
+                                               item.submit_no, item.dispatch_index,
+                                               item.command_order, item.code_addr);
+                        continue;
+                    }
+                    const bool changed = !compute_buffers_equal(
+                        destination, result, buffer.bytes);
+                    if (trace) {
+                        buffer.after_hash = fnv1a(result, buffer.bytes);
+                        for (size_t i = 0; i < buffer.bytes; i++)
+                            buffer.changed_bytes += destination[i] != result[i];
+                        // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
+                        //
+                        // `changed_bytes` says how much moved and nothing about where, which is the only
+                        // question that separates a wrong VALUE from a wrong INDEX. For a structure written
+                        // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
+                        // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
+                        // count or a hash.
+                        // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
+                        // merged and writability is ORed onto the first owner, so the owner's binding is
+                        // NOT evidence that the owner performed the store: a read-only binding followed by
+                        // a writable exact alias reports as though the first wrote, and with several
+                        // writable aliases no single store site can be named at all. The changed indices
+                        // below are allocation-level evidence and stand on their own; the binding is
+                        // reported as `owner-binding` with the alias count beside it so a reader cannot
+                        // mistake it for attribution.
+                        size_t alias_count = 0;
+                        for (const auto& other : buffers)
+                            if (other.alias_of != SIZE_MAX &&
+                                &buffers[other.alias_of] == &buffer) ++alias_count;
+                        if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
+                            char* end = nullptr;
+                            const unsigned long limit = std::strtoul(limit_env, &end, 0);
+                            if (end && !*end && limit) {
+                                // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
+                                // storage and `result` is mapped device memory, and neither contract
+                                // promises uint32_t alignment or a uint32_t object lifetime there. The byte
+                                // bound below deliberately ignores a partial trailing dword.
+                                const size_t dwords = buffer.bytes / sizeof(uint32_t);
+                                const auto load_dword = [](const uint8_t* bytes, size_t index) {
+                                    uint32_t value = 0;
+                                    std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
+                                    return value;
+                                };
+                                unsigned long shown = 0;
+                                for (size_t i = 0; i < dwords && shown < limit; ++i) {
+                                    const uint32_t before_value = load_dword(destination, i);
+                                    const uint32_t after_value = load_dword(result, i);
+                                    if (before_value == after_value) continue;
+                                    // Carry submit/dispatch on EVERY line. Without them the lines from
+                                    // consecutive dispatches concatenate into one stream that looks like a
+                                    // single dispatch's writes -- and a per-dispatch structural claim built
+                                    // on that stream is meaningless. The first analysis run here did exactly
+                                    // that and reported one index changing twice in "one" dispatch.
+                                    std::fprintf(stderr,
+                                                 "[compute]     changed submit=%llu dispatch=%llu "
+                                                 "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
+                                                 "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
+                                                 (unsigned long long)item.submit_no,
+                                                 (unsigned long long)item.dispatch_index,
+                                                 (unsigned long long)(buffer.resource
+                                                     ? buffer.resource->gpu_addr : 0ull),
+                                                 buffer.resource ? buffer.resource->binding : 0u,
+                                                 alias_count, i,
+                                                 before_value, after_value, after_value & 7u,
+                                                 (after_value >> 30) & 1u,
+                                                 (after_value >> 3) & 0x07FFFFFFu);
+                                    ++shown;
+                                }
+                            }
+                        }
+                    }
+                    // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
+                    // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
+                    // after its first dispatch all later readbacks are identical. Avoiding the redundant host
+                    // write removes one full pass over both source and destination. Renderer-alias
+                    // invalidation and writer provenance remain unconditional: renderer-resident state can
+                    // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
+                    if (changed) {
+                        if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                            prosper::host::guest_write_watch_notify_host_write(
+                                buffer.resource->gpu_addr, buffer.resource->size);
+                        copy_compute_buffer(destination, result, buffer.bytes);
+                    }
+                    if (buffer.persistent && !buffer.result_baseline &&
+                        ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
                         std::fprintf(stderr,
-                                     "[compute]   skipped GPU-identical buffer writeback binding=%u "
+                                     "[compute]   retained exact GPU buffer result baseline binding=%u "
                                      "addr=0x%llx bytes=%u\n",
                                      buffer.resource->binding,
                                      (unsigned long long)buffer.resource->gpu_addr,
                                      buffer.resource->size);
-                    if (buffer.resource->gpu_addr)
-                        notify_guest_gpu_write_preserving_bytes(
-                            buffer.resource->gpu_addr, buffer.resource->size);
+                    ctx.unmap_memory(buffer.memory);
+                    if (buffer.resource->gpu_addr) {
+                        if (changed) {
+                            set_guest_gpu_write_origin("compute-writeback(buffer-full)");
+                            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+                            set_guest_gpu_write_origin(nullptr);
+                        } else {
+                            notify_guest_gpu_write_preserving_bytes(
+                                buffer.resource->gpu_addr, buffer.resource->size);
+                        }
+                    }
                     if (buffer.persistent)
                         ctx.validate_cached_buffer_source(buffer.cache_key);
                     if (!buffer.resource->host_data && writer_provenance_enabled())
@@ -9217,780 +9378,626 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                            buffer.resource->gpu_addr, buffer.resource->size,
                                            item.submit_no, item.dispatch_index,
                                            item.command_order, item.code_addr);
-                    continue;
                 }
-                void* mapped = nullptr;
-                if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
-                    readback_ok = false;
-                    break;
-                }
-                uint8_t* destination = buffer.atomic_image
-                    ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
-                    : resource_bytes_for(buffer.resource, buffer.guest_bytes);
-                const auto* result = static_cast<const uint8_t*>(mapped);
-                if (buffer.atomic_image) {
-                    if (trace) {
-                        buffer.after_hash = fnv1a(result, buffer.bytes);
-                        for (size_t i = 0; i < buffer.bytes; ++i)
-                            buffer.changed_bytes += buffer.linear_seed[i] != result[i];
+                writeback_buffers_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_buffers_start).count();
+                if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                                  // site turns a false return back into that break
+                const auto writeback_images_start = ComputeClock::now();
+                // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
+                // into the guest format, then restore its linear or 3D tiled address layout and notify the
+                // render side exactly like the buffer path.
+                for (size_t i = 0; i < images.size() && readback_ok; i++) {
+                    BoundImage& bi = images[i];
+                    if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
+                    const auto image_writeback_start = ComputeClock::now();
+                    const bool image_cache_hit = bi.persistent;
+                    const ShaderResource* r = bi.resource;
+                    const uint32_t cb = data_format_bytes(r->format);
+                    const uint32_t nc = r->num_components ? r->num_components : 1;
+                    const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
+                                                r->format == DataFormat::Unorm2_10_10_10)
+                        ? 4u : (size_t)cb * nc;
+                    const size_t texels = (size_t)r->width * r->height * r->depth;
+                    const size_t linear_bytes = texels * guest_texel;
+                    uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
+                    // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
+                    // independently proved that the guest mirror still contains that baseline. This path
+                    // therefore needs neither a large staging mapping nor a CPU memory pass.
+                    if (bi.gpu_result_unchanged && bi.upload_skipped) {
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   skipped GPU-identical storage writeback binding=%u "
+                                         "addr=0x%llx bytes=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.exact_result_bytes);
+                        if (r->gpu_addr)
+                            notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                        continue;
                     }
-                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                        prosper::host::guest_write_watch_notify_host_write(
-                            buffer.resource->gpu_addr, buffer.guest_bytes);
-                    // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
-                    const size_t layer_linear_bytes =
-                        static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
-                    for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
-                        uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
-                        const uint8_t* src = result + layer * layer_linear_bytes;
-                        if (buffer.resource->tile_mode) {
-                            tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
-                                         buffer.resource->tile_mode, 0, sizeof(uint32_t));
-                        } else {
-                            const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
-                            const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
-                                ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
-                            for (uint32_t y = 0; y < buffer.resource->height; ++y)
-                                std::memcpy(dst + y * destination_pitch,
-                                            src + y * tight_pitch, tight_pitch);
-                        }
-                    }
-                    ctx.unmap_memory(buffer.memory);
-                    if (buffer.resource->gpu_addr) {
-                        set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
-                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
-                        set_guest_gpu_write_origin(nullptr);
-                    }
-                    if (!buffer.resource->host_data && writer_provenance_enabled())
-                        record_guest_write(GuestWriterKind::ComputeBuffer,
-                                           buffer.resource->gpu_addr, buffer.guest_bytes,
-                                           item.submit_no, item.dispatch_index,
-                                           item.command_order, item.code_addr);
-                    continue;
-                }
-                const bool changed = !compute_buffers_equal(
-                    destination, result, buffer.bytes);
-                if (trace) {
-                    buffer.after_hash = fnv1a(result, buffer.bytes);
-                    for (size_t i = 0; i < buffer.bytes; i++)
-                        buffer.changed_bytes += destination[i] != result[i];
-                    // PROSPER_COMPUTELOG_CHANGED=N: the first N changed DWORD indices with old->new.
-                    //
-                    // `changed_bytes` says how much moved and nothing about where, which is the only
-                    // question that separates a wrong VALUE from a wrong INDEX. For a structure written
-                    // as adjacent pairs, the indices are the evidence: a head at k and its tail at k+1
-                    // is correct, a head at k and a tail at k+2 is not, and neither is visible in a byte
-                    // count or a hash.
-                    // How many bindings collapsed onto this one Vulkan buffer. Exact aliases are
-                    // merged and writability is ORed onto the first owner, so the owner's binding is
-                    // NOT evidence that the owner performed the store: a read-only binding followed by
-                    // a writable exact alias reports as though the first wrote, and with several
-                    // writable aliases no single store site can be named at all. The changed indices
-                    // below are allocation-level evidence and stand on their own; the binding is
-                    // reported as `owner-binding` with the alias count beside it so a reader cannot
-                    // mistake it for attribution.
-                    size_t alias_count = 0;
-                    for (const auto& other : buffers)
-                        if (other.alias_of != SIZE_MAX &&
-                            &buffers[other.alias_of] == &buffer) ++alias_count;
-                    if (const char* limit_env = std::getenv("PROSPER_COMPUTELOG_CHANGED")) {
-                        char* end = nullptr;
-                        const unsigned long limit = std::strtoul(limit_env, &end, 0);
-                        if (end && !*end && limit) {
-                            // memcpy, not a reinterpret_cast: `destination` is guest-addressed byte
-                            // storage and `result` is mapped device memory, and neither contract
-                            // promises uint32_t alignment or a uint32_t object lifetime there. The byte
-                            // bound below deliberately ignores a partial trailing dword.
-                            const size_t dwords = buffer.bytes / sizeof(uint32_t);
-                            const auto load_dword = [](const uint8_t* bytes, size_t index) {
-                                uint32_t value = 0;
-                                std::memcpy(&value, bytes + index * sizeof(uint32_t), sizeof(value));
-                                return value;
-                            };
-                            unsigned long shown = 0;
-                            for (size_t i = 0; i < dwords && shown < limit; ++i) {
-                                const uint32_t before_value = load_dword(destination, i);
-                                const uint32_t after_value = load_dword(result, i);
-                                if (before_value == after_value) continue;
-                                // Carry submit/dispatch on EVERY line. Without them the lines from
-                                // consecutive dispatches concatenate into one stream that looks like a
-                                // single dispatch's writes -- and a per-dispatch structural claim built
-                                // on that stream is meaningless. The first analysis run here did exactly
-                                // that and reported one index changing twice in "one" dispatch.
-                                std::fprintf(stderr,
-                                             "[compute]     changed submit=%llu dispatch=%llu "
-                                             "addr=0x%llx owner-binding=%u aliases=%zu index=%zu "
-                                             "0x%08x -> 0x%08x (tag=%u bit30=%u next=%u)\n",
-                                             (unsigned long long)item.submit_no,
-                                             (unsigned long long)item.dispatch_index,
-                                             (unsigned long long)(buffer.resource
-                                                 ? buffer.resource->gpu_addr : 0ull),
-                                             buffer.resource ? buffer.resource->binding : 0u,
-                                             alias_count, i,
-                                             before_value, after_value, after_value & 7u,
-                                             (after_value >> 30) & 1u,
-                                             (after_value >> 3) & 0x07FFFFFFu);
-                                ++shown;
-                            }
-                        }
-                    }
-                }
-                // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
-                // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
-                // after its first dispatch all later readbacks are identical. Avoiding the redundant host
-                // write removes one full pass over both source and destination. Renderer-alias
-                // invalidation and writer provenance remain unconditional: renderer-resident state can
-                // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
-                if (changed) {
-                    if (!buffer.resource->host_data && buffer.resource->gpu_addr)
-                        prosper::host::guest_write_watch_notify_host_write(
-                            buffer.resource->gpu_addr, buffer.resource->size);
-                    copy_compute_buffer(destination, result, buffer.bytes);
-                }
-                if (buffer.persistent && !buffer.result_baseline &&
-                    ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
-                    std::fprintf(stderr,
-                                 "[compute]   retained exact GPU buffer result baseline binding=%u "
-                                 "addr=0x%llx bytes=%u\n",
-                                 buffer.resource->binding,
-                                 (unsigned long long)buffer.resource->gpu_addr,
-                                 buffer.resource->size);
-                ctx.unmap_memory(buffer.memory);
-                if (buffer.resource->gpu_addr) {
-                    if (changed) {
-                        set_guest_gpu_write_origin("compute-writeback(buffer-full)");
-                        notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
-                        set_guest_gpu_write_origin(nullptr);
-                    } else {
-                        notify_guest_gpu_write_preserving_bytes(
-                            buffer.resource->gpu_addr, buffer.resource->size);
-                    }
-                }
-                if (buffer.persistent)
-                    ctx.validate_cached_buffer_source(buffer.cache_key);
-                if (!buffer.resource->host_data && writer_provenance_enabled())
-                    record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       buffer.resource->gpu_addr, buffer.resource->size,
-                                       item.submit_no, item.dispatch_index,
-                                       item.command_order, item.code_addr);
-            }
-            writeback_buffers_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_buffers_start).count();
-            if (!readback_ok) return false;   // was `break` out of the do-while; the call
-                                              // site turns a false return back into that break
-            const auto writeback_images_start = ComputeClock::now();
-            // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
-            // into the guest format, then restore its linear or 3D tiled address layout and notify the
-            // render side exactly like the buffer path.
-            for (size_t i = 0; i < images.size() && readback_ok; i++) {
-                BoundImage& bi = images[i];
-                if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
-                const auto image_writeback_start = ComputeClock::now();
-                const bool image_cache_hit = bi.persistent;
-                const ShaderResource* r = bi.resource;
-                const uint32_t cb = data_format_bytes(r->format);
-                const uint32_t nc = r->num_components ? r->num_components : 1;
-                const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
-                                            r->format == DataFormat::Unorm2_10_10_10)
-                    ? 4u : (size_t)cb * nc;
-                const size_t texels = (size_t)r->width * r->height * r->depth;
-                const size_t linear_bytes = texels * guest_texel;
-                uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
-                // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
-                // independently proved that the guest mirror still contains that baseline. This path
-                // therefore needs neither a large staging mapping nor a CPU memory pass.
-                if (bi.gpu_result_unchanged && bi.upload_skipped) {
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   skipped GPU-identical storage writeback binding=%u "
-                                     "addr=0x%llx bytes=%llu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     (unsigned long long)bi.exact_result_bytes);
-                    if (r->gpu_addr)
-                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                    continue;
-                }
-                void* mapped = nullptr;
-                const auto map_start = ComputeClock::now();
-                if (g_fail_next_storage_readback_for_test.exchange(
-                        false, std::memory_order_acq_rel)) {
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   injected storage readback failure binding=%u\n",
-                                     bi.binding);
-                    readback_ok = false;
-                    break;
-                }
-                if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
-                    readback_ok = false;
-                    break;
-                }
-                const auto map_done = ComputeClock::now();
-                const bool array_image = backend_uses_2d_array(*r);
-                static const bool direct_tiled_writeback_disabled =
-                    std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
-                const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
-                    bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
-                    direct_tiled_writeback_disabled);
-                std::unique_ptr<uint8_t[]> linear;
-                uint8_t* packed = destination;
-                if ((r->tile_mode && !tile_mapped_bytes) ||
-                    (!r->tile_mode && array_image && r->depth > 1)) {
-                    linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
-                    packed = linear.get();
-                }
-                const uint32_t* channels = static_cast<const uint32_t*>(mapped);
-                const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
-                // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
-                // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
-                // that guest memory still contains the prior result, and this dispatch reproduced the
-                // same row-major bytes. If either comparison fails, take the ordinary writeback below.
-                const bool repeated_output = bi.cache_candidate && bi.persistent &&
-                    bi.upload_skipped && bi.exact_storage_bytes() &&
-                    ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
-                const auto prepare_done = ComputeClock::now();
-                if (repeated_output) {
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   skipped identical storage writeback binding=%u "
-                                     "addr=0x%llx bytes=%llu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     (unsigned long long)bi.exact_result_bytes);
-                    ctx.unmap_memory(staging_memory[i]);
-                    if (r->gpu_addr)
-                        notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
-                    continue;
-                }
-                // Notify page-based dirty trackers only when bytes will actually be written. Doing this
-                // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
-                // even on the no-write path, defeating the validation that made that path safe.
-                if (!r->host_data && r->gpu_addr)
-                    prosper::host::guest_write_watch_notify_host_write(
-                        r->gpu_addr, bi.guest_bytes);
-                const auto watch_done = ComputeClock::now();
-                // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
-                // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
-                // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
-                // and, for a partial write, restore the un-stored texels from the clean seed after packing.
-                std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
-                if (bi.poison_verify) {
-                    size_t survived = 0;
-                    poison_texel.assign(texels, 0);
-                    for (size_t t = 0; t < texels; ++t) {
-                        bool all = true;
-                        if (bi.exact_storage_bytes()) {
-                            const uint8_t* texel = native_texels + t * guest_texel;
-                            for (size_t b = 0; b < guest_texel; ++b)
-                                if (texel[b] != 0x5a) all = false;
-                        } else {
-                            for (uint32_t c = 0; c < 4; ++c)
-                                if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
-                        }
-                        if (all) { ++survived; poison_texel[t] = 1; }
-                    }
-                    {
-                        const SeedCoverageKey proof_key{item.code_addr, bi.binding,
-                                                        r->width, r->height, r->depth};
-                        std::lock_guard<std::mutex> lk(seed_coverage_mu);
-                        // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                        seed_coverage_proof[proof_key] =
-                            SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
-                    }
-                    std::fprintf(stderr,
-                                 "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
-                                 (unsigned long long)item.code_addr, bi.binding, texels, survived,
-                                 survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
-                }
-                if (trace) {
-                    if (bi.exact_storage_bytes()) {
-                        for (size_t t = 0; t < texels; ++t) {
-                            const uint8_t* texel = native_texels + t * guest_texel;
-                            for (size_t b = 0; b < guest_texel; ++b)
-                                bi.nonzero_channels += texel[b] != 0;
-                        }
-                    } else {
-                        for (size_t t = 0; t < texels; t++)
-                            for (uint32_t c = 0; c < 4; c++)
-                                bi.nonzero_channels += channels[t * 4 + c] != 0;
-                    }
-                }
-                const auto pack_start = ComputeClock::now();
-                static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
-                if (bi.exact_storage_bytes()) {
-                    // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
-                    // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
-                    // non-proving write can feed those bytes straight to the tiler, avoiding a second
-                    // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
-                    if (!tile_mapped_bytes)
-                        parallel_compute_texels(texels, linear_bytes * 2,
-                            [&](size_t begin, size_t end) {
-                                std::memcpy(packed + begin * guest_texel,
-                                            native_texels + begin * guest_texel,
-                                            (end - begin) * guest_texel);
-                            });
-                } else if (pack_range_enabled) {
-                    storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
-                } else {
-                    for (size_t t = 0; t < texels; t++)
-                        storage_pack_texel(channels + t * 4, r->format, nc,
-                                           packed + t * guest_texel);
-                }
-                // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
-                // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
-                // content (exactly a partial write's contract). Full-coverage proving frames have no
-                // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
-                if (bi.poison_verify && !poison_texel.empty() &&
-                    bi.seed_linear.size() == linear_bytes) {
-                    for (size_t t = 0; t < texels; ++t) {
-                        if (poison_texel[t])
-                            std::memcpy(packed + t * guest_texel,
-                                        bi.seed_linear.data() + t * guest_texel, guest_texel);
-                    }
-                }
-                const auto pack_done = ComputeClock::now();
-                static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
-                if (verify_pack && !bi.exact_storage_bytes()) {
-                    // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
-                    // be bit-identical to the per-texel path it replaces, verified against the real
-                    // workload's texels. Logs the clean case too, so a verified run is self-proving.
-                    std::vector<uint8_t> expect(guest_texel);
-                    size_t bad = 0, first_bad = 0;
-                    for (size_t t = 0; t < texels; ++t) {
-                        std::memset(expect.data(), 0, expect.size());
-                        storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
-                        if (std::memcmp(expect.data(), packed + t * guest_texel,
-                                        guest_texel) != 0) {
-                            if (!bad) first_bad = t;
-                            ++bad;
-                        }
-                    }
-                    std::fprintf(stderr,
-                                 "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
-                                 "texels=%zu mismatches=%zu%s\n",
-                                 bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
-                                 nc, texels, bad, bad ? " MISMATCH" : "");
-                    if (bad)
-                        std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
-                                     first_bad);
-                }
-                const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
-                if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
-                    if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
-                                     r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                    void* mapped = nullptr;
+                    const auto map_start = ComputeClock::now();
+                    if (g_fail_next_storage_readback_for_test.exchange(
+                            false, std::memory_order_acq_rel)) {
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   injected storage readback failure binding=%u\n",
+                                         bi.binding);
                         readback_ok = false;
-                        ctx.unmap_memory(staging_memory[i]);
                         break;
                     }
-                } else if (array_image && r->depth > 1) {
-                    const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
-                    const size_t selected_slice = r->in_mip_tail
-                        ? r->mip_tail_bytes
-                        : (r->tile_mode
-                               ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
-                                                     static_cast<uint32_t>(guest_texel))
-                               : (r->layer_stride_bytes
-                                      ? linear_array_surface_bytes(
-                                            *r, static_cast<uint32_t>(guest_texel))
-                                      : linear_slice));
-                    const size_t layer_stride = r->layer_stride_bytes
-                        ? r->layer_stride_bytes : selected_slice;
-                    for (uint32_t layer = 0; layer < r->depth; ++layer) {
-                        uint8_t* layer_base = destination + layer_stride * layer;
-                        if (!r->tile_mode) {
-                            const size_t row_pitch = r->layer_stride_bytes
-                                ? linear_array_row_pitch(
-                                      *r, static_cast<uint32_t>(guest_texel))
-                                : static_cast<size_t>(r->width) * guest_texel;
-                            for (uint32_t y = 0; y < r->height; ++y)
-                                std::memcpy(
-                                    layer_base + r->layer_mip_offset_bytes + y * row_pitch,
-                                    layout_source + linear_slice * layer +
-                                        static_cast<size_t>(y) * r->width * guest_texel,
-                                    static_cast<size_t>(r->width) * guest_texel);
-                        } else if (r->in_mip_tail) {
-                            tile_surface_level(
-                                layer_base, r->mip_tail_bytes,
-                                layout_source + linear_slice * layer,
-                                r->width, r->height, r->tile_mode,
-                                static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
+                    if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
+                        readback_ok = false;
+                        break;
+                    }
+                    const auto map_done = ComputeClock::now();
+                    const bool array_image = backend_uses_2d_array(*r);
+                    static const bool direct_tiled_writeback_disabled =
+                        std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
+                    const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
+                        bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
+                        direct_tiled_writeback_disabled);
+                    std::unique_ptr<uint8_t[]> linear;
+                    uint8_t* packed = destination;
+                    if ((r->tile_mode && !tile_mapped_bytes) ||
+                        (!r->tile_mode && array_image && r->depth > 1)) {
+                        linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
+                        packed = linear.get();
+                    }
+                    const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+                    const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
+                    // A retained, proven-full output can avoid the expensive CPU pack/retile and renderer
+                    // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
+                    // that guest memory still contains the prior result, and this dispatch reproduced the
+                    // same row-major bytes. If either comparison fails, take the ordinary writeback below.
+                    const bool repeated_output = bi.cache_candidate && bi.persistent &&
+                        bi.upload_skipped && bi.exact_storage_bytes() &&
+                        ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
+                    const auto prepare_done = ComputeClock::now();
+                    if (repeated_output) {
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   skipped identical storage writeback binding=%u "
+                                         "addr=0x%llx bytes=%llu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         (unsigned long long)bi.exact_result_bytes);
+                        ctx.unmap_memory(staging_memory[i]);
+                        if (r->gpu_addr)
+                            notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                        continue;
+                    }
+                    // Notify page-based dirty trackers only when bytes will actually be written. Doing this
+                    // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
+                    // even on the no-write path, defeating the validation that made that path safe.
+                    if (!r->host_data && r->gpu_addr)
+                        prosper::host::guest_write_watch_notify_host_write(
+                            r->gpu_addr, bi.guest_bytes);
+                    const auto watch_done = ComputeClock::now();
+                    // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
+                    // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
+                    // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
+                    // and, for a partial write, restore the un-stored texels from the clean seed after packing.
+                    std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
+                    if (bi.poison_verify) {
+                        size_t survived = 0;
+                        poison_texel.assign(texels, 0);
+                        for (size_t t = 0; t < texels; ++t) {
+                            bool all = true;
+                            if (bi.exact_storage_bytes()) {
+                                const uint8_t* texel = native_texels + t * guest_texel;
+                                for (size_t b = 0; b < guest_texel; ++b)
+                                    if (texel[b] != 0x5a) all = false;
+                            } else {
+                                for (uint32_t c = 0; c < 4; ++c)
+                                    if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
+                            }
+                            if (all) { ++survived; poison_texel[t] = 1; }
+                        }
+                        {
+                            const SeedCoverageKey proof_key{item.code_addr, bi.binding,
+                                                            r->width, r->height, r->depth};
+                            std::lock_guard<std::mutex> lk(seed_coverage_mu);
+                            // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
+                            seed_coverage_proof[proof_key] =
+                                SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
+                        }
+                        std::fprintf(stderr,
+                                     "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
+                                     (unsigned long long)item.code_addr, bi.binding, texels, survived,
+                                     survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
+                    }
+                    if (trace) {
+                        if (bi.exact_storage_bytes()) {
+                            for (size_t t = 0; t < texels; ++t) {
+                                const uint8_t* texel = native_texels + t * guest_texel;
+                                for (size_t b = 0; b < guest_texel; ++b)
+                                    bi.nonzero_channels += texel[b] != 0;
+                            }
                         } else {
-                            tile_surface(
-                                layer_base + r->layer_mip_offset_bytes,
-                                layout_source + linear_slice * layer,
-                                r->width, r->height, r->tile_mode, 0,
-                                static_cast<uint32_t>(guest_texel));
+                            for (size_t t = 0; t < texels; t++)
+                                for (uint32_t c = 0; c < 4; c++)
+                                    bi.nonzero_channels += channels[t * 4 + c] != 0;
                         }
                     }
-                } else if (r->tile_mode && r->in_mip_tail) {
-                    tile_surface_level(destination, bi.guest_bytes, layout_source,
-                                       r->width, r->height, r->tile_mode,
-                                       static_cast<uint32_t>(guest_texel),
-                                       r->mip_tail_x, r->mip_tail_y);
-                } else if (r->tile_mode) {
-                    tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
-                                 static_cast<uint32_t>(guest_texel));
-                }
-                const auto layout_done = ComputeClock::now();
-                pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
-                layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
-                if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
-                const auto notify_start = ComputeClock::now();
-                // Name the writer. "a guest write covers this surface" and "prosper's own compute
-                // writeback covers this surface" are different facts, and only the second says the
-                // emulator is invalidating its own caches. Everything reaching the DS invalidation path
-                // used to report the default `gpu`, which cannot distinguish them.
-                set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
-                notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
-                set_guest_gpu_write_origin(nullptr);
-                if (!r->host_data && writer_provenance_enabled())
-                    record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       r->gpu_addr, bi.guest_bytes,
-                                       item.submit_no, item.dispatch_index,
-                                       item.command_order, item.code_addr);
-                if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
-                    const bool leave_compressed_for_test =
-                        g_leave_next_dcc_metadata_compressed_for_test.exchange(
-                            false, std::memory_order_acq_rel);
-                    if (!leave_compressed_for_test) {
-                        std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
-                        // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
-                        // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
-                        // aspects" and invalidates depth as well as stencil. So this reset can discard a
-                        // retained depth image. Tagged so that consequence is attributable rather than
-                        // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
-                        // separate question that needs the operation's real HTILE semantics proven.
-                        set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
-                        notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
-                        set_guest_gpu_write_origin(nullptr);
-                        if (!r->dcc_metadata_host_data && writer_provenance_enabled())
-                            record_guest_write(GuestWriterKind::ComputeBuffer,
-                                               r->metadata_addr, bi.dcc_metadata_bytes,
-                                               item.submit_no, item.dispatch_index,
-                                               item.command_order, item.code_addr);
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   DCC uncompressed binding=%u meta=0x%llx "
-                                         "bytes=%zu code=0xff\n",
-                                         bi.binding, (unsigned long long)r->metadata_addr,
-                                         bi.dcc_metadata_bytes);
-                    } else if (trace) {
-                        std::fprintf(stderr,
-                                     "[compute]   injected unresolved DCC writeback binding=%u\n",
-                                     bi.binding);
+                    const auto pack_start = ComputeClock::now();
+                    static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
+                    if (bi.exact_storage_bytes()) {
+                        // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
+                        // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
+                        // non-proving write can feed those bytes straight to the tiler, avoiding a second
+                        // full-surface allocation and memcpy (66.8 MiB for Astro Bot's 4K RGBA16F target).
+                        if (!tile_mapped_bytes)
+                            parallel_compute_texels(texels, linear_bytes * 2,
+                                [&](size_t begin, size_t end) {
+                                    std::memcpy(packed + begin * guest_texel,
+                                                native_texels + begin * guest_texel,
+                                                (end - begin) * guest_texel);
+                                });
+                    } else if (pack_range_enabled) {
+                        storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
+                    } else {
+                        for (size_t t = 0; t < texels; t++)
+                            storage_pack_texel(channels + t * 4, r->format, nc,
+                                               packed + t * guest_texel);
                     }
-                }
-                if (bi.mirror_result_to_imported) {
-                    const BoundImage& mirror = images[bi.seed_from_imported];
-                    notify_live_render_target_image_written({
-                        r->gpu_addr, mirror.imported_width, mirror.imported_height,
-                        mirror.imported_pixel_format});
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   mirrored storage result into renderer RTT "
-                                     "binding=%u addr=0x%llx extent=%ux%u\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     mirror.imported_width, mirror.imported_height);
-                }
-                const auto notify_done = ComputeClock::now();
-                bool retain_gpu_result_baseline = false;
-                bool promoted_after_writeback = false;
-                const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
-                    std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
-                                [](uint8_t value) { return value == 0xff; });
-                if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
-                    const uint8_t* retained_source =
-                        (adaptive_storage_result_validation_enabled() &&
-                         cold_storage_result_snapshot_can_defer(
-                             r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
-                             cold_storage_result_snapshot_defer_min_bytes()))
-                        ? nullptr : destination;
-                    if (bi.forced_seed_allocation_reused) {
-                        // The exact cache entry was already pinned and forcibly reseeded before this
-                        // dispatch. Successful writeback plus the final all-uncompressed metadata scan
-                        // may now restore source/transfer authority without replacing its allocation.
-                        bi.cache_candidate = true;
-                        g_dcc_post_writeback_promotions.fetch_add(
-                            1, std::memory_order_relaxed);
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   promoted reused post-writeback DCC storage "
-                                         "image binding=%u addr=0x%llx allocation=%llu\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.allocation_bytes);
-                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                        ctx.replace_or_retain_image(
-                            bi.cache_key, bi.image, bi.memory,
-                            bi.allocation_bytes, retained_source)) {
-                        bi.cache_candidate = true;
-                        bi.persistent = true;
-                        promoted_after_writeback = true;
-                        g_dcc_post_writeback_promotions.fetch_add(
-                            1, std::memory_order_relaxed);
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   promoted post-writeback DCC storage image "
-                                         "binding=%u addr=0x%llx allocation=%llu\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.allocation_bytes);
+                    // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
+                    // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
+                    // content (exactly a partial write's contract). Full-coverage proving frames have no
+                    // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
+                    if (bi.poison_verify && !poison_texel.empty() &&
+                        bi.seed_linear.size() == linear_bytes) {
+                        for (size_t t = 0; t < texels; ++t) {
+                            if (poison_texel[t])
+                                std::memcpy(packed + t * guest_texel,
+                                            bi.seed_linear.data() + t * guest_texel, guest_texel);
+                        }
                     }
-                }
-                if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
-                    ctx.invalidate_cached_image_source(bi.cache_key);
-                if (bi.cache_candidate) {
-                    if (bi.persistent && !promoted_after_writeback) {
-                        // Guest bytes now mirror the retained image again. A changing full-overwrite
-                        // target needs no source snapshot; the first repeated result retains one exact
-                        // baseline, and subsequent identical GPU skips do not recopy it.
-                        ctx.validate_cached_image_source(
-                            bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
-                            bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
-                                native_3d_transfer_enabled());
-                    } else if (bi.image && bi.memory && bi.allocation_bytes &&
-                               ctx.retain_image(bi.cache_key, bi.image, bi.memory,
-                                                bi.allocation_bytes,
-                                                (adaptive_storage_result_validation_enabled() &&
-                                                 cold_storage_result_snapshot_can_defer(
-                                                     r->host_data != nullptr, bi.seed_skip,
-                                                     bi.guest_bytes,
-                                                     cold_storage_result_snapshot_defer_min_bytes()))
-                                                    ? nullptr : destination)) {
-                        bi.persistent = true;
+                    const auto pack_done = ComputeClock::now();
+                    static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
+                    if (verify_pack && !bi.exact_storage_bytes()) {
+                        // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
+                        // be bit-identical to the per-texel path it replaces, verified against the real
+                        // workload's texels. Logs the clean case too, so a verified run is self-proving.
+                        std::vector<uint8_t> expect(guest_texel);
+                        size_t bad = 0, first_bad = 0;
+                        for (size_t t = 0; t < texels; ++t) {
+                            std::memset(expect.data(), 0, expect.size());
+                            storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
+                            if (std::memcmp(expect.data(), packed + t * guest_texel,
+                                            guest_texel) != 0) {
+                                if (!bad) first_bad = t;
+                                ++bad;
+                            }
+                        }
+                        std::fprintf(stderr,
+                                     "[compute] pack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
+                                     "texels=%zu mismatches=%zu%s\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr, (unsigned)r->format,
+                                     nc, texels, bad, bad ? " MISMATCH" : "");
+                        if (bad)
+                            std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
+                                         first_bad);
+                    }
+                    const uint8_t* layout_source = tile_mapped_bytes ? native_texels : packed;
+                    if (r->tile_mode && r->img_dim == 2 && r->depth > 1) {
+                        if (!tile_volume(destination, bi.guest_bytes, layout_source, r->width, r->height,
+                                         r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
+                            readback_ok = false;
+                            ctx.unmap_memory(staging_memory[i]);
+                            break;
+                        }
+                    } else if (array_image && r->depth > 1) {
+                        const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
+                        const size_t selected_slice = r->in_mip_tail
+                            ? r->mip_tail_bytes
+                            : (r->tile_mode
+                                   ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
+                                                         static_cast<uint32_t>(guest_texel))
+                                   : (r->layer_stride_bytes
+                                          ? linear_array_surface_bytes(
+                                                *r, static_cast<uint32_t>(guest_texel))
+                                          : linear_slice));
+                        const size_t layer_stride = r->layer_stride_bytes
+                            ? r->layer_stride_bytes : selected_slice;
+                        for (uint32_t layer = 0; layer < r->depth; ++layer) {
+                            uint8_t* layer_base = destination + layer_stride * layer;
+                            if (!r->tile_mode) {
+                                const size_t row_pitch = r->layer_stride_bytes
+                                    ? linear_array_row_pitch(
+                                          *r, static_cast<uint32_t>(guest_texel))
+                                    : static_cast<size_t>(r->width) * guest_texel;
+                                for (uint32_t y = 0; y < r->height; ++y)
+                                    std::memcpy(
+                                        layer_base + r->layer_mip_offset_bytes + y * row_pitch,
+                                        layout_source + linear_slice * layer +
+                                            static_cast<size_t>(y) * r->width * guest_texel,
+                                        static_cast<size_t>(r->width) * guest_texel);
+                            } else if (r->in_mip_tail) {
+                                tile_surface_level(
+                                    layer_base, r->mip_tail_bytes,
+                                    layout_source + linear_slice * layer,
+                                    r->width, r->height, r->tile_mode,
+                                    static_cast<uint32_t>(guest_texel), r->mip_tail_x, r->mip_tail_y);
+                            } else {
+                                tile_surface(
+                                    layer_base + r->layer_mip_offset_bytes,
+                                    layout_source + linear_slice * layer,
+                                    r->width, r->height, r->tile_mode, 0,
+                                    static_cast<uint32_t>(guest_texel));
+                            }
+                        }
+                    } else if (r->tile_mode && r->in_mip_tail) {
+                        tile_surface_level(destination, bi.guest_bytes, layout_source,
+                                           r->width, r->height, r->tile_mode,
+                                           static_cast<uint32_t>(guest_texel),
+                                           r->mip_tail_x, r->mip_tail_y);
+                    } else if (r->tile_mode) {
+                        tile_surface(destination, layout_source, r->width, r->height, r->tile_mode, 0,
+                                     static_cast<uint32_t>(guest_texel));
+                    }
+                    const auto layout_done = ComputeClock::now();
+                    pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
+                    layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
+                    if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
+                    const auto notify_start = ComputeClock::now();
+                    // Name the writer. "a guest write covers this surface" and "prosper's own compute
+                    // writeback covers this surface" are different facts, and only the second says the
+                    // emulator is invalidating its own caches. Everything reaching the DS invalidation path
+                    // used to report the default `gpu`, which cannot distinguish them.
+                    set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
+                    notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+                    set_guest_gpu_write_origin(nullptr);
+                    if (!r->host_data && writer_provenance_enabled())
+                        record_guest_write(GuestWriterKind::ComputeBuffer,
+                                           r->gpu_addr, bi.guest_bytes,
+                                           item.submit_no, item.dispatch_index,
+                                           item.command_order, item.code_addr);
+                    if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
+                        const bool leave_compressed_for_test =
+                            g_leave_next_dcc_metadata_compressed_for_test.exchange(
+                                false, std::memory_order_acq_rel);
+                        if (!leave_compressed_for_test) {
+                            std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                            // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
+                            // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
+                            // aspects" and invalidates depth as well as stencil. So this reset can discard a
+                            // retained depth image. Tagged so that consequence is attributable rather than
+                            // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
+                            // separate question that needs the operation's real HTILE semantics proven.
+                            set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
+                            notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                            set_guest_gpu_write_origin(nullptr);
+                            if (!r->dcc_metadata_host_data && writer_provenance_enabled())
+                                record_guest_write(GuestWriterKind::ComputeBuffer,
+                                                   r->metadata_addr, bi.dcc_metadata_bytes,
+                                                   item.submit_no, item.dispatch_index,
+                                                   item.command_order, item.code_addr);
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   DCC uncompressed binding=%u meta=0x%llx "
+                                             "bytes=%zu code=0xff\n",
+                                             bi.binding, (unsigned long long)r->metadata_addr,
+                                             bi.dcc_metadata_bytes);
+                        } else if (trace) {
+                            std::fprintf(stderr,
+                                         "[compute]   injected unresolved DCC writeback binding=%u\n",
+                                         bi.binding);
+                        }
+                    }
+                    if (bi.mirror_result_to_imported) {
+                        const BoundImage& mirror = images[bi.seed_from_imported];
+                        notify_live_render_target_image_written({
+                            r->gpu_addr, mirror.imported_width, mirror.imported_height,
+                            mirror.imported_pixel_format});
                         if (trace)
                             std::fprintf(stderr,
-                                         "[compute]   retained storage image binding=%u "
-                                         "addr=0x%llx allocation=%llu\n",
+                                         "[compute]   mirrored storage result into renderer RTT "
+                                         "binding=%u addr=0x%llx extent=%ux%u\n",
                                          bi.binding, (unsigned long long)r->gpu_addr,
-                                         (unsigned long long)bi.allocation_bytes);
+                                         mirror.imported_width, mirror.imported_height);
                     }
-                    // An aligned exact result is retained as the staging buffer immediately below.
-                    // Copying it into a host vector first only to clear that vector after ownership
-                    // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
-                    // setup keeps the exact current host fallback; a failed ownership attempt invalidates
-                    // any older fallback so the next dispatch takes the ordinary writeback path.
-                    const bool force_host_result_fallback =
-                        bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
-                        !(bi.exact_result_bytes & 15u) &&
-                        g_force_next_image_result_host_fallback_for_test.exchange(
-                            false, std::memory_order_acq_rel);
-                    retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
-                        bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
-                        !force_host_result_fallback && ctx.prepare_compare_pipeline();
-                    if (bi.persistent && !retain_gpu_result_baseline)
-                        ctx.remember_cached_image_result(
-                            bi.cache_key, native_texels,
-                            static_cast<size_t>(bi.exact_result_bytes));
-                }
-                const auto cache_done = ComputeClock::now();
-                ctx.unmap_memory(staging_memory[i]);
-                const VkBuffer retained_result = staging[i];
-                if (retain_gpu_result_baseline &&
-                    ctx.retain_cached_image_result_buffer(
-                        bi.cache_key, staging[i], staging_memory[i],
-                        bi.staging_allocation_bytes, bi.exact_result_bytes)) {
-                    bi.result_baseline = retained_result;
-                    if (trace)
+                    const auto notify_done = ComputeClock::now();
+                    bool retain_gpu_result_baseline = false;
+                    bool promoted_after_writeback = false;
+                    const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
+                        std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
+                                    [](uint8_t value) { return value == 0xff; });
+                    if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
+                        const uint8_t* retained_source =
+                            (adaptive_storage_result_validation_enabled() &&
+                             cold_storage_result_snapshot_can_defer(
+                                 r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
+                                 cold_storage_result_snapshot_defer_min_bytes()))
+                            ? nullptr : destination;
+                        if (bi.forced_seed_allocation_reused) {
+                            // The exact cache entry was already pinned and forcibly reseeded before this
+                            // dispatch. Successful writeback plus the final all-uncompressed metadata scan
+                            // may now restore source/transfer authority without replacing its allocation.
+                            bi.cache_candidate = true;
+                            g_dcc_post_writeback_promotions.fetch_add(
+                                1, std::memory_order_relaxed);
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   promoted reused post-writeback DCC storage "
+                                             "image binding=%u addr=0x%llx allocation=%llu\n",
+                                             bi.binding, (unsigned long long)r->gpu_addr,
+                                             (unsigned long long)bi.allocation_bytes);
+                        } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                            ctx.replace_or_retain_image(
+                                bi.cache_key, bi.image, bi.memory,
+                                bi.allocation_bytes, retained_source)) {
+                            bi.cache_candidate = true;
+                            bi.persistent = true;
+                            promoted_after_writeback = true;
+                            g_dcc_post_writeback_promotions.fetch_add(
+                                1, std::memory_order_relaxed);
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   promoted post-writeback DCC storage image "
+                                             "binding=%u addr=0x%llx allocation=%llu\n",
+                                             bi.binding, (unsigned long long)r->gpu_addr,
+                                             (unsigned long long)bi.allocation_bytes);
+                        }
+                    }
+                    if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
+                        ctx.invalidate_cached_image_source(bi.cache_key);
+                    if (bi.cache_candidate) {
+                        if (bi.persistent && !promoted_after_writeback) {
+                            // Guest bytes now mirror the retained image again. A changing full-overwrite
+                            // target needs no source snapshot; the first repeated result retains one exact
+                            // baseline, and subsequent identical GPU skips do not recopy it.
+                            ctx.validate_cached_image_source(
+                                bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
+                                bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
+                                    native_3d_transfer_enabled());
+                        } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                                   ctx.retain_image(bi.cache_key, bi.image, bi.memory,
+                                                    bi.allocation_bytes,
+                                                    (adaptive_storage_result_validation_enabled() &&
+                                                     cold_storage_result_snapshot_can_defer(
+                                                         r->host_data != nullptr, bi.seed_skip,
+                                                         bi.guest_bytes,
+                                                         cold_storage_result_snapshot_defer_min_bytes()))
+                                                        ? nullptr : destination)) {
+                            bi.persistent = true;
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   retained storage image binding=%u "
+                                             "addr=0x%llx allocation=%llu\n",
+                                             bi.binding, (unsigned long long)r->gpu_addr,
+                                             (unsigned long long)bi.allocation_bytes);
+                        }
+                        // An aligned exact result is retained as the staging buffer immediately below.
+                        // Copying it into a host vector first only to clear that vector after ownership
+                        // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
+                        // setup keeps the exact current host fallback; a failed ownership attempt invalidates
+                        // any older fallback so the next dispatch takes the ordinary writeback path.
+                        const bool force_host_result_fallback =
+                            bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
+                            !(bi.exact_result_bytes & 15u) &&
+                            g_force_next_image_result_host_fallback_for_test.exchange(
+                                false, std::memory_order_acq_rel);
+                        retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
+                            bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
+                            !force_host_result_fallback && ctx.prepare_compare_pipeline();
+                        if (bi.persistent && !retain_gpu_result_baseline)
+                            ctx.remember_cached_image_result(
+                                bi.cache_key, native_texels,
+                                static_cast<size_t>(bi.exact_result_bytes));
+                    }
+                    const auto cache_done = ComputeClock::now();
+                    ctx.unmap_memory(staging_memory[i]);
+                    const VkBuffer retained_result = staging[i];
+                    if (retain_gpu_result_baseline &&
+                        ctx.retain_cached_image_result_buffer(
+                            bi.cache_key, staging[i], staging_memory[i],
+                            bi.staging_allocation_bytes, bi.exact_result_bytes)) {
+                        bi.result_baseline = retained_result;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   retained exact GPU result baseline binding=%u "
+                                         "addr=0x%llx bytes=%zu\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
+                    }
+                    const auto image_writeback_done = ComputeClock::now();
+                    const auto image_milliseconds = [](auto begin, auto end) {
+                        return std::chrono::duration<double, std::milli>(end - begin).count();
+                    };
+                    image_map_ms += image_milliseconds(map_start, map_done);
+                    image_prepare_ms += image_milliseconds(map_done, prepare_done);
+                    image_watch_ms += image_milliseconds(prepare_done, watch_done);
+                    image_notify_ms += image_milliseconds(notify_start, notify_done);
+                    image_cache_ms += image_milliseconds(notify_done, cache_done);
+                    if (image_timing)
                         std::fprintf(stderr,
-                                     "[compute]   retained exact GPU result baseline binding=%u "
-                                     "addr=0x%llx bytes=%zu\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
+                                     "[compute-image-writeback] code=0x%llx hash=0x%016llx "
+                                     "binding=%u addr=0x%llx "
+                                     "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
+                                     "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
+                                     "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
+                                     "total_ms=%.3f\n",
+                                     (unsigned long long)item.code_addr,
+                                     (unsigned long long)timing_program_hash, bi.binding,
+                                     (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
+                                     r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
+                                     bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
+                                     image_milliseconds(map_start, map_done),
+                                     image_milliseconds(map_done, prepare_done),
+                                     image_milliseconds(prepare_done, watch_done),
+                                     image_milliseconds(pack_start, pack_done),
+                                     image_milliseconds(pack_done, layout_done),
+                                     image_milliseconds(notify_start, notify_done),
+                                     image_milliseconds(notify_done, cache_done),
+                                     image_milliseconds(image_writeback_start, image_writeback_done));
                 }
-                const auto image_writeback_done = ComputeClock::now();
-                const auto image_milliseconds = [](auto begin, auto end) {
-                    return std::chrono::duration<double, std::milli>(end - begin).count();
-                };
-                image_map_ms += image_milliseconds(map_start, map_done);
-                image_prepare_ms += image_milliseconds(map_done, prepare_done);
-                image_watch_ms += image_milliseconds(prepare_done, watch_done);
-                image_notify_ms += image_milliseconds(notify_start, notify_done);
-                image_cache_ms += image_milliseconds(notify_done, cache_done);
-                if (image_timing)
-                    std::fprintf(stderr,
-                                 "[compute-image-writeback] code=0x%llx hash=0x%016llx "
-                                 "binding=%u addr=0x%llx "
-                                 "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
-                                 "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
-                                 "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
-                                 "total_ms=%.3f\n",
-                                 (unsigned long long)item.code_addr,
-                                 (unsigned long long)timing_program_hash, bi.binding,
-                                 (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
-                                 r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
-                                 bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
-                                 image_milliseconds(map_start, map_done),
-                                 image_milliseconds(map_done, prepare_done),
-                                 image_milliseconds(prepare_done, watch_done),
-                                 image_milliseconds(pack_start, pack_done),
-                                 image_milliseconds(pack_done, layout_done),
-                                 image_milliseconds(notify_start, notify_done),
-                                 image_milliseconds(notify_done, cache_done),
-                                 image_milliseconds(image_writeback_start, image_writeback_done));
-            }
-            writeback_images_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_images_start).count();
-            if (!readback_ok) return false;   // was `break` out of the do-while; the call
-                                              // site turns a false return back into that break
-            const auto writeback_publish_start = ComputeClock::now();
-            // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
-            // completed, and a failed dispatch cannot reach here. Native results may seed a later
-            // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
-            // also be exported directly to graphics. Raw interchange images are compatible with neither.
-            for (const BoundImage& image : images) {
-                if (!image.storage) continue;
-                const bool unique = image.alias_of == SIZE_MAX;
-                const bool native_exact_storage = image.native_float_storage ||
-                    image.native_uint_storage || image.packed_r11_storage;
-                const bool publish_eligible = native_exact_storage && unique &&
-                    image.cache_candidate && image.persistent;
-                const bool authorized = publish_eligible &&
-                    ctx.authorize_cached_image_compute_transfer(image.cache_key);
-                transfer_gate_census.record_storage_publish(
-                    transfer_gate_observation.role, native_exact_storage, unique,
-                    image.cache_candidate, image.persistent, authorized);
-                if (authority_observation.selected && unique && image.resource) {
-                    authority_census.record_selected_storage_output(
-                        item, image.binding,
-                        ShadowComputeAuthorityRange::from(
-                            image.resource->gpu_addr, image.guest_bytes),
-                        authorized);
+                writeback_images_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_images_start).count();
+                if (!readback_ok) return false;   // was `break` out of the do-while; the call
+                                                  // site turns a false return back into that break
+                const auto writeback_publish_start = ComputeClock::now();
+                // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
+                // completed, and a failed dispatch cannot reach here. Native results may seed a later
+                // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
+                // also be exported directly to graphics. Raw interchange images are compatible with neither.
+                for (const BoundImage& image : images) {
+                    if (!image.storage) continue;
+                    const bool unique = image.alias_of == SIZE_MAX;
+                    const bool native_exact_storage = image.native_float_storage ||
+                        image.native_uint_storage || image.packed_r11_storage;
+                    const bool publish_eligible = native_exact_storage && unique &&
+                        image.cache_candidate && image.persistent;
+                    const bool authorized = publish_eligible &&
+                        ctx.authorize_cached_image_compute_transfer(image.cache_key);
+                    transfer_gate_census.record_storage_publish(
+                        transfer_gate_observation.role, native_exact_storage, unique,
+                        image.cache_candidate, image.persistent, authorized);
+                    if (authority_observation.selected && unique && image.resource) {
+                        authority_census.record_selected_storage_output(
+                            item, image.binding,
+                            ShadowComputeAuthorityRange::from(
+                                image.resource->gpu_addr, image.guest_bytes),
+                            authorized);
+                    }
+                    if (publish_eligible && image.graphics_sampled_usage)
+                        ctx.authorize_cached_image_export(image.cache_key, item.command_order);
                 }
-                if (publish_eligible && image.graphics_sampled_usage)
-                    ctx.authorize_cached_image_export(image.cache_key, item.command_order);
-            }
-            writeback_publish_ms = std::chrono::duration<double, std::milli>(
-                ComputeClock::now() - writeback_publish_start).count();
-            ok = true;
-            phase_writeback = ComputeClock::now();
+                writeback_publish_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - writeback_publish_start).count();
+                ok = true;
+                phase_writeback = ComputeClock::now();
+                return true;
+            };
+            if (!consume_dispatch()) return false;
             return true;
         };
-        if (!consume_dispatch()) return false;
-        return true;
-    };
-    // Run it inline for now; a dispatch ring will store it in a slot instead. `ok`
-    // carries the outcome, which is why the result is not re-tested here -- the old
-    // `break` on failure simply left the do-block, which had nothing after it.
-    if (submitted_dispatch) wait_and_consume();
+        // Run it inline for now; a dispatch ring will store it in a slot instead. `ok`
+        // carries the outcome, which is why the result is not re-tested here -- the old
+        // `break` on failure simply left the do-block, which had nothing after it.
+        if (submitted_dispatch) wait_and_consume();
 
-    if (trace)
-        std::fprintf(stderr, "[compute] execute submit=%llu dispatch=%llu code=0x%llx "
-                     "threads=%ux%ux%u local=%ux%ux%u groups=%ux%ux%u "
-                     "buffers=%zu images=%zu spirv=%zu/%016llx result=%s\n",
-                     (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
-                     (unsigned long long)item.code_addr, item.launch.threads_x,
-                     item.launch.threads_y, item.launch.threads_z, item.launch.local_x,
-                     item.launch.local_y, item.launch.local_z, item.launch.groups_x,
-                     item.launch.groups_y, item.launch.groups_z, buffers.size(), images.size(),
-                     spirv.size(), (unsigned long long)gpu_capture_hash(
-                         reinterpret_cast<const uint8_t*>(spirv.data()),
-                         spirv.size() * sizeof(uint32_t)),
-                     ok ? "ok" : "failed");
-    if (trace) {
-        for (const auto& buffer : buffers) {
-            if (!buffer.resource || buffer.alias_of != SIZE_MAX) continue;
-            const uint8_t* bytes = resource_bytes(buffer.resource);
-            // POST-dispatch half of PROSPER_COMPUTE_PARENTSCAN. The pre-dispatch scan says whether a
-            // dispatch's INPUT was cyclic; this says whether its OUTPUT is. A dispatch whose input was
-            // clean and whose output is cyclic is the one that INTRODUCED the cycle -- which is the
-            // whole question, and neither half answers it alone.
-            if (const char* pscan_after = std::getenv("PROSPER_COMPUTE_PARENTSCAN")) {
-                if (std::strtoull(pscan_after, nullptr, 16) ==
-                        static_cast<uint64_t>(item.code_addr) && buffer.resource->stride == 4u) {
-                    const ParentScanResult pa = scan_parent_array(bytes, buffer.resource->size);
-                    std::fprintf(stderr,
-                                 "[parentscan-after] program=0x%llx submit=%llu dispatch=%llu "
-                                 "binding=%u addr=0x%llx records=%u terminating=%u cyclic=%u "
-                                 "cycle-nodes=%u longest=%u changed=%llu\n",
-                                 (unsigned long long)item.code_addr,
-                                 (unsigned long long)item.submit_no,
-                                 (unsigned long long)item.dispatch_index,
-                                 buffer.resource->binding,
-                                 (unsigned long long)buffer.resource->gpu_addr,
-                                 pa.records, pa.terminating, pa.cyclic, pa.cycle_nodes, pa.longest,
-                                 (unsigned long long)buffer.changed_bytes);
-                    parent_scan_dump_pair(buffer.resource->gpu_addr, bytes,
-                                          buffer.resource->size, item.code_addr,
-                                          item.submit_no, item.dispatch_index, pa.cyclic);
-                    for (uint32_t s = 0; s < pa.sample_count; ++s)
+        if (trace)
+            std::fprintf(stderr, "[compute] execute submit=%llu dispatch=%llu code=0x%llx "
+                         "threads=%ux%ux%u local=%ux%ux%u groups=%ux%ux%u "
+                         "buffers=%zu images=%zu spirv=%zu/%016llx result=%s\n",
+                         (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
+                         (unsigned long long)item.code_addr, item.launch.threads_x,
+                         item.launch.threads_y, item.launch.threads_z, item.launch.local_x,
+                         item.launch.local_y, item.launch.local_z, item.launch.groups_x,
+                         item.launch.groups_y, item.launch.groups_z, buffers.size(), images.size(),
+                         spirv.size(), (unsigned long long)gpu_capture_hash(
+                             reinterpret_cast<const uint8_t*>(spirv.data()),
+                             spirv.size() * sizeof(uint32_t)),
+                         ok ? "ok" : "failed");
+        if (trace) {
+            for (const auto& buffer : buffers) {
+                if (!buffer.resource || buffer.alias_of != SIZE_MAX) continue;
+                const uint8_t* bytes = resource_bytes(buffer.resource);
+                // POST-dispatch half of PROSPER_COMPUTE_PARENTSCAN. The pre-dispatch scan says whether a
+                // dispatch's INPUT was cyclic; this says whether its OUTPUT is. A dispatch whose input was
+                // clean and whose output is cyclic is the one that INTRODUCED the cycle -- which is the
+                // whole question, and neither half answers it alone.
+                if (const char* pscan_after = std::getenv("PROSPER_COMPUTE_PARENTSCAN")) {
+                    if (std::strtoull(pscan_after, nullptr, 16) ==
+                            static_cast<uint64_t>(item.code_addr) && buffer.resource->stride == 4u) {
+                        const ParentScanResult pa = scan_parent_array(bytes, buffer.resource->size);
                         std::fprintf(stderr,
-                                     "[parentscan-ring]   idx=%u word=0x%08x -> next=%u%s\n",
-                                     pa.sample_idx[s], pa.sample_word[s], pa.sample_next[s],
-                                     pa.sample_next[s] == pa.sample_idx[s] ? "  SELF-LOOP" : "");
+                                     "[parentscan-after] program=0x%llx submit=%llu dispatch=%llu "
+                                     "binding=%u addr=0x%llx records=%u terminating=%u cyclic=%u "
+                                     "cycle-nodes=%u longest=%u changed=%llu\n",
+                                     (unsigned long long)item.code_addr,
+                                     (unsigned long long)item.submit_no,
+                                     (unsigned long long)item.dispatch_index,
+                                     buffer.resource->binding,
+                                     (unsigned long long)buffer.resource->gpu_addr,
+                                     pa.records, pa.terminating, pa.cyclic, pa.cycle_nodes, pa.longest,
+                                     (unsigned long long)buffer.changed_bytes);
+                        parent_scan_dump_pair(buffer.resource->gpu_addr, bytes,
+                                              buffer.resource->size, item.code_addr,
+                                              item.submit_no, item.dispatch_index, pa.cyclic);
+                        for (uint32_t s = 0; s < pa.sample_count; ++s)
+                            std::fprintf(stderr,
+                                         "[parentscan-ring]   idx=%u word=0x%08x -> next=%u%s\n",
+                                         pa.sample_idx[s], pa.sample_word[s], pa.sample_next[s],
+                                         pa.sample_next[s] == pa.sample_idx[s] ? "  SELF-LOOP" : "");
+                    }
                 }
+                std::fprintf(stderr,
+                             "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "
+                             "hash=%016llx->%016llx first=%08x,%08x,%08x,%08x,%08x,%08x,%08x,%08x\n",
+                             buffer.resource->binding, (unsigned long long)buffer.resource->gpu_addr,
+                             buffer.resource->size, (unsigned long long)buffer.changed_bytes,
+                             (unsigned long long)buffer.before_hash, (unsigned long long)buffer.after_hash,
+                             buffer.resource->size >= 4 ? reinterpret_cast<const uint32_t*>(bytes)[0] : 0,
+                             buffer.resource->size >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
+                             buffer.resource->size >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
+                             buffer.resource->size >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0,
+                             buffer.resource->size >= 20 ? reinterpret_cast<const uint32_t*>(bytes)[4] : 0,
+                             buffer.resource->size >= 24 ? reinterpret_cast<const uint32_t*>(bytes)[5] : 0,
+                             buffer.resource->size >= 28 ? reinterpret_cast<const uint32_t*>(bytes)[6] : 0,
+                             buffer.resource->size >= 32 ? reinterpret_cast<const uint32_t*>(bytes)[7] : 0);
             }
-            std::fprintf(stderr,
-                         "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "
-                         "hash=%016llx->%016llx first=%08x,%08x,%08x,%08x,%08x,%08x,%08x,%08x\n",
-                         buffer.resource->binding, (unsigned long long)buffer.resource->gpu_addr,
-                         buffer.resource->size, (unsigned long long)buffer.changed_bytes,
-                         (unsigned long long)buffer.before_hash, (unsigned long long)buffer.after_hash,
-                         buffer.resource->size >= 4 ? reinterpret_cast<const uint32_t*>(bytes)[0] : 0,
-                         buffer.resource->size >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
-                         buffer.resource->size >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
-                         buffer.resource->size >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0,
-                         buffer.resource->size >= 20 ? reinterpret_cast<const uint32_t*>(bytes)[4] : 0,
-                         buffer.resource->size >= 24 ? reinterpret_cast<const uint32_t*>(bytes)[5] : 0,
-                         buffer.resource->size >= 28 ? reinterpret_cast<const uint32_t*>(bytes)[6] : 0,
-                         buffer.resource->size >= 32 ? reinterpret_cast<const uint32_t*>(bytes)[7] : 0);
+            for (const auto& image : images) {
+                if (!image.storage || !image.resource || image.alias_of != SIZE_MAX) continue;
+                const uint8_t* bytes = resource_bytes_for(image.resource, image.guest_bytes);
+                std::fprintf(stderr,
+                             "[compute]   image-writeback binding=%u addr=0x%llx size=%zu "
+                             "hash=%016llx->%016llx nonzero-ch=%llu "
+                             "first=%08x,%08x,%08x,%08x\n",
+                             image.binding, (unsigned long long)image.resource->gpu_addr,
+                             image.guest_bytes, (unsigned long long)image.before_hash,
+                             (unsigned long long)image.after_hash,
+                             (unsigned long long)image.nonzero_channels,
+                             image.guest_bytes >= 4 ? reinterpret_cast<const uint32_t*>(bytes)[0] : 0,
+                             image.guest_bytes >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
+                             image.guest_bytes >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
+                             image.guest_bytes >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0);
+            }
         }
-        for (const auto& image : images) {
-            if (!image.storage || !image.resource || image.alias_of != SIZE_MAX) continue;
-            const uint8_t* bytes = resource_bytes_for(image.resource, image.guest_bytes);
-            std::fprintf(stderr,
-                         "[compute]   image-writeback binding=%u addr=0x%llx size=%zu "
-                         "hash=%016llx->%016llx nonzero-ch=%llu "
-                         "first=%08x,%08x,%08x,%08x\n",
-                         image.binding, (unsigned long long)image.resource->gpu_addr,
-                         image.guest_bytes, (unsigned long long)image.before_hash,
-                         (unsigned long long)image.after_hash,
-                         (unsigned long long)image.nonzero_channels,
-                         image.guest_bytes >= 4 ? reinterpret_cast<const uint32_t*>(bytes)[0] : 0,
-                         image.guest_bytes >= 8 ? reinterpret_cast<const uint32_t*>(bytes)[1] : 0,
-                         image.guest_bytes >= 12 ? reinterpret_cast<const uint32_t*>(bytes)[2] : 0,
-                         image.guest_bytes >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0);
+        if (ctx.device_lost && submission_entered && !completion_proven)
+            ctx.completion_unproven = true;
+        // VK_ERROR_DEVICE_LOST from a queue call gives no completion proof for the affected submission.
+        // cleanup() would destroy/recycle command resources and release borrowed renderer-image pins
+        // that the GPU may still own. Deliberately retain this raw-handle closure; the sticky entry
+        // check prevents reuse and the atexit handler retains the context itself.
+        if (!ctx.completion_unproven) cleanup();
+        const auto phase_cleanup = ComputeClock::now();
+        auto phase_milliseconds = [](auto begin, auto end) {
+            return std::chrono::duration<double, std::milli>(end - begin).count();
+        };
+        if (perf_capture_timing) {
+            g_perf_compute_setup_ms += phase_milliseconds(phase_start, phase_setup);
+            g_perf_compute_pipeline_ms += phase_milliseconds(phase_setup, phase_pipeline);
+            g_perf_compute_dispatch_wait_ms += phase_milliseconds(phase_pipeline, phase_dispatch);
+            g_perf_compute_writeback_ms += phase_milliseconds(phase_dispatch, phase_writeback);
+            g_perf_compute_cleanup_ms += phase_milliseconds(phase_writeback, phase_cleanup);
         }
-    }
-    if (ctx.device_lost && submission_entered && !completion_proven)
-        ctx.completion_unproven = true;
-    // VK_ERROR_DEVICE_LOST from a queue call gives no completion proof for the affected submission.
-    // cleanup() would destroy/recycle command resources and release borrowed renderer-image pins
-    // that the GPU may still own. Deliberately retain this raw-handle closure; the sticky entry
-    // check prevents reuse and the atexit handler retains the context itself.
-    if (!ctx.completion_unproven) cleanup();
-    const auto phase_cleanup = ComputeClock::now();
-    auto phase_milliseconds = [](auto begin, auto end) {
-        return std::chrono::duration<double, std::milli>(end - begin).count();
+        if (phase_timing) {
+            std::fprintf(stderr,
+                         "[compute-phase] submit=%llu code=0x%llx hash=0x%016llx ok=%u "
+                         "setup_ms=%.2f setup_validate_ms=%.2f setup_buffers_ms=%.2f "
+                         "pipeline_ms=%.2f dispatch_ms=%.2f "
+                         "writeback_ms=%.2f writeback_prepare_ms=%.2f "
+                         "writeback_buffers_ms=%.2f writeback_images_ms=%.2f "
+                         "writeback_publish_ms=%.2f map_ms=%.2f prepare_ms=%.2f watch_ms=%.2f "
+                         "pack_ms=%.2f layout_ms=%.2f notify_ms=%.2f cache_ms=%.2f "
+                         "cleanup_ms=%.2f total_ms=%.2f subgroup=%u\n",
+                         (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
+                         (unsigned long long)timing_program_hash, ok ? 1u : 0u,
+                         phase_milliseconds(phase_start, phase_setup),
+                         setup_validate_ms, setup_buffers_ms,
+                         phase_milliseconds(phase_setup, phase_pipeline),
+                         phase_milliseconds(phase_pipeline, phase_dispatch),
+                         phase_milliseconds(phase_dispatch, phase_writeback),
+                         writeback_prepare_ms, writeback_buffers_ms,
+                         writeback_images_ms, writeback_publish_ms,
+                         image_map_ms, image_prepare_ms, image_watch_ms,
+                         pack_ms, layout_ms, image_notify_ms, image_cache_ms,
+                         phase_milliseconds(phase_writeback, phase_cleanup),
+                         phase_milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
+        }
+        return ok;
     };
-    if (perf_capture_timing) {
-        g_perf_compute_setup_ms += phase_milliseconds(phase_start, phase_setup);
-        g_perf_compute_pipeline_ms += phase_milliseconds(phase_setup, phase_pipeline);
-        g_perf_compute_dispatch_wait_ms += phase_milliseconds(phase_pipeline, phase_dispatch);
-        g_perf_compute_writeback_ms += phase_milliseconds(phase_dispatch, phase_writeback);
-        g_perf_compute_cleanup_ms += phase_milliseconds(phase_writeback, phase_cleanup);
-    }
-    if (phase_timing) {
-        std::fprintf(stderr,
-                     "[compute-phase] submit=%llu code=0x%llx hash=0x%016llx ok=%u "
-                     "setup_ms=%.2f setup_validate_ms=%.2f setup_buffers_ms=%.2f "
-                     "pipeline_ms=%.2f dispatch_ms=%.2f "
-                     "writeback_ms=%.2f writeback_prepare_ms=%.2f "
-                     "writeback_buffers_ms=%.2f writeback_images_ms=%.2f "
-                     "writeback_publish_ms=%.2f map_ms=%.2f prepare_ms=%.2f watch_ms=%.2f "
-                     "pack_ms=%.2f layout_ms=%.2f notify_ms=%.2f cache_ms=%.2f "
-                     "cleanup_ms=%.2f total_ms=%.2f subgroup=%u\n",
-                     (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
-                     (unsigned long long)timing_program_hash, ok ? 1u : 0u,
-                     phase_milliseconds(phase_start, phase_setup),
-                     setup_validate_ms, setup_buffers_ms,
-                     phase_milliseconds(phase_setup, phase_pipeline),
-                     phase_milliseconds(phase_pipeline, phase_dispatch),
-                     phase_milliseconds(phase_dispatch, phase_writeback),
-                     writeback_prepare_ms, writeback_buffers_ms,
-                     writeback_images_ms, writeback_publish_ms,
-                     image_map_ms, image_prepare_ms, image_watch_ms,
-                     pack_ms, layout_ms, image_notify_ms, image_cache_ms,
-                     phase_milliseconds(phase_writeback, phase_cleanup),
-                     phase_milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
-    }
-    return ok;
+    return finish_dispatch();
 }
 
 } // namespace

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5072,6 +5072,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // #3157: free this dispatch's ring slot before touching any cached resource (see the note on
     // reserve_dispatch_slot). No-op unless the ring is enabled.
     if (!ctx.reserve_dispatch_slot()) return false;
+    // Alias guard, and it has to run HERE -- before the dispatch acquires anything. Draining runs
+    // an earlier dispatch's cleanup, which releases cached buffers and images by key; doing that
+    // partway through this dispatch's setup frees resources it is already holding, and the crash
+    // lands inside a libc memory routine with a null argument, nowhere near the cause.
+    //
+    // So the test is over the item's whole resource table rather than over the exact bytes each
+    // binding seeds. That over-approximates -- it counts resources this dispatch will never read
+    // from guest memory -- and so drains more often than the ~6% the census measured. Correctness
+    // first; the tighter test needs the seed set known before acquisition, which it is not.
+    if (ctx.dispatch_ring_depth() > 1 && item.resources) {
+        for (const auto& resource : item.resources->resources) {
+            if (!ctx.drain_ring_if_overlaps(resource.gpu_addr, resource.size)) break;
+        }
+    }
     auto decline = [&item](const char* reason) {
         report_compute_decline(item, reason);
         return false;
@@ -5641,6 +5655,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     };
     std::vector<CompareTarget> compare_targets;
     bool submitted_dispatch = false;
+    // This dispatch's own fence, bound at submit time -- see the note there.
+    VkFence dispatch_fence = VK_NULL_HANDLE;
     bool image_timing = false;
     do {
         std::vector<VkDescriptorSetLayoutBinding> layout_bindings(descriptors.size());
@@ -5757,10 +5773,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 break;
             }
             if (buffers[i].alias_of == SIZE_MAX) {
-                // #3157: an in-flight dispatch may still owe a writeback to exactly these
-                // guest bytes. Reading them now would seed from stale memory, so drain first.
-                // Measured overlap is ~6%, so this is rare enough to leave the pipelining win.
-                (void)ctx.drain_ring_if_overlaps(resource->gpu_addr, buffers[i].guest_bytes);
                 const uint8_t* source = buffers[i].atomic_image
                     ? resource_bytes_for(resource, buffers[i].guest_bytes)
                     : resource_bytes_for(resource, buffers[i].guest_bytes);
@@ -7345,10 +7357,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     skip_image(r, "storage backing size is invalid"); break;
                 }
                 bi.guest_bytes = guest_bytes;
-                // #3157: an in-flight dispatch may still owe a writeback to exactly these
-                // guest bytes. Reading them now would seed from stale memory, so drain first.
-                // Measured overlap is ~6%, so this is rare enough to leave the pipelining win.
-                (void)ctx.drain_ring_if_overlaps(r->gpu_addr, guest_bytes);
                 const uint8_t* src = (renderer_owned || bi.seed_skip)
                     ? nullptr : resource_bytes_for(r, guest_bytes);
                 if (collect_alias_ranges) {
@@ -9135,6 +9143,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 ? VK_ERROR_DEVICE_LOST
                 : vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
         }
+        // Bind THIS dispatch's fence now. ctx.dispatch_fence aliases the ring's CURRENT slot, so
+        // reading it again when the deferred phase runs would name a LATER dispatch's fence: the
+        // wait then returns without this dispatch's GPU work having finished, and the writeback
+        // publishes unfinished results into guest memory. It surfaces as the guest following a
+        // pointer it was never given, faulting inside a libc memory routine -- nowhere near here.
+        dispatch_fence = ctx.dispatch_fence;
+        {
+        }
         if (!vk_ok(compute_submit_rc, "queue-submit")) break;
         submitted_dispatch = true;
     } while (false);
@@ -9150,7 +9166,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // the BoundBuffer*/BoundImage* inside compare_targets stay valid. Everything else is a
     // handle, a scalar, or a lambda already made copy-safe (#3157).
     auto finish_dispatch = [&authority_census, &ctx, &item, &spirv, &transfer_gate_census, 
-        buffers = std::move(buffers), compare_targets = std::move(compare_targets), 
+        buffers = std::move(buffers), compare_targets = std::move(compare_targets), dispatch_fence, 
         images = std::move(images), staging = std::move(staging), 
         staging_bytes = std::move(staging_bytes), staging_memory = std::move(staging_memory), 
         authority_observation, compare_descriptor_pool, compare_flags, compare_flags_memory, 
@@ -9228,7 +9244,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
             const auto fence_wait_start = ComputeClock::now();
             const VkResult wait_result = vkWaitForFences(
-                ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
+                ctx.device, 1, &dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
             // Report a LONG wait even when it succeeds.
             //
             // A zero timeout count was read as proof that no compute dispatch hangs. That inference has a
@@ -10816,6 +10832,12 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
         runtime_compute_authority_census();
     const bool authority_requested = authority_census.requested();
     for (const auto& item : items) {
+        // #3157: the CPU fast path reads and writes guest memory directly, without going through
+        // execute_item, so none of the ring's drain hooks are on it. A deferred dispatch still
+        // owing a writeback would let this path read stale bytes -- which is what it did: the
+        // guest then followed a pointer it had not been given yet and faulted inside a libc
+        // memory routine with a null argument, nowhere near the compute path.
+        if (!context.dispatch_slots.empty()) context.drain_dispatch_ring();
         if (const std::optional<bool> cpu_result = execute_cpu_fast_path(item)) {
             if (authority_requested) {
                 const uint64_t program_hash = prosper::gpu::gpu_capture_hash(

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -8970,6 +8970,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                                 ctx.dispatch_timestamp_pool, 5);
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
+        if (alias_census_enabled()) {
+            // Storage buffers alias through guest memory exactly as images do, so a guard that
+            // saw only the image path would be a correctness hole rather than a tradeoff. An
+            // `alias_of` entry shares an earlier entry's guest range and would double-count.
+            for (const auto& b : buffers) {
+                if (!b.resource || b.guest_bytes == 0 || b.alias_of != SIZE_MAX) continue;
+                if (!b.upload_skipped)
+                    alias_seeds.push_back({b.resource->gpu_addr, b.guest_bytes});
+                if (b.writable)
+                    alias_writes.push_back({b.resource->gpu_addr, b.guest_bytes});
+            }
+        }
         if (alias_census_enabled() && !alias_seeds.empty()) {
             g_alias_census.dispatches++;
             g_alias_census.seed_ranges += alias_seeds.size();

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -8983,7 +8983,26 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // must follow it. cleanup(), inside the epilogue, destroys the compare-flags buffer the
     // consume reads, so the two cannot be separated. wait_and_consume stays a nested lambda so
     // its failure returns skip the remaining consume work WITHOUT skipping the epilogue.
-    auto finish_dispatch = [&]() -> bool {
+    // Explicit captures so this phase can outlive execute_item's frame when a ring defers it.
+    // by-ref: all five outlive every dispatch -- ctx and the two censuses are process-lifetime,
+    // item belongs to the caller's batch vector, and spirv aliases either a static override or
+    // item.spirv. moved: the per-dispatch containers; vector move transfers the allocation, so
+    // the BoundBuffer*/BoundImage* inside compare_targets stay valid. Everything else is a
+    // handle, a scalar, or a lambda already made copy-safe (#3157).
+    auto finish_dispatch = [&authority_census, &ctx, &item, &spirv, &transfer_gate_census, 
+        buffers = std::move(buffers), compare_targets = std::move(compare_targets), 
+        images = std::move(images), staging = std::move(staging), 
+        staging_bytes = std::move(staging_bytes), staging_memory = std::move(staging_memory), 
+        authority_observation, compare_descriptor_pool, compare_flags, compare_flags_memory, 
+        compare_pool_owned_by_context, completion_proven, descriptor_layout, descriptor_pool, 
+        descriptor_pool_reused, image_cache_ms, image_map_ms, image_notify_ms, 
+        image_prepare_ms, image_timing, image_watch_ms, layout_ms, ok, pack_ms, 
+        perf_capture_timing, perf_gpu_timing, phase_dispatch, phase_pipeline, phase_setup, 
+        phase_start, phase_timing, phase_writeback, pipeline, pipeline_cached, pipeline_layout, 
+        resource_bytes, resource_bytes_for, setup_buffers_ms, setup_validate_ms, shader, 
+        submission_entered, submitted_dispatch, timing_program_hash, trace, 
+        transfer_gate_observation, vk_ok, vk_soft_ok, writeback_buffers_ms, 
+        writeback_images_ms, writeback_prepare_ms, writeback_publish_ms]() mutable -> bool {
         // Defined here, not at function scope: it releases buffers/images and reads `ok`, which
         // the deferred phase owns. Binding it inside means it acts on the deferred copies rather
         // than on a moved-from original (#3157).

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5464,59 +5464,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         return false;
     };
 
-    auto cleanup = [&] {
-        if (compare_descriptor_pool && !compare_pool_owned_by_context)
-            vkDestroyDescriptorPool(ctx.device, compare_descriptor_pool, nullptr);
-        if (compare_flags) vkDestroyBuffer(ctx.device, compare_flags, nullptr);
-        if (compare_flags_memory) ctx.release_memory(compare_flags_memory);
-        if (!pipeline_cached) {
-            if (pipeline) vkDestroyPipeline(ctx.device, pipeline, nullptr);
-            if (pipeline_layout) vkDestroyPipelineLayout(ctx.device, pipeline_layout, nullptr);
-            if (shader) vkDestroyShaderModule(ctx.device, shader, nullptr);
-            if (descriptor_layout)
-                vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
-        }
-        if (descriptor_pool && !descriptor_pool_reused)
-            vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
-        for (auto& buffer : buffers) {
-            if (buffer.alias_of != SIZE_MAX) continue;
-            if (buffer.persistent) {
-                // A failed command/submit/readback may have modified the retained host-visible
-                // buffer without publishing matching guest bytes. Force exact source validation on
-                // its next use rather than trusting the pre-dispatch write snapshot.
-                if (!ok) ctx.invalidate_cached_buffer_source(buffer.cache_key);
-                ctx.release_cached_buffer(buffer.cache_key);
-                continue;
-            }
-            if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
-            if (buffer.memory) ctx.release_memory(buffer.memory);
-        }
-        for (size_t i = 0; i < images.size(); i++) {
-            // A pin is taken per successful import, so it is released per import -- including for a
-            // binding that a later alias check folded into an earlier one (#1095).
-            if (images[i].imported || images[i].depth_bits_source)
-                release_live_render_target_image(images[i].imported_addr);
-            if (images[i].alias_of != SIZE_MAX) continue;
-            if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
-            if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
-            if (images[i].compute_transfer_seed_borrowed)
-                ctx.release_cached_image(images[i].compute_transfer_seed_key);
-            if (images[i].persistent) {
-                // A failed submit/readback can leave the retained VkImage and its exact-result
-                // baseline newer than guest memory. Force the retry to upload and publish again;
-                // otherwise it could compare against that newer baseline and skip forever.
-                if (!ok) ctx.invalidate_cached_image_source(images[i].cache_key);
-                ctx.release_cached_image(images[i].cache_key);
-            } else {
-            // An imported image belongs to the live renderer: release the pin, destroy nothing.
-                if (images[i].image && !images[i].imported)
-                    vkDestroyImage(ctx.device, images[i].image, nullptr);
-                if (images[i].memory) ctx.release_memory(images[i].memory);
-            }
-            if (staging[i]) vkDestroyBuffer(ctx.device, staging[i], nullptr);
-            if (staging_memory[i]) ctx.release_memory(staging_memory[i]);
-        }
-    };
     auto resource_bytes = [](const ShaderResource* resource) -> uint8_t* {
         if (resource->host_data && resource->host_data_size >= resource->size)
             return resource->host_data;
@@ -9037,6 +8984,62 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // consume reads, so the two cannot be separated. wait_and_consume stays a nested lambda so
     // its failure returns skip the remaining consume work WITHOUT skipping the epilogue.
     auto finish_dispatch = [&]() -> bool {
+        // Defined here, not at function scope: it releases buffers/images and reads `ok`, which
+        // the deferred phase owns. Binding it inside means it acts on the deferred copies rather
+        // than on a moved-from original (#3157).
+        auto cleanup = [&] {
+            if (compare_descriptor_pool && !compare_pool_owned_by_context)
+                vkDestroyDescriptorPool(ctx.device, compare_descriptor_pool, nullptr);
+            if (compare_flags) vkDestroyBuffer(ctx.device, compare_flags, nullptr);
+            if (compare_flags_memory) ctx.release_memory(compare_flags_memory);
+            if (!pipeline_cached) {
+                if (pipeline) vkDestroyPipeline(ctx.device, pipeline, nullptr);
+                if (pipeline_layout) vkDestroyPipelineLayout(ctx.device, pipeline_layout, nullptr);
+                if (shader) vkDestroyShaderModule(ctx.device, shader, nullptr);
+                if (descriptor_layout)
+                    vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
+            }
+            if (descriptor_pool && !descriptor_pool_reused)
+                vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
+            for (auto& buffer : buffers) {
+                if (buffer.alias_of != SIZE_MAX) continue;
+                if (buffer.persistent) {
+                    // A failed command/submit/readback may have modified the retained host-visible
+                    // buffer without publishing matching guest bytes. Force exact source validation on
+                    // its next use rather than trusting the pre-dispatch write snapshot.
+                    if (!ok) ctx.invalidate_cached_buffer_source(buffer.cache_key);
+                    ctx.release_cached_buffer(buffer.cache_key);
+                    continue;
+                }
+                if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
+                if (buffer.memory) ctx.release_memory(buffer.memory);
+            }
+            for (size_t i = 0; i < images.size(); i++) {
+                // A pin is taken per successful import, so it is released per import -- including for a
+                // binding that a later alias check folded into an earlier one (#1095).
+                if (images[i].imported || images[i].depth_bits_source)
+                    release_live_render_target_image(images[i].imported_addr);
+                if (images[i].alias_of != SIZE_MAX) continue;
+                if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
+                if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
+                if (images[i].compute_transfer_seed_borrowed)
+                    ctx.release_cached_image(images[i].compute_transfer_seed_key);
+                if (images[i].persistent) {
+                    // A failed submit/readback can leave the retained VkImage and its exact-result
+                    // baseline newer than guest memory. Force the retry to upload and publish again;
+                    // otherwise it could compare against that newer baseline and skip forever.
+                    if (!ok) ctx.invalidate_cached_image_source(images[i].cache_key);
+                    ctx.release_cached_image(images[i].cache_key);
+                } else {
+                // An imported image belongs to the live renderer: release the pin, destroy nothing.
+                    if (images[i].image && !images[i].imported)
+                        vkDestroyImage(ctx.device, images[i].image, nullptr);
+                    if (images[i].memory) ctx.release_memory(images[i].memory);
+                }
+                if (staging[i]) vkDestroyBuffer(ctx.device, staging[i], nullptr);
+                if (staging_memory[i]) ctx.release_memory(staging_memory[i]);
+            }
+        };
         // #3157 step B1: the whole post-submit phase -- fence wait, its failure handling, GPU
         // timestamps, and the consume tail -- as ONE callable. Immediately invoked here, so
         // behaviour is unchanged. This is the unit a dispatch ring defers: cleanup() (run in

--- a/prosper/tests/shared/compute/test_compute_timing_selector.cpp
+++ b/prosper/tests/shared/compute/test_compute_timing_selector.cpp
@@ -276,6 +276,25 @@ int main() {
               !claim_compute_transfer_gate_selector_summary(missing_consumer),
           "transfer selector summary is claimed exactly once");
 
+    // #3157: the guest-range overlap test that decides whether a dispatch may be pipelined
+    // past the previous one. A false negative here would let a dispatch seed from stale guest
+    // bytes, so the boundary cases are the point.
+    CHECK(compute_guest_ranges_overlap({0x1000, 0x100}, {0x1080, 0x100}),
+          "partially overlapping guest ranges alias");
+    CHECK(compute_guest_ranges_overlap({0x1000, 0x100}, {0x1040, 0x10}),
+          "a contained guest range aliases");
+    CHECK(compute_guest_ranges_overlap({0x1040, 0x10}, {0x1000, 0x100}),
+          "containment aliases in either argument order");
+    CHECK(!compute_guest_ranges_overlap({0x1000, 0x100}, {0x1100, 0x100}),
+          "adjacent half-open guest ranges do NOT alias");
+    CHECK(!compute_guest_ranges_overlap({0x1100, 0x100}, {0x1000, 0x100}),
+          "adjacency is symmetric");
+    CHECK(!compute_guest_ranges_overlap({0x1000, 0}, {0x1000, 0x100}) &&
+              !compute_guest_ranges_overlap({0x1000, 0x100}, {0x1000, 0}),
+          "a zero-length range reads nothing and never aliases");
+    CHECK(compute_guest_ranges_overlap({0x1000, 0x100}, {0x1000, 0x100}),
+          "identical guest ranges alias");
+
     if (failures) {
         std::printf("%d check(s) failed\n", failures);
         return 1;

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -328,7 +328,23 @@ def summarize(records):
     # prosper-app arms one. The `PROSPER_TILECENSUS` readback trap (instrument trap 237) is a
     # different instrument that happens to share the mechanism.
     readback_note = None
-    if classification == "readback":
+    # Warn whenever readback is a LEADING component, not only when it wins the classification.
+    # A capture where readback is the largest single component but sits under the evidence
+    # threshold gets classified "inconclusive" -- and then prints the biggest number on the page
+    # with no warning attached, which is the exact shape that sends a reader chasing the harness.
+    # Measured on a Dragon Quest capture: readback=977.7ms was the top component, classification
+    # was "inconclusive", and the note stayed silent.
+    # Ranking is the wrong trigger: on the capture that motivated this, readback was 977.7ms and
+    # merely SECOND to compute's 1134.0ms, so a "is it the max" test stayed silent on a number a
+    # reader would still have chased. If the frontend is copying scanout frames at all, say so.
+    material_readback = False
+    try:
+        _c = components if isinstance(components, dict) else {}
+        _rb = _c.get("readback")
+        material_readback = isinstance(_rb, (int, float)) and _rb > 0.0
+    except Exception:
+        material_readback = False
+    if classification == "readback" or material_readback:
         adopted = _gpu_present_adopted(post)
         if adopted is None:
             readback_note = (

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -337,11 +337,20 @@ def summarize(records):
     # Ranking is the wrong trigger: on the capture that motivated this, readback was 977.7ms and
     # merely SECOND to compute's 1134.0ms, so a "is it the max" test stayed silent on a number a
     # reader would still have chased. If the frontend is copying scanout frames at all, say so.
+    # Materiality, not presence and not ranking. Presence warns on a capture with 2ms of readback
+    # in 100ms, which is noise on every report. Ranking stays SILENT on the case that motivated
+    # this -- a Dragon Quest capture where readback was 977.7ms and merely second to compute's
+    # 1134.0ms, i.e. ~23% of measured work and the number a reader would have chased.
+    READBACK_NOTE_SHARE = 0.10
     material_readback = False
     try:
-        _c = components if isinstance(components, dict) else {}
-        _rb = _c.get("readback")
-        material_readback = isinstance(_rb, (int, float)) and _rb > 0.0
+        _c = {k: v for k, v in (components or {}).items() if isinstance(v, (int, float))}
+        # NOT `_total`: that is the module-level helper this function calls throughout, and a
+        # local of the same name shadows it for the WHOLE function scope, breaking every earlier
+        # call. Python binds by scope, not by position.
+        _rb = _c.get("readback", 0.0)
+        _measured = sum(v for v in _c.values() if v > 0.0)
+        material_readback = _measured > 0.0 and (_rb / _measured) >= READBACK_NOTE_SHARE
     except Exception:
         material_readback = False
     if classification == "readback" or material_readback:

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -189,6 +189,18 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertEqual(summary["classification"], "renderer-resource")
         self.assertIsNone(summary["readback_note"])
 
+    def test_material_readback_is_called_out_even_when_not_the_verdict(self):
+        # The Dragon Quest shape: readback is a large minority of measured work and loses the
+        # classification, so a ranking- or verdict-gated note stays silent on exactly the number
+        # a reader would chase. 300 of 1000ms is 30%.
+        summary = summarize(capture(SAMPLES, renderer=[{
+            "total_ms": 1000, "gpu_device_ms": 100, "gpu_wait_ms": 100,
+            "build_resources_ms": 250, "setup_resources_ms": 250, "readback_ms": 300,
+        }]))
+        self.assertNotEqual(summary["classification"], "readback")
+        self.assertIsNotNone(summary["readback_note"])
+        self.assertIn("NOT adopted", summary["readback_note"])
+
     def test_pacing_gap_is_evidence_not_cause(self):
         summary = summarize(capture(SAMPLES, renderer=[{
             "total_ms": 100, "gpu_device_ms": 60, "gpu_timestamp_samples": 1,


### PR DESCRIPTION
## What this is

The per-dispatch fence wait dominates the live compute path. Measured with an `LD_PRELOAD`
interposer across **three UE titles**:

| title | `vkQueueSubmit` | `vkWaitForFences` mean | **wait % of wall** |
| --- | --- | --- | --- |
| Stray `PPSA02101` | 1.2% | 329.8 us | **37.9%** |
| Little Nightmares III `PPSA05143` | 1.3% | 367.0 us | **33.0%** |
| Dragon Quest VII `PPSA17942` | 1.0% | 230.7 us | **19.6%** |

Submission is ~1% everywhere, so batching submits is dead. GPU execution is ~171 us against a
~330 us wait, so ~160 us per dispatch is scheduling latency with the GPU idle.

This adds a dispatch ring: `PROSPER_COMPUTE_RING=<1..8>`, **default 1**, which reproduces the
historical submit/wait/consume behaviour exactly.

## Status: correct and fully tested — but it does NOT deliver the sized win

**Working:** `ctest` **315/315 at ring off, ring=3, and ring=8**. Five interleaved 55 s Stray
runs, **zero faults at every depth**.

**Performance, measured interleaved (5 paired runs):**

| | mean | median | range |
| --- | --- | --- | --- |
| ring off | 65.3 fps | 67.5 | 60.0-68.0 |
| ring=3 | 68.6 fps | 68.5 | 67.9-69.4 |

The medians are within noise. The clear difference is **variance**, not throughput.

**Why it is not the ~13% the fence measurement sized, and this is the important part:** on this
route the guest submits roughly **one dispatch per batch** -- 23,294 dispatches across ~23,400
batches -- and the end-of-batch drain is mandatory, because the guest may read its memory as soon
as the submit returns. So every slot is drained immediately after it is filled and **the ring never
overlaps anything**. What little it gains comes from per-slot command pools, not from pipelining.

Capturing the sized win requires deferring **across** batches, which needs a guest-visibility
contract this does not have. That is a separate piece of work; this PR does not pretend to it.

## The refactor

`execute_item` is ~5,000 lines with the consume tail woven through its frame. Turning that into a
deferrable closure was done in verified steps, each `ctest` green:

1. isolate the consume tail as one callable
2. widen it to enclose the fence wait
3. make `vk_note_failure` / `vk_ok` / `vk_soft_ok` copy-safe
4. hoist `compare_targets` / `image_timing` out of the `do`-block
5. move the phase out of the `do`-block, fold in the epilogue, bind `cleanup` inside it
6. replace `[&]` with explicit captures so the closure can outlive its frame

Every structural fact came from the **compiler**, not from reading -- the escape count (exactly
two) and the capture set both. Brace-depth analysis had already produced one wrong answer here.

## Four real bugs, all found by running

1. **Slot reservation ordering.** Consuming a slot inside `prepare_dispatch_commands` ran the
   *previous* dispatch's cleanup after the current one had acquired its cached buffers and images;
   that cleanup releases by cache key, so it freed live resources.
2. **Aliased-handle double destroy.** `command_buffer`/`dispatch_fence` alias the current slot, so
   the destructor destroyed each fence twice -- a heap double free at exit from the atexit context
   teardown, nowhere near the dispatch path.
3. **Wrong fence.** The deferred phase waited on `ctx.dispatch_fence` read at *consume* time, which
   by then aliased a later slot. Each deferred dispatch waited on another dispatch's fence and
   published unfinished GPU results.
4. **Dangling `buffer_resources`.** `std::vector<ShaderResource> buffer_resources` is frame-local
   and held **by value** (`:5510`); `:5688`/`:5707` make every `BoundBuffer::resource` point into
   it. `buffers` moved into the closure, that vector did not, so the deferred writeback read
   `resource->gpu_addr` through a dangling pointer and published guest memory at a garbage address.
   It surfaced as the guest faulting at `addr=(nil)` inside a libc AVX-512 routine. Found by
   bisection, then narrowed to prove this vector alone is the necessary capture.

## Falsified along the way

Recorded so nobody re-runs them: compute image/buffer cache eviction (`*_CACHE_MB=0`), the CPU fast
path (drain hook added), `TripBoundWitnessScope` (no-ops unless instrumented), descriptor/compare
pool reuse (`PROSPER_NO_*_POOL_REUSE=1`), `spirv` capture lifetime, and both `*_observation`
structs.

## Merge judgement

It is correct, tested at three depths, and default-off, so it changes nothing unless enabled. But
it does not currently buy the performance it was built for, and I would rather say that plainly
than let the three-title table above imply otherwise. Reasonable to merge as infrastructure plus
the recorded evidence, or to hold until cross-batch deferral makes it actually pipeline.

Refs #3157