### PR TITLE
tools/perf: fix audio_delivery_report's +1/(N-1) drift bias and burst-clustering wording

### DIFF
--- a/prosper/tools/perf/audio_delivery_report.py
+++ b/prosper/tools/perf/audio_delivery_report.py
@@ -17,16 +17,20 @@ that log into the numbers that name the failure mode, offline, without listening
   * effective delivery rate vs the device rate -- a persistent deficit is a CLOCK DRIFT
     between the guest's budgeted audio clock and the device crystal; no cushion survives it,
     and the fix is drift compensation, not deeper buffering;
-  * burst clustering -- the fraction of arrivals that carry more than one grain of audio
-    after a gap of more than two grain periods. This shape is CONSISTENT WITH a quantized
-    mixer wake, but the cadence alone cannot prove it: a producer simply delivering audio
-    below real time also arrives in clusters, spaced by production rather than by a wait
-    (#3080 -- the verdict named the wrong cause on a title where a `PROSPER_TIMEDWAIT_CENSUS=1`
-    measurement, in the same log, showed the guest's only timed wait resolving at x1.02, i.e.
-    not quantized at all; the -55% delivery-rate deficit already explained the clustering). So
-    if `[timedwait Ns]` census lines are present in the same input, their ratio for the
-    dominant wait primitive SETTLES which cause applies; if they are absent, the report says so
-    and names the census as the discriminator instead of asserting a mechanism it cannot see.
+  * burst clustering -- the fraction of arrivals whose inter-arrival GAP exceeds two grain
+    periods (#3061: earlier wording here promised a stronger conjunct -- "carries more than
+    one grain of audio" -- that the code has never tested; frames-per-arrival is available in
+    the log but is not examined, so this is gap-only, same as the code). This shape is
+    CONSISTENT WITH a quantized mixer wake, but the cadence alone cannot prove it -- and, being
+    gap-only, it does not distinguish a real multi-grain flush from a producer simply
+    delivering audio below real time, which also arrives in clusters, spaced by production
+    rather than by a wait (#3080 -- the verdict named the wrong cause on a title where a
+    `PROSPER_TIMEDWAIT_CENSUS=1` measurement, in the same log, showed the guest's only timed
+    wait resolving at x1.02, i.e. not quantized at all; the -55% delivery-rate deficit already
+    explained the clustering). So if `[timedwait Ns]` census lines are present in the same
+    input, their ratio for the dominant wait primitive SETTLES which cause applies; if they are
+    absent, the report says so and names the census as the discriminator instead of asserting a
+    mechanism it cannot see.
 
 WHAT THIS TOOL DOES NOT SEE
 ---------------------------
@@ -225,7 +229,31 @@ def report_port(port, slot, device_hz, channels, bytes_per_frame, census=None):
               f" ({100 * empty / len(queued):.1f}%) -- STARVED: nothing left to play")
 
     if span_s > 0 and device_hz:
-        delivered_hz = frames_total / span_s
+        # The emitter logs gap=0.00ms for a port's FIRST arrival -- there is no previous arrival
+        # on that port to measure from -- so `gaps` holds only (calls - 1) REAL inter-arrival
+        # intervals, and span_s = sum(gaps) covers exactly those: the time from the first arrival
+        # to the last. frames_total, though, sums frames from all `calls` arrivals, including the
+        # first one, whose own accumulation time was never captured by any logged gap (it may
+        # have been building up for a full grain period before this log even starts). Dividing
+        # the full frame total by that (calls - 1)-interval span overcounts by one arrival's
+        # worth of frames, inflating delivered_hz by a factor of calls / (calls - 1) -- roughly
+        # +1/(calls - 1) at the calls this tool typically sees -- issue #3061. Measured example:
+        # 11 records of 100 frames at an exact 1000 Hz real-time cadence have a TRUE drift of
+        # 0.00%, but frames_total/span_s reports 1100 frames / 1.0 s = 1100 vs device 1000, i.e.
+        # +10.00% -- comfortably past the +-0.3% threshold below, so a real-time log at small N
+        # was reported as running the audio clock fast.
+        #
+        # Fix: drop the first arrival's frames from the numerator to match what span_s already
+        # spans, rather than stretching span_s by an imputed extra grain period -- the two give
+        # the same answer only when every arrival is the same size, and dropping the frame needs
+        # no such assumption. Gate on the emitter's own zero-gap sentinel (not just "index 0")
+        # so a log excerpt that starts mid-stream -- where the first logged gap is a real,
+        # already-elapsed interval, not the emitter's "no previous arrival" zero -- is left
+        # unadjusted rather than having a genuine arrival's frames silently discarded.
+        frames_in_span = frames_total
+        if slot["gaps"][0] == 0.0:
+            frames_in_span = frames_total - slot["frames"][0]
+        delivered_hz = frames_in_span / span_s
         device_hz_total = device_hz
         drift_pct = 100.0 * (delivered_hz - device_hz_total) / device_hz_total
         print(f"  effective delivery: {delivered_hz:.0f} frames/s vs device {device_hz_total}"
@@ -244,6 +272,15 @@ def report_port(port, slot, device_hz, channels, bytes_per_frame, census=None):
                   " burst rows above.")
 
     if grain_ms > 0:
