### PR TITLE
fix(snapshot): cmd_check refuses a snap set with zero snaps

### DIFF
--- a/prosper/tools/snapshot/snaps.py
+++ b/prosper/tools/snapshot/snaps.py
@@ -882,6 +882,18 @@ def cmd_check(args):
     failures = 0
     for name in names:
         entry = load_entry(name)
+        # A set with no snaps is a broken store, not a guard that passed -- symmetric with
+        # cmd_import's own refusal to ever WRITE one. Without this the loop below simply never
+        # runs, `failures` never moves, and `check` reports "replaying 0 anchor(s)" then exits 0
+        # -- a guard that guards nothing, silently answering "still fine" for ever. Caught by
+        # review of #3103, which had to add the mirror-image guard to cmd_import to see it.
+        if not entry.get("snaps"):
+            failures += 1
+            print(f"[snaps] {name}: FAIL -- this snap set has ZERO snaps ({store_path(name)}). "
+                  f"A store with no snaps can never fail, so it is refused rather than treated "
+                  f"as a pass. Re-import it from an authoring session, or remove the set if it "
+                  f"was never meant to exist.")
+            continue
         out_dir = os.environ.get("PROSPER_SNAP_OUT", default_check_out_dir(name))
         shutil.rmtree(out_dir, ignore_errors=True)
         os.makedirs(out_dir, exist_ok=True)

--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -1036,6 +1036,109 @@ def main():
         check(rc_v == 0 and "NOT REACHED" in out_v,
               "...while an unreached known-bad snap is reported without failing the run")
 
