### PR TITLE
recompiler: give flat-shaded fragment varyings SPIR-V Flat (#3051)

### DIFF
--- a/prosper/docs/RECOMPILER_REMAINING.md
+++ b/prosper/docs/RECOMPILER_REMAINING.md
@@ -399,6 +399,34 @@ instruction later, at `bf8a0000` (`s_barrier`, pc=8) — the **generic NGG merge
 which is item 2 of the Recommendation list above and a frontier rather than a missing opcode. See
 `YAKUZA_JUDGMENT_BRINGUP.md`.
 
+## Fragment varyings never got SPIR-V `Flat` from the guest's own FLAT_SHADE bit — **FIXED** (2026-09-01)
+
+`AgcShaderSemantic::is_flat_shaded()` was decoded into the guest's PS_INPUT_CNTL control word
+(`agc_shader_layout.cpp:98`/`:123`, the `0x400` FLAT_SHADE bit) and then discarded: `flat_attrs`, the
+only thing that decorated a fragment Input variable `Flat`, was populated from exactly one source —
+`VINTRP opcode == 2` (`v_interp_mov`, #152/#897) — so an attribute the guest declared flat-shaded but
+the shader happened to read with an ordinary `v_interp_p1`/`v_interp_p2` pair stayed
+smooth-interpolated. On hardware FLAT_SHADE makes the parameter cache deliver only the provoking
+vertex's value for that slot (P10=P20=0), so *every* VINTRP read of it is a constant across the
+primitive regardless of opcode; Vulkan needs the `Flat` decoration to reproduce that.
+
+`FragmentInterpolationLayout` now carries `flat_mask`, from the new
+`PixelInputMapping::effective_flat_mask()` (mirrors `effective_passthrough_mask()`'s shape),
+computed in `fragment_interpolation_layout()` alongside `passthrough_mask` and unioned with the
+existing `flat_attrs` set in `frag_input()` — the two sources are unioned, not one substituted for
+the other, since either alone misses cases the other catches. It also had to be threaded into the
+`InterpolationCacheKey` memo (`gpu_executor.cpp`), which keyed on shader identity plus
+`passthrough_mask` alone: without `flat_mask` in that key, two draws sharing one fragment shader's
+bytes but different guest FLAT_SHADE state could answer from a stale layout computed for the other
+draw's flat-ness — a caching defect the fix itself would have introduced silently.
+
+No title in the corpus was found to exercise the bit before this fix — #3051's own investigation
+measured 224,363 live `[interp]` control words on *Tomb Raider I-III Remastered* with none setting
+`0x400` — so this closes a latent correctness gap rather than a live regression. `test_rdna2_spirv_struct`
+pins it: the same smooth-only bytes as the pre-existing "stays smooth" negative case are recompiled
+again with a synthetic `PixelInputMapping` control word carrying only `0x400`, and the emitted module
+must now carry a `Flat` decoration it did not have before. #3051
+
 ## Ruled out
 
 Cross-title falsifications where the **recompiler was blamed and exonerated**. One line per dead

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -931,6 +931,14 @@ struct InterpolationCacheKey {
     PixelSystemInputMapping system_inputs{};
     bool has_system_inputs = false;
     uint32_t passthrough_mask = 0;
+    // #3051: FragmentInterpolationLayout now also carries flat_mask, derived from pixel_inputs's raw
+    // control words exactly as passthrough_mask is (PixelInputMapping::effective_flat_mask()). It
+    // must be part of this key for the same reason passthrough_mask is: SPI_PS_INPUT_CNTL is a
+    // context register that can carry a different FLAT_SHADE bit across two draws sharing identical
+    // shader bytes, and this cache is keyed on shader identity alone otherwise -- omitting it would
+    // let a flat-shaded draw's layout silently answer a later non-flat draw of the same shader, or
+    // vice versa.
+    uint32_t flat_mask = 0;
 
     bool operator==(const InterpolationCacheKey&) const = default;
 };
@@ -945,6 +953,7 @@ struct InterpolationCacheKeyHash {
             hash = hash_mix(hash, key.system_inputs.addr);
         }
         hash = hash_mix(hash, key.passthrough_mask);
+        hash = hash_mix(hash, key.flat_mask);
         return static_cast<size_t>(hash);
     }
 };
@@ -1892,6 +1901,7 @@ FragmentInterpolationLayout fragment_interpolation_layout_cached(
     key.has_system_inputs = system_inputs != nullptr;
     if (system_inputs) key.system_inputs = *system_inputs;
     key.passthrough_mask = pixel_inputs ? pixel_inputs->effective_passthrough_mask() : 0u;
+    key.flat_mask = pixel_inputs ? pixel_inputs->effective_flat_mask() : 0u;   // #3051
     auto& cache = interpolation_cache();
     std::lock_guard lock(cache.mutex);
     auto found = cache.entries.find(key);

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -159,9 +159,16 @@ FragmentInterpolationLayout fragment_interpolation_layout(
         else if (instruction.opcode == 2 && instruction.src[0].value < 3)
             selectors[attr] |= static_cast<uint8_t>(1u << instruction.src[0].value);
     }
-    if (pixel_inputs)
+    if (pixel_inputs) {
         layout.passthrough_mask =
             pixel_inputs->effective_passthrough_mask() & layout.attribute_mask;
+        // #3051: the guest's own FLAT_SHADE control bit, independent of which VINTRP opcode the
+        // shader used to read the attribute (see PixelInputMapping::effective_flat_mask()). Computed
+        // here, before the requires_geometry early-out below, because it must apply to every
+        // fragment program -- not only ones that also need the portable interpolation-geometry
+        // fallback.
+        layout.flat_mask = pixel_inputs->effective_flat_mask() & layout.attribute_mask;
+    }
 
     // P10/P20 have no ordinary Vulkan varying equivalent. P0 can retain the cheap Flat-input path
     // when it is the attribute's only interpolation mode; mixed P0+smooth needs the geometry copy too.

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
@@ -244,6 +244,24 @@ struct PixelInputMapping {
         return mask & valid_mask;
     }
 
+    // Slots whose SPI_PS_INPUT_CNTL.FLAT_SHADE bit (0x400, GFX10/RDNA2 doc 70648) is set (#3051).
+    // On hardware this makes the parameter cache deliver only the provoking vertex's value for that
+    // slot (P10=P20=0), so EVERY read of it -- including an ordinary v_interp_p1/p2 pair, not only
+    // v_interp_mov -- yields a constant across the primitive. This is a property of the SLOT the
+    // guest declared, independent of which VINTRP opcode the shader happens to use to read it; the
+    // recompiler's separate v_interp_mov detection (rdna2_to_spirv.cpp) recognises flat-ness from
+    // the shader's own instruction choice; this recognises it from the guest's declared semantic.
+    // The two must be unioned, not one substituted for the other, because either alone misses cases
+    // the other catches.
+    uint32_t effective_flat_mask() const {
+        uint32_t mask = 0;
+        for (uint32_t input = 0; input < controls.size(); ++input) {
+            if (!(valid_mask & (1u << input))) continue;
+            if (controls[input] & 0x400u) mask |= 1u << input;
+        }
+        return mask;
+    }
+
     uint32_t ambiguous_passthrough_mask() const {
         uint32_t mask = 0;
         for (uint32_t input = 0; input < controls.size(); ++input) {
@@ -317,6 +335,11 @@ struct FragmentInterpolationLayout {
     uint32_t attribute_mask = 0;                                  // attributes consumed by VINTRP
     uint32_t smooth_mask = 0;                                     // attributes consumed by P1/P2
     uint32_t passthrough_mask = 0;                                // explicit inputs exposing raw vertex values
+    // Attributes the guest's PS_INPUT_CNTL declares FLAT_SHADE for (#3051), from
+    // PixelInputMapping::effective_flat_mask(). Every such attribute's SPIR-V Input variable is
+    // decorated Flat in recompile_fragment regardless of which VINTRP opcode reads it -- see that
+    // helper's comment for why this must be unioned with, not replace, the v_interp_mov detection.
+    uint32_t flat_mask = 0;
     bool requires_geometry = false;
     bool valid = true;
 

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -4094,13 +4094,20 @@ struct SpirvCompute {
     // pre-scan; an attribute read via BOTH v_interp_mov (flat) and v_interp_p2 (smooth) is rejected
     // there (a varying can't be both), so this set never contradicts a smooth read.
     std::unordered_set<uint32_t> flat_attrs;
-    // FS: an Input vec4 at Location=attr, rasterizer-interpolated (or Flat if flat_attrs says so).
+    // FS: an Input vec4 at Location=attr, rasterizer-interpolated (or Flat if flat_attrs says so, OR
+    // if the guest's own PS_INPUT_CNTL declared FLAT_SHADE for this slot -- #3051. Both sources feed
+    // the same SPIR-V property and are unioned: flat_attrs recognises flat-ness from the shader's own
+    // choice of VINTRP opcode (v_interp_mov), while fragment_interpolation->flat_mask recognises it
+    // from the guest's declared semantic, which still applies to an ordinary v_interp_p1/p2 read).
     uint32_t frag_input(uint32_t attr) {
         auto it = in_varying.find(attr); if (it != in_varying.end()) return it->second;
         if (!t_ptr_in_v4f) { t_ptr_in_v4f = id(); put(types, Op_TypePointer, {t_ptr_in_v4f, SC_Input, t_v4f}); }
         uint32_t v = id(); put(types, Op_Variable, {t_ptr_in_v4f, v, SC_Input});
         put(deco, Op_Decorate, {v, Dec_Location, attr});
-        if (flat_attrs.count(attr)) put(deco, Op_Decorate, {v, Dec_Flat});   // un-interpolated (v_interp_mov)
+        const bool flat = flat_attrs.count(attr) != 0 ||
+            (fragment_interpolation && attr < 32 &&
+             (fragment_interpolation->flat_mask & (1u << attr)) != 0);
+        if (flat) put(deco, Op_Decorate, {v, Dec_Flat});
         in_varying[attr] = v; iface.push_back(v); return v;
     }
     // Read component `chan` (0..3) of interpolated attribute `attr` -> float bits (v_interp_p2 / mov).

--- a/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
@@ -6375,6 +6375,29 @@ int main() {
         return 1;
     }
     printf("  [ok]   v_interp_p2-only attribute stays smooth (no Flat decoration)\n");
+    // #3051: the guest's own PS_INPUT_CNTL FLAT_SHADE bit (0x400) must force Flat on attr0 even
+    // though THIS program reads it with ordinary v_interp_p1/p2, not v_interp_mov. On hardware,
+    // FLAT_SHADE makes the parameter cache deliver only the provoking vertex's value for that slot
+    // (P10=P20=0), so any VINTRP read of it -- smooth-opcode included -- yields a constant across
+    // the primitive. Before the fix, is_flat_shaded() was decoded into the guest's PS_INPUT_CNTL
+    // control word (agc_shader_layout.cpp) and never reached the recompiler: flat_attrs was
+    // populated ONLY from a v_interp_mov opcode scan, so this exact shader -- same bytes as
+    // ps_smooth above -- stayed un-Flat regardless of what the guest declared.
+    PixelInputMapping flat_control_inputs;
+    flat_control_inputs.controls[0] = 0x400u;   // FLAT_SHADE alone -- not the 0x420 passthrough form
+    flat_control_inputs.valid_mask = 1u << 0;
+    FragmentInterpolationLayout smooth_flat_layout = fragment_interpolation_layout(
+        ps_smooth, sizeof(ps_smooth)/sizeof(ps_smooth[0]), nullptr, &flat_control_inputs);
+    std::vector<uint32_t> smooth_flat_spv = recompile_fragment(
+        ps_smooth, sizeof(ps_smooth)/sizeof(ps_smooth[0]), nullptr, nullptr, UINT32_MAX,
+        &smooth_flat_layout);
+    if (smooth_flat_layout.flat_mask != 1u || smooth_flat_spv.empty() ||
+        !has_decoration(smooth_flat_spv, DecFlat)) {
+        printf("  [FAIL] guest FLAT_SHADE control word (#3051) did not force Flat on a v_interp_p1/p2 "
+               "varying (layout.flat_mask=%08x)\n", smooth_flat_layout.flat_mask);
+        return 1;
+    }
+    printf("  [ok]   guest PS_INPUT_CNTL FLAT_SHADE forces Flat on an ordinary VINTRP read (#3051)\n");
     // Mixed: attr0 read via BOTH P0 and smooth interpolation needs separate interface locations.
     const uint32_t ps_mixed[] = { 0xc80e0002u, 0xc8110002u, 0xf800000fu, 0x03030303u, 0xbf810000u };
     FragmentInterpolationLayout mixed_layout = fragment_interpolation_layout(


### PR DESCRIPTION
## Summary

Fixes #3051: `AgcShaderSemantic::is_flat_shaded()` was decoded into the guest's PS_INPUT_CNTL
control word (`agc_shader_layout.cpp:98`/`:123`, the `0x400` FLAT_SHADE bit) and then discarded.
`flat_attrs` — the only thing that decorated a fragment SPIR-V Input variable `Flat` — was
populated from exactly one source: `VINTRP opcode == 2` (`v_interp_mov`). An attribute the guest
declared flat-shaded but the shader happened to read with an ordinary `v_interp_p1`/`v_interp_p2`
pair stayed smooth-interpolated, which is invalid for an integer/index varying and silently wrong
for anything else (a texture-array slice, a material/instance id).

## Behavioral contract

- On RDNA2 hardware, `SPI_PS_INPUT_CNTL.FLAT_SHADE` (bit 10, `0x400` — AMD "RDNA 2" ISA Reference,
  doc 70648) makes the parameter cache deliver only the provoking vertex's value for that
  interpolation slot (P10=P20=0). Every VINTRP read of that slot is therefore constant across the
  primitive **regardless of which VINTRP opcode the shader uses** — `v_interp_mov` and ordinary
  `v_interp_p1`/`v_interp_p2` both see the same flattened data on real hardware.
- Vulkan needs the `Flat` decoration on the corresponding `Input` variable to reproduce that;
  without it the driver perspective-interpolates, giving a different value per fragment.
- The guest's own control-word bit (`is_flat_shaded()`) is therefore authoritative and independent
  of — must be UNIONED with, not replace — the existing `v_interp_mov`-opcode detection, since
  either source alone misses cases the other catches (a shader can use `v_interp_mov` for a
  varying whose semantic isn't marked flat by the producer/consumer match, and vice versa).

**CONFIDENCE: HIGH** on the FLAT_SHADE-forces-provoking-vertex-value mechanism itself (directly
from the RDNA2 ISA doc's PS input control description, and consistent with how the existing,
already-shipped `v_interp_mov` -> `Flat` path is justified in `rdna2_to_spirv_internal.hpp`).
**CONFIDENCE: MED** on scope/impact — no title in the corpus has been observed to actually set the
bit. #3051's own investigation measured 224,363 live `[interp]` control words on *Tomb Raider I-III
Remastered* with none setting `0x400`, so this closes a **latent** correctness gap rather than a
live regression; the fix is defensive against the first title that does exercise it.

## Implementation

- `PixelInputMapping::effective_flat_mask()` (`rdna2_to_spirv.hpp`) extracts the `0x400` bit per
  slot from the guest's raw control words, mirroring the existing `effective_passthrough_mask()`.
- `fragment_interpolation_layout()` (`rdna2_to_spirv.cpp`) computes the new
  `FragmentInterpolationLayout::flat_mask` from it, alongside `passthrough_mask`, before the
  `requires_geometry` early-return (so it applies to every fragment program, not only ones needing
  the portable interpolation-geometry fallback).
- `frag_input()` in the SPIR-V builder (`rdna2_to_spirv_internal.hpp`) now decorates `Flat` when
  **either** `flat_attrs.count(attr)` (existing `v_interp_mov` detection) **or**
  `fragment_interpolation->flat_mask` has the bit set.
- `gpu_executor.cpp`'s `InterpolationCacheKey` (a separate memoization cache for
  `FragmentInterpolationLayout`, keyed on shader identity + `passthrough_mask` alone) now also
  carries `flat_mask`. Without this, two draws sharing one fragment shader's bytes but different
  guest FLAT_SHADE state — `SPI_PS_INPUT_CNTL` is a context register, so this can legitimately
  differ draw-to-draw for the same shader — could silently answer from a stale layout computed for
  the other draw's flat-ness. This is exactly the kind of caching bug the fix itself would have
  introduced if left unaddressed, mirroring how `passthrough_mask` is already handled there.
- The primary graphics-shader recompile cache (`ShaderCompileKey`/`ShaderCompileKeyHash`) already
  hashes the full raw `PixelInputMapping::controls[]` array bit-for-bit, so it needed no change.

## Affected / unaffected behavior

- Affected: any fragment program reading an attribute whose guest PS_INPUT_CNTL sets FLAT_SHADE via
  an ordinary (non-`v_interp_mov`) VINTRP read. That varying now gets SPIR-V `Flat`.
- Unaffected: every existing `v_interp_mov`-flat and smooth-only case (both have dedicated
  regression coverage that keeps passing — see Testing), the primary shader recompile cache
  (already fully keyed), and any title/route not exercising FLAT_SHADE at all (measured: none in
  the corpus today).

## Testing

Added a case to `test_rdna2_spirv_struct.cpp` (pure structural test, no Vulkan device needed),
right after the existing "stays smooth" negative case: the same smooth-only instruction bytes are
recompiled again with a synthetic `PixelInputMapping` whose only set bit is `0x400` (FLAT_SHADE, not
the `0x420` passthrough form) on that attribute's slot. Asserts both `layout.flat_mask == 1` (the
layout computation) and `has_decoration(spv, Flat)` (the emitted module).

**Verified the test fails without the fix**: stashed only the `rdna2_to_spirv_internal.hpp` hunk
(the `frag_input()` consumer change), rebuilt, and reran — the new case failed with
`layout.flat_mask=00000001` printed alongside the failure (confirming the layout-side computation
was already correct and the failure was specifically the missing decoration), while every other
case still passed. Restored the fix and reran clean.

- `./test_rdna2_spirv_struct` (direct binary run): all cases pass, including the new one:
  `[ok] guest PS_INPUT_CNTL FLAT_SHADE forces Flat on an ordinary VINTRP read (#3051)`.
- Full suite: `ctest --no-tests=error` — **314/314 passed (100%)**, exit code 0, real time 151.55s.
- **Not yet run**: `spirv-val` on an emitted module carrying the new decoration. I did not get to
  this before handing off; the emitted `Flat` decoration follows the exact same code path
  (`Op_Decorate`/`Dec_Flat`) already used and validated for the `v_interp_mov` case, so I expect it
  to validate cleanly, but that is an expectation, not an observed result — please run it as part of
  review.

## Risks

- Low. The change only adds a decoration that was previously missing when a guest control word says
  it belongs; it cannot turn a previously-valid smooth varying into a flat one unless the guest's
  own control word says so. The cache-key fix is additive (widens a key, can only turn a stale hit
  into a correct miss, never the reverse).
- No title in the corpus currently exercises the bit, so there is no available live-boot evidence to
  cross-check the composite against; this is recorded as latent rather than regression-fixing in
  `docs/RECOMPILER_REMAINING.md`.

## Also filed

While isolating a `git stash` step for the fail-without-fix verification above, I hit and recovered
from a **shared `refs/stash` collision with a concurrent agent working in its own separate
worktree** — both agents' stash pushes interleaved on the single repo-wide stash ref, and each
agent's `pop` briefly picked up the other's unrelated WIP. Both agents independently recognized and
recovered the foreign content without loss, but it is a real hazard for CLAUDE.md's worktree
guidance. Filed separately as #3174 (process/tooling, not code — out of scope here).

## Docs

`docs/RECOMPILER_REMAINING.md` gets a new `## ... -- **FIXED**` entry recording the mechanism,
implementation, and the corpus measurement showing no title depends on it today.
