### PR TITLE
recompiler: keep [mimg-unresolved] visible under PROSPER_MIMG_SOFT (#3143)

### DIFF
--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -6948,41 +6948,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // Ungated, and deduped per (pc, srsrc). It fires only when an image op has already
                 // failed to resolve, so its volume is bounded by the defect it reports. Behind
                 // PROSPER_DBG it was unreachable in practice on any routed boot.
-            // PROSPER_MIMG_SOFT=1 -- diagnostic only, and deliberately WRONG output.
-            //
-            // Placed BEFORE the reporting dedupe below on purpose. That dedupe fires once per
-            // (program, pc, srsrc); downstream of it, only the FIRST compile of each site would be
-            // softened and every later one -- reachable through ordinary shader-cache eviction --
-            // would take the reject path unchanged. The recorded result would then be
-            // indistinguishable from "nothing was softened", which is exactly the reading this
-            // diagnostic exists to produce. When an image
-            // op cannot resolve its descriptor, write a constant instead of failing the stage, so a
-            // frame can be seen that would otherwise be discarded entirely. It answers one question
-            // nothing else here can: how much of the picture is riding on THIS resolution failure.
-            // On Stray it showed the answer was "none" -- the composite compiled and the frame did
-            // not change -- which is what redirected #3126 away from the recompiler.
-            //
-            // Never acceptable in a run that produces progression evidence: every unresolved sample
-            // reads a flat value.
-            if (!res && getenv("PROSPER_MIMG_SOFT")) {
-                const uint32_t soft = b.uconst(fbits(0.5f));
-                uint32_t comps = 0;
-                for (uint32_t m = 0; m < 4; ++m) if (in.mimg_dmask & (1u << m)) ++comps;
-                if (!comps) comps = 1;
-                for (uint32_t k = 0; k < comps; ++k) {
-                    const int dst = in.dst.value + static_cast<int>(k);
-                    if (dst < 0) break;
-                    const uint32_t old = vreg_old(b, rs, dst);
-                    rs.vreg[dst] = soft;
-                    predicate_write(b, rs, dst, old);
-                }
-                static std::mutex smx; static std::set<uint64_t> sseen;
-                std::lock_guard<std::mutex> lk(smx);
-                if (sseen.insert(((uint64_t)b.diagnostic.program_address << 16) | in.pc).second)
-                    fprintf(stderr, "[mimg-soft] program=0x%llx pc=%u -> constant %u comps\n",
-                            (unsigned long long)b.diagnostic.program_address, in.pc, comps);
-                return true;
-            }
+                //
+                // #3143: this report used to sit downstream of the PROSPER_MIMG_SOFT early return
+                // below, so arming that switch to see whether softening changes a frame ALSO deleted
+                // the one line that names which descriptor failed -- the switch was least informative
+                // exactly when it was armed for its intended purpose ("softening changed nothing"
+                // became indistinguishable from "there was nothing here to soften"). It now runs
+                // before either the soft or the reject path decides what to DO about the failure, so
+                // both keep the same descriptor identification; the soft path still gets its own
+                // confirmation line below ([mimg-soft]) once the constant is written.
                 static std::mutex mimg_mutex;
                 // Keyed by PROGRAM as well as (pc, srsrc): every shader has a pc 16, so a
                 // pc-only key lets the first program to reach one silence all later programs and
@@ -6994,35 +6968,35 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     first_report = mimg_reported.emplace(b.diagnostic.program_address, in.pc,
                                                          in.src[1].value).second;
                 }
