### PR TITLE
tools/snapshot: pin all three min_structural_similarity threshold routes

### DIFF
--- a/prosper/tools/snapshot/test_snaps.py
+++ b/prosper/tools/snapshot/test_snaps.py
@@ -189,6 +189,11 @@ def main():
             name = "unit2"
             det_fps = snaps.DEFAULT_DET_FPS      # the CLI default, NOT what was authored
             det_clock = "on"                     # ditto
+            # Distinct from Args.min_ssim (snaps.DEFAULT_MIN_SSIM) on purpose -- #3164's second
+            # route is `cmd_import` hardcoding `min_structural_similarity` instead of recording
+            # `args.min_ssim` verbatim. A value equal to the default could not tell "recorded
+            # correctly" apart from "silently replaced with the default".
+            min_ssim = 0.42
 
         snaps.cmd_import(Args2())
         authored = snaps.load_entry("unit2")
@@ -196,6 +201,8 @@ def main():
               "import records the rate the session was AUTHORED at, not its own default")
         check(authored.get("det_clock") == "off",
               "...and the clock stance the session was authored under")
+        check(authored.get("min_structural_similarity") == 0.42,
+              "import records the caller's --min-ssim value VERBATIM, not a hardcoded constant")
         # The whole point is that both halves then agree.
         env2 = snaps.replay_env(authored, tmp, base={})
         check(env2.get("PROSPER_FLIP_PACE_FPS") == "30",
@@ -935,17 +942,19 @@ def main():
         # asymmetry IS the design: a correct snap that stops matching is a FAILURE; an incorrect one
         # that stops matching is INFO, because a known-bad frame may have been fixed and this is the
         # only signal that would ever say so. None of it was asserted.
-        def check_run(verdict, ref_pixel, actual_pixel, mode="anchor", flip=900):
+        def check_run(verdict, ref_pixel, actual_pixel, mode="anchor", flip=900, min_ssim=None):
             """Run cmd_check over one snap with a controlled reference/actual pair.
 
             Returns (exit_code, output). The reference is what was approved; the actual is what the
-            stubbed replay produced, so the two pixels decide whether it matches.
+            stubbed replay produced, so the two pixels decide whether it matches. `min_ssim`, when
+            given, is stored on the entry as `min_structural_similarity` -- the per-set threshold
+            `cmd_check` is supposed to compare against instead of its own compiled-in default.
             """
             # Deterministic, so repeated runs reuse one directory instead of seeding a new one
             # each time. hash() is randomised per process, which made this a slow leak into
             # ~/.cache on every machine that runs ctest.
-            nm = "vc-{}-{}-{}-{}".format(verdict, "".join(str(c) for c in ref_pixel),
-                                         "".join(str(c) for c in actual_pixel), mode)
+            nm = "vc-{}-{}-{}-{}-{}".format(verdict, "".join(str(c) for c in ref_pixel),
+                                            "".join(str(c) for c in actual_pixel), mode, min_ssim)
             vdir = os.path.join(tmp, nm)
             os.makedirs(vdir, exist_ok=True)
             ref_bmp = os.path.join(vdir, "ref.bmp")
@@ -956,6 +965,8 @@ def main():
             entry_v = {"name": nm, "dump": "D-app0", "route": "r.pad", "det_fps": 60,
                        "timeout": 60, "savedata": "none",
                        "snaps": [dict(sig, index=0, verdict=verdict, mode=mode, pad_flip=flip)]}
+            if min_ssim is not None:
+                entry_v["min_structural_similarity"] = min_ssim
             with open(snaps.store_path(nm), "w", encoding="utf-8") as handle:
                 json.dump(entry_v, handle)
 
@@ -1035,6 +1046,40 @@ def main():
         rc_v, out_v = check_unreached("incorrect")
         check(rc_v == 0 and "NOT REACHED" in out_v,
               "...while an unreached known-bad snap is reported without failing the run")
+
+        # ---- 6a1b-iv-c-2. cmd_check's THRESHOLD comes from the ENTRY, not a stale default -----
+        # #3164: `threshold = entry.get("min_structural_similarity", DEFAULT_MIN_SSIM)` can be
+        # computed and then never actually reach `matched = ssim >= threshold` -- a stale local
+        # default substituted instead -- or the read can be dropped entirely. Every arm above
+        # never sets a custom threshold, so none of them can tell an entry's own
+        # min_structural_similarity apart from the compiled-in DEFAULT_MIN_SSIM; both routes
+        # would leave this whole suite green.
+        thresh_lo_bmp, thresh_hi_bmp = (os.path.join(tmp, "thresh_lo.bmp"),
+                                        os.path.join(tmp, "thresh_hi.bmp"))
+        write_bmp(thresh_lo_bmp, 64, 36, lambda x, y: (60, 60, 60))
+        write_bmp(thresh_hi_bmp, 64, 36, lambda x, y: (90, 90, 90))
+        mid_pair_ssim = snaps.structural_similarity(
+            snaps.decode_luma(snaps.signature_of(thresh_lo_bmp)["luma16x9"]),
+            snaps.decode_luma(snaps.signature_of(thresh_hi_bmp)["luma16x9"]))
+        # The fixture must sit strictly between the default and a stricter custom threshold, or
+        # the arms below prove nothing.
+        check(snaps.DEFAULT_MIN_SSIM < mid_pair_ssim < 0.99,
+              f"fixture pair scores {mid_pair_ssim:.4f} -- strictly between the {snaps.DEFAULT_MIN_SSIM} "
+              f"default and a stricter 0.99 -- so the arms below can tell them apart")
+
+        # A threshold STRICTER than the default: the default (0.85) would PASS this pair, so only
+        # an entry whose OWN 0.99 threshold actually reached the comparison makes it FAIL.
+        rc_v, out_v = check_run("correct", (60, 60, 60), (90, 90, 90), min_ssim=0.99)
+        check(rc_v != 0 and "FAIL" in out_v,
+              "a stored min_structural_similarity STRICTER than the default is honoured -- proof "
+              "the entry's own threshold, not the compiled-in default, decided the verdict")
+
+        # A threshold LOOSER than the default: the default would FAIL this wildly different pair,
+        # so only an entry whose OWN 0.0 threshold actually reached the comparison makes it PASS.
+        rc_v, out_v = check_run("correct", (10, 20, 30), (240, 250, 200), min_ssim=0.0)
+        check(rc_v == 0 and "OK" in out_v,
+              "a stored min_structural_similarity of 0.0 makes even a wildly different frame "
+              "pass -- proof the ENTRY's threshold reached the comparison, not a hardcoded 0.85")
 
         # ---- 6a1b-iv-d. cmd_check REFUSES a snap set with ZERO snaps -------------------------
         # cmd_import already refuses to ever STORE a zero-snap set (arm 6a1b-iii-e above); nothing
@@ -1302,6 +1347,22 @@ def main():
                   f"`{sub}` defaults to isolated saves, so a run cannot touch real ones by default")
             forced = parser.parse_args(base_argv + ["--det-clock", "on"])
             check(forced.det_clock == "on", f"`{sub}` still accepts --det-clock on explicitly")
