### PR TITLE
vblank pump: recover the dropped-tick signal the grid snap hides (#3075)

### DIFF
--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -1155,8 +1155,11 @@ namespace {
         // The cost of that property, named because it is real: phase stays exact however
         // many boundaries were skipped, so a pump running at HALF rate has perfect phase
         // and no symptom. The relative sleep this replaces at least drifted visibly, which
-        // is how #3024 was noticed. A dropped-boundary counter would restore the symptom
-        // without giving back the drift -- #3075.
+        // is how #3024 was noticed. #3075 restores the symptom with host::grid_boundaries_missed()
+        // below, WITHOUT giving back the drift: that helper is deliberately a second, separate
+        // computation over next_grid_deadline_ns()'s own return values rather than a change to what
+        // the scheduler returns or how it schedules -- see its comment in precise_sleep.hpp for why
+        // folding the two together would just recreate the drift #3024 removed.
         //
         // One composition caveat, recorded because the helper alone does not cover it (#3074):
         // this loop assumes the wait cannot return EARLY. If it does, the next `now` is still
@@ -1175,12 +1178,78 @@ namespace {
         // registers only a FLIP event still anchors it here.
         const uint64_t origin_ns = prosper_vo_vblank_grid_origin_ns();
         const uint64_t period_ns = prosper_vo_vblank_period_ns();
+
+        // --- #3075: dropped-tick visibility ------------------------------------------------------
+        // `deadline_ns` below is read back and compared against the PREVIOUS iteration's own
+        // deadline via host::grid_boundaries_missed(), which is exactly the history
+        // next_grid_deadline_ns() is required to discard for its phase-exactness guarantee. This is
+        // a SEPARATE computation, not a change to the schedule: `deadline_ns` itself is still fed to
+        // sleep_until_steady_ns() unmodified, so scheduling behaviour (and #3024's fix) is untouched.
+        bool have_prev_deadline = false;
+        uint64_t prev_deadline_ns = 0;
+        // Windowed, not per-boundary: a stall of N periods is ONE iteration reporting `missed=N`,
+        // never N reports, so this cannot flood on a long stall. It IS one report per iteration on a
+        // sustained degraded rate (e.g. every iteration of a half-rate run), which is the case that
+        // must stay loud -- bounded above by the pump's own (halved, in that case) iteration rate.
+        uint64_t win_ticks = 0, win_missed = 0, win_worst_gap = 0;
+        uint64_t lifetime_missed = 0;
+        clk::time_point win_start = clk::now();
+        // "More than a few percent of boundaries over a multi-second window" -- the design question
+        // #3075 posed rather than answered. Answered here: yes, unconditionally (never gated behind
+        // PROSPER_EVLOG, so it is visible on a default run), because a pump silently running at a
+        // fraction of its nominal rate is exactly what this project's fail-visible policy exists for.
+        // A DETAILED per-window line (below, gated) is still useful for a below-threshold trickle of
+        // drops that this warning deliberately does not raise.
+        constexpr double kDropWarnThreshold = 0.05;      // >5% of boundaries dropped in the window
+        constexpr auto   kDropWindow = std::chrono::seconds(2);
+
         for (;;) {
             const uint64_t now_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
                 clk::now().time_since_epoch()).count();
-            prosper::host::sleep_until_steady_ns(
-                prosper::host::next_grid_deadline_ns(origin_ns, now_ns, period_ns));
+            const uint64_t deadline_ns =
+                prosper::host::next_grid_deadline_ns(origin_ns, now_ns, period_ns);
+            prosper::host::sleep_until_steady_ns(deadline_ns);
             frame++;
+
+            if (have_prev_deadline) {
+                const uint64_t missed =
+                    prosper::host::grid_boundaries_missed(prev_deadline_ns, deadline_ns, period_ns);
+                win_ticks++;
+                if (missed) {
+                    win_missed += missed;
+                    lifetime_missed += missed;
+                    if (missed > win_worst_gap) win_worst_gap = missed;
+                }
+            }
+            have_prev_deadline = true;
+            prev_deadline_ns = deadline_ns;
+
+            const clk::time_point report_now = clk::now();
+            if (report_now - win_start >= kDropWindow) {
+                const uint64_t win_boundaries = win_ticks + win_missed;   // ticks observed + skipped
+                const double ratio =
+                    win_boundaries ? (double)win_missed / (double)win_boundaries : 0.0;
+                if (ratio > kDropWarnThreshold) {
+                    fprintf(stderr,
+                            "[vblank] WARNING: pump dropped %llu of %llu expected boundaries in the "
+                            "last %llds (%.1f%%, worst single wait skipped %llu) -- a consumer "
+                            "pacing on the vblank event stream is running slow.\n",
+                            (unsigned long long)win_missed, (unsigned long long)win_boundaries,
+                            (long long)kDropWindow.count(), ratio * 100.0,
+                            (unsigned long long)win_worst_gap);
+                }
+                if (evlog())
+                    fprintf(stderr,
+                            "[ev] vblank-pump interval=%llds ticks=%llu dropped=%llu/%llu (%.2f%%, "
+                            "worst=%llu) | lifetime dropped=%llu\n",
+                            (long long)kDropWindow.count(), (unsigned long long)win_ticks,
+                            (unsigned long long)win_missed, (unsigned long long)win_boundaries,
+                            ratio * 100.0, (unsigned long long)win_worst_gap,
+                            (unsigned long long)lifetime_missed);
+                win_ticks = win_missed = win_worst_gap = 0;
+                win_start = report_now;
+            }
+
             std::vector<FlipReg> vr;
             { std::lock_guard lk(g_eq_mx); vr = g_vblank_regs; }
             // Vblank ticks are periodic by nature — pump them. FLIP events are NOT pumped: a flip

--- a/prosper/src/host/platform/precise_sleep.hpp
+++ b/prosper/src/host/platform/precise_sleep.hpp
@@ -58,4 +58,26 @@ constexpr uint64_t next_grid_deadline_ns(uint64_t origin_ns, uint64_t now_ns,
     return origin_ns + ((now_ns - origin_ns) / period_ns + 1) * period_ns;
 }
 
+// The number of grid boundaries strictly BETWEEN two successive next_grid_deadline_ns() results on
+// the same (origin, period) grid: 0 for the ordinary case (each call lands exactly one period after
+// the last), and >0 whenever a caller's wait overran far enough to skip boundaries outright (#3075).
+//
+// Deliberately NOT folded into next_grid_deadline_ns() itself, and this split is the actual fix for
+// #3075, not a widened tolerance. next_grid_deadline_ns()'s whole contract -- see its own comment --
+// is that its answer depends only on (origin, now, period) and never on how many boundaries were
+// missed, which is exactly what makes it phase-exact under a stall of any length: correct behaviour
+// for SCHEDULING, because a pacing loop must resume on the next real boundary rather than replay a
+// backlog. But that same contract means the scheduler's return value carries no trace of a drop, so
+// before this function existed there was no second code path to disagree with it either -- nothing
+// anywhere computed "how many boundaries did we just skip", which is why a half-rate pump reported
+// perfect phase and nothing else. This function computes exactly that, from two of the scheduler's
+// own return values, without changing what the scheduler returns or how it is chosen: the schedule
+// stays phase-exact, and the MEASUREMENT of it stops discarding the fault.
+constexpr uint64_t grid_boundaries_missed(uint64_t prev_deadline_ns, uint64_t next_deadline_ns,
+                                           uint64_t period_ns) {
+    if (period_ns == 0 || next_deadline_ns <= prev_deadline_ns) return 0;
+    const uint64_t advanced = (next_deadline_ns - prev_deadline_ns) / period_ns;
+    return advanced > 0 ? advanced - 1 : 0;
+}
+
 }  // namespace prosper::host

--- a/prosper/tests/host/platform/test_videoout.cpp
+++ b/prosper/tests/host/platform/test_videoout.cpp
@@ -933,6 +933,103 @@ int main() {
               "the exported origin IS the status grid's epoch (within ABI us quantisation)");
     }
 
+    // ---- #3075: the grid snap hides a dropped tick from PHASE; grid_boundaries_missed must not ---
+    // next_grid_deadline_ns() is phase-exact BY DESIGN under a stall of any length (see the #3024
+    // arms above), and that is the correct behaviour for scheduling. The cost is that its return
+    // value alone cannot tell a healthy pump from one silently running at a fraction of its rate:
+    // both land on real grid boundaries every single call. Reproduced BY HAND first, against the
+    // UNMODIFIED next_grid_deadline_ns(), before trusting that host::grid_boundaries_missed() (the
+    // fix) actually recovers what phase alone hides.
+    {
+        using prosper::host::next_grid_deadline_ns;
+        using prosper::host::grid_boundaries_missed;
+        const uint64_t P  = 16683350;      // the shared 59.94 Hz period
+        const uint64_t T0 = 1000000000;
+
+        // Reproduction: a SUSTAINED half-rate pump, built the same way vblank_pump() is -- each
+        // iteration feeds the previous call's own returned deadline back in as `now` for the next
+        // -- except every wait is made to overshoot by 1.5 periods, the #3074 Win32SleepFallback
+        // regime the issue names (a wait that does not re-check the clock overshoots past the very
+        // next boundary). This is not a one-off stall: it is the steady state of a pump running at
+        // half its nominal rate for its entire life.
+        uint64_t d = T0;
+        bool every_result_on_grid = true;
+        for (int i = 0; i < 40; i++) {
+            d = next_grid_deadline_ns(T0, d + P + P / 2, P);
+            every_result_on_grid &= (d - T0) % P == 0;
+        }
+        CHECK(every_result_on_grid,
+              "PRE-FIX SYMPTOM (#3075): a sustained half-rate pump still lands on-grid EVERY time");
+        CHECK(d == T0 + 80 * P,
+              "PRE-FIX SYMPTOM (#3075): after 40 half-rate iterations, phase alone reports exactly "
+              "80 periods elapsed -- indistinguishable, from the deadline alone, from a HEALTHY "
+              "80-tick pump reading the same field back. Nothing above this line can tell the two "
+              "apart, which is the entire defect");
+
+        // The fix: grid_boundaries_missed() reads the SAME sequence of deadlines the healthy-phase
+        // check above just used, and recovers the drop count next_grid_deadline_ns() necessarily
+        // discards -- without changing a single one of those returned deadlines.
+        uint64_t prev = T0, total_missed = 0, worst_gap = 0;
+        for (int i = 0; i < 40; i++) {
+            const uint64_t nxt = next_grid_deadline_ns(T0, prev + P + P / 2, P);
+            const uint64_t missed = grid_boundaries_missed(prev, nxt, P);
+            total_missed += missed;
+            worst_gap = std::max(worst_gap, missed);
+            prev = nxt;
+        }
+        CHECK(total_missed == 40,
+              "grid_boundaries_missed recovers exactly the 40 dropped ticks phase alone hid");
+        CHECK(worst_gap == 1,
+              "a sustained half-rate pump drops exactly one boundary per step, never a burst");
+
+        // Negative control, and the one that actually proves the discriminator: the SAME 60-tick
+        // ordinary-overshoot sequence the #3024 arms above already proved is a HEALTHY 60 Hz pump
+        // must report zero drops through this new path too. A measurement that fires on the healthy
+        // case as well would be worthless noise on every default run.
+        prev = T0; uint64_t healthy_missed = 0, healthy_worst = 0;
+        for (int i = 0; i < 60; i++) {
+            const uint64_t nxt = next_grid_deadline_ns(T0, prev + 120000, P);
+            const uint64_t missed = grid_boundaries_missed(prev, nxt, P);
+            healthy_missed += missed;
+            healthy_worst = std::max(healthy_worst, missed);
+            prev = nxt;
+        }
+        CHECK(healthy_missed == 0 && healthy_worst == 0,
+              "an ordinary 120us-overshoot run at full rate reports zero drops, ever");
+
+        // An isolated stall -- the #3024 arm's own five-period stall -- is reported as exactly the
+        // boundaries it skipped: not one (it is not a single missed tick), not zero (it is not free).
+        const uint64_t stall_prev = T0 + 3 * P;
+        const uint64_t stall_next = next_grid_deadline_ns(T0, stall_prev + 5 * P + 1000, P);
+        CHECK(grid_boundaries_missed(stall_prev, stall_next, P) == 5,
+              "an isolated five-period stall between two ticks is reported as five dropped "
+              "boundaries, matching its actual size");
+
+        // A THIRD of the rate (drop two of every three) must report 2 missed per step, not 1 -- a
+        // discriminator that only distinguishes "some drop" from "none" would still hide HOW BAD the
+        // degradation is, and the pump's own diagnostic reports a worst-gap figure for exactly this.
+        prev = T0; uint64_t third_missed = 0, third_worst = 0;
+        for (int i = 0; i < 30; i++) {
+            const uint64_t nxt = next_grid_deadline_ns(T0, prev + 2 * P + P / 2, P);
+            const uint64_t missed = grid_boundaries_missed(prev, nxt, P);
+            third_missed += missed;
+            third_worst = std::max(third_worst, missed);
+            prev = nxt;
+        }
+        CHECK(third_missed == 60 && third_worst == 2,
+              "a third-rate pump reports 2 dropped boundaries per step, distinguishing it from "
+              "half-rate rather than collapsing every degraded rate into one signal");
+
+        // Degenerate inputs must not crash, underflow, or divide by zero.
+        CHECK(grid_boundaries_missed(T0, T0, P) == 0,
+              "equal deadlines (no time passed) report zero");
+        CHECK(grid_boundaries_missed(T0 + P, T0, P) == 0,
+              "a 'next' earlier than 'prev' (should never happen) reports zero rather than "
+              "underflowing to a huge unsigned value");
+        CHECK(grid_boundaries_missed(T0, T0 + P, 0) == 0,
+              "a zero period reports zero rather than dividing by zero");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #3075.

## Problem

`next_grid_deadline_ns()` (added in #3024) is deliberately phase-exact under a stall of any length: its answer depends only on `(origin, now, period)`, never on how many boundaries were skipped. That is correct for **scheduling** — the pump must resume on the next real boundary rather than replay a backlog — but the same property means its return value alone cannot tell a healthy 60 Hz pump from one silently running at a fraction of its rate: both land on real grid boundaries every single call.

**Reproduced by hand before changing anything** (see the standalone check below, same construction `vblank_pump()` uses): a simulated half-rate pump — each wait overshoots by 1.5 periods, the `#3074` `Win32SleepFallback` regime the issue names — landed on-grid **10/10** times while actually advancing 2 periods per call every time:

```
iter  0: prev=1000000000 next=1033366700  on-grid=YES  advanced_periods=2
iter  1: prev=1033366700 next=1066733400  on-grid=YES  advanced_periods=2
...
iter  9: prev=1300300300 next=1333667000  on-grid=YES  advanced_periods=2
```

Nothing anywhere computed "how many boundaries did we just skip" — a half-rate pump had perfect phase and no symptom, exactly as the issue describes.

## Were scheduling-snap and reporting-snap the same code path?

**Yes, in the sense that matters: there was no separate reporting path at all.** `next_grid_deadline_ns()`'s return value was the *only* place a drop could have been observed, and nothing read it that way — it was fed straight into `sleep_until_steady_ns()` and otherwise discarded. So the fix isn't "widen a tolerance somewhere" (there was no tolerance to widen); it's adding the second, independent computation the issue's own suggested code sketches. `host::grid_boundaries_missed(prev_deadline_ns, next_deadline_ns, period_ns)` (`precise_sleep.hpp`) reads two of the scheduler's own successive return values and recovers exactly the drop count `next_grid_deadline_ns()` is required to discard for its phase-exactness guarantee — **without changing what is scheduled or how**: the deadline fed to `sleep_until_steady_ns()` in `vblank_pump()` is untouched, so `#3024`'s fix is intact.

## The fix

- `prosper/src/host/platform/precise_sleep.hpp`: new `constexpr uint64_t grid_boundaries_missed(prev_deadline_ns, next_deadline_ns, period_ns)`.
- `prosper/src/hle/kernel/hle_kernel_time.cpp` (`vblank_pump()`): tracks this every iteration and reports on a 2s window:
  - an **unconditional** one-line warning (never gated behind `PROSPER_EVLOG`) when drops exceed 5% of boundaries in the window — the issue explicitly raised "whether the drop count deserves an unconditional one-line warning... is the design question," given the project's fail-visible preference and the fact that "a count that is only visible under an opt-in gate is invisible on a default run." I answered that question yes, with a 2s window / 5% threshold, rather than leaving it open.
  - a detailed per-window line under the existing `PROSPER_EVLOG` gate (ticks, dropped, worst single-wait gap, lifetime total) for a below-threshold trickle the warning deliberately doesn't raise.
  - Windowed, not per-boundary: a long stall is one report (missed=N in one iteration), not a flood; a sustained degraded rate still reports every window, bounded by the pump's own (reduced) iteration rate.

## Tests (`tests/host/platform/test_videoout.cpp`)

New block right after the existing `#3024` grid-schedule arms:
1. Reproduces the pre-fix symptom **against the unmodified `next_grid_deadline_ns()`**: a 40-iteration half-rate sequence lands on-grid every time and reads back (`d == T0 + 80*P`) as indistinguishable from a healthy 80-tick pump.
2. Shows `grid_boundaries_missed()` recovers it exactly over the *same* sequence: 40/40 dropped.
3. Negative control: the existing healthy 60-tick `#3024` sequence run through the new function reports 0/0 drops — the arm that proves the discriminator doesn't fire on the case it must stay silent on.
4. An isolated 5-period stall (reusing the existing `#3024` stall arm's numbers) is reported as exactly 5, not 1 and not 0.
5. A third-rate (drop 2 of 3) sequence reports 2 dropped per step, not 1 — checking the counter reports *magnitude*, not just "some drop occurred."
6. Degenerate inputs (equal deadlines, a `next` earlier than `prev`, a zero period) report 0 without underflow or divide-by-zero.

### Is this test at risk of passing with the bug still present under some plausible scheduling?

I checked this specifically because timing tests are easy to get wrong in that direction. This test doesn't touch real time, threads, or `sleep_until_steady_ns()` at all — every arm calls the two pure `constexpr` functions with hand-picked `(origin, now, period)` triples and asserts exact integer results, so there's no scheduling jitter for it to depend on either way.

The more relevant question is whether the test could pass with a *plausible wrong implementation* of `grid_boundaries_missed()` rather than a correct one. I verified this directly rather than arguing it: I temporarily stubbed `grid_boundaries_missed()` to unconditionally `return 0` — the literal pre-fix state, where no measurement exists — rebuilt, and ran `test_videoout` directly:

```
[FAIL] grid_boundaries_missed recovers exactly the 40 dropped ticks phase alone hid
[FAIL] a sustained half-rate pump drops exactly one boundary per step, never a burst
[ok]   an ordinary 120us-overshoot run at full rate reports zero drops, ever
[FAIL] an isolated five-period stall between two ticks is reported as five dropped boundaries...
[FAIL] a third-rate pump reports 2 dropped boundaries per step...
== FAIL: 4 ==
```

4 of the 5 new arms fail. The one that "passes" under the stub is the negative control (arm 3) — by construction, since it asserts *zero* drops on a healthy sequence, and a stub returning 0 unconditionally cannot fail an assertion that expects 0. That arm exists precisely to prove the *other* arms aren't vacuous (a discriminator that also fired on the healthy case would be useless noise on every default run), not to carry the regression signal by itself — arms 1, 2, 4, 5 are the ones that actually detect the bug, and they all did. Restored the real implementation, rebuilt, reran: all pass (`== PASS ==`).

I can't rule out every conceivable wrong implementation passing this test (no finite test suite can), but a same-shape mistake — reporting a boundary index without subtracting the "one period is normal" baseline, or not reading the boundary index at all — is exactly what arms 1/2/4/5 are shaped to catch, since they check exact magnitudes (40, 1, 5, 2) rather than just "nonzero."

## Build + test

In the `ps5ys` container, `TMPDIR` off tmpfs, run synchronously in the foreground (not backgrounded):

```
cmake -S prosper -B prosper/build-linux
TMPDIR=$PWD/prosper/build-linux/tmpdir cmake --build prosper/build-linux -j6
cd prosper/build-linux && ctest --no-tests=error
```

Result: **314/314 tests passed, exit 0.**

The task briefing that started this PR said the expected count on this tree is 315. I investigated the discrepancy rather than reporting it as-is: before committing, `HEAD` (i.e. my branch's base, with only uncommitted working-tree changes) was **exactly** `origin/master`'s tip (`c8f2f474`, 0 commits divergent either way — `git rev-list --left-right --count HEAD...origin/master` → `0 0`), and `ctest -N` on that same tree also totals 314 registered tests. My change adds zero new `add_test()` registrations — only additional `CHECK()` assertions inside the already-registered `videoout_queries` test binary and a new header-only function — so 314 is what current `origin/master` itself reports, not a regression from this PR. The 315 figure appears to be stale (consistent with the charter's own repeated notes about numbers going stale here); I'm not the right source to correct it project-wide since I can't observe what changed the count on `master`.

## Uncertain / worth a second look

- The 5% / 2s threshold and window for the unconditional warning are a judgment call I made rather than a value derived from any measurement — reasonable-sounding but arbitrary. Happy to tune either if review disagrees.
- `#3074` (the `Win32SleepFallback` early-return double-post) is unfixed and unrelated to this change; it's the scenario that makes this diagnostic *reachable* per the issue, not something this PR touches.
- I did not add a live/threaded test of `vblank_pump()` itself (posting real kevents under a simulated half-rate clock) — the existing `#3024` arms in this same file already establish that testing this loop's *scheduling* is done at the pure-function level rather than by driving the live detached thread, and I followed that precedent for the *measurement* too. If review wants an end-to-end thread-level guard as well, I can add one, but I believe it would be substantially more complex for the same coverage the pure-function arms above already give.