-                if (!first_report) { ok = false; return true; }
-                uint32_t srt_tag = 0;
-                const bool has_srt_tag = sreg_srt_range_tag(rs, in.src[1].value, 8, srt_tag);
-                const ShaderResource* pk = has_srt_tag ? rt->by_srt_offset(srt_tag) : nullptr;
-                const ShaderResource* pp = rt->by_fetch_pc(in.pc);
-                // Report the copy-alias step too. Without it a staged descriptor (#1773) and a
-                // genuinely absent one print the identical line, which is the output-vs-input
-                // confusion that cost #1590 several sessions -- name which provenance route failed.
-                int ud_origin = 0;
-                const bool has_ud_alias = sreg_range_ud_alias(rs, in.src[1].value, 8, ud_origin);
-                const ShaderResource* pa = has_ud_alias ? rt->by_sgpr_base(ud_origin) : nullptr;
-                fprintf(stderr, "[mimg-unresolved] program=0x%llx pc=%u op=0x%02x storage=%d srsrc=s%d srt_tag=%s0x%x key_res=%s pc_res=%s ud_alias=%s%d alias_res=%s written=%d (%zu res)\n",
-                        (unsigned long long)b.diagnostic.program_address,
-                        in.pc, in.opcode, (int)storage_only_op,
-                        in.src[1].value, has_srt_tag ? "" : "NONE ",
-                        has_srt_tag ? srt_tag : 0u,
-                        pk ? (pk->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
-                        pp ? (pp->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
-                        has_ud_alias ? "s" : "NONE ", has_ud_alias ? ud_origin : 0,
-                        pa ? (pa->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
-                        sreg_range_written(rs, in.src[1].value, 8) ? 1 : 0,
-                        rt->resources.size());
-                // #3126: say what WAS available, not only what failed. "key_res=null pc_res=null"
-                // tells you the lookups missed; it does not tell you whether the table holds the
-                // descriptor under a different key, holds it classified as something else, or does
-                // not hold it at all -- and those are three different bugs. Print every resource's
-                // class and provenance so the miss can be diagnosed from one line instead of a
-                // rebuild. Bounded, and only on a reject.
-                {
+                if (first_report) {
+                    uint32_t srt_tag = 0;
+                    const bool has_srt_tag = sreg_srt_range_tag(rs, in.src[1].value, 8, srt_tag);
+                    const ShaderResource* pk = has_srt_tag ? rt->by_srt_offset(srt_tag) : nullptr;
+                    const ShaderResource* pp = rt->by_fetch_pc(in.pc);
+                    // Report the copy-alias step too. Without it a staged descriptor (#1773) and a
+                    // genuinely absent one print the identical line, which is the output-vs-input
+                    // confusion that cost #1590 several sessions -- name which provenance route failed.
+                    int ud_origin = 0;
+                    const bool has_ud_alias = sreg_range_ud_alias(rs, in.src[1].value, 8, ud_origin);
+                    const ShaderResource* pa = has_ud_alias ? rt->by_sgpr_base(ud_origin) : nullptr;
+                    fprintf(stderr, "[mimg-unresolved] program=0x%llx pc=%u op=0x%02x storage=%d srsrc=s%d srt_tag=%s0x%x key_res=%s pc_res=%s ud_alias=%s%d alias_res=%s written=%d (%zu res)\n",
+                            (unsigned long long)b.diagnostic.program_address,
+                            in.pc, in.opcode, (int)storage_only_op,
+                            in.src[1].value, has_srt_tag ? "" : "NONE ",
+                            has_srt_tag ? srt_tag : 0u,
+                            pk ? (pk->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
+                            pp ? (pp->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
+                            has_ud_alias ? "s" : "NONE ", has_ud_alias ? ud_origin : 0,
+                            pa ? (pa->cls == ResourceClass::Texture ? "tex" : "other-cls") : "null",
+                            sreg_range_written(rs, in.src[1].value, 8) ? 1 : 0,
+                            rt->resources.size());
+                    // #3126: say what WAS available, not only what failed. "key_res=null pc_res=null"
+                    // tells you the lookups missed; it does not tell you whether the table holds the
+                    // descriptor under a different key, holds it classified as something else, or does
+                    // not hold it at all -- and those are three different bugs. Print every resource's
+                    // class and provenance so the miss can be diagnosed from one line instead of a
+                    // rebuild. Bounded, and printed once per site regardless of whether the site is
+                    // then softened or rejected (#3143).
                     std::string avail;
                     size_t shown = 0;
                     for (const ShaderResource& r : rt->resources) {
@@ -7043,6 +7017,43 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     fprintf(stderr, "[mimg-unresolved]   available:%s\n",
                             avail.empty() ? " (none)" : avail.c_str());
                 }
+
+                // PROSPER_MIMG_SOFT=1 -- diagnostic only, and deliberately WRONG output.
+                //
+                // Placed BEFORE the reject gate below on purpose. That gate fires once per
+                // (program, pc, srsrc); downstream of it, only the FIRST compile of each site would be
+                // softened and every later one -- reachable through ordinary shader-cache eviction --
+                // would take the reject path unchanged. The recorded result would then be
+                // indistinguishable from "nothing was softened", which is exactly the reading this
+                // diagnostic exists to produce. When an image
+                // op cannot resolve its descriptor, write a constant instead of failing the stage, so a
+                // frame can be seen that would otherwise be discarded entirely. It answers one question
+                // nothing else here can: how much of the picture is riding on THIS resolution failure.
+                // On Stray it showed the answer was "none" -- the composite compiled and the frame did
+                // not change -- which is what redirected #3126 away from the recompiler.
+                //
+                // Never acceptable in a run that produces progression evidence: every unresolved sample
+                // reads a flat value.
+                if (!res && getenv("PROSPER_MIMG_SOFT")) {
+                    const uint32_t soft = b.uconst(fbits(0.5f));
+                    uint32_t comps = 0;
+                    for (uint32_t m = 0; m < 4; ++m) if (in.mimg_dmask & (1u << m)) ++comps;
+                    if (!comps) comps = 1;
+                    for (uint32_t k = 0; k < comps; ++k) {
+                        const int dst = in.dst.value + static_cast<int>(k);
+                        if (dst < 0) break;
+                        const uint32_t old = vreg_old(b, rs, dst);
+                        rs.vreg[dst] = soft;
+                        predicate_write(b, rs, dst, old);
+                    }
+                    static std::mutex smx; static std::set<uint64_t> sseen;
+                    std::lock_guard<std::mutex> lk(smx);
+                    if (sseen.insert(((uint64_t)b.diagnostic.program_address << 16) | in.pc).second)
+                        fprintf(stderr, "[mimg-soft] program=0x%llx pc=%u -> constant %u comps\n",
+                                (unsigned long long)b.diagnostic.program_address, in.pc, comps);
+                    return true;
+                }
+                if (!first_report) { ok = false; return true; }
             }
             if (!res) { ok = false; return true; }
             const bool uint_texture = res->format == DataFormat::Uint8 ||

--- a/prosper/tests/gpu/test_recompile_coverage.cpp
+++ b/prosper/tests/gpu/test_recompile_coverage.cpp
@@ -8,13 +8,58 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstdio>
+#include <string>
 #include <vector>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace prosper::gpu;
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
+
+#ifdef _WIN32
+static int test_fileno(FILE* stream) { return _fileno(stream); }
+static int test_dup(int descriptor) { return _dup(descriptor); }
+static int test_dup2(int source, int destination) { return _dup2(source, destination); }
+static void test_close(int descriptor) { _close(descriptor); }
+#else
+static int test_fileno(FILE* stream) { return fileno(stream); }
+static int test_dup(int descriptor) { return dup(descriptor); }
+static int test_dup2(int source, int destination) { return dup2(source, destination); }
+static void test_close(int descriptor) { close(descriptor); }
+#endif
+
+// Redirects stderr to a temp file for the duration of `action`, then returns everything written to
+// it. Used by the #3143 regression below to see whether [mimg-unresolved] survives PROSPER_MIMG_SOFT.
+template <typename Fn>
+static std::string capture_stderr(Fn&& action) {
+    FILE* capture = std::tmpfile();
+    if (!capture) return {};
+    std::fflush(stderr);
+    const int stderr_fd = test_fileno(stderr);
+    const int saved_fd = test_dup(stderr_fd);
+    if (saved_fd < 0 || test_dup2(test_fileno(capture), stderr_fd) < 0) {
+        if (saved_fd >= 0) test_close(saved_fd);
+        std::fclose(capture);
+        return {};
+    }
+    action();
+    std::fflush(stderr);
+    test_dup2(saved_fd, stderr_fd);
+    test_close(saved_fd);
+    std::rewind(capture);
+    std::string output;
+    char chunk[2048];
+    while (const size_t bytes = std::fread(chunk, 1, sizeof(chunk), capture))
+        output.append(chunk, bytes);
+    std::fclose(capture);
+    return output;
+}
 
 int main() {
     printf("== test_recompile_coverage ==\n");
@@ -2982,6 +3027,67 @@ int main() {
     CHECK(typed_pcrel_folds(pcrel_table_vs_typed_branch_entry,
                             std::size(pcrel_table_vs_typed_branch_entry)) == 0,
           "detector: a branch entering after the s_getpc is refused (#2862)");
+
+    // #3143: PROSPER_MIMG_SOFT must not blind the operator to WHICH descriptor failed to resolve.
+    // [mimg-unresolved] is the only diagnostic that names the failing srsrc/provenance; it used to be
+    // printed only downstream of the soft path's own early return, so arming the switch to see
+    // whether softening changes a frame ALSO deleted the one line that would say what got softened.
+    // Build a program whose single MIMG op cannot resolve against an empty resource table (no
+    // fetch-pc key, no SRT tag, and the SRSRC range was never written so the sgpr_base fallback also
+    // misses), and prove [mimg-unresolved] survives PROSPER_MIMG_SOFT while [mimg-soft] -- the
+    // existing confirmation that a constant was substituted -- keeps firing too.
+    {
+        const uint32_t mimg_unresolved_probe[] = {
+            0x7E080300u,               // v_mov_b32 v4, v0 (1D image coordinate)
+            0xF0000F00u, 0x00000004u,  // image_load v[0:3], v4, s[0:7], dmask:0xf dim:1D
+            0xBF810000u,               // s_endpgm
+        };
+        ShaderResourceTable empty_rt; // deliberately no resources: s[0:7] resolves to nothing.
+        ComputeShaderConfig probe_config;
+        probe_config.user_sgprs.resize(16);
+
+        // Reject path (PROSPER_MIMG_SOFT unset): a sanity check that the reordering in emit_alu.cpp
+        // did not also break the reject path's own (pre-existing) reporting.
+#ifdef _WIN32
+        _putenv_s("PROSPER_MIMG_SOFT", "");
+#else
+        unsetenv("PROSPER_MIMG_SOFT");
+#endif
+        const std::string reject_log = capture_stderr([&] {
+            std::vector<uint32_t> spv = recompile_compute(
+                mimg_unresolved_probe, std::size(mimg_unresolved_probe), &empty_rt, probe_config,
+                RecompileDiagnosticContext{RecompileDiagnosticStage::Compute, 0x3143a1ull});
+            CHECK(spv.empty(), "an unresolved MIMG descriptor rejects the compile");
+        });
+        CHECK(reject_log.find("[mimg-unresolved]") != std::string::npos,
+              "reject path reports which descriptor failed to resolve (sanity)");
+
+        // Soft path (PROSPER_MIMG_SOFT=1): the switch must still soften (compile succeeds AND
+        // [mimg-soft] confirms the substitution, both unchanged), but [mimg-unresolved] must now
+        // ALSO appear -- this is the exact assertion that fails without the #3143 fix, since the old
+        // code returned from the soft branch before ever reaching that report.
+#ifdef _WIN32
+        _putenv_s("PROSPER_MIMG_SOFT", "1");
+#else
+        setenv("PROSPER_MIMG_SOFT", "1", 1);
+#endif
+        const std::string soft_log = capture_stderr([&] {
+            std::vector<uint32_t> spv = recompile_compute(
+                mimg_unresolved_probe, std::size(mimg_unresolved_probe), &empty_rt, probe_config,
+                RecompileDiagnosticContext{RecompileDiagnosticStage::Compute, 0x3143a2ull});
+            CHECK(!spv.empty(), "PROSPER_MIMG_SOFT still substitutes a constant and compiles");
+        });
+#ifdef _WIN32
+        _putenv_s("PROSPER_MIMG_SOFT", "");
+#else
+        unsetenv("PROSPER_MIMG_SOFT");
+#endif
+        CHECK(soft_log.find("[mimg-soft]") != std::string::npos,
+              "PROSPER_MIMG_SOFT still confirms it substituted a constant (unchanged behaviour)");
+        CHECK(soft_log.find("[mimg-unresolved]") != std::string::npos,
+              "#3143: PROSPER_MIMG_SOFT must not suppress [mimg-unresolved] -- the failing "
+              "descriptor must stay identifiable even when the failure is softened");
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
## Summary

`PROSPER_MIMG_SOFT` softens an unresolved MIMG descriptor by substituting a
constant instead of rejecting the compile, so an investigator can see how
much of a frame depends on that one resolution failure. But its early
return sat upstream of the `[mimg-unresolved]` report — the only diagnostic
that names *which* descriptor failed to resolve (srsrc, SRT tag, fetch-pc,
UD-alias provenance, and the full resource table). So arming the switch to
answer "does softening change this frame?" also deleted the one line that
would say what got softened, and "softening changed nothing" became
indistinguishable from "there was nothing here to soften" — the exact
ambiguity the switch exists to resolve. Raised as non-blocking finding N3 in
review of #3141 and deliberately left out of that PR since it's a
behavioural change to logging.

## Root cause

In `prosper/src/gpu/recompiler/rdna2_emit_alu.cpp`'s MIMG resolution-failure
path, the `PROSPER_MIMG_SOFT` branch `return true`s before the code reaches
the `[mimg-unresolved]` report a few lines below it. That ordering was
intentional for a different reason: the report is gated by a per-site
dedupe (`(program, pc, srsrc)`), and the soft path had to sit *above* that
dedupe so every compile gets softened, not just the first per site
(#3141's fix). But "above the dedupe" ended up meaning "before the report
entirely," which is a different thing.

## Fix

Hoist the dedupe check and the `[mimg-unresolved]` report itself above
*both* the soft and the reject decision, so:
- The report still runs exactly once per site (same dedupe key and
  semantics as before), regardless of whether the site ends up softened or
  rejected.
- The soft path still substitutes a constant and prints its own
  `[mimg-soft]` confirmation line, still unconditioned by the dedupe (every
  compile is still softened, not just the first per site — #3141's fix is
  untouched).
- The reject path is otherwise unchanged.

This is a visibility-only change. `PROSPER_MIMG_SOFT` accepts exactly the
same set of descriptors it did before; only the log output around it
changed.

## What's affected / deliberately unaffected

- Affected: stderr output when `PROSPER_MIMG_SOFT` is armed and an MIMG op
  fails to resolve — `[mimg-unresolved]` now also appears, not just
  `[mimg-soft]`.
- Unaffected: which descriptors resolve, what `PROSPER_MIMG_SOFT` writes in
  place of an unresolved sample, the reject path's behavior/output, and the
  per-site dedupe semantics themselves.

## Test

Added a regression case to `prosper/tests/gpu/test_recompile_coverage.cpp`
(a pure, no-Vulkan ctest target). It builds a minimal compute program with
one MIMG `image_load` whose SRSRC (`s[0:7]`) cannot resolve against a
deliberately empty `ShaderResourceTable` (no fetch-pc key, no SRT tag, and
the range is never written so the `sgpr_base` fallback also misses), then:

1. Reject path (`PROSPER_MIMG_SOFT` unset): asserts the compile is rejected
   and `[mimg-unresolved]` is present (sanity check that the reorder didn't
   also break the pre-existing reject-path report).
2. Soft path (`PROSPER_MIMG_SOFT=1`): asserts the compile still succeeds,
   `[mimg-soft]` still fires (softening behaviour unchanged), **and**
   `[mimg-unresolved]` now also fires — this last assertion is the one that
   catches the bug.

Both calls use distinct explicit `RecompileDiagnosticContext` program
addresses so the per-site dedupe (keyed on `(program, pc, srsrc)`) can't
mask one call's report with the other's, since the file's `recompile_valu`
calls elsewhere default to address 0 and could otherwise collide.

**Verified the test fails without the fix**: stashed only the
`rdna2_emit_alu.cpp` hunk (kept the new test in place), rebuilt just
`test_recompile_coverage`, and reran it. Every other check in the file
still passed, including the two new sanity checks (reject-path report,
soft-path substitution+confirmation) — only the new
`#3143: PROSPER_MIMG_SOFT must not suppress [mimg-unresolved]...` assertion
failed, exactly as expected since the old code returns from the soft branch
before the report is reached. Restored the fix (`git stash pop`), rebuilt,
and reran clean.

## Build / test results (exact head)

Built and tested inside the project's `ps5ys` distrobox container (a host
build silently drops the Vulkan execution tests):

```
cmake -S prosper -B prosper/build-linux
cmake --build prosper/build-linux -j6
ctest --no-tests=error   # from prosper/build-linux
```

```
100% tests passed out of 314
Total Test time (real) =  85.67 sec
```

314 is the count this shared build environment produces on a vanilla
configure of current master (no extra `-D` flags) — confirmed independent
of this change by a from-scratch reconfigure. The gap from the 324 raw
`add_test(...)` call sites in `CMakeLists.txt` is fully accounted for by
ordinary default-off gates in this configuration: `PROSPER_AUDIO_SDL3=OFF`
and `PROSPER_PAD_SDL3=OFF` (2 tests), four Windows-only tests on this Linux
build, and `PROSPER_DIAGNOSTICS=OFF` by default (2 tests) — 8 total,
matching the observed gap exactly. Not a regression from this PR.

Fixes #3143