+        # ---- 6a1b-iv-d. cmd_check REFUSES a snap set with ZERO snaps -------------------------
+        # cmd_import already refuses to ever STORE a zero-snap set (arm 6a1b-iii-e above); nothing
+        # stopped a hand-edited snaps/<name>.json from holding one anyway. With no per-name guard,
+        # `for snap in entry["snaps"]` iterates zero times, `failures` never moves, and the run
+        # prints "replaying 0 anchor(s)" and exits 0 -- a guard that guards nothing, reporting
+        # success for ever. #3105.
+        nm_empty = "zero-snaps"
+        empty_dir = os.path.join(tmp, nm_empty)
+        os.makedirs(empty_dir, exist_ok=True)
+        entry_empty = {"name": nm_empty, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                       "timeout": 60, "savedata": "none", "snaps": []}
+        with open(snaps.store_path(nm_empty), "w", encoding="utf-8") as handle:
+            json.dump(entry_empty, handle)
+
+        # A flag rather than a raise: without the fix, cmd_check calls run_replay for an empty
+        # entry (it iterates candidate_flips() etc. over nothing and returns cleanly), so a raising
+        # stub would only prove "it was called" by crashing the whole test binary and hiding every
+        # arm after it. Recording the call and asserting on it separately keeps the mutant's actual
+        # symptom -- exit 0 -- visible in the output alongside this one.
+        never_calls = []
+
+        def stub_never(entry_, out_dir_):
+            never_calls.append(entry_.get("name"))
+            return {}, os.path.join(out_dir_, "run.log")
+
+        saved_re, saved_here_e = snaps.run_replay, snaps.HERE
+        snaps.HERE = empty_dir
+        buf_e = io.StringIO(); saved_o_e, sys.stdout = sys.stdout, buf_e
+        try:
+            snaps.run_replay = stub_never
+
+            class EmptyArgs:
+                names = [nm_empty]
+            rc_e = snaps.cmd_check(EmptyArgs())
+            out_e = buf_e.getvalue()
+        finally:
+            snaps.run_replay, snaps.HERE, sys.stdout = saved_re, saved_here_e, saved_o_e
+        check(rc_e != 0, "a snap set with ZERO snaps FAILS the run, not passes it")
+        check(nm_empty in out_e and "ZERO snaps" in out_e,
+              "...and the failure message NAMES the empty set, not just a bare failure code")
+        check(never_calls == [],
+              "...and it is refused BEFORE any replay is launched -- there is nothing to replay")
+
+        # A set with the "snaps" key missing entirely must be refused the same way as one holding
+        # an explicit []. entry.get("snaps") -- not entry["snaps"] -- is what makes that true.
+        nm_missing = "missing-snaps-key"
+        with open(snaps.store_path(nm_missing), "w", encoding="utf-8") as handle:
+            json.dump({"name": nm_missing, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                      "timeout": 60, "savedata": "none"}, handle)
+        saved_re2, saved_here_e2 = snaps.run_replay, snaps.HERE
+        snaps.HERE = empty_dir
+        buf_e2 = io.StringIO(); saved_o_e2, sys.stdout = sys.stdout, buf_e2
+        try:
+            snaps.run_replay = stub_never
+
+            class MissingArgs:
+                names = [nm_missing]
+            rc_e2 = snaps.cmd_check(MissingArgs())
+        finally:
+            snaps.run_replay, snaps.HERE, sys.stdout = saved_re2, saved_here_e2, saved_o_e2
+        check(rc_e2 != 0, "a set with NO 'snaps' key at all is refused too, not just an empty list")
+
+        # A run over SEVERAL names must still fail overall and still check every other name -- the
+        # empty set does not silently swallow the rest of the run or abort it early.
+        nm_ok = "alongside-a-real-one"
+        ok_dir = os.path.join(tmp, nm_ok)
+        os.makedirs(ok_dir, exist_ok=True)
+        ok_ref = os.path.join(ok_dir, "ref.bmp")
+        write_bmp(ok_ref, 64, 36, lambda x, y: same)
+        entry_ok = {"name": nm_ok, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
+                   "timeout": 60, "savedata": "none",
+                   "snaps": [dict(snaps.signature_of(ok_ref), index=0, verdict="correct",
+                                  mode="anchor", pad_flip=900)]}
+        with open(snaps.store_path(nm_ok), "w", encoding="utf-8") as handle:
+            json.dump(entry_ok, handle)
+
+        def stub_ok(entry_, out_dir_):
+            os.makedirs(out_dir_, exist_ok=True)
+            write_bmp(os.path.join(out_dir_, "a.bmp"), 64, 36, lambda x, y: same)
+            return ({900: {"target_flip": 900, "actual_flip": 900, "file": "a.bmp"}},
+                    os.path.join(out_dir_, "run.log"))
+
+        replayed = []
+
+        def stub_mixed(entry_, out_dir_):
+            replayed.append(entry_.get("name"))
+            return stub_ok(entry_, out_dir_)
+
+        saved_re3, saved_here_e3 = snaps.run_replay, snaps.HERE
+        snaps.HERE = ok_dir
+        buf_e3 = io.StringIO(); saved_o_e3, sys.stdout = sys.stdout, buf_e3
+        try:
+            snaps.run_replay = stub_mixed
+
+            class MixedArgs:
+                names = [nm_empty, nm_ok]
+            rc_e3 = snaps.cmd_check(MixedArgs())
+        finally:
+            snaps.run_replay, snaps.HERE, sys.stdout = saved_re3, saved_here_e3, saved_o_e3
+        check(rc_e3 != 0, "a run mixing an empty set with a passing one still fails overall")
+        check(replayed == [nm_ok],
+              "...the empty set is skipped without a replay while the real one is still checked")
+
         # The threshold is read from the ENTRY, so a set can be more or less tolerant than default.
         strict = check_run("correct", same, (12, 22, 32))
         check(strict[0] == 0, "a near-identical frame passes at the default threshold")


### PR DESCRIPTION
## Summary

Fixes #3105.

`snaps.py check` on a snap set containing **zero snaps** printed `replaying 0 anchor(s)` and
**exited 0** — a guarded title reporting success while guarding nothing. This is the same class
of defect as `ctest` exiting 0 with nothing registered, which the project charter calls out at
length: "no tests ran" and "everything passed" are the same exit code.

## Failure scenario

`cmd_check` iterated `entry["snaps"]` and returned `1 if failures else 0`. With an empty list the
loop body never runs, `failures` stays 0, and the exit code is indistinguishable from a set whose
every snap matched:

```
$ python3 tools/snapshot/snaps.py check mytitle
[snaps] mytitle: replaying 0 anchor(s)
$ echo $?
0
```

