### PR TITLE
PROSPER_TEXCOMMIT: scan the source extent, not the decoded byte count

### DIFF
--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4843,27 +4843,40 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // level's backgrounds read ~0% committed, they're GPU-DMA'd pages the CPU never
                         // touched, so we read zeros -> the scene samples black (#300 black-gameplay probe).
                         if (PROSPER_ENV_ON("PROSPER_TEXCOMMIT")) {
+                            // Walk the SOURCE extent, never `nb` (the DECODED byte count computed just
+                            // above for `texture_pixels`): for a block-compressed format `nb` is 4x+ the
+                            // real guest bytes (BC7 decodes 1 source byte/texel to 4 RGBA8 bytes), and an
+                            // array multiplies that again by the layer count. Scanning `nb` over
+                            // `sampled_source_addr` both mis-measured "committed" (it counted whatever
+                            // guest memory happened to follow the real texture) and read guest memory
+                            // past the real allocation (#3053). `gpu_capture_resource_footprint()` is the
+                            // same T#-driven source-byte computation the capture/replay path already uses
+                            // for this resource, so it is correct here too regardless of format.
+                            const size_t src_bytes = texcommit_scan_extent(
+                                prosper::gpu::gpu_capture_resource_footprint(r));
                             const size_t PG = 0x10000; size_t committed = 0;
                             for (uint64_t a = sampled_source_addr;
-                                 a < sampled_source_addr + nb; a += PG)
+                                 a < sampled_source_addr + src_bytes; a += PG)
                                 if (a >= 0x1000 && prosper_reserved_range_state(a) != 0) committed += PG;
                             static std::set<uint64_t> tcseen;
                             if (tcseen.insert(r.gpu_addr).second) {
                                 // Also sample the first 8 dwords and count non-zero bytes over the whole
-                                // surface: zero content => the texture was allocated but never filled (a
-                                // GPU-side upload/copy we don't execute); non-zero => it's a decode/tiling
-                                // problem. tile_mode tells tiled vs linear.
+                                // SOURCE surface (src_bytes, not nb): zero content => the texture was
+                                // allocated but never filled (a GPU-side upload/copy we don't execute);
+                                // non-zero => it's a decode/tiling problem. tile_mode tells tiled vs linear.
                                 uint32_t w0[8] = {0}; size_t nzb = 0;
                                 if (committed) {
                                     const uint8_t* p =
                                         (const uint8_t*)(uintptr_t)sampled_source_addr;
                                     for (int i = 0; i < 8; i++) w0[i] = ((const uint32_t*)p)[i];
-                                    for (size_t i = 0; i < nb; i += 997) nzb += (p[i] != 0);   // sparse scan
+                                    for (size_t i = 0; i < src_bytes; i += 997) nzb += (p[i] != 0);   // sparse scan
                                 }
-                                fprintf(stderr, "[texcommit] tex 0x%llx %ux%u f%u tile=%u nb=%zu committed=%zu%% "
-                                        "nz~%zu/%zu first=%08x %08x %08x %08x\n",
-                                        (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format, r.tile_mode, nb,
-                                        nb ? (size_t)(100 * committed / nb) : 100, nzb, nb/997,
+                                fprintf(stderr, "[texcommit] tex 0x%llx %ux%u f%u tile=%u nb=%zu src=%zu "
+                                        "committed=%zu%% nz~%zu/%zu first=%08x %08x %08x %08x\n",
+                                        (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format, r.tile_mode,
+                                        nb, src_bytes,
+                                        src_bytes ? (size_t)(100 * committed / src_bytes) : 100, nzb,
+                                        src_bytes / 997,
                                         w0[0], w0[1], w0[2], w0[3]);
                             }
                         }

--- a/prosper/frontends/shared/tests/test_texture_decode_diagnostic.cpp
+++ b/prosper/frontends/shared/tests/test_texture_decode_diagnostic.cpp
@@ -8,6 +8,7 @@ using prosper::frontend::should_report_texture_decode_miss;
 using prosper::frontend::should_report_texture_decode_hit;
 using prosper::frontend::block_compressed_cube_source_size;
 using prosper::frontend::layered_array_source_size;
+using prosper::frontend::texcommit_scan_extent;
 using prosper::frontend::texture_decode_cache_candidate;
 using prosper::frontend::texture_decode_miss_reason;
 using prosper::frontend::texture_decode_miss_is_expensive_block;
@@ -130,6 +131,41 @@ int main() {
                 layered_array_source_size(0u, 352256u, 256u) == 0u);
     CHECK_NAMED("array_span_fails_closed_on_overflow",
                 layered_array_source_size(4096u, UINT64_MAX / 2u, 8u) == 0u);
+
+    // #3053: PROSPER_TEXCOMMIT scanned the DECODED byte count (`nb`) over the SOURCE address,
+    // overshooting on any block-compressed texture (BC7 decodes 1 source byte/texel to 4 RGBA8
+    // bytes) and further on an array (multiplied again by the layer count). These are the reported
+    // real numbers: Tomb Raider I-III Remastered's 512x512 BC7 world atlas, 256 tiled layers
+    // (tile_mode 5 == SW_4KB_S, matching the issue's own "tile=5" log line).
+    prosper::gpu::ShaderResource tomb_raider_bc7_array{};
+    tomb_raider_bc7_array.cls = prosper::gpu::ResourceClass::Texture;
+    tomb_raider_bc7_array.gpu_addr = 0x20491cc000ull;
+    tomb_raider_bc7_array.format = prosper::gpu::DataFormat::Bc7;
+    tomb_raider_bc7_array.num_components = 4u;
+    tomb_raider_bc7_array.img_dim = 5u;   // graphics 2D-array base-slice view
+    tomb_raider_bc7_array.width = tomb_raider_bc7_array.height = 512u;
+    tomb_raider_bc7_array.depth = 256u;
+    tomb_raider_bc7_array.tile_mode = 5u;
+    const uint64_t tomb_raider_footprint =
+        prosper::gpu::gpu_capture_resource_footprint(tomb_raider_bc7_array);
+    // What the OLD (buggy) TEXCOMMIT scanned: nb = tw * th * decoded_bpp(RGBA8 == 4) * layers --
+    // exactly the 268,435,456 the issue reports for this texture.
+    constexpr uint64_t tomb_raider_decoded_nb = 512ull * 512ull * 4ull * 256ull;
+    CHECK_NAMED("tomb_raider_bc7_array_decoded_nb_matches_the_reported_overshoot",
+                tomb_raider_decoded_nb == 268435456ull);
+    CHECK_NAMED("tomb_raider_bc7_array_source_footprint_matches_the_reported_extent",
+                tomb_raider_footprint == 67108864ull);
+    CHECK_NAMED("tomb_raider_bc7_array_source_footprint_is_a_quarter_of_decoded_nb",
+                tomb_raider_decoded_nb == 4u * tomb_raider_footprint);
+    // The actual regression guard: PROSPER_TEXCOMMIT must scan the SOURCE footprint, never `nb`.
+    // This fails if `texcommit_scan_extent()` (or its live_renderer.cpp caller) is ever reverted to
+    // pass the decoded byte count instead of `gpu_capture_resource_footprint()`.
+    CHECK_NAMED("texcommit_scans_the_source_footprint",
+                texcommit_scan_extent(tomb_raider_footprint) == tomb_raider_footprint);
+    CHECK_NAMED("texcommit_never_scans_the_decoded_byte_count",
+                texcommit_scan_extent(tomb_raider_footprint) != tomb_raider_decoded_nb);
+    // A non-array, non-BC texture's declared size is unaffected: nothing to overshoot.
+    CHECK(texcommit_scan_extent(65536u) == 65536u);
 
     if (!failures) std::printf("texture_decode_diagnostic: OK\n");
     return failures ? 1 : 0;

--- a/prosper/frontends/shared/texture/texture_decode_cache_policy.hpp
+++ b/prosper/frontends/shared/texture/texture_decode_cache_policy.hpp
@@ -90,4 +90,22 @@ constexpr size_t block_compressed_cube_source_size(bool block_compressed_cube,
         block_compressed_cube, gpu_address, descriptor_footprint);
 }
 
+// PROSPER_TEXCOMMIT (#3053): the guest-memory byte extent to scan from a sampled texture's SOURCE
+// address. Must be a source-side quantity -- `source_footprint_bytes` is the caller's
+// `gpu_capture_resource_footprint()` for this exact resource, which already folds in BC block
+// bytes, tiling, and the array/cube layer span the same way `layered_array_source_size()` and
+// `layered_cube_source_size()` above do -- and must NEVER be the DECODED byte count
+// (`tw * th * decoded_bpp * layers`, the size a surface expands to once converted to the backend's
+// RGBA8/RGBA16F decode format). For a block-compressed texture the decoded count is 4x+ the source
+// (BC7 decodes 1 source byte/texel to 4 RGBA8 bytes), and a layered array multiplies that again by
+// the layer count: Tomb Raider I-III Remastered's 512x512 BC7 256-layer world atlas measured a
+// decoded count of 268,435,456 against a real source extent of 67,108,864 -- a 4x overshoot that
+// both mis-measured "committed" guest memory (it counted whatever happened to follow the real
+// texture) and read guest memory past the real allocation. This function's signature deliberately
+// has no slot for a decoded byte count, so that value cannot be passed here by mistake.
+constexpr size_t texcommit_scan_extent(uint64_t source_footprint_bytes) {
+    return source_footprint_bytes > SIZE_MAX
+        ? SIZE_MAX : static_cast<size_t>(source_footprint_bytes);
+}
+
 } // namespace prosper::frontend


