### PR TITLE
test(#3057): bind dmem caller-chain attribution to the alloc_dmem call site

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1497,6 +1497,23 @@ if(TARGET prosper_core)
   target_include_directories(test_dmem_caller_chain PRIVATE src)
   add_test(NAME dmem_caller_chain COMMAND test_dmem_caller_chain)
 
+  # #3057: test_dmem_caller_chain above covers format_dmem_caller_chain_definition (the formatter)
+  # only -- it never calls k_alloc_dmem/k_alloc_main_dmem, so deleting the actual
+  # attribute_dmem_allocation(...) call sites #3055 added left that suite green. These two bind to
+  # the real call sites through the NID dispatch table, one process each (see the header comment in
+  # the first file for why they cannot share a process).
+  add_executable(test_dmem_caller_attribution_alloc_dmem
+                 tests/hle/memory/test_dmem_caller_attribution_alloc_dmem.cpp)
+  target_link_libraries(test_dmem_caller_attribution_alloc_dmem PRIVATE prosper_core)
+  add_test(NAME dmem_caller_attribution_alloc_dmem
+           COMMAND test_dmem_caller_attribution_alloc_dmem)
+
+  add_executable(test_dmem_caller_attribution_alloc_main_dmem
+                 tests/hle/memory/test_dmem_caller_attribution_alloc_main_dmem.cpp)
+  target_link_libraries(test_dmem_caller_attribution_alloc_main_dmem PRIVATE prosper_core)
+  add_test(NAME dmem_caller_attribution_alloc_main_dmem
+           COMMAND test_dmem_caller_attribution_alloc_main_dmem)
+
   # Capped-diagnostic rate limit (issue #1761): a print budget must never be readable as a
   # population. Pins the sparse tail and the per-key budget; header-only, no GPU state.
   add_executable(test_diag_ratelimit tests/gpu/diagnostics/test_diag_ratelimit.cpp)

--- a/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_dmem.cpp
+++ b/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_dmem.cpp
@@ -9,23 +9,45 @@
 // the first dmem call (dmem_caller_log() caches its getenv() read in a function-local static, so
 // ordering matters), redirect stderr to a capture stream, call sceKernelAllocateDirectMemory
 // through the real NID dispatch table exactly as a guest does, and require the one-shot
-// "[dmem-caller] caller-chain=unknown alloc_dmem ..." line that attribute_dmem_allocation prints
-// even with no guest frames on the stack (a bare host stack has no return address inside a fixed
-// guest module range, so the chain always interns as Unknown here -- see dmem_caller_chain.hpp).
+// "[dmem-caller] caller-chain=..." line that attribute_dmem_allocation prints on the first
+// allocation this process makes.
 //
 // Without the fix this allocator publishes no record at all, so the line is never printed and the
 // assertion below fails -- verified by mutation as part of this PR (delete the call site, rerun,
 // confirm red; restore, rerun, confirm green).
 //
+// WHAT THE ASSERTION CHECKS, AND WHY IT DOES NOT PIN THE "unknown" FORM (review correction, #3178):
+// an earlier version of this test required the exact text "caller-chain=unknown alloc_dmem ...",
+// reasoning that a bare host stack (no guest image is loaded here) has no return address inside a
+// fixed guest module VA range, so the scan would always come up empty and the chain would always
+// intern as Unknown. That reasoning was environment-dependent, not a property of the call site:
+// guest_va_in_module_code (boot_program.hpp) tests only whether a VALUE FALLS IN A FIXED ADDRESS
+// RANGE, never whether anything is actually mapped there. On CI's Linux runner an ordinary garbage
+// word already sitting on the host stack landed inside the BOOT_SAVEDATA range by coincidence, so
+// the scan resolved a (bogus) "SaveData.prx+0x10000002" and the chain interned as Known -- and the
+// exact-"unknown" assertion failed even though attribution had genuinely happened. That is the same
+// failure shape #3057 exists to fix, just relocated one level down: the arm was bound to "nothing on
+// this machine's stack happens to look like a guest address" rather than to the call site.
+// attribute_dmem_allocation's OWN comment says as much: the scan is a heuristic over live stack
+// content, "a stale spill slot looks exactly like a return address". Forcing the Unknown state
+// deterministically would mean controlling that same uninitialized memory, which is exactly the
+// thing the scan is deliberately tolerant of and cannot be pinned by a portable test.
+//
+// So the check below is resolve-agnostic: it accepts EITHER "caller-chain=unknown" (no resolvable
+// frame) OR "caller-chain=<digits>" (a frame -- real or coincidental -- resolved), and requires
+// that whichever form printed, it is immediately followed by " alloc_dmem len=0x" -- i.e. that
+// *some* attribution record was published, naming the right allocator. That is the actual contract
+// of the call site under test; what the stack scan happens to resolve to is environmental.
+//
 // A DEDICATED BINARY, not an arm folded into tests/host/test_dmem.cpp or this repo's other dmem
-// coverage: DmemCallerChainInterner's "Unknown" state is a ONE-SHOT PER PROCESS (see
-// attribute_dmem_allocation in hle_kernel_mem.cpp -- it returns before printing anything once
-// `correlation.first` is false). Any other dmem allocation earlier in the same process that also
-// interns as Unknown -- including one made through sceKernelAllocateMainDirectMemory, covered by
-// the companion test_dmem_caller_attribution_alloc_main_dmem binary -- would silently consume the
-// one shot, and this assertion would find an empty capture even with the fix present (flagged in
-// the issue's review follow-up comment). Keeping the two allocators in separate processes gives
-// each its own first Unknown chain to observe.
+// coverage: DmemCallerChainInterner's "first" bookkeeping (both the Unknown-announced-once state
+// and the Known per-key first-seen state) is PER PROCESS (see attribute_dmem_allocation in
+// hle_kernel_mem.cpp -- it returns before printing anything once `correlation.first` is false). Any
+// earlier dmem allocation in the same process -- including one made through
+// sceKernelAllocateMainDirectMemory, covered by the companion test_dmem_caller_attribution_alloc_main_dmem
+// binary -- could consume that process's one shot for its own key and leave this assertion looking
+// at an empty capture even with the fix present (flagged in the issue's review follow-up comment).
+// Keeping the two allocators in separate processes gives each its own first observation.
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/dispatch/nid.hpp"
 
@@ -33,6 +55,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #ifdef _WIN32
 #include <io.h>
 #ifndef WIN32_LEAN_AND_MEAN
@@ -44,6 +67,31 @@
 #endif
 
 using namespace prosper;
+
+namespace {
+// True when `output` contains a "[dmem-caller] caller-chain=<token> <api> len=0x..." record,
+// where <token> is either "unknown" or a run of decimal digits (a resolved chain id). Deliberately
+// agnostic to WHICH token appears -- that is environmental (see the file header comment) -- and
+// deliberately anchored so the api label must immediately follow the token, not merely appear
+// anywhere in the captured text.
+bool dmem_caller_attribution_present(const char* output, const char* api) {
+    const char* const kPrefix = "[dmem-caller] caller-chain=";
+    const char* pos = std::strstr(output, kPrefix);
+    if (!pos) return false;
+    pos += std::strlen(kPrefix);
+    if (std::strncmp(pos, "unknown", 7) == 0) {
+        pos += 7;
+    } else {
+        const char* digits_start = pos;
+        while (*pos >= '0' && *pos <= '9') ++pos;
+        if (pos == digits_start) return false;   // neither "unknown" nor a numeric id
+    }
+    if (*pos != ' ') return false;
+    ++pos;
+    const std::string expect = std::string(api) + " len=0x";
+    return std::strncmp(pos, expect.c_str(), expect.size()) == 0;
+}
+} // namespace
 
 int main() {
     // Must happen before ANY dmem allocation in this process: dmem_caller_log() is
@@ -119,9 +167,9 @@ int main() {
 
     const bool allocated = rc == 0 && phys != 0;
     // The exact label k_alloc_dmem passes to attribute_dmem_allocation. This is the call site
-    // #3055 added and #3057 says is untested -- deleting it removes this line entirely.
-    const bool attributed =
-        std::strstr(output, "[dmem-caller] caller-chain=unknown alloc_dmem len=0x") != nullptr;
+    // #3055 added and #3057 says is untested -- deleting it removes this line entirely, regardless
+    // of whether the chain resolves to "unknown" or a (possibly coincidental) module+offset.
+    const bool attributed = dmem_caller_attribution_present(output, "alloc_dmem");
 
     const bool ok = redirected && restored && allocated && attributed;
     if (!ok) {

--- a/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_dmem.cpp
+++ b/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_dmem.cpp
@@ -1,0 +1,138 @@
+// #3057: test_dmem_caller_chain.cpp's arms (added by #3055) cover
+// format_dmem_caller_chain_definition -- the FORMATTER -- and never drive an allocation through the
+// real dispatch table. Deleting the `attribute_dmem_allocation(...)` call that #3055 added to
+// k_alloc_dmem's success path (hle_kernel_mem.cpp) removes the whole behaviour change -- the entire
+// reason #3055/#2998 exist, publishing a caller chain from sceKernelAllocateDirectMemory, not only
+// the Main variant -- and left that suite green, because nothing in it ever calls k_alloc_dmem.
+//
+// This test does. Following the recipe from #3057's issue body: set PROSPER_DMEM_CALLER=1 before
+// the first dmem call (dmem_caller_log() caches its getenv() read in a function-local static, so
+// ordering matters), redirect stderr to a capture stream, call sceKernelAllocateDirectMemory
+// through the real NID dispatch table exactly as a guest does, and require the one-shot
+// "[dmem-caller] caller-chain=unknown alloc_dmem ..." line that attribute_dmem_allocation prints
+// even with no guest frames on the stack (a bare host stack has no return address inside a fixed
+// guest module range, so the chain always interns as Unknown here -- see dmem_caller_chain.hpp).
+//
+// Without the fix this allocator publishes no record at all, so the line is never printed and the
+// assertion below fails -- verified by mutation as part of this PR (delete the call site, rerun,
+// confirm red; restore, rerun, confirm green).
+//
+// A DEDICATED BINARY, not an arm folded into tests/host/test_dmem.cpp or this repo's other dmem
+// coverage: DmemCallerChainInterner's "Unknown" state is a ONE-SHOT PER PROCESS (see
+// attribute_dmem_allocation in hle_kernel_mem.cpp -- it returns before printing anything once
+// `correlation.first` is false). Any other dmem allocation earlier in the same process that also
+// interns as Unknown -- including one made through sceKernelAllocateMainDirectMemory, covered by
+// the companion test_dmem_caller_attribution_alloc_main_dmem binary -- would silently consume the
+// one shot, and this assertion would find an empty capture even with the fix present (flagged in
+// the issue's review follow-up comment). Keeping the two allocators in separate processes gives
+// each its own first Unknown chain to observe.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#ifdef _WIN32
+#include <io.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace prosper;
+
+int main() {
+    // Must happen before ANY dmem allocation in this process: dmem_caller_log() is
+    // `static int v = getenv(...) ? 1 : 0;` -- read once, on the first call.
+#ifdef _WIN32
+    _putenv_s("PROSPER_DMEM_CALLER", "1");
+#else
+    setenv("PROSPER_DMEM_CALLER", "1", 1);
+#endif
+
+    register_builtin_hle();
+    auto alloc = Hle::lookup(nid_hash("sceKernelAllocateDirectMemory"));
+    if (!alloc) {
+        std::fprintf(stderr, "sceKernelAllocateDirectMemory was not registered\n");
+        return 1;
+    }
+
+    FILE* capture = std::tmpfile();
+    if (!capture) {
+        std::fprintf(stderr, "tmpfile() failed\n");
+        return 1;
+    }
+    if (std::fflush(stderr) != 0) {
+        std::fclose(capture);
+        return 1;
+    }
+
+#ifdef _WIN32
+    const int stderr_fd = _fileno(stderr);
+    const int saved_stderr = _dup(stderr_fd);
+    const bool redirected = saved_stderr >= 0 && _dup2(_fileno(capture), stderr_fd) == 0;
+#else
+    const int stderr_fd = fileno(stderr);
+    const int saved_stderr = dup(stderr_fd);
+    const bool redirected = saved_stderr >= 0 && dup2(fileno(capture), stderr_fd) >= 0;
+#endif
+    if (!redirected) {
+        if (saved_stderr >= 0) {
+#ifdef _WIN32
+            _close(saved_stderr);
+#else
+            close(saved_stderr);
+#endif
+        }
+        std::fclose(capture);
+        std::fprintf(stderr, "stderr redirection failed\n");
+        return 1;
+    }
+
+    // sceKernelAllocateDirectMemory(off_t start, off_t end, size_t len, size_t align, int memType,
+    // off_t* physOut). A 16 KiB-granular, self-aligned request inside the pool's default window,
+    // mirroring a request that succeeds in tests/host/test_dmem.cpp. This process's direct-memory
+    // pool starts empty, so it must succeed.
+    uint64_t phys = 0;
+    constexpr uint64_t kBase = 0x10000ull;
+    constexpr uint64_t kEnd = kBase + 16ull * 1024 * 1024 * 1024;
+    const uint64_t rc = alloc(0, kEnd, 0x4000, 0x4000, 0, (uint64_t)(uintptr_t)&phys);
+
+    std::fflush(stderr);
+#ifdef _WIN32
+    const bool restored = _dup2(saved_stderr, stderr_fd) == 0;
+    _close(saved_stderr);
+#else
+    const bool restored = dup2(saved_stderr, stderr_fd) >= 0;
+    close(saved_stderr);
+#endif
+
+    char output[1024]{};
+    std::rewind(capture);
+    const size_t bytes = std::fread(output, 1, sizeof(output) - 1, capture);
+    std::fclose(capture);
+    output[bytes] = '\0';
+
+    const bool allocated = rc == 0 && phys != 0;
+    // The exact label k_alloc_dmem passes to attribute_dmem_allocation. This is the call site
+    // #3055 added and #3057 says is untested -- deleting it removes this line entirely.
+    const bool attributed =
+        std::strstr(output, "[dmem-caller] caller-chain=unknown alloc_dmem len=0x") != nullptr;
+
+    const bool ok = redirected && restored && allocated && attributed;
+    if (!ok) {
+        std::fprintf(stderr,
+            "FAIL: rc=0x%llx phys=0x%llx restored=%d allocated=%d attributed=%d\n"
+            "captured stderr (%zu bytes):\n%s\n",
+            (unsigned long long)rc, (unsigned long long)phys, restored, allocated, attributed,
+            bytes, output);
+    } else {
+        std::printf("OK: sceKernelAllocateDirectMemory published a [dmem-caller] record naming"
+                    " alloc_dmem\n");
+    }
+    return ok ? 0 : 1;
+}

--- a/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_main_dmem.cpp
+++ b/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_main_dmem.cpp
@@ -1,0 +1,116 @@
+// #3057 (companion to test_dmem_caller_attribution_alloc_dmem.cpp): drives
+// sceKernelAllocateMainDirectMemory through the real NID dispatch table and requires the
+// "[dmem-caller] caller-chain=unknown alloc_main_dmem ..." line k_alloc_main_dmem publishes.
+//
+// sceKernelAllocateMainDirectMemory's attribution predates #3055 and is not the regression #3057
+// is about -- but the issue asks for it too ("worth covering the alloc_main_dmem path in the same
+// test so a regression that swaps the labels cannot pass either"), and this binary is what makes
+// that reachable: it names its OWN one-shot Unknown chain (see the companion file's header comment
+// for why the two allocators cannot share a process). If a future change ever passed the wrong
+// literal to attribute_dmem_allocation here -- "alloc_dmem" instead of "alloc_main_dmem", or vice
+// versa in the sibling binary -- this line would name the wrong allocator and the assertion below
+// would catch it.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#ifdef _WIN32
+#include <io.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace prosper;
+
+int main() {
+#ifdef _WIN32
+    _putenv_s("PROSPER_DMEM_CALLER", "1");
+#else
+    setenv("PROSPER_DMEM_CALLER", "1", 1);
+#endif
+
+    register_builtin_hle();
+    auto alloc_main = Hle::lookup(nid_hash("sceKernelAllocateMainDirectMemory"));
+    if (!alloc_main) {
+        std::fprintf(stderr, "sceKernelAllocateMainDirectMemory was not registered\n");
+        return 1;
+    }
+
+    FILE* capture = std::tmpfile();
+    if (!capture) {
+        std::fprintf(stderr, "tmpfile() failed\n");
+        return 1;
+    }
+    if (std::fflush(stderr) != 0) {
+        std::fclose(capture);
+        return 1;
+    }
+
+#ifdef _WIN32
+    const int stderr_fd = _fileno(stderr);
+    const int saved_stderr = _dup(stderr_fd);
+    const bool redirected = saved_stderr >= 0 && _dup2(_fileno(capture), stderr_fd) == 0;
+#else
+    const int stderr_fd = fileno(stderr);
+    const int saved_stderr = dup(stderr_fd);
+    const bool redirected = saved_stderr >= 0 && dup2(fileno(capture), stderr_fd) >= 0;
+#endif
+    if (!redirected) {
+        if (saved_stderr >= 0) {
+#ifdef _WIN32
+            _close(saved_stderr);
+#else
+            close(saved_stderr);
+#endif
+        }
+        std::fclose(capture);
+        std::fprintf(stderr, "stderr redirection failed\n");
+        return 1;
+    }
+
+    // sceKernelAllocateMainDirectMemory(size_t len, size_t align, int memType, off_t* physOut) --
+    // physOut is arg3 here, NOT arg5 (a different signature from AllocateDirectMemory). This
+    // process's direct-memory pool starts empty, so a fresh 16 KiB-granular request must succeed.
+    uint64_t phys = 0;
+    const uint64_t rc = alloc_main(0x4000, 0x4000, 0, (uint64_t)(uintptr_t)&phys, 0, 0);
+
+    std::fflush(stderr);
+#ifdef _WIN32
+    const bool restored = _dup2(saved_stderr, stderr_fd) == 0;
+    _close(saved_stderr);
+#else
+    const bool restored = dup2(saved_stderr, stderr_fd) >= 0;
+    close(saved_stderr);
+#endif
+
+    char output[1024]{};
+    std::rewind(capture);
+    const size_t bytes = std::fread(output, 1, sizeof(output) - 1, capture);
+    std::fclose(capture);
+    output[bytes] = '\0';
+
+    const bool allocated = rc == 0 && phys != 0;
+    const bool attributed =
+        std::strstr(output, "[dmem-caller] caller-chain=unknown alloc_main_dmem len=0x") !=
+        nullptr;
+
+    const bool ok = redirected && restored && allocated && attributed;
+    if (!ok) {
+        std::fprintf(stderr,
+            "FAIL: rc=0x%llx phys=0x%llx restored=%d allocated=%d attributed=%d\n"
+            "captured stderr (%zu bytes):\n%s\n",
+            (unsigned long long)rc, (unsigned long long)phys, restored, allocated, attributed,
+            bytes, output);
+    } else {
+        std::printf("OK: sceKernelAllocateMainDirectMemory published a [dmem-caller] record"
+                    " naming alloc_main_dmem\n");
+    }
+    return ok ? 0 : 1;
+}

--- a/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_main_dmem.cpp
+++ b/prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_main_dmem.cpp
@@ -1,15 +1,20 @@
 // #3057 (companion to test_dmem_caller_attribution_alloc_dmem.cpp): drives
 // sceKernelAllocateMainDirectMemory through the real NID dispatch table and requires the
-// "[dmem-caller] caller-chain=unknown alloc_main_dmem ..." line k_alloc_main_dmem publishes.
+// "[dmem-caller] caller-chain=... alloc_main_dmem ..." record k_alloc_main_dmem publishes -- see
+// the companion file's header comment for why the assertion is agnostic to whether the chain
+// resolves to "unknown" or a (possibly coincidental) module+offset: guest_va_in_module_code checks
+// only an address RANGE, not whether anything real is mapped there, so on some runners an ordinary
+// garbage stack word resolves into a fixed guest module window purely by chance. That is
+// environmental, not part of the contract under test.
 //
 // sceKernelAllocateMainDirectMemory's attribution predates #3055 and is not the regression #3057
 // is about -- but the issue asks for it too ("worth covering the alloc_main_dmem path in the same
 // test so a regression that swaps the labels cannot pass either"), and this binary is what makes
-// that reachable: it names its OWN one-shot Unknown chain (see the companion file's header comment
-// for why the two allocators cannot share a process). If a future change ever passed the wrong
-// literal to attribute_dmem_allocation here -- "alloc_dmem" instead of "alloc_main_dmem", or vice
-// versa in the sibling binary -- this line would name the wrong allocator and the assertion below
-// would catch it.
+// that reachable: it names its OWN first-seen chain (see the companion file's header comment for
+// why the two allocators cannot share a process). If a future change ever passed the wrong literal
+// to attribute_dmem_allocation here -- "alloc_dmem" instead of "alloc_main_dmem", or vice versa in
+// the sibling binary -- this record would name the wrong allocator and the assertion below would
+// catch it.
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/dispatch/nid.hpp"
 
@@ -17,6 +22,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #ifdef _WIN32
 #include <io.h>
 #ifndef WIN32_LEAN_AND_MEAN
@@ -28,6 +34,30 @@
 #endif
 
 using namespace prosper;
+
+namespace {
+// See the companion file (test_dmem_caller_attribution_alloc_dmem.cpp) for the full rationale.
+// True when `output` contains a "[dmem-caller] caller-chain=<token> <api> len=0x..." record, where
+// <token> is either "unknown" or a run of decimal digits -- whichever the stack scan happened to
+// resolve is environmental, not part of the contract under test.
+bool dmem_caller_attribution_present(const char* output, const char* api) {
+    const char* const kPrefix = "[dmem-caller] caller-chain=";
+    const char* pos = std::strstr(output, kPrefix);
+    if (!pos) return false;
+    pos += std::strlen(kPrefix);
+    if (std::strncmp(pos, "unknown", 7) == 0) {
+        pos += 7;
+    } else {
+        const char* digits_start = pos;
+        while (*pos >= '0' && *pos <= '9') ++pos;
+        if (pos == digits_start) return false;   // neither "unknown" nor a numeric id
+    }
+    if (*pos != ' ') return false;
+    ++pos;
+    const std::string expect = std::string(api) + " len=0x";
+    return std::strncmp(pos, expect.c_str(), expect.size()) == 0;
+}
+} // namespace
 
 int main() {
 #ifdef _WIN32
@@ -97,9 +127,7 @@ int main() {
     output[bytes] = '\0';
 
     const bool allocated = rc == 0 && phys != 0;
-    const bool attributed =
-        std::strstr(output, "[dmem-caller] caller-chain=unknown alloc_main_dmem len=0x") !=
-        nullptr;
+    const bool attributed = dmem_caller_attribution_present(output, "alloc_main_dmem");
 
     const bool ok = redirected && restored && allocated && attributed;
     if (!ok) {


### PR DESCRIPTION
## The gap (#3057)

#3055 published a dmem caller chain from `sceKernelAllocateDirectMemory`, not only the Main
variant, by adding an `attribute_dmem_allocation(...)` call to `k_alloc_dmem`'s success path
(`prosper/src/hle/memory/hle_kernel_mem.cpp`, one call in the Linux block, one in the Windows
block). Its two new arms in `test_dmem_caller_chain.cpp` only exercise
`format_dmem_caller_chain_definition` — the **formatter** — and never drive an allocation through
the real dispatch table. Deleting both call sites removes the entire behaviour change and leaves
that suite green.

## What I confirmed, by direct observation

I applied the exact mutation the issue names — deleted both `attribute_dmem_allocation(...)` calls
in `k_alloc_dmem` (Linux block and Windows block) — rebuilt, and ran the tests directly:

- **Blindness confirmed**: with the mutation applied, `test_dmem_caller_chain` (the pre-existing
  #3055 arms) stayed **100% green**, all 12 `PASS` lines, exit 0. This reproduces the bug the issue
  reports: the suite is blind to the call site.
- **New arm binds to the call site**: under the same mutation, the new
  `test_dmem_caller_attribution_alloc_dmem` binary **failed** (exit 1, empty stderr capture —
  `attributed=0`).
- **Discrimination is specific, not incidental**: the sibling
  `test_dmem_caller_attribution_alloc_main_dmem` — guarding the *other*, untouched call site —
  **stayed green** under the same mutation, so the new arm's failure is caused by the deleted call,
  not by some global breakage.
- Restored the fix (`git checkout -- prosper/src/hle/memory/hle_kernel_mem.cpp`), rebuilt, reran all
  three binaries: all green again.

I only rebuilt/ran the four targeted binaries above (`test_dmem_caller_chain`,
`test_dmem_caller_attribution_alloc_dmem`, `test_dmem_caller_attribution_alloc_main_dmem`,
`test_dmem`) directly and observed their output myself. **I did not obtain a full-suite `ctest`
count for this PR** — the full-project rebuild I attempted exceeded the interactive foreground
timeout and moved to the background, and its completion notification never reached this session.
I am not reporting a ctest count I did not personally observe; the coordinator will run the full
build/test/verification themselves.

## What the new arms bind to

Two dedicated ctest binaries, each its own process:

- `prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_dmem.cpp` — sets
  `PROSPER_DMEM_CALLER=1` before the first dmem call (required: `dmem_caller_log()` caches its
  `getenv()` read in a function-local static), redirects `stderr` to a `tmpfile()`, calls
  `sceKernelAllocateDirectMemory` through `Hle::lookup(nid_hash(...))` exactly as a guest does, and
  asserts the captured text contains
  `[dmem-caller] caller-chain=unknown alloc_dmem len=0x...`.
- `prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_main_dmem.cpp` — same recipe for
  `sceKernelAllocateMainDirectMemory`, asserting `...alloc_main_dmem len=0x...`. This call site
  predates #3055 and isn't the regression #3057 is about, but the issue asked for it too ("a
  regression that swaps the labels cannot pass either"), and it also serves as the specificity
  control described above.

**Why two binaries, not one test with two arms** (per the issue's own follow-up review comment):
`DmemCallerChainInterner`'s `Unknown` state is a **one-shot per process** —
`attribute_dmem_allocation` returns before printing anything once `correlation.first` is false. A
bare host test stack has no return address inside a fixed guest module range (no image is loaded),
so every allocation in this harness interns as `Unknown`. If both allocators ran in one process, the
first call would consume the one-shot print and the second assertion would find an empty capture
**even with the fix present** — a false failure, not a real one. Separate processes give each
allocator its own first-Unknown observation.

## What I did with the existing formatter arms

**Kept them unchanged.** They are still the only coverage for
`format_dmem_caller_chain_definition`'s own contract — that the allocator label is carried from the
caller and not hardcoded, that an empty label falls back to `<unknown-allocator>` instead of a
plausible default, and that concurrent writers each produce one intact, uncorrupted line. That is a
real, independently useful property. It just never claimed to cover the call site, and now something
else does.

## Files

- `prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_dmem.cpp` (new)
- `prosper/tests/hle/memory/test_dmem_caller_attribution_alloc_main_dmem.cpp` (new)
- `prosper/CMakeLists.txt` — registers both as ctest binaries right after `dmem_caller_chain`

## Verification commands (for the reviewer to reproduce)

```bash
TMPDIR=<worktree>/prosper/build-linux/tmpdir cmake --build prosper/build-linux -j6 \
    --target test_dmem_caller_attribution_alloc_dmem test_dmem_caller_attribution_alloc_main_dmem \
    test_dmem_caller_chain
./prosper/build-linux/test_dmem_caller_attribution_alloc_dmem
./prosper/build-linux/test_dmem_caller_attribution_alloc_main_dmem
```

Mutation test (delete both `attribute_dmem_allocation(...)` calls in `k_alloc_dmem`, rebuild, rerun):
`test_dmem_caller_attribution_alloc_dmem` should fail; `test_dmem_caller_chain` and
`test_dmem_caller_attribution_alloc_main_dmem` should stay green.

Fixes #3057
