### PR TITLE
docs: catch a table row wrapped onto a second physical line (#3088)

### DIFF
--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -937,6 +937,7 @@ force:
 | `PROSPER_CAPTURE_MAX_SUBMITS` | **uncapped** — the inverse of the request | **the process refuses to start**, exit status 3. There is no honest default: `0` means uncapped, so a typo removed the only content bound on exactly the run that needed it. Express "uncapped" by leaving the variable unset. |
 | `PROSPER_CAPTURE_BUNDLE_MAX_MB` | the default budget, so a raise was discarded | same value in force, plus one `[grab]` line saying the raise was discarded (or naming the 64/3072 MiB bound it was clamped to) |
 | `PROSPER_CAPTURE_FRAMES` | 1 — the very width the `window had no submits` message tells you to widen | same value in force, plus one `[grab]` line; a mistyped remedy no longer reproduces the original failure in silence |
+
 If present counts vary and the title emits no honest guest-stdout marker, use the headless F9 control:
 set `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=/path/capture.ready` together with
 `PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`, keep the trigger absent at process start, and create it

--- a/prosper/tools/docs/check_numbered_table.py
+++ b/prosper/tools/docs/check_numbered_table.py
@@ -29,6 +29,47 @@ the first data row, which orphans the entire body.
 Fenced code blocks are skipped: this repository's docs paste tool output containing pipe
 characters, and this file's own defect example would otherwise fail the check that documents it.
 
+A THIRD BLIND SPOT (#3088, 2026-08-31): a row wrapped onto a second physical line. GFM does not
+require a table row to start with `|` -- once the header and delimiter are seen, EVERY following
+non-blank line becomes another row of the SAME table, pipe-prefixed or not, until a blank line or
+another block construct ends it. `parse_tables` used to require every row to start with `|`, so a
+continuation line simply fell OUT of the run: it was never counted as a row, never arity-checked,
+and (unless something pipe-prefixed happened to follow it) left no trace at all -- the file exited
+0, "unbroken, every row matching its header". PR #3049 lost a qualifying clause and its `#2790`
+link this way; `tools/AGENTS.md:917` still carries the same shape pre-existing on master.
+
+MEASURED against GitHub's own renderer (`POST /markdown`, mode=gfm), not reasoned:
+
+    | abc | def |            renders bar as a genuine second row (one cell, `def` blank) when it
+    | --- | --- |            directly abuts the table, but as an ordinary <p> when a blank line
+    | bar | baz |            separates them -- this is the GFM spec's own worked example, and it
+    bar                      is what makes a wrapped continuation dangerous: nothing SYNTACTIC
+                             marks it as wrong.
+
+    | # | What |             a row missing ONLY its leading pipe, with an interior/trailing pipe
+    | --- | --- |            count that still matches the header, renders as a completely normal,
+    | 1 | a |                unbroken 3-row table -- so the pre-#3088 STRUCTURE message ("did it
+    2 | b |                  lose its leading '|'?") was itself a FALSE POSITIVE on this shape,
+    | 3 | c |                fixed as a consequence of fixing the blind spot above (see the
+                             corrected test, formerly "a row that lost its leading pipe ends the
+                             table").
+
+    | # | What |             a genuine block construct -- ATX heading, blockquote, bullet/ordered
+    | --- | --- |            list item, thematic break, HTML block -- interrupts an open table
+    | 1 | a |                WITHOUT needing a blank line, the same way each interrupts a plain
+    ## Heading               paragraph: it renders as its own block (`<h2>Heading</h2>` here), not
+                             as an absorbed row. `interrupts_table()` recognizes these so the fix
+                             does not swallow ordinary trailing prose sections into the table above
+                             them.
+
+So the fix is not "any non-pipe line ends the table" (the old rule, too strict -- misses the
+wrap) and not "any non-pipe line is absorbed" (too loose -- would report a false break on the
+missing-leading-pipe case above, and would silently swallow a heading/list/quote/rule/HTML block
+that legitimately follows a table with no blank line). It is: once a table is OPEN (header +
+valid delimiter matched), a non-blank line that does not start another recognized block is
+ABSORBED as another body row, exactly as GFM renders it -- letting the pre-existing ARITY class
+see it and report the cell-count mismatch a wrap or a stray paragraph almost always produces.
+
 FOUR CLASSES OF CHECK, deliberately separated:
 
   STRUCTURE (always on) -- no blank line may split a table. A fact about Markdown, true of
@@ -91,13 +132,18 @@ What ARITY specifically cannot see, stated so silence is not read as coverage:
   * Any pipe run with no delimiter row -- a fragment has no header to be measured against, so its
     rows are unchecked. The structure class reports the fragment itself when it abuts a real table
     above it, but an isolated delimiter-less pipe block is invisible to every class here.
-  * Tables whose rows have NO LEADING PIPE (`a | b` / `--- | ---`), and tables inside a BLOCKQUOTE
-    (`> | a | b |`). GitHub renders both as real tables and truncates them exactly the same way,
-    and `parse_tables` sees neither, because it requires a row to start with `|`. Both are real
+  * A table whose HEADER row has NO LEADING PIPE (`a | b` / `--- | ---`), and a table inside a
+    BLOCKQUOTE (`> | a | b |`). GitHub renders both as real tables, and `parse_tables` sees
+    neither, because opening a run still requires the FIRST line to start with `|`. Both are real
     false negatives rather than judgement calls; there are zero instances in the corpus today,
     which is the only reason they are recorded here instead of fixed. Note the shape of this
     entry: it is trap 112's own rule -- a gate's silence is only evidence about the class it
     inspects -- applied to trap 112's own gate (#2116 review).
+    **This no longer covers BODY rows.** Until #3088 a body row with no leading pipe was equally
+    invisible -- `parse_tables` ended the run the moment any row lost its `|`. It is now absorbed
+    into the still-open table like every other GFM continuation line, so ARITY sees it if its cell
+    count disagrees with the header. Only the table's OPENING line is still required to lead with
+    a pipe; nothing here parses a header that does not.
   * Content INSIDE a cell. A pipe that is correctly escaped is counted as text and nothing asks
     whether `\|` was what the author meant; equally, a cell count that matches the header proves
     nothing about the cells being in the right ORDER or the right columns.
@@ -216,6 +262,39 @@ from pathlib import Path
 FENCE = re.compile(r"^\s*(```|~~~)")
 DELIMITER = re.compile(r"^\s*\|[\s:|-]+\|?\s*$")
 LEADING_NUMBER = re.compile(r"^\s*\|\s*(\d+)\s*\|")
+
+# Block constructs that interrupt an OPEN table without needing a blank line first -- the same
+# family of constructs that can interrupt a plain paragraph in CommonMark, generalised (measured
+# against GitHub's renderer, #3088) to apply to an open GFM table too. Each was checked with a
+# table's last row directly followed by one of these, no blank line: an ATX heading rendered as
+# `<h2>`, a blockquote as `<blockquote>`, a bullet/ordered list as `<ul>`/`<ol>`, `---` as `<hr>`,
+# and `<div>...</div>` as itself -- none became an absorbed row. An indented (4+ space) code block
+# was NOT added: CommonMark's own rule is that indented code cannot interrupt a paragraph either,
+# so the default (absorb) is already the measured-correct answer there, matching a plain wrapped
+# continuation.
+_ATX_HEADING = re.compile(r"^ {0,3}#{1,6}(\s|$)")
+_BLOCKQUOTE = re.compile(r"^ {0,3}>")
+_BULLET_LIST = re.compile(r"^ {0,3}[-*+](\s|$)")
+_ORDERED_LIST = re.compile(r"^ {0,3}\d{1,9}[.)](\s|$)")
+_THEMATIC_BREAK = re.compile(r"^ {0,3}([-*_])[ \t]*(\1[ \t]*){2,}$")
+_HTML_BLOCK_START = re.compile(r"^ {0,3}<")
+
+
+def interrupts_table(line: str) -> bool:
+    """True if `line` opens a block construct that ends an open table on its own, with no blank
+    line required -- see the measurements above the regexes. Checked BEFORE a line is considered
+    for absorption into a still-open table (parse_tables); a line that matches nothing here is
+    ordinary text, which GFM keeps consuming as another table row regardless of a leading `|`.
+    """
+    return bool(
+        _ATX_HEADING.match(line)
+        or _BLOCKQUOTE.match(line)
+        or _THEMATIC_BREAK.match(line)
+        or _BULLET_LIST.match(line)
+        or _ORDERED_LIST.match(line)
+        or _HTML_BLOCK_START.match(line)
+    )
+
 
 # See N1 in persistence_problems: how far above the baseline's maximum a NEW row number may
 # sit before it is treated as a typo rather than as a deliberate step clear of a collision.
@@ -339,6 +418,14 @@ def parse_tables(lines: list[str]) -> tuple[list[Table], set[int], set[int]]:
     a split table (#1709) -- it is a non-blank line between two pipe runs -- but it is a
     correct document. It is separable by a rule as principled as the blank-line one, which
     is why this is a fix rather than another entry in KNOWN LIMIT.
+
+    #3088: once a run has become an OPEN table (header + a matching delimiter row already seen),
+    a non-blank line that does not open another block construct is ABSORBED into the run instead
+    of ending it -- exactly how GFM keeps consuming lines as table rows with no leading-pipe
+    requirement. See the module docstring for the measurements this is built from. A run that has
+    NOT yet opened a proper table (a fragment -- body rows already orphaned by an earlier break)
+    is not absorbed into; that heuristic exists to flag orphaned rows, not to model real parsing,
+    and only a PROPER table is ever "open" in GFM's sense to begin with.
     """
     tables: list[Table] = []
     blanks: set[int] = set()
@@ -367,7 +454,12 @@ def parse_tables(lines: list[str]) -> tuple[list[Table], set[int], set[int]]:
                 run_start = i
             run.append(line)
             continue
-        if not line.strip():
+        if line.strip():
+            run_open = len(run) >= 2 and bool(DELIMITER.match(run[1]))
+            if run and run_open and not interrupts_table(line):
+                run.append(line)
+                continue
+        else:
             blanks.add(i)
         if run:
             tables.append(Table(run_start, run))
@@ -628,9 +720,14 @@ def check(
     # one.
     #
     # What separates the runs does NOT decide whether this is a break -- only whether the run
-    # below is a proper table does. A blank line and a row that lost its leading pipe both end a
-    # table, and the second is the likelier lane accident. Treating a non-blank gap as "these are
-    # unrelated" loses that entirely: the rows below leave the sequence check with it, so a
+    # below is a proper table does. A blank line always ends a table; since #3088 a non-blank,
+    # non-pipe line does NOT (parse_tables absorbs it into the still-open table instead, letting
+    # ARITY see it -- see the module docstring). This branch is only reachable now when the RUN
+    # ABOVE the gap was never itself open (a fragment left by an earlier break), or when the
+    # interrupting line is a genuine block construct (heading/list/quote/rule/HTML) that GFM lets
+    # interrupt a table without a blank line -- either way parse_tables correctly ended the run,
+    # and the fragment below it is the interruption's fallout. Treating a non-blank gap as "these
+    # are unrelated" loses that entirely: the rows below leave the sequence check with it, so a
     # duplicate number underneath passes green, and the success line reports the truncated row
     # count as though it were the whole table.
     origin: Table | None = None

--- a/prosper/tools/docs/test_check_numbered_table.py
+++ b/prosper/tools/docs/test_check_numbered_table.py
@@ -117,23 +117,50 @@ run("two blank lines split the same table",
     want_problems=True, want_count=2, want_lines=[4, 6],
     expect_text="blank line splits the table")
 
-# R1: a row that lost its leading pipe ends the table just as a blank line does, and is the more
-# likely lane accident. Everything below it silently leaves the sequence check too, so a duplicate
-# number underneath would pass green -- which is the defect this whole check exists to prevent.
-run("a row that lost its leading pipe ends the table",
+# R1 (SUPERSEDED by #3088; kept as the corrected case rather than deleted, since it is what
+# proves the fix is not merely permissive). A row missing ONLY its leading pipe, whose interior
+# pipes still land on the header's cell count, renders as a completely normal, unbroken 3-row
+# table -- measured against GitHub's renderer (module docstring). The previous version of this
+# test asserted the OPPOSITE ("ends the table... did it lose its leading '|'?"), which was a false
+# positive on correct Markdown: a checker that fires on correct data gets deleted rather than
+# heeded, and this shape is exactly the kind of thing #3088's fix corrects as a side effect of
+# making the wrapped-row blind spot visible (parse_tables absorbs the row into the still-open
+# table instead of ending it; ARITY finds nothing wrong because there is nothing wrong).
+run("a row missing its leading pipe still renders correctly when its arity matches",
     "| # | What |\n|---|---|\n| 1 | a |\n2 | b |\n| 3 | c |\n",
+    want_problems=False)
+
+# The genuine defect hides in the arity, not in the missing pipe by itself: once the row's cell
+# count actually disagrees with the header -- the realistic shape of a lost leading pipe, since a
+# stray edit rarely preserves the exact column count -- ARITY catches it, on the absorbed row
+# itself, the same class that already catches an unescaped pipe in a code span (#2108).
+run("a row missing its leading pipe IS still a defect once its arity disagrees",
+    "| # | Instrument | How it lied |\n|---|---|---|\n| 1 | x | y |\n2 | z |\n| 3 | a | b |\n",
     want_problems=True, want_count=1, want_lines=[4],
-    expect_text="lose its leading")
+    expect_text="has 2 cells but the header")
+
+# --ordered is a narrower residual case worth naming rather than hiding: a leading-pipe loss
+# defeats LEADING_NUMBER (`^\s*\|\s*(\d+)\s*\|`) even when it does not defeat ARITY, so the
+# absorbed row is never counted as numbered and the table fails all_rows_numbered -- reported as
+# "no numbered table found" rather than silently accepted. This is a real behaviour change from R1
+# above (whose --ordered form is want_problems=False, since the plain sweep this repository
+# actually runs on every PR passes no --ordered flag at all), recorded so it is a decision and not
+# a surprise.
+run("--ordered still flags a leading-pipe loss, even when arity is fine",
+    "| # | What |\n|---|---|\n| 1 | a |\n2 | b |\n| 3 | c |\n",
+    ordered=True, want_problems=True, expect_text="no numbered table")
 
 # Structural errors are reported first and the broken remainder leaves the sequence check, the way
 # a compiler stops elaborating a malformed declaration. What matters is that the file CANNOT pass
 # green while hiding a duplicate below the break -- the previous revision reported
 # "contiguous and unbroken", exit 0, on exactly this input. Fix the structure, re-run, get the
-# duplicate.
+# duplicate. (Uses a blank-line break, not a missing leading pipe: since #3088 the latter no longer
+# ends an open table by itself -- see R1 above -- so it can no longer orphan a fragment this way.
+# A blank line still can, and is this project's own real incident for exactly this shape.)
 run("a duplicate hidden below an interruption cannot pass green",
-    "| # | What |\n|---|---|\n| 1 | a |\n2 | b |\n| 5 | c |\n| 5 | d |\n",
+    "| # | What |\n|---|---|\n| 1 | a |\n\n| 5 | c |\n| 5 | d |\n",
     ordered=True, want_problems=True, want_count=1, want_lines=[4],
-    expect_text="drops out of any sequence check")
+    expect_text="blank line splits the table")
 
 # The #1696 collision: two branches append the same number; the merge is textually clean. This is
 # the check that survives the removal of gaplessness, and it is the one that protects the citation
@@ -335,6 +362,63 @@ run("a row that dropped a cell",
 run("a delimiter that disagrees with the header",
     "| # | Instrument | How it lied |\n|---|---|\n| 1 | x | y |\n",
     want_problems=True, expect_text="does NOT render as a table at all")
+
+# ---------------------------------------------------------------------------------------------
+# #3088: a row wrapped onto a second physical line. GFM does not require a table row to start
+# with `|` -- it keeps consuming non-blank lines as rows of the same table regardless. Before this
+# fix, parse_tables required every row to start with `|`, so a continuation line simply fell out
+# of the run: never counted, never arity-checked, and -- when nothing pipe-prefixed happened to
+# follow it -- entirely invisible. Reproduced by hand against current master before the fix
+# (issue #3088): this exact fixture, with the fix reverted, prints
+# "1 table(s), 1 rows, unbroken, every row matching its header" and exits 0.
+#
+# This is the PR #3049 shape reduced to a fixture: a two-column table whose answer cell wraps, so
+# the qualifying clause lands on its own line with nothing to mark it as part of the row. Header
+# and row count intentionally stay small so the mismatch (1 cell vs 2) is unambiguous.
+run("a row wrapped onto a second physical line is caught (#3088)",
+    "| Question | Answer |\n|---|---|\n| Does X leak? | no, bounded by the page count, not the "
+    "wider\ncontext, per the #2790 fix |\n",
+    want_problems=True, want_count=1, want_lines=[4],
+    expect_text="has 1 cells but the header")
+
+# The AGENTS.md:917 shape: a paragraph that forgot the blank line before it, landing directly
+# under a table's last row. GFM absorbs the first line of that paragraph as another row with no
+# pipes at all (a single cell), and every following non-blank line keeps being absorbed too until
+# a real blank line appears -- both physical lines of the two-line paragraph below become rows.
+run("a paragraph directly below a table with no blank line is caught (#3088)",
+    "| # | What |\n|---|---|\n| 1 | a |\nThis paragraph forgot its blank line\nand runs two "
+    "lines besides.\n",
+    want_problems=True, want_count=2, want_lines=[4, 5])
+
+# The discriminating counter-arm, and the reason the fix is not simply "absorb everything": a
+# block construct that legitimately follows a table with no blank line must NOT be swallowed into
+# it. Each shape below was checked against GitHub's renderer (module docstring) and renders as its
+# own block, never as an absorbed row -- so a checker that instead absorbed it would report a
+# false arity mismatch here (1 cell vs the header's 2), which is exactly what makes this arm
+# falsifiable: deleting interrupts_table()'s effect turns every one of these red.
+run("a heading right after a table is not absorbed",
+    "| # | What |\n|---|---|\n| 1 | a |\n## A heading with several words\n",
+    want_problems=False)
+run("a bullet list right after a table is not absorbed",
+    "| # | What |\n|---|---|\n| 1 | a |\n- a list item with several words\n",
+    want_problems=False)
+run("an ordered list right after a table is not absorbed",
+    "| # | What |\n|---|---|\n| 1 | a |\n1. a list item with several words\n",
+    want_problems=False)
+run("a blockquote right after a table is not absorbed",
+    "| # | What |\n|---|---|\n| 1 | a |\n> a quoted line with several words\n",
+    want_problems=False)
+run("a thematic break right after a table is not absorbed",
+    "| # | What |\n|---|---|\n| 1 | a |\n---\n",
+    want_problems=False)
+run("an HTML block right after a table is not absorbed",
+    "| # | What |\n|---|---|\n| 1 | a |\n<div>a whole html block</div>\n",
+    want_problems=False)
+
+# A conflict marker is handled by an earlier, separate scan (see below), but it is also a
+# realistic "line right after a table" shape and must not be absorbed as a row either -- covered
+# by the existing "a conflict marker after the last row is caught" case further down, which still
+# passes unmodified because that scan runs and returns before parse_tables is ever reached.
 
 # A stray conflict marker AFTER the last row. This is the shape that escaped every other class and
 # reached a pushed branch: the marker is not a table row, so it merely ends the table, and with no


### PR DESCRIPTION
## Summary

`check_numbered_table.py` required every table row to start with `|`. GFM does not: once a
table's header and delimiter are seen, GitHub keeps consuming every following non-blank line as
another row of the *same* table, pipe-prefixed or not, until a blank line or another block
construct ends it. A row wrapped onto a second physical line -- or a trailing paragraph that
forgot its blank line -- therefore fell out of `parse_tables` entirely: never counted as a row,
never arity-checked, and (unless something pipe-prefixed happened to follow it) left no trace at
all. The file read `"unbroken, every row matching its header"`, exit 0, while GitHub silently
truncated the row and orphaned the continuation as a garbled second row.

## Root cause and fix

`parse_tables` treated any non-`|`-prefixed line as ending the current table run. Fixed by
absorbing a non-blank, non-pipe line into a table that is already **open** (header + valid
delimiter already matched) instead of ending the run -- matching GFM's real continuation rule.
This lets the pre-existing ARITY class see the row and report the cell-count mismatch a wrap or
stray paragraph almost always produces.

The one thing that must NOT be absorbed is a line that starts its own block construct (an ATX
heading, blockquote, bullet/ordered list item, thematic break, or HTML block) -- GFM lets each of
those interrupt an open table without a blank line too, the same way they interrupt a plain
paragraph, and none of them become a table row. `interrupts_table()` recognizes these; each shape
was checked against GitHub's own renderer (`POST /markdown`, mode=gfm) before and after the fix,
not reasoned from the spec alone.

**A necessary side effect, worth calling out:** the old STRUCTURE message ("did it lose its
leading `|`?") fired on *every* non-`|`-prefixed row, including one whose interior pipes still
land on the header's cell count -- which GitHub actually renders as a completely normal, unbroken
row. That was a pre-existing false positive sharing the same code path; fixing the blind spot
necessarily corrects it too. The old test asserting the wrong behavior is kept, corrected, rather
than deleted (see `tools/docs/test_check_numbered_table.py`, the case formerly named "a row that
lost its leading pipe ends the table").

## Reproduction (before the fix)

Constructed by hand against current master before making any change:

```
| Question | Answer |
| --- | --- |
| Does X leak? | no, bounded by the page count, not the wider
context, per the #2790 fix |
```

```
$ python3 tools/docs/check_numbered_table.py repro.md
repro.md: 1 table(s), 1 rows, unbroken, every row matching its header
$ echo $?
0
```

GitHub's renderer on the same input produces a genuine second, garbled row (`<td>context, per the
#2790 fix</td><td></td>`) -- confirmed via the `/markdown` API before writing the fix. This is
exactly the PR #3049 shape the issue names.

## tools/AGENTS.md also fixed (one blank line)

The repo-wide sweep (`git ls-files '*.md' -z | xargs -0 check_numbered_table.py`) finds the
second instance the issue names as pre-existing: `tools/AGENTS.md`'s paragraph at line 940 forgot
the blank line separating it from the 3-column table above it, so GitHub renders the whole
following paragraph (~130 lines) as single-cell rows appended to that table. The fixed checker
reports exactly 128 problems here and nowhere else in the corpus. Since this sweep is a
**required CI job on every PR** (not just docs PRs), landing the checker fix without repairing
the document would turn the `Docs` job red on master immediately. Fixed with one blank line.

## Regression test

Added to `tools/docs/test_check_numbered_table.py`:
- `a row wrapped onto a second physical line is caught (#3088)`
- `a paragraph directly below a table with no blank line is caught (#3088)`
- Six counter-arms proving each recognized block construct (heading, bullet list, ordered list,
  blockquote, thematic break, HTML block) is *not* falsely absorbed
- The corrected false-positive case, its inverse (arity actually mismatches -> still caught), and
  a `--ordered` arm documenting the one residual case (a lost leading pipe still defeats
  `LEADING_NUMBER`, so `--ordered` alone still flags it as "no numbered table found" even when
  ARITY is clean)
- `a duplicate hidden below an interruption cannot pass green`, re-pointed at a blank-line break
  (the mechanism the original 2026-08-01 incident actually was) since a missing leading pipe no
  longer ends an open table by itself

**How I verified the new tests fail without the fix:** saved `git HEAD`'s copy of
`check_numbered_table.py` to a scratch directory and ran the three key new fixtures'
`check()` calls against it directly. All three produce a **different** verdict pre- vs post-fix:

```
a row wrapped onto a second physical line is caught (#3088):
  fixed checker expects want_problems=True
  OLD (pre-fix) checker: has_problems=False, problems=[]
  -> DIFFERENT verdict: this fixture is a genuine regression test.

a paragraph directly below a table with no blank line is caught (#3088):
  fixed checker expects want_problems=True
  OLD (pre-fix) checker: has_problems=False, problems=[]
  -> DIFFERENT verdict: this fixture is a genuine regression test.

a row missing its leading pipe still renders correctly when its arity matches:
  fixed checker expects want_problems=False
  OLD (pre-fix) checker: has_problems=True, problems=[".../case.md:4: line is not a table row
  but sits inside the table that starts at line 1, ending it ... Did it lose its leading '|'?
  Line reads: '2 | b |'"]
  -> DIFFERENT verdict: this fixture is a genuine regression test.
```

## Verification

- `python3 tools/docs/test_check_numbered_table.py`: **104 cases, exit 0** (up from the
  pre-existing suite plus 13 new cases; two pre-existing cases corrected as described above).
- Repo-wide sweep, matching CI's `Docs` job exactly (`git ls-files '*.md' -z | xargs -0 python3
  tools/docs/check_numbered_table.py`):
  - **Before** (pre-fix checker, against a `git archive` of the branch's base commit, 146 tracked
    `.md` files): exit 0, 0 problems -- the blind spot in action.
  - **After fixing the checker only** (still-broken `tools/AGENTS.md`): exit 123 (xargs), **128
    problems, all in `tools/AGENTS.md`**, all one defect.
  - **After fixing `tools/AGENTS.md` too** (final state of this PR): **146 files, exit 0**.
  - Confirmed no other file in the corpus disagrees between the old and new checker -- the AGENTS.md
    instance is the only behavioral difference across the whole tracked corpus.
- CI's other `check_numbered_table.py` invocation, run locally against the exact recipe
  (`--ordered --table-header Instrument --baseline <origin/master's copy>
  docs/GAME_COMPAT_ORCHESTRATION.md`): exit 0, 239 rows, unique and ascending, none of the
  baseline's 239 rows deleted.
- `git diff --check`: clean.

This is a documentation-tooling-only change (`tools/docs/*.py` plus a one-line `tools/AGENTS.md`
fix) with no C++ build dependency, so no `ctest`/build verification was run.

Fixes #3088