### PR DESCRIPTION
## Summary

Fixes #3053.

`PROSPER_TEXCOMMIT` walked `sampled_source_addr` for `nb` bytes, but `nb` is the **decoded** byte
count (`tw * th * decoded_bpp * layers`), not the guest **source** extent. For a block-compressed
format this overshoots by 4x+ (BC7 decodes 1 source byte/texel to 4 RGBA8 bytes), and a layered
array multiplies that again by the layer count.

Concrete numbers from the issue (Tomb Raider I-III Remastered): a 512x512 BC7 world-atlas texture
with 256 tiled layers measured `nb` at 268,435,456 while its real source extent is 67,108,864 -- a
4x overshoot. Both the "committed" scan and the sparse non-zero scan therefore ran three-to-four
times past the end of the real texture, over whatever guest allocations happened to follow it,
which is worse than useless for the diagnostic's own stated purpose (distinguishing "unfilled
texture" from "decode/tiling bug") -- it misled the investigation on #2998, which is what surfaced
this bug.

## Fix

Scan `prosper::gpu::gpu_capture_resource_footprint(r)` instead of `nb`. That function is the same
T#-driven source-byte computation the capture/replay path already uses for this exact resource --
BC block bytes, tiling, and the array/cube layer span already folded in -- and it's already
extensively tested against real title numbers in `test_gpu_capture.cpp` (BC arrays, cubes, mip
tails, linear row padding, etc.), so no new formula is introduced.