+
+        # ---- 6a1b-v-c. The --min-ssim CLI default is 0.85, wired to DEFAULT_MIN_SSIM -----------
+        # #3164's third route: the constant itself (`DEFAULT_MIN_SSIM = 0.85`) can be weakened --
+        # e.g. to 0.0, which would make every future check pass regardless of what the frame looks
+        # like. That constant is also `cmd_check`'s own fallback when an entry has no stored
+        # threshold, so pinning the LITERAL value (not merely equality to the constant, which a
+        # weakened constant would still satisfy) is the point.
+        check(snaps.DEFAULT_MIN_SSIM == 0.85,
+              "DEFAULT_MIN_SSIM is the failure threshold every existing snap set was authored "
+              "under; weakening it silently loosens every guard that never overrides it")
+        ssim_defaults = parser.parse_args(["import", "somedir", "--name", "n"])
+        check(ssim_defaults.min_ssim == snaps.DEFAULT_MIN_SSIM,
+              "`import`'s --min-ssim default is WIRED to the module constant, not a separate "
+              "hardcoded literal that could drift from it")
+        ssim_forced = parser.parse_args(["import", "somedir", "--name", "n", "--min-ssim", "0.42"])
+        check(ssim_forced.min_ssim == 0.42, "...and an explicit --min-ssim still overrides it")
 
         # ---- 6a1b-vi. _flag_was_passed sees argparse ABBREVIATIONS -----------------------------
         # argparse accepts any unambiguous prefix, so `--det-f 30` sets det_fps. An exact-match


### PR DESCRIPTION
## Summary

Fixes #3164. `snaps.py`'s SSIM threshold (`min_structural_similarity`) is what decides every
guard's verdict, and `test_snaps.py` never observed it. The issue named three separate routes
that could each silently make every future check pass:

1. `cmd_check` could ignore the entry's stored `min_structural_similarity` and compare against a
   stale local default instead.
2. `cmd_import` could hardcode `min_structural_similarity` rather than recording `args.min_ssim`
   verbatim.
3. The `--min-ssim` CLI default (`DEFAULT_MIN_SSIM = 0.85`) could be weakened.

This is the remaining half of the class of defect #3105/#3163 fixed for the zero-snap-set case:
a guard reporting success while silently guarding nothing.