`cmd_import` already refuses to ever *store* an empty set (`if not snaps: raise SystemExit(...)`),
so the normal authoring path cannot reach this. It is reachable by hand-editing a
`tools/snapshot/snaps/<name>.json` to drop its snaps, by a future regression in that import guard,
or by a future tool (e.g. `cmd_accept`) that rewrites an entry down to nothing.

## Contract

`cmd_check` now refuses a set whose `"snaps"` is empty or missing **before** launching a replay:
it counts as a failure, names the empty set and its store path in the printed message, and moves
on to the next name in the run rather than aborting the whole check — symmetric with `cmd_import`'s
own refusal to ever write one.

```python
if not entry.get("snaps"):
    failures += 1
    print(f"[snaps] {name}: FAIL -- this snap set has ZERO snaps ({store_path(name)}). "
          f"A store with no snaps can never fail, so it is refused rather than treated "
          f"as a pass. Re-import it from an authoring session, or remove the set if it "
          f"was never meant to exist.")
    continue
```

## Affected / unaffected behavior

- Affected: a hand-edited or otherwise corrupted zero-snap store now fails `check` loudly instead
  of silently passing.
- Unaffected: every set with at least one snap replays and scores exactly as before — this change
  adds a guard ahead of the existing loop, it does not touch `run_replay`, `best_match`, or the
  per-snap verdict logic.
- A multi-name run (`snaps.py check a b c`) still checks every name even when one of them is
  empty; the empty one is skipped without launching a replay for it, and the others are checked
  normally. Covered by a new test arm.

## Out of scope

The issue's "Also worth covering while there" section flags a related but separate blind spot:
`min_structural_similarity` is entirely unobserved by the test suite (the threshold can be ignored
by `cmd_check`, hardcoded by `cmd_import`, or defaulted to `0.0` on the CLI, and nothing would
notice). That is a distinct defect from the one this PR fixes and is not addressed here.

## Test plan

Added a regression block in `test_snaps.py` (arm "6a1b-iv-d") with three parts:

1. A stored entry with `"snaps": []` — asserts `cmd_check` exits non-zero, the message names the
   set (`"zero-snaps"` and `"ZERO snaps"` both appear in the output), and `run_replay` is never
   invoked for it (tracked via a stub that records its calls rather than raising, so a regression
   shows as a clean `FAIL:` line instead of crashing the test binary).
2. A stored entry with the `"snaps"` key missing entirely — asserts the same refusal, proving the
   guard uses `entry.get("snaps")` rather than `entry["snaps"]`.
3. A mixed run (`names=[empty_set, real_set]`) — asserts the overall run still fails, the empty set
   is skipped without a replay, and the real set is still replayed and checked normally.

**Verified the regression test fails without the fix.** I stashed only the `snaps.py` change
(keeping the new test), then ran `test_snaps.py`:

```
$ python3 tools/snapshot/test_snaps.py
...
FAIL: a snap set with ZERO snaps FAILS the run, not passes it
FAIL: ...and the failure message NAMES the empty set, not just a bare failure code
FAIL: ...and it is refused BEFORE any replay is launched -- there is nothing to replay
...
KeyError: 'snaps'
```

The first three arms fail cleanly against the unfixed code (it silently returns 0 and never prints
the refusal message, so `run_replay` genuinely gets called on the empty entry). The suite then
crashes with a `KeyError` on `entry['snaps']` once it reaches the missing-key arm, which is the
unfixed code's actual behavior — it indexes `entry["snaps"]` directly rather than using `.get()`.

Restoring the fix (`git stash pop`) returns the suite to green:

```
$ python3 tools/snapshot/test_snaps.py
...
== PASS ==
$ echo $?
0
```

235 `ok:` lines, 0 `FAIL:` lines, exit 0 (up from 234 on master — one net new assertion beyond the
three headline arms).

Also ran the sibling suite `test_snapshot.py` (untouched by this change) to confirm no collateral
breakage: 18/18 tests, exit 0.

This is a pure Python tool with no C++/build surface touched, so no `ctest`/CMake build was run.
