### PR TITLE
docs: correct the stale readback-only present-path claim (#1270 falsified it)

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -229,6 +229,14 @@ pipelines and image/buffer objects per batch. At that point, unify on a single f
 or share the render target via `VK_KHR_external_memory` (zero-copy), while retaining `present_readback`
 for headless tests and screenshot tooling.
 
+**Update (#1270, landed 2026-07-24):** the "unify on a single device" half of this landed for real game
+boots, ahead of the pipeline/resource-caching precondition this note originally set — `prosper-app`
+adopts the *renderer's* device (rather than a frontend-provided one) and GPU-blits its front-buffer image
+straight to the swapchain by default, with `PROSPER_APP_GPU_PRESENT=0` as the explicit opt-out. The
+two-context design above is still real and still runs: it is what `--test-pattern`, any failed device
+adoption, and `tools/screenshot` all use today. `present_readback` was retained exactly as this note
+anticipated, for headless tests and screenshot tooling.
+
 ## Present loop (sketch)
 
 ```
@@ -647,16 +655,30 @@ large logical arenas sparse and physical aliases coherent without letting Window
 overwrite guest SysV red-zone locals. If sparse backing cannot be created, direct-memory mapping fails
 closed instead of silently returning to the unsafe `SEC_RESERVE` exception path.
 
-The current renderer remains a deterministic readback-based implementation. It retains CPU-visible pixels
-for screenshots and temporal RTT composition, so it is not the final zero-copy architecture. Issue #702
-tracks persistent Vulkan resource/pipeline caching and direct image presentation beyond the initial
-readback-memory, detile, compute-context, transient-memory-pool, scratch-reuse, and shader-cache fixes.
+**Present-path correction (2026-09-01, #3087):** this paragraph used to open with "the current renderer
+remains a deterministic readback-based implementation," stated with no date, as though it described the
+renderer generally. **#1270 (landed 2026-07-24) falsified that for the shipped app.** `prosper-app`
+defaults to GPU present for any real game boot: the renderer publishes its front-buffer image directly
+and the app GPU-blits it straight to the swapchain, skipping the CPU round-trip
+(`PROSPER_APP_GPU_PRESENT=0` is the explicit opt-out; the app also falls back to the private-device CPU
+path at runtime if shared-device adoption fails). The CPU readback described in "The Vulkan-context
+decision" above is still real code — it is what `--test-pattern`, any adoption failure, and every caller
+that never invokes `set_gpu_present_active` still take, which includes `tools/screenshot` (the sole call
+site is `frontends/prosper-app/main.cpp:668`) and every headless/ctest/CI path. Before quoting an FPS
+figure or calling "the renderer" readback-based, check which of the two paths produced it — see
+CLAUDE.md's "before quoting an FPS number" bullet, which carries this exact distinction; it is not
+restated here. Issue #702, which this paragraph used to cite as tracking "direct image presentation,"
+closed 2026-07-19 — five days before #1270 delivered exactly that for the interactive path.
+
 On the native Windows Messenger first level, the exact-byte texture cache improved the same-binary
-workload from about 20 FPS to 24 FPS (resource construction 10.1-10.5 ms to about 3.9 ms). The remaining
-roughly 36-38 ms submit time is primarily ordered graphics/compute backend work: four graphics spans,
-four compute dispatches, synchronous fence waits/readbacks, and transient Vulkan pipelines/resources.
-Further work should be validated against a 3D title and converge graphics/compute resource ownership;
-title-specific 2D cache additions are not the current priority.
+workload from about 20 FPS to 24 FPS (resource construction 10.1-10.5 ms to about 3.9 ms). **That figure
+is itself a readback-path measurement from 2026-07-14, ten days before #1270**, and is not a current
+renderer rate — see CLAUDE.md and `RENDERER_PERFORMANCE_2026_07.md` for the 2026-08-27 windowed
+re-measurement (median ~156 presented fps under GPU present) before treating it as current. The
+remaining roughly 36-38 ms submit time was primarily ordered graphics/compute backend work: four
+graphics spans, four compute dispatches, synchronous fence waits/readbacks, and transient Vulkan
+pipelines/resources. Further work should be validated against a 3D title and converge graphics/compute
+resource ownership; title-specific 2D cache additions are not the current priority.
 The complete A/B table, heavy-frame budget, corrected capture graph, rejected experiments, and handoff
 decision are preserved in `RENDERER_PERFORMANCE_2026_07.md`.
 
@@ -728,5 +750,8 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
 - **Present latency/vsync** defaults to FIFO. `--present-mode mailbox` opts into low-latency vsync,
   and `--present-mode immediate` explicitly permits tearing; unsupported optional modes fall back to
   FIFO with a diagnostic.
-- **Later zero-copy** (`external_memory`) is deliberately deferred; the readback seam is the v1 answer.
+- **Later zero-copy** (`external_memory`) is deliberately deferred; the readback seam was the v1 answer.
+  **Superseded 2026-07-24 for the shipped app:** #1270 made GPU present (renderer device adoption + a
+  direct front-buffer blit, not `external_memory`) the default for a real game boot; the readback seam
+  remains the fallback (`PROSPER_APP_GPU_PRESENT=0`, adoption failure, `--test-pattern`, `tools/screenshot`).
 - **area:** shared/host infrastructure — needs an `area:` decision and coordination before build.

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -23,7 +23,11 @@ The guest, on Windows (MinGW, native), reproducibly:
   (`WriteData`/`ReleaseMem`/`WaitRegMem`) and delivers flip/vblank/EOP events.
 - Delivers IL2CPP's exception-type `0x1e` asynchronously on the requested target thread, allowing
   repeated GC stop-the-world suspend/resume cycles to complete.
-- Runs the shared live Vulkan renderer and normal 1920x1080 present/readback path on an NVIDIA host.
+- Runs the shared live Vulkan renderer and presents 1920x1080 frames on an NVIDIA host. This predates
+  #1270 (2026-07-24), which is platform-independent: `prosper-app` now defaults to GPU present (the
+  renderer's device is adopted and its front-buffer image is blitted straight to the swapchain, no CPU
+  round-trip) on Windows exactly as on Linux, with the CPU present/readback path as the
+  `PROSPER_APP_GPU_PRESENT=0` fallback.
 - Builds SDL3 with native Win32 video, WASAPI audio, XInput/HIDAPI controllers, and Vulkan support.
 
 ### Current GC delivery model (#690)

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -270,8 +270,12 @@ an optional new-save item; prosper never exposes a host path or opens an arbitra
 Progress uses a non-focusable utility window updated from the app's main thread, so the title keeps
 presenting and retains keyboard/controller focus.
 
-- Two Vulkan contexts by design (`docs/FRONTEND_APP.md`): the core renders headless; the app owns a
-  separate presentation device; frames cross as CPU pixels via `present_readback`.
+- Two Vulkan contexts by design (`docs/FRONTEND_APP.md`), but since #1270 (2026-07-24) that is the
+  **fallback**, not the default: for a real game boot the app adopts the renderer's own device and
+  GPU-blits its front-buffer image straight to the swapchain, with no CPU round-trip
+  (`PROSPER_APP_GPU_PRESENT=0` opts out). The private-device path — the core renders headless, the app
+  owns a separate presentation device, frames cross as CPU pixels via `present_readback` — is still what
+  `--test-pattern`, `tools/screenshot`, and any failed device adoption use.
 - On window-close the guest thread is detached and reclaimed by process exit (a cooperative
   flip-boundary stop is a documented follow-up).
 - `PROSPER_APP_STALL_DUMP_MS=<milliseconds>` prints the recent Windows guest-exception ring when no new


### PR DESCRIPTION
## Summary

`FRONTEND_APP.md:650-656` stated, in the present tense, that "the current renderer remains a
deterministic readback-based implementation." #1270 (landed 2026-07-24) falsified that: `prosper-app`
now defaults to GPU present for a real game boot — the renderer publishes its front-buffer image
directly and the app GPU-blits it straight to the swapchain, skipping the CPU round-trip entirely.
`PROSPER_APP_GPU_PRESENT=0` is the explicit opt-out, and the app still falls back to the private-device
CPU path if shared-device adoption fails at runtime.

## Changes

**`prosper/docs/FRONTEND_APP.md`** (the file named in #3087):
- Rewrote the paragraph at the old line 650-659: states both paths, dates the claim, drops the
  now-stale reference to issue #702 (closed 2026-07-19, five days *before* #1270 delivered exactly
  what it was cited as tracking), and points at CLAUDE.md's "before quoting an FPS number" bullet
  instead of restating the readback-vs-GPU-present distinction.
- The adjacent 20 -> 24 FPS figure in that same paragraph is itself a pre-#1270 readback-path
  measurement (2026-07-14, ten days before #1270) — now says so and points at the 2026-08-27
  windowed re-measurement (median ~156 presented fps).
- Two more restatements of the *same* stale claim, in the same file, both get a dated update note
  rather than deletion (the private-device path they describe is still real and still used by
  `--test-pattern`, failed device adoption, and `tools/screenshot`):
  - "The Vulkan-context decision: two contexts, one shared CPU frame" section's "When to revisit" note.
  - The "Risks & open questions" bullet: "the readback seam is the v1 answer."

**`prosper/frontends/prosper-app/README.md`**: its "Two Vulkan contexts by design" bullet stated the
private-device CPU-readback path as prosper-app's design with no mention that #1270 made it the
*fallback* rather than the default. Actively maintained (last touched 2026-08-24), not a dated
snapshot.

**`prosper/docs/WINDOWS_PORT_HANDOFF.md`**: "What works today" said the Windows build runs "the normal
... present/readback path." True when written (2026-07-16, before #1270), but the doc has had several
commits since (most recently 2026-08-10) without correcting it, and #1270 is platform-independent —
`prosper-app` defaults to GPU present on Windows exactly as on Linux.

## Swept and deliberately left unchanged

Grepped the whole repo for "readback" and related phrasing. Every other hit refers to a different,
**still-accurate** concept and was left alone:

- `docs/GRAPHICS.md`, `docs/GTA5_STATUS.md`, `docs/SYBERIA_STATUS.md`, `docs/ARCRUNNER_STATUS.md`,
  `docs/OREGON_TRAIL_STATUS.md`, `docs/BLUE_PRINCE_STATUS.md`, `docs/EVERGATE_PERFORMANCE_HANDOFF_2026_07.md`,
  `docs/THREAD_WAIT_PROFILING.md`, `docs/ASTERIX_BABYLON_STATUS.md`, `docs/DEAD_CELLS_*`,
  `tools/AGENTS.md`, `tools/gpu_replay/README.md`, `tools/gpu_timeline/README.md`,
  `tools/hostprof/README.md`, `tools/vkprobe/*`, `tools/index_fetch_probe/AGENTS.md`,
  `docs/GPU_EXECUTOR_DESIGN.md`, `docs/VERIFICATION.md`, `prosper/README.md`: these all describe the
  renderer's own **diagnostic-forced** CPU readback of intermediate/persistent render *targets*
  (`PROSPER_RTTLOG`, `PROSPER_DUMP_RTGROUPS`, `PROSPER_GPU_CAPTURE`, `live_gpu_targets` disable list,
  etc.), or test/verification-harness readback of a rendered frame for pixel assertions — an unrelated,
  correct concept from #1270's app-present-path claim.
- `docs/GAME_COMPAT_ORCHESTRATION.md` traps #127, #234, #237: these correctly state that
  `tools/screenshot` never calls `set_gpu_present_active` and so forces CPU readback, while
  `prosper-app` is the shipped GPU-present path — this is the **true** distinction and must not be
  "corrected."
- `prosper/docs/RENDERER_PERFORMANCE_2026_07.md` and `prosper/src/gpu/present/present_frame_rate.hpp`:
  already caveated by #3082 (referenced in #3087's body as done).

## Verification

Docs-only diff (`git diff --name-only origin/master...HEAD` confirms no non-`.md` files touched).

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py
```
Ran clean: every listed file reports `unbroken, every row matching its header`, including
`CLAUDE.md` (33 rows) and `GAME_COMPAT_ORCHESTRATION.md` (301 rows). Exit code 0.

`git diff --check`: clean (no whitespace errors).

Fixes #3087