## What was confirmed before changing anything

Per-route, I mutated a scratch copy of `snaps.py` and ran **master's own** `test_snaps.py`
(unmodified) against each mutation:

- **Route 1** (`cmd_check` ignoring the stored threshold): `threshold = DEFAULT_MIN_SSIM` instead
  of `entry.get("min_structural_similarity", DEFAULT_MIN_SSIM)` -> master's suite: exit 0, 0
  failures.
- **Route 2** (`cmd_import` hardcoding the stored value): `"min_structural_similarity":
  DEFAULT_MIN_SSIM` instead of `args.min_ssim` -> master's suite: exit 0, 0 failures.
- **Route 3** (the constant weakened): `DEFAULT_MIN_SSIM = 0.5` -> master's suite: exit 0, 0
  failures.
  - Also checked `DEFAULT_MIN_SSIM = 0.0`: master's suite actually **does** catch this one, but
    only incidentally -- the pre-existing SSIM-correctness fixtures score ~8.9e-6 (black vs.
    gradient) and ~0.99994 (a 2/255 perturbation), and `0.0` breaks the `different < DEFAULT`
    comparison. Anything in roughly `(0.15, 0.99)` -- e.g. `0.5` -- evades every existing check,
    including #3103's own verdict-logic arms, because their fixture pair happens to score ~0.1487
    against a fixed default. This is the more honest demonstration of the hole.
  - Also checked decoupling the CLI flag from the constant (`default=0.5` on `--min-ssim` while
    leaving `DEFAULT_MIN_SSIM = 0.85`): master's suite -> exit 0, 0 failures.

All four mutations above ran clean on master. This is the "confirm it currently passes silently"
step the issue asked for.

## What each route now does

- **Route 1**: `check_run()` (the verdict-logic harness added for #3103) now accepts an optional
  per-entry `min_ssim` override. Two new arms assert both directions: a fixture pair whose SSIM
  sits between the default and a stricter custom threshold (`0.99`) now FAILS when the entry
  stores `0.99`, and a wildly different pair now PASSES when the entry stores `0.0`. Either
  direction alone could be coincidentally satisfied by a constant-threshold implementation; both
  together prove the entry's own number reached the comparison.
- **Route 2**: the existing `unit2` round-trip import test now passes `min_ssim = 0.42` (distinct
  from `Args.min_ssim`'s inherited `DEFAULT_MIN_SSIM`, so "recorded correctly" can't be confused
  with "silently replaced with the default") and asserts the stored entry's
  `min_structural_similarity` equals `0.42` verbatim.
- **Route 3**: two new assertions next to the existing `--det-clock`/`--det-fps`/`--savedata`
  CLI-default arms (`6a1b-v-b`): the literal `snaps.DEFAULT_MIN_SSIM == 0.85` (catches the
  constant being weakened), and `import`'s parsed `--min-ssim` default equalling
  `snaps.DEFAULT_MIN_SSIM` (catches the CLI flag's default being hardcoded separately and drifting
  from the constant).

## Proof each new test fails without its fix

For each route, I re-ran the **new** `test_snaps.py` against the same scratch mutation used above
(mutation applied, fix/coverage otherwise unchanged), then reverted:

- Route 1 mutation -> new suite: exit 1, 2 failures (`FAIL: a stored min_structural_similarity
  STRICTER than the default is honoured...` / `FAIL: ...0.0 makes even a wildly different frame
  pass...`).
- Route 2 mutation -> new suite: exit 1, 1 failure (`FAIL: import records the caller's --min-ssim
  value VERBATIM, not a hardcoded constant`).
- Route 3 (`DEFAULT_MIN_SSIM = 0.5`) -> new suite: exit 1, 1 failure (`FAIL: DEFAULT_MIN_SSIM is
  the failure threshold every existing snap set was authored under...`).
- Route 3 variant (CLI flag decoupled, `default=0.5`, constant left at `0.85`) -> new suite:
  exit 1, 1 failure (`` FAIL: `import`'s --min-ssim default is WIRED to the module constant... ``).

Reverting each mutation restores a clean run. No source file (`snaps.py`) is touched in this PR --
the current implementation of all three routes is already correct; only the missing coverage is
added.

## Test results (current head, unmutated)

```
python3 prosper/tools/snapshot/test_snaps.py
== PASS ==   (242 ok, 0 FAIL, exit 0)

python3 prosper/tools/snapshot/test_snapshot.py
Ran 18 tests in 0.390s
OK   (exit 0)
```

## Scope

Pure test-coverage change to `prosper/tools/snapshot/test_snaps.py`. No behavioral change to
`snaps.py`, `snapshot.py`, or any other file.
