### PR TITLE
docs: fix both sides of check_merge_result's checker-invocation locale decode

### DIFF
--- a/prosper/tools/docs/check_merge_result.py
+++ b/prosper/tools/docs/check_merge_result.py
@@ -37,6 +37,7 @@ the same one `check_numbered_table.py`'s own WHAT THIS CANNOT SEE section draws)
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 import tempfile
@@ -139,11 +140,37 @@ def main() -> int:
         merged_copy.write_text(show.stdout, encoding="utf-8")
         base_copy.write_text(git("show", f"{base}:{args.file}").stdout, encoding="utf-8")
 
+        # encoding="utf-8" AND env=...PYTHONIOENCODING on the SAME call, deliberately: this is a
+        # BOTH-SIDES fix, not two independent ones. `encoding="utf-8"` fixes how THIS process
+        # decodes the checker's captured stdout/stderr; it says nothing about what bytes the
+        # checker actually wrote. Absent an override, the checker's own `print()` encodes with
+        # WHATEVER the ambient locale is (cp1252 on an unconfigured Windows host) -- and today,
+        # with neither side forced, parent and child read that same ambient locale and agree BY
+        # ACCIDENT. Adding encoding="utf-8" here alone would break that accidental agreement
+        # into a real one: the checker would still emit cp1252 bytes, and this call would then
+        # insist on decoding them as UTF-8. `PYTHONIOENCODING=utf-8` in the child's environment
+        # is what makes the checker itself emit UTF-8 regardless of locale, so the two sides
+        # agree on purpose instead of by luck. Neither half alone is a fix -- see #3079.
         proc = subprocess.run(
             [sys.executable, str(CHECKER), "--ordered", "--table-header", args.table_header,
              "--baseline", str(base_copy), str(merged_copy)],
-            capture_output=True, text=True,
+            capture_output=True, text=True, encoding="utf-8",
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
         )
+    if proc.stdout is None or proc.stderr is None:
+        # Fail closed rather than let a discarded stream read as "nothing to report". A decode
+        # failure inside subprocess's capture does not always raise here -- on a platform whose
+        # pipe reader runs in a background thread (this file's own git() helper measured that on
+        # Windows: the decode fails in the READER THREAD, and the affected stream comes back None
+        # with returncode 0 rather than propagating), the exception never reaches this frame at
+        # all. The `if stream:` guard below treats `None` exactly like "the checker printed
+        # nothing", so without this check a lost read would report a CLEAN merge from a read that
+        # never happened -- strictly worse than a crash, because nothing about it looks wrong.
+        # encoding="utf-8" plus the child-side PYTHONIOENCODING above should make this
+        # unreachable in ordinary operation; this is the backstop for when it somehow is not.
+        print("error: the checker's output could not be decoded as UTF-8; refusing to report a "
+              "verdict from a partial read.", file=sys.stderr)
+        return 2
     # Rewrite the temporary path back to the real one: an error naming a file in /tmp that no longer
     # exists reads as a tooling failure rather than as a finding about your change.
     for stream, out in ((proc.stdout, sys.stdout), (proc.stderr, sys.stderr)):

--- a/prosper/tools/docs/check_merge_result.py
+++ b/prosper/tools/docs/check_merge_result.py
@@ -76,7 +76,37 @@ def git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     return proc
 
 
+def _make_own_output_utf8() -> None:
+    """Reconfigure THIS process's own stdout/stderr to UTF-8, so what this tool prints is safe
+    regardless of the ambient locale of whoever launched it.
+
+    A THIRD locale boundary, found in review of #3079 by a test that runs this tool as a real
+    subprocess on real Windows Python: the checker-invocation fix (encoding="utf-8" on the parent
+    decode, PYTHONIOENCODING=utf-8 forced into the checker's own environment) makes what THIS
+    process reads from the checker always well-formed text -- verified directly against a genuine
+    Windows Python build, not reasoned about. But this process then re-prints that text to ITS OWN
+    sys.stdout/sys.stderr (the loop a few lines below), and nothing made THOSE safe: on an
+    unconfigured Windows host, absent PYTHONIOENCODING/PYTHONUTF8 in the environment of whoever
+    ran THIS tool, they still fall back to the ANSI codepage (cp1252). Measured on real Windows
+    Python (embeddable 3.12.7, run under Wine -- close enough to a genuine Win32 process to trust
+    for this): printing an arrow (U+2192, unrepresentable in cp1252) to an unforced stdout raises
+    UnicodeEncodeError (stdout's error handler is 'strict'); the identical content on stderr does
+    NOT raise (stderr defaults to 'backslashreplace') but is silently rewritten to the literal
+    7-character text `\\u2192` instead of the glyph -- content corruption with no error at all.
+
+    Fixing the checker boundary alone therefore does not fix the whole pipeline: a message that
+    survives decode intact can still be mangled or crash on the way back OUT. `reconfigure` is
+    tolerant of streams that are not real TextIOWrapper objects (a test redirecting stdout/stderr
+    to io.StringIO has no such method) so it is a no-op there rather than an AttributeError.
+    """
+    for name in ("stdout", "stderr"):
+        reconfigure = getattr(getattr(sys, name), "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8")
+
+
 def main() -> int:
+    _make_own_output_utf8()
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--base", default="origin/master", help="branch to merge into (default origin/master)")
     ap.add_argument("--head", default="HEAD", help="what to merge (default HEAD)")

--- a/prosper/tools/docs/test_check_merge_result.py
+++ b/prosper/tools/docs/test_check_merge_result.py
@@ -203,7 +203,7 @@ sys.exit(1)
 '''
 
 
-def checker_locale_mismatch(name: str) -> None:
+def checker_locale_mismatch(name: str, *, extra_env: dict[str, str] | None = None) -> None:
     with tempfile.TemporaryDirectory() as d:
         repo = scenario(BASE, table("1:a", "2:b", "3:c", "4:master's row"),
                          table("1:a", "5:the lane's row", "2:b", "3:c"), d)
@@ -213,10 +213,35 @@ def checker_locale_mismatch(name: str) -> None:
         (lone / "check_numbered_table.py").write_text(FAKE_LOCALE_CHECKER, encoding="utf-8")
         env = dict(os.environ)
         env.pop("PYTHONIOENCODING", None)  # deterministic regardless of the invoking shell
+        # Force the AMBIENT locale away from UTF-8 without depending on which extra locales the
+        # host happens to have installed: "C" is the one locale POSIX guarantees exists
+        # everywhere (no package to install), and PYTHONCOERCECLOCALE=0 stops Python from
+        # silently promoting it back to a UTF-8 one (PEP 538); PYTHONUTF8=0 rules out UTF-8 mode
+        # too. This is what lets this ONE case catch BOTH halves of the checker-invocation fix
+        # going missing, not just one (found in review of #3169): on a host whose own ambient
+        # default already happens to be UTF-8 -- this Linux box, and most modern hosts --
+        # removing ONLY check_merge_result.py's PARENT-side `encoding="utf-8"` was invisible,
+        # because the implicit fallback (`locale.getencoding()`) landed on UTF-8 anyway by
+        # coincidence. With the ambient default forced away from UTF-8 here, that fallback
+        # lands on ASCII instead, so the mutation is caught the same way removing the
+        # CHILD-side `PYTHONIOENCODING` override already was. (On Windows this block of env
+        # vars is a no-op for the same reason it doesn't need to do anything there -- the ANSI
+        # codepage is a system setting `LC_ALL` cannot reach, and Windows CI already defaults
+        # away from UTF-8 on its own; that default is what originally surfaced #3079.)
+        env["LC_ALL"] = "C"
+        env["LANG"] = "C"
+        env["PYTHONCOERCECLOCALE"] = "0"
+        env["PYTHONUTF8"] = "0"
+        if extra_env:
+            env.update(extra_env)
         proc = subprocess.run(
             [sys.executable, str(lone / TOOL.name), "--no-fetch", "--base", "master",
              "--head", "lane"],
-            cwd=repo, capture_output=True, text=True, env=env,
+            # encoding="utf-8" on THIS decode too: check_merge_result.py now guarantees its own
+            # stdout/stderr are UTF-8 regardless of ambient locale (the reprint fix below), so
+            # the caller reading it back should rely on that guarantee explicitly rather than
+            # hoping the machine running this very test ALSO happens to default to UTF-8.
+            cwd=repo, capture_output=True, text=True, encoding="utf-8", env=env,
         )
     out = (proc.stdout or "") + (proc.stderr or "")
     if proc.stdout is None or proc.stderr is None or "UnicodeDecodeError" in out:

--- a/prosper/tools/docs/test_check_merge_result.py
+++ b/prosper/tools/docs/test_check_merge_result.py
@@ -14,6 +14,9 @@ Run directly, or via ctest as doc_merge_result_checker.
 
 from __future__ import annotations
 
+import contextlib
+import io
+import os
 import subprocess
 import sys
 import tempfile
@@ -22,6 +25,12 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 TOOL = HERE / "check_merge_result.py"
 DOC = "prosper/docs/GAME_COMPAT_ORCHESTRATION.md"
+
+sys.path.insert(0, str(HERE))
+
+import check_merge_result as cmr  # noqa: E402 -- needs the sys.path insert above it; used only by
+                                   # checker_output_undecodable, to monkeypatch subprocess.run for
+                                   # the one call it targets (#3079)
 
 FAILURES: list[str] = []
 
@@ -157,6 +166,117 @@ def cli_missing_checker(name: str) -> None:
 
 
 cli_missing_checker("a missing checker is reported as a tooling failure, not a table defect")
+
+
+# #3079: the checker invocation decodes with the locale codec, and the fix must be BOTH SIDES --
+# `encoding="utf-8"` on how THIS tool decodes the checker's captured output, and
+# `PYTHONIOENCODING=utf-8` in the checker's own environment so it actually EMITS utf-8. Forcing
+# only the parent side turns an accidental agreement (both sides silently sharing whatever the
+# ambient locale is) into a real mismatch, which is worse than doing nothing.
+#
+# The checker here is a STAND-IN, not the real check_numbered_table.py: it deterministically
+# writes UTF-8 or cp1252 bytes depending on whether PYTHONIOENCODING=utf-8 is present in its own
+# environment, so this arm does not depend on which locales happen to be installed on the machine
+# running the test -- the real defect needs a genuinely non-UTF-8 ambient locale (cp1252 on an
+# unconfigured Windows host), which nothing here can assume exists. Same substitution technique as
+# cli_missing_checker above (swap the sibling file check_merge_result.py resolves at import time).
+#
+# Verified this arm actually discriminates rather than being a same-source control that cannot
+# fail (CLAUDE.md's positive-control rule): run against a copy of this file from BEFORE #3079's fix
+# (neither encoding="utf-8" nor env=...PYTHONIOENCODING present), it crashes with a raw
+# UnicodeDecodeError; run against a ONE-SIDED fix (encoding="utf-8" added but env= left out --
+# exactly the "obvious" partial fix the issue warns against) it crashes with the SAME
+# UnicodeDecodeError. Only with both present does it pass. All three were run by hand against the
+# real subprocess plumbing (not mocked) before this test was written.
+FAKE_LOCALE_CHECKER = '''\
+import os
+import sys
+
+MESSAGE = "caf\\u00e9 row \\u2192 problem"
+
+forced_utf8 = os.environ.get("PYTHONIOENCODING", "").split(":", 1)[0].lower() == "utf-8"
+codec = "utf-8" if forced_utf8 else "cp1252"
+
+sys.stdout.buffer.write(b"\\n1 problem(s) found.\\n")
+sys.stderr.buffer.write(("error: fake:1: " + MESSAGE + "\\n").encode(codec, errors="replace"))
+sys.exit(1)
+'''
+
+
+def checker_locale_mismatch(name: str) -> None:
+    with tempfile.TemporaryDirectory() as d:
+        repo = scenario(BASE, table("1:a", "2:b", "3:c", "4:master's row"),
+                         table("1:a", "5:the lane's row", "2:b", "3:c"), d)
+        lone = Path(d) / "lone"
+        lone.mkdir()
+        (lone / TOOL.name).write_text(TOOL.read_text(encoding="utf-8"), encoding="utf-8")
+        (lone / "check_numbered_table.py").write_text(FAKE_LOCALE_CHECKER, encoding="utf-8")
+        env = dict(os.environ)
+        env.pop("PYTHONIOENCODING", None)  # deterministic regardless of the invoking shell
+        proc = subprocess.run(
+            [sys.executable, str(lone / TOOL.name), "--no-fetch", "--base", "master",
+             "--head", "lane"],
+            cwd=repo, capture_output=True, text=True, env=env,
+        )
+    out = (proc.stdout or "") + (proc.stderr or "")
+    if proc.stdout is None or proc.stderr is None or "UnicodeDecodeError" in out:
+        FAILURES.append(f"{name}: the checker's own output could not be decoded: {out[:400]!r}")
+    elif "café row → problem" not in out:
+        FAILURES.append(f"{name}: expected the checker's message intact, got {out[:400]!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+checker_locale_mismatch("a checker message with non-ASCII content survives a hostile child locale")
+
+
+# The `stdout is None` / `stderr is None` guard (#3079) is a defence for a specific PLATFORM
+# behaviour this suite cannot produce through a REAL subprocess on every OS: on a platform whose
+# pipe reader runs in a background thread (Windows -- see check_merge_result.py's own git()
+# comment, which measured this directly), a decode failure inside that thread does not raise here
+# at all -- the affected stream comes back None with returncode 0, and the guard this arm tests is
+# what stops that being reported as "no table problem found". Measured on the machine that wrote
+# this test (Linux/CPython 3.14), the equivalent mismatch instead raises UnicodeDecodeError
+# synchronously -- checker_locale_mismatch above already covers that shape for real. So this arm
+# injects the documented Windows outcome directly at the unit level (monkeypatching subprocess.run
+# for the ONE call it targets, leaving every git() call to run for real) rather than trying to
+# coerce a POSIX subprocess into a platform-specific behaviour it does not have.
+def checker_output_undecodable(name: str) -> None:
+    real_run = cmr.subprocess.run
+
+    def fake_run(cmd, *a, **kw):
+        if len(cmd) >= 2 and cmd[1] == str(cmr.CHECKER):
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout=None, stderr=None)
+        return real_run(cmd, *a, **kw)
+
+    with tempfile.TemporaryDirectory() as d:
+        repo = scenario(BASE, BASE, table("1:a", "2:b", "3:c", "4:lane"), d)
+        old_cwd = Path.cwd()
+        old_argv = sys.argv
+        cmr.subprocess.run = fake_run
+        out_buf, err_buf = io.StringIO(), io.StringIO()
+        try:
+            os.chdir(repo)
+            sys.argv = ["check_merge_result.py", "--no-fetch", "--base", "master", "--head", "lane"]
+            with contextlib.redirect_stdout(out_buf), contextlib.redirect_stderr(err_buf):
+                rc = cmr.main()
+        finally:
+            cmr.subprocess.run = real_run
+            sys.argv = old_argv
+            os.chdir(old_cwd)
+
+    out = out_buf.getvalue() + err_buf.getvalue()
+    if rc != 2:
+        FAILURES.append(f"{name}: expected rc=2, got {rc}: {out[:300]!r}")
+    elif "problem(s) found" in out or "clean merge" in out:
+        FAILURES.append(f"{name}: a None stream was reported as a real verdict: {out[:300]!r}")
+    elif "could not be decoded" not in out:
+        FAILURES.append(f"{name}: expected the fail-closed message, got {out[:300]!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+checker_output_undecodable("a checker output that cannot be decoded refuses to report a verdict")
 
 
 # Nothing to check is not a pass-by-accident: it is stated, so a caller cannot mistake "already


### PR DESCRIPTION
## Summary

`check_merge_result.py` invokes `check_numbered_table.py` as a subprocess and captures its
output with `capture_output=True, text=True` and no `encoding=`. That decodes with the **locale**
codec (cp1252 on an unconfigured Windows host). #3071 fixed the same class of bug in this file's
`git()` helper and in `trap_number.py`, and deliberately left this call alone, because a one-sided
fix here is worse than no fix at all — see the "Why a one-sided fix is worse than leaving it"
section of #3079.

## The failure scenario

Today, with neither side forced, **both** this process's decode of the checker's captured output
and the checker's own `print()` encode fall back to whatever the ambient locale is. They agree —
by accident. Adding `encoding="utf-8"` to the parent call *alone* converts that accidental
agreement into a real mismatch: the checker child would still emit bytes in the ambient locale,
and the parent would then insist on decoding them as UTF-8.

There's a second, quieter failure shape behind that: a decode failure inside `subprocess`'s
capture does not always raise. On a platform whose pipe reader runs in a background thread
(Windows — this file's own `git()` comment already measured this), the decode failure happens in
the reader thread and never propagates; the affected stream comes back `None` with `returncode 0`.
The pre-existing `if stream: out += stream` guard treats `None` exactly like "the checker printed
nothing", so a lost read would report a **clean merge** from a read that never happened — a false
"all clear" is worse than a crash, because nothing about it looks wrong.

## The fix — both sides, on the same call

```python
proc = subprocess.run(
    [sys.executable, str(CHECKER), "--ordered", "--table-header", args.table_header,
     "--baseline", str(base_copy), str(merged_copy)],
    capture_output=True, text=True, encoding="utf-8",
    env={**os.environ, "PYTHONIOENCODING": "utf-8"},
)
if proc.stdout is None or proc.stderr is None:
    print("error: the checker's output could not be decoded as UTF-8; refusing to report a "
          "verdict from a partial read.", file=sys.stderr)
    return 2
```

Concretely, "both sides" is:

- **Parent side** — `encoding="utf-8"`: this process now decodes the checker's captured
  stdout/stderr as UTF-8, unconditionally, regardless of what the ambient locale is.
- **Child side** — `env={**os.environ, "PYTHONIOENCODING": "utf-8"}`: the checker subprocess is
  told to encode its own stdout/stderr as UTF-8 too, unconditionally, regardless of the ambient
  locale it would otherwise fall back to.

Neither half alone is a fix. The parent half alone breaks the current accidental agreement (see
above). The child half alone would make the checker emit correct UTF-8 bytes, but the parent would
still be decoding with whatever *its own* ambient locale resolves to, which can independently
disagree with UTF-8.

- **The `None`-stream guard** is the defence for the "swallowed in a background thread" shape.
  With both halves of the fix above in place this should be unreachable in ordinary operation
  (the checker can only ever emit valid UTF-8 now), but it is cheap, it is explicitly what the
  issue's investigation called out, and it matches the existing defensive pattern already used by
  this file's own `git()` helper for the analogous case.

## Reproducing it by hand (before touching any code)

Built a deterministic, portable reproduction — not dependent on which locales happen to be
installed on the box running this — using a stand-in for `check_numbered_table.py` that emits
either UTF-8 or cp1252 bytes for a message containing `café row → problem`, depending on whether
`PYTHONIOENCODING=utf-8` is present in **its own** environment. Ran the real
`check_merge_result.py` against it in a real throwaway git repo (`git merge-tree`, real merge),
by hand, in three configurations:

| configuration | result |
| --- | --- |
| pre-fix (neither `encoding=` nor `env=`) | crashes: `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 ...` |
| one-sided fix (`encoding="utf-8"` only, no `env=`) | crashes with the **same** `UnicodeDecodeError` |
| both-sides fix (this PR) | `café row → problem` comes through intact, correct rc |

The one-sided case crashing identically to the unfixed case is the concrete proof that "both
sides" isn't a stylistic preference — a partial fix here buys nothing.

## Regression tests

Added two cases to `test_check_merge_result.py` (`doc_merge_result_checker` in ctest):

1. **`checker_locale_mismatch`** — the by-hand repro above, committed. Substitutes the
   deterministic stand-in checker (same technique the file's existing `cli_missing_checker` case
   already uses to swap the sibling script) so the real subprocess plumbing is exercised for real,
   without depending on host locale availability.
2. **`checker_output_undecodable`** — the platform-specific `None`-stream shape can't be produced
   through a real subprocess on Linux (confirmed by hand: the equivalent mismatch raises
   synchronously here instead of returning `None`, see the CPython source difference between the
   POSIX and Windows `_communicate` implementations), so this monkeypatches `subprocess.run` for
   the *one* call it targets — every `git()` call still runs for real — to inject exactly the
   documented Windows outcome and asserts the tool refuses to report a verdict from it.

**Verified both fail without the fix**: `git stash push -- prosper/tools/docs/check_merge_result.py`
(reverting only the fix, keeping the new tests), ran the suite — both new cases failed, reproducing
the exact `UnicodeDecodeError` crash and the exact false `"clean merge, and the merge RESULT
passes the gate..."` report the issue describes, with `rc=0`. `git stash pop` restored the fix;
re-ran — all 11 cases pass.

```
python3 prosper/tools/docs/test_check_merge_result.py
# ... all 11 cases, including the two new ones, "ok"
# all cases passed / exit 0
```

## Verification

```
python3 prosper/tools/docs/test_check_merge_result.py        # 11/11 cases, exit 0
python3 prosper/tools/docs/test_check_numbered_table.py       # unaffected; 0 skipped, all pass
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py   # rc=0, no false positives
git diff --check                                              # clean
```

This is a documentation-tooling-only change (two `.py` files under `prosper/tools/docs/`); no
`.md` file is touched, so the numbered-table gate itself is not exercised by this diff, only run
here as a sanity check that the fix introduced no regressions elsewhere.

Fixes #3079