+        # GAP-ONLY, deliberately (#3061): this counts arrivals separated from the previous one by
+        # more than two grain periods, not arrivals that themselves carry more than one grain of
+        # frames -- the emitter logs frames= per record, so that conjunct could be tested, but
+        # doing so would make this gate blind to exactly the case #3080 needed it for: a producer
+        # delivering ordinary single-grain arrivals, delayed by a clock deficit rather than a
+        # quantized wake, which never carries more than a grain per arrival. The three-way verdict
+        # below (present since #3168) already exists to tell that case apart from a real multi-grain
+        # burst using the timedwait census; narrowing the gate here to frames > grain would silence
+        # that verdict for the scenario it was built to diagnose instead.
         bursts = sum(1 for g in gaps if g > 2 * grain_ms)
         if bursts > len(gaps) * 0.2 and mean_gap > 1.5 * grain_ms:
             # This cadence shape (clustering beyond two grain periods) is what a quantized mixer

--- a/prosper/tools/perf/test_audio_delivery_report.py
+++ b/prosper/tools/perf/test_audio_delivery_report.py
@@ -192,6 +192,39 @@ def main():
     expect(out, "Fix the wait primitive's resolution",
            "case 8: the imperative IS earned when the census supports it")
 
+    # 9. Drift bias hand-check (#3061). The `[audio-dbg]` emitter logs gap=0.00ms for a port's
+    #    FIRST arrival -- no previous arrival to measure from -- so `span_s = sum(gaps)` covers
+    #    only the REAL inter-arrival intervals while `frames_total` sums frames from every
+    #    arrival, including that first, unmeasured one. `frames_total / span_s` overcounts by one
+    #    arrival's worth of frames.
+    #
+    #    Chosen so the TRUE rate is exact and the bias is exact too: 11 records of 100 frames at
+    #    a 1000 Hz device, delivered at EXACTLY real-time cadence (100.00 ms per 100-frame grain
+    #    == 100 frames/s * 1000 == 1000 Hz). By construction the true delivered rate is exactly
+    #    the device rate:
+    #
+    #      true_drift = (delivered_hz - device_hz) / device_hz
+    #                 = (frames_after_first / real_span_s - device_hz) / device_hz
+    #                 = ((10 * 100) / 1.0 - 1000) / 1000 = 0 / 1000 = 0.00%
+    #
+    #    The pre-fix formula divides ALL 11 records' frames by the same 1.0 s real span:
+    #
+    #      biased_hz   = frames_total / span_s = (11 * 100) / 1.0 = 1100
+    #      biased_drift = (1100 - 1000) / 1000 = +10.00%    (== calls / (calls - 1) - 1 = 1/10)
+    #
+    #    +10.00% is comfortably past the +-0.3% threshold, so the bug does not just misreport a
+    #    number -- it flips the verdict to the false "runs above the device rate" the issue names.
+    log = dbg(gap=0.00, frames=100, queued=100000, bpf=1, channels=1)
+    log += "".join(
+        dbg(gap=100.00, frames=100, queued=100000, bpf=1, channels=1) for _ in range(10))
+    out, _ = run(log, ["--device-hz", "1000"])
+    expect(out, "-> drift +0.00%",
+           "case 9: an exact real-time 11-record log must report the true 0.00% drift, not +10.00%")
+    expect(out, "delivery matches the device rate",
+           "case 9: the true rate must read as matching, not as a clock excess")
+    reject(out, "runs above the device rate",
+           "case 9: the pre-fix +1/(N-1) bias (+10.00% at N=11) must not survive")
+
     if failures:
         print("FAILURES:")
         for failure in failures:


### PR DESCRIPTION
Fixes #3061

## Two distinct defects, per the issue

### 1. Drift figure biased by +1/(N-1)

The `[audio-dbg]` emitter logs `gap=0.00ms` for a port's first arrival (no previous arrival to
measure from). `span_s = sum(gaps)` therefore covers only the `(calls - 1)` REAL inter-arrival
intervals -- the elapsed time from the first arrival to the last -- while `frames_total` sums
frames from all `calls` arrivals, including that first one, whose own accumulation time was
never captured by any logged gap. Dividing the full frame total by that `(calls - 1)`-interval
span overcounts by exactly one arrival's worth of frames.

**Derivation.** For `calls = N` records with a constant grain size `F` and a true steady-state
gap `g` between the `N - 1` real arrivals:

```
span_s (as computed)      = (N - 1) * g            -- unchanged by the fix
frames_total               = N * F
delivered_hz (pre-fix)     = frames_total / span_s = N * F / ((N - 1) * g)
delivered_hz (true rate)   = F / g                  -- one grain per grain period, steady state
```