The call site routes through a new pure function, `texcommit_scan_extent()`, added to
`frontends/shared/texture/texture_decode_cache_policy.hpp` (the existing home for this class of
"how many bytes does this texture decode/scan actually touch" helper, alongside
`layered_array_source_size()` and `layered_cube_source_size()` from #2998). Its signature
deliberately has **no parameter for a decoded byte count**, so the exact mistake this issue reports
cannot be reintroduced by passing the wrong variable at the call site.

The log line now reports `src=<bytes scanned>` alongside the existing `nb=<decoded bytes>`, so a
future reader can tell which extent was walked -- per the issue's own suggestion.

## Behavioral contract

- `PROSPER_TEXCOMMIT` (an opt-in diagnostic, off by default) now scans and reports on the guest
  SOURCE bytes a sampled texture actually occupies, never the backend's decoded byte count.
- No change to any non-diagnostic code path: `nb` itself, and everything that uses it to size/decode
  `texture_pixels`, is untouched.
- Fixes a real out-of-bounds read: the old code could read guest memory 3-4x past the real
  allocation for BC/array textures.

## Verification

**Reproduced/confirmed on current master before changing anything:** computed
`gpu_capture_resource_footprint()` for a synthetic `ShaderResource` matching the issue's exact Tomb
Raider shape (512x512 BC7, `img_dim=5`, `depth=256`, `tile_mode=5`/SW_4KB_S -- matching the issue's
own "tile=5" log line) and confirmed it returns exactly 67,108,864, a quarter of the
268,435,456-byte `nb` the old code scanned -- reproducing the issue's reported numbers exactly.

**New test** (`test_texture_decode_diagnostic.cpp`), covering the BC case and the array case
together (the reported texture is both):
- Pins `gpu_capture_resource_footprint()` for the Tomb Raider BC7/256-layer shape at exactly
  67,108,864, and the old `nb` formula at exactly 268,435,456 (4x, matching the issue).
- Asserts `texcommit_scan_extent()` returns the source footprint, never the decoded count.

**Verified the test fails without the fix**: temporarily changed `texcommit_scan_extent()`'s body to
`source_footprint_bytes * 4` (simulating the pre-fix BC overshoot), rebuilt just that test target,
and reran it -- all three new assertions failed:
```
FAIL texcommit_scans_the_source_footprint: texcommit_scan_extent(tomb_raider_footprint) == tomb_raider_footprint
FAIL texcommit_never_scans_the_decoded_byte_count: texcommit_scan_extent(tomb_raider_footprint) != tomb_raider_decoded_nb
FAIL ...: texcommit_scan_extent(65536u) == 65536u
EXIT=1
```
Restored the real implementation, rebuilt, and reran -- green (`texture_decode_diagnostic: OK`,
exit 0).

Note on scope: the wiring decision at the `live_renderer.cpp` call site (use the footprint, not
`nb`) is not itself exercised by a unit test -- `live_renderer.cpp`'s draw/texture-decode function is
not practically unit-testable in isolation, and no existing test harness in this repo captures a live
`PROSPER_*` diagnostic's stderr output. The extracted `texcommit_scan_extent()` function's signature
(no decoded-byte-count parameter) is the structural guard against that specific class of regression
at the call site.

**Build:**
```
cmake -S prosper -B prosper/build-linux
TMPDIR=.../build-linux/tmpdir cmake --build prosper/build-linux -j6   # exit 0, full rebuild clean
```

**Full ctest:**
```
ctest --no-tests=error
100% tests passed out of 314
Total Test time (real) = 125.45 sec
```
(314 matches the documented fresh-configure baseline.)

## Risk / scope

Diagnostic-only change, gated behind `PROSPER_TEXCOMMIT` (opt-in, off by default in all normal runs
and CI). No behavioral change to rendering, decoding, or any non-diagnostic code path.