So `delivered_hz (pre-fix) = delivered_hz (true) * N / (N - 1)`, i.e. inflated by a factor of
`N / (N - 1)`, or roughly `+1/(N - 1)` -- exactly the bias the issue names.

**Fix:** drop the first arrival's frames from the numerator instead of stretching `span_s` by an
imputed extra grain period -- the two give the same answer only when every arrival is the same
size, and dropping the frame needs no such assumption. Gated on the emitter's own `gap == 0.0`
sentinel (not just "index 0"), so a log excerpt that starts mid-stream -- where the first logged
gap is a real, already-elapsed interval rather than the emitter's "no previous arrival" zero --
is left unadjusted rather than having a genuine arrival's frames silently discarded.

**Analytic test case (added as case 9).** 11 records of 100 frames each, delivered at an
*exact* real-time cadence against a 1000 Hz device: gap=0.00ms for the first record, then ten
real gaps of exactly 100.00 ms (100 frames / 1000 Hz * 1000 = 100 ms per grain, i.e. exactly
real time).

```
true_drift   = (frames_after_first / real_span_s - device_hz) / device_hz
             = ((10 * 100) / 1.0 - 1000) / 1000 = 0.00%

biased_drift = (frames_total / real_span_s - device_hz) / device_hz
             = ((11 * 100) / 1.0 - 1000) / 1000 = +10.00%    (== calls/(calls-1) - 1 = 1/10)
```

Pre-fix output (captured by temporarily reverting only the numerator change and re-running):

```
effective delivery: 1100 frames/s vs device 1000 -> drift +10.00%
VERDICT: the guest's audio clock runs above the device rate -- the cushion grows until the
depth cap; drift compensation should slow the delivery.
```

Post-fix output:

```
effective delivery: 1000 frames/s vs device 1000 -> drift +0.00%
VERDICT: delivery matches the device rate -- a stutter at this rate is a burst/quantization
problem, not a clock deficit. See the cadence and burst rows above.
```

+10.00% is well past the tool's own +-0.3% threshold, so the bug does not just misreport a
number -- at small N it flips the verdict to a false "runs above the device rate", exactly as
#3016's review found at N=60.

**Verification that the test actually discriminates:** disabled only the fix (reverted the
numerator line to the pre-fix `frames_in_span = frames_total`), re-ran
`test_audio_delivery_report.py`, and all three new assertions failed with the +10.00%/false-
verdict output quoted above. Restored the fix and confirmed `git diff` against the pre-revert
file was empty, then re-ran green.

### 2. Burst-clustering docstring promised an untested conjunct

The header advertised: "the fraction of arrivals that carry **more than one grain of audio**
after a gap of more than two grain periods." The code only ever tested the gap half
(`bursts = sum(1 for g in gaps if g > 2 * grain_ms)`); nothing examines `frames=` per record, so
ordinary single-grain arrivals separated by a long gap are folded into the same "clustered"
count as a real multi-grain flush.

**Chosen fix: narrow the wording, not the code** (the issue offered both options). Reasoning:
the code's gap-only gate is not an oversight -- it is exactly what the #3168 three-way verdict
(RULES OUT / CONFIRMS / hedge, driven by the `PROSPER_TIMEDWAIT_CENSUS=1` ratio) needs to see in
order to diagnose the #3080 scenario: a producer delivering *ordinary single-grain* arrivals,
delayed by a clock deficit rather than a quantized mixer wake. That scenario, by definition,
never carries more than a grain per arrival. Adding the frames-per-arrival conjunct to the gate
would make it blind to precisely the case #3168 was built to diagnose -- the existing self-test
cases 6/7/8 (the #3080 reconstruction: 488 single-grain records at gap=11.85ms) would stop
entering the verdict block at all, silently regressing #3168's own coverage.

So: reworded the docstring bullet to describe what is actually measured (gap-only), and added a
comment at the `bursts` computation explaining *why* it stays gap-only, so a future reader
doesn't "fix" it the wrong way. No behavioral/runtime change for this half -- confirmed the
existing self-test (cases 3, 6, 7, 8, which exercise this exact code path) is unaffected.

## Interaction with #3168's verdict logic

Explicitly: **defect 2's fix does not touch #3168's three-way verdict branching at all** --
only the docstring and an explanatory comment changed. Defect 1's fix touches the `delivered_hz`
number that feeds the *drift* verdict above the burst block, not the burst block itself, and
none of #3168's added test cases (6, 7, 8) model a genuine `gap=0.00` first record (they all use
a constant `gap` value for every record via the shared `dbg()` helper), so the drift fix is a
no-op for those fixtures and their expected output is unchanged.

## Testing

```
python3 prosper/tools/perf/test_audio_delivery_report.py
# audio_delivery_report self-test: all cases pass (10 cases, exit 0)
```

`git diff --check`: clean. `python3 -m py_compile` on both changed files: clean.
`git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'` -> 0.

This is a pure-Python tool under `tools/perf/`; no C++ build or ctest is implicated.
