### PR TITLE
hle: scePthreadSemInit forwards sem_init's real error instead of discarding it

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -680,6 +680,16 @@ if(TARGET prosper_core)
   # regression that reverts to a blocking wait on a semaphore nothing will ever post would hang
   # rather than fail, and CTest's default 1500 s hang reads as neither pass nor fail.
   set_tests_properties(kernel_sem_timedwait PROPERTIES TIMEOUT 60)
+
+  # scePthreadSemInit must forward a real sem_init() failure instead of discarding it and
+  # manufacturing success (#3068). Platform-neutral: it probes the host sem_init() with an
+  # out-of-range value first and only asserts the guest-visible contract when the host call
+  # actually failed, so it is meaningful on every CI platform (EINVAL on Linux, ENOSYS on Darwin)
+  # without needing per-platform code, and skips itself explicitly rather than passing vacuously
+  # if some future libc happens to accept the probe value.
+  add_executable(test_kernel_sem_init_error tests/hle/kernel/test_kernel_sem_init_error.cpp)
+  target_link_libraries(test_kernel_sem_init_error PRIVATE prosper_core)
+  add_test(NAME kernel_sem_init_error COMMAND test_kernel_sem_init_error)
   # Bounded because arm 3 guards a ~292-YEAR sleep: without a timeout a regression there presents as
   # CTest hanging for its default 1500 s rather than as a failure, and a hang is the one outcome nobody
   # reads as a red test. Generous against a loaded host -- what it catches is seconds-to-forever.

--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -3073,7 +3073,42 @@ SCE_PTHREAD_ALIAS(k_sce_rwlock_timedwrlock, k_rwlock_timedwrlock)
 // SemGetvalue left *value uninitialized -> a producer/consumer or gate built on these got NO
 // synchronization (the silent-unsync / UAF class). Back them with host sem_t.
 namespace { bool semlog() { static const bool on = getenv("PROSPER_SEMLOG") != nullptr; return on; } }
-HLE(k_sem_init)      { if (!a0) return 0x16; auto* s = (sem_t*)calloc(1, sizeof(sem_t)); sem_init(s, 0, (unsigned)a2); *(void**)(uintptr_t)a0 = s; if (semlog()) fprintf(stderr, "[sem] init slot=%p value=%u\n", (void*)(uintptr_t)a0, (unsigned)a2); return 0; }
+// #3068: sem_init() CAN fail -- most notably, Darwin does not implement unnamed POSIX semaphores at
+// all, so sem_init() there sets errno=ENOSYS and returns -1 unconditionally. This used to discard
+// that return value outright and report success no matter what, publishing a pointer to a `sem_t`
+// that was never actually initialised. Every other member of the family --  `k_sem_wait`,
+// `k_sem_trywait`, `k_sem_timedwait`, `k_sem_post`, `k_sem_getvalue` -- resolves its host `sem_t`
+// straight out of the slot via `ensure_sem`, so a published-but-uninitialised object turned one
+// honest, traceable failure here into undefined behaviour on every later call instead, with the
+// guest told throughout that its synchronisation was working.
+//
+// Fixed by PROPAGATING the real error rather than manufacturing success, and by refusing to publish
+// the slot when init failed -- the fail-visible choice the charter prefers over a shim that fakes
+// output. A `sem_open`-backed or condvar-backed fallback for platforms lacking unnamed semaphores is
+// deliberately NOT attempted here: nobody has verified what such an emulation needs to preserve on a
+// live macOS boot, and an unverified fallback risks trading one silently-wrong behaviour for
+// another. If a title is later found to depend on this family on such a platform, that is its own
+// issue once the real behaviour is confirmed (see #3068's discussion).
+HLE(k_sem_init) {
+    if (!a0) return 0x16;
+    auto* s = (sem_t*)calloc(1, sizeof(sem_t));
+    if (!s) return 12;   // ENOMEM (bare FreeBSD errno -- encoded/converted by the aliases below)
+    if (sem_init(s, 0, (unsigned)a2) != 0) {
+        const uint64_t rc = fbsd_errno(errno);
+        // Loud but bounded: on a platform where this fails unconditionally (Darwin), every single
+        // semaphore init would otherwise flood stderr once per call. Capped the same way the
+        // __stack_chk_fail diagnostic above is (n++ < 4): visible immediately, not a firehose.
+        static int logged = 0;
+        if (logged++ < 4)
+            fprintf(stderr, "[sem] init FAILED slot=%p value=%u host_errno=%d(%s)\n",
+                    (void*)(uintptr_t)a0, (unsigned)a2, errno, strerror(errno));
+        free(s);
+        return rc;
+    }
+    *(void**)(uintptr_t)a0 = s;
+    if (semlog()) fprintf(stderr, "[sem] init slot=%p value=%u\n", (void*)(uintptr_t)a0, (unsigned)a2);
+    return 0;
+}
 HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; if (semlog()) fprintf(stderr, "[sem] wait slot=%p enter\n", (void*)(uintptr_t)a0); int rc = sem_wait(s); if (semlog()) fprintf(stderr, "[sem] wait slot=%p exit rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_trywait(s) == 0 ? 0 : fbsd_errno(errno); }   // EAGAIN (would block) is 11 here, 35 on the PS5
 // scePthreadSemTimedwait is the one member of the family with no POSIX spelling registered on its

--- a/prosper/src/host/platform/posix_shim.hpp
+++ b/prosper/src/host/platform/posix_shim.hpp
@@ -69,6 +69,7 @@ static inline int prosper_mincore(const void* addr, size_t len, unsigned char* v
 #include <sys/uio.h>
 #include <unistd.h>
 #include <cerrno>
+#include <climits>
 #include <cstdio>
 #include <ctime>
 #include <csignal>
@@ -167,6 +168,15 @@ struct prosper_sem_t {
     int             count;
 };
 static inline int prosper_sem_init(prosper_sem_t* s, int /*pshared*/, unsigned value) {
+    // POSIX: sem_init() must fail EINVAL when `value` exceeds {SEM_VALUE_MAX} (sem_init(3)). `count`
+    // is a plain `int` here, so INT_MAX is the real bound this representation can hold -- accepting
+    // more would silently truncate the cast below into a negative count, and every subsequent
+    // wait/trywait/timedwait would then see "not ready" (`count <= 0`) even after enough posts to
+    // reach the value the guest actually asked for. Found in review of #3068: the out-of-range probe
+    // that test proved failed on Linux (real sem_init's own SEM_VALUE_MAX check) fell straight
+    // through this shim's unconditional `return 0` on Darwin, so the one platform this whole shim
+    // exists for was the one platform where SemInit could never report a real failure.
+    if (value > (unsigned)INT_MAX) { errno = EINVAL; return -1; }
     pthread_mutex_init(&s->m, nullptr); pthread_cond_init(&s->c, nullptr);
     s->count = (int)value; return 0;
 }

--- a/prosper/tests/hle/kernel/test_kernel_sem_init_error.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_init_error.cpp
@@ -1,0 +1,100 @@
+// test_kernel_sem_init_error (#3068) - scePthreadSemInit must forward a real sem_init() failure
+// rather than reporting success and publishing a pointer to an object that was never initialised.
+//
+// Before the fix, k_sem_init (hle_kernel.cpp) DISCARDED sem_init()'s return value, always returned
+// SCE_OK, and always wrote the (possibly-uninitialised) sem_t pointer through the guest's handle
+// slot. Every other member of the family -- k_sem_wait, k_sem_trywait, k_sem_timedwait, k_sem_post,
+// k_sem_getvalue -- reads that pointer straight back out via ensure_sem() and operates on it, so a
+// failed init was silently turned into undefined behaviour on every LATER call instead of one
+// honest, traceable failure at init time.
+//
+// This matters most on Darwin, where unnamed POSIX semaphores are not implemented at all --
+// sem_init() there is unconditionally ENOSYS -- but that specific errno cannot be produced on this
+// host (Linux, where unnamed semaphores work). What CAN be produced here, and is a real, portable
+// sem_init() failure rather than a Linux quirk, is POSIX's own SEM_VALUE_MAX check: sem_init(3)
+// must fail EINVAL when the requested initial value exceeds SEM_VALUE_MAX. glibc enforces this
+// (measured: sem_init(&s, 0, UINT32_MAX) -> rc=-1, errno=22).
+//
+// So rather than assuming that check exists on whatever platform this runs on, the test PROBES the
+// host sem_init() directly with the exact value the guest call below also uses, and only asserts
+// the guest-visible failure contract when the host call actually failed. That is the "prefer an
+// experiment that detects its own invalidity" rule: on a hypothetical platform whose libc accepts
+// an absurd value, this test explains why it has nothing to check instead of either flaking or
+// passing for the wrong reason. On every platform this suite's CI actually runs (Linux: EINVAL,
+// confirmed; Darwin: ENOSYS on any value, per Apple's documented sem_init) the probe fails and the
+// regression arms below run for real.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+#include "hle/kernel/sce_errno.hpp"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <semaphore.h>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_kernel_sem_init_error ==\n");
+    register_builtin_hle();
+
+    HleFn sem_init_fn = Hle::lookup(nid_hash("scePthreadSemInit").c_str());
+    CHECK(sem_init_fn != nullptr, "scePthreadSemInit is registered");
+    if (!sem_init_fn) { printf("== FAIL (unresolved) ==\n"); return 1; }
+
+    // UINT32_MAX: exceeds SEM_VALUE_MAX (INT_MAX on glibc, and Darwin rejects everything anyway)
+    // on every platform this project targets.
+    const unsigned kOutOfRange = 4294967295u;
+
+    sem_t probe;
+    errno = 0;
+    const int host_rc = sem_init(&probe, 0, kOutOfRange);
+    const int host_errno = errno;
+    if (host_rc == 0) sem_destroy(&probe);
+    printf("         (host sem_init(%u) -> rc=%d errno=%d)\n", kOutOfRange, host_rc, host_errno);
+
+    if (host_rc == 0) {
+        // Self-invalidating rather than silently green: this platform's sem_init doesn't reject
+        // the probe value, so this run cannot exercise the failure path at all.
+        printf("== SKIP (this platform's sem_init() accepted an out-of-range value; the failure "
+               "path cannot be exercised here) ==\n");
+        return 0;
+    }
+
+    // GUEST SIDE: same value, through the HLE entry point. The handle is a POINTER CELL (see the
+    // note in test_kernel_sem_timedwait.cpp -- k_sem_init does `*(void**)a0 = s`, an 8-byte write),
+    // pre-seeded with a sentinel that is neither nullptr nor a plausible heap pointer, so "the slot
+    // was published" and "the slot was left alone" are distinguishable afterwards.
+    void* slot = (void*)(uintptr_t)0x1;
+    const uint64_t handle = (uint64_t)(uintptr_t)&slot;
+    const uint64_t rc = sem_init_fn(handle, 0, kOutOfRange, 0, 0, 0);
+
+    // THE MECHANISM ARM: pre-fix, k_sem_init discards sem_init's return and this is 0 (SCE_OK)
+    // unconditionally regardless of what the host call did -- this is what reddens without #3068.
+    CHECK(rc != 0, "scePthreadSemInit reports the real failure instead of manufactured success");
+
+    // Sony spellings encode via sce_kernel_error() (0x8002_0000 | FreeBSD errno) -- decode it back
+    // and check it names EINVAL, the FreeBSD errno for an out-of-range semaphore value.
+    hle::FreeBsdErrno decoded{};
+    const bool decodes = hle::sce_kernel_error_errno(rc, decoded);
+    CHECK(decodes, "the failure is encoded the libkernel way (0x8002_0000 | errno), not a bare number");
+    if (decodes)
+        CHECK(decoded == hle::FreeBsdErrno::EInval,
+              "...and names EINVAL, the FreeBSD errno for an out-of-range initial value");
+
+    // THE OTHER HALF OF THE FIX: nothing was published into the guest's slot. Pre-fix, the handler
+    // wrote `*(void**)a0 = s` unconditionally, so a failed init still handed the guest a pointer to
+    // a sem_t that sem_init() never successfully touched -- and every later scePthreadSem* call
+    // resolves that exact pointer out of the slot (ensure_sem) and dereferences it.
+    CHECK(slot == (void*)(uintptr_t)0x1,
+          "the guest slot is left untouched, not published with a pointer to storage that was "
+          "never initialised");
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
@@ -108,11 +108,13 @@ int main() {
     // Asserts that init REPORTS success, not that the count is observably 0 -- the count is then
     // established by arm 1 timing out rather than being acquired.
     //
-    // Weaker still than that, and named rather than left implied: k_sem_init DISCARDS
-    // sem_init's return and returns 0 unconditionally, so this CHECK cannot fail as the code
-    // stands. It is kept as a tripwire for the day that is fixed, and the fix is #3068 --
-    // which matters on macOS, where unnamed POSIX semaphores are ENOSYS and this family may
-    // therefore be operating on an uninitialised object while reporting success.
+    // Until #3068, k_sem_init DISCARDED sem_init's return and reported success unconditionally, so
+    // this CHECK could not fail as the code stood -- it was kept only as a tripwire. #3068 made init
+    // forward the real host result, so this now genuinely exercises the success path (value 0 is
+    // always a legal initial count) rather than an unconditional 0. The FAILURE path -- a value
+    // sem_init genuinely rejects, and the guest slot staying unpublished when it does -- is covered
+    // by test_kernel_sem_init_error.cpp, which is what actually reddens without #3068's fix; this
+    // CHECK alone still cannot (init with 0 succeeds on every platform this suite runs on).
     CHECK(sem_init_fn(handle, 0, 0, 0, 0, 0) == 0, "scePthreadSemInit reports success");
 
     // ARM 1 + 2 + 3: one unposted wait, three independent properties.


### PR DESCRIPTION
## Fixes #3068

`scePthreadSemInit` (`k_sem_init`, `prosper/src/hle/kernel/hle_kernel.cpp`) discarded `sem_init()`'s
return value and unconditionally reported success, publishing a pointer to a `sem_t` through the
guest's handle slot even when initialisation failed. Every other member of the family —
`k_sem_wait`, `k_sem_trywait`, `k_sem_timedwait`, `k_sem_post`, `k_sem_getvalue` — resolves that
exact pointer back out of the slot via `ensure_sem()` and operates on it, so a failed init became
undefined behaviour on every later call instead of one honest, traceable failure at init time.

This is not theoretical: **unnamed POSIX semaphores are ENOSYS on Darwin**, so `sem_init()` there
fails unconditionally on every call, on every title that uses this family.

## UPDATE (after CI): the "no fallback exists" framing below was wrong

CI's macOS (Rosetta 2) job reddened the new test: the guest-visible `scePthreadSemInit` still
reported success for an out-of-range value, even though a direct probe of the real host `sem_init()`
correctly failed with `ENOSYS`. Root cause: `hle_kernel.cpp` includes
`src/host/platform/posix_shim.hpp`, which `#define`s `sem_t`/`sem_init`/... to a real mutex+cond
counting-semaphore implementation (`prosper_sem_t`/`prosper_sem_init`/...) on `__APPLE__`, because
Darwin's real `sem_init` is unconditionally ENOSYS. **That fallback already existed** and already
backs `SemWait`/`SemPost`/etc. for every title that hits this family on macOS today -- I hadn't found
it when I wrote the section below, which claims no fallback exists and that building one is out of
scope. That claim is wrong; a follow-up commit (`34acb13c`) fixes the actual gap: `prosper_sem_init`
unconditionally returned success regardless of `value`, ignoring it entirely, so my error-propagation
fix in `k_sem_init` was correctly written but structurally unreachable on macOS specifically -- the
call it makes could never fail. Worse, `count` is a plain `int`, so an out-of-range value was being
cast straight into it, silently wrapping negative. Fixed by adding the same `SEM_VALUE_MAX` bounds
check every other `sem_init` on this project's platforms already enforces (`value > INT_MAX` ->
`EINVAL`), touching nothing else in the shim. **Not built or tested by me -- still no macOS host**;
this is reasoned from reading the source, and the Rosetta 2 job is what actually verifies it.

## (Original PR description follows, and is superseded on this one point)

## Fix strategy chosen, and why

**Propagate the real error; do not publish the slot on failure.** I did *not* build a
`sem_open`-backed or condvar-backed fallback for platforms lacking unnamed semaphores, which is the
other option the issue names. Reasons:

- Nobody has confirmed what a live macOS boot actually needs preserved from this family's semantics
  (initial-value handling, `getvalue` behaviour, destroy-while-waiting, etc.). Building an unverified
  emulation layer risks silently trading one wrong behaviour (undefined behaviour on an
  uninitialised object) for a different, more plausible-looking wrong one — exactly the shape the
  project charter singles out as worse than a loud failure.
- The issue's own suggested fix is "propagate the error... If titles actually need this family on
  macOS, the real fix is a `sem_open`-backed or condvar-backed implementation there, and that should
  be its own issue once someone confirms the behaviour." I followed that scoping rather than
  expanding it.

So the change: `k_sem_init` now checks `calloc`'s result (ENOMEM), checks `sem_init`'s result, and on
failure frees the allocation, logs (capped at 4 lines, matching the existing `__stack_chk_fail`
pattern) and returns the real FreeBSD-numbered errno **without writing anything into the guest's
slot**. Both existing aliases (`SCE_PTHREAD_ALIAS` for the Sony spelling, `POSIX_SEM_ALIAS` for the
POSIX one) already encode/convert whatever bare errno the body returns, so no caller-side change was
needed — the body already returned bare FreeBSD errno on every other path in this family.

## What I verified on Linux vs. what is reasoned-only for macOS

**Verified on Linux (this host):**
- `sem_init(&s, 0, 4294967295u)` genuinely fails here: `rc=-1 errno=22 (EINVAL)`, confirmed with a
  throwaway probe before writing the test. That's POSIX's own `SEM_VALUE_MAX` check (glibc:
  `SEM_VALUE_MAX == INT_MAX`), not a Linux quirk.
- With the fix: `scePthreadSemInit` given that value returns a non-zero, libkernel-encoded EINVAL,
  and the guest slot is left untouched (unpublished). Directly observed, all green.
- **With the fix reverted** (confirmed by grepping the file back to the original one-line body):
  the same test reddens — 3 of 4 substantive assertions fail (`init reports the real failure`,
  `encoded the libkernel way`, `slot left untouched` all FAIL; exit 1). Rebuilt and ran this myself
  before restoring the fix.
- Full local build: clean, no errors. Full `ctest --no-tests=error`: **315/315 passed, exit 0**
  (314 baseline + this PR's new test), run against this PR's exact final commit on `origin/master`.

**Reasoned only, NOT verified — I have no macOS host:**
- That Darwin's `sem_init()` is unconditionally `ENOSYS` for unnamed semaphores (this is the issue's
  own claim, and it is Apple's long-documented behaviour, but I have not run it).
- That the fix's Darwin behaviour (a clean, encoded `ENOSYS`/errno instead of silent UB) is what
  actually happens on the Rosetta 2 CI runner. The test's Darwin path is designed to exercise the
  *same* probe-then-assert logic that passed on Linux (any out-of-range value should fail there too,
  and ENOSYS should fail unconditionally), but I have not seen it run. **Please read the macOS CI job
  on this PR as the actual verification, not this description.**

## Test

New `prosper/tests/hle/kernel/test_kernel_sem_init_error.cpp`, registered in `CMakeLists.txt`
next to `test_kernel_sem_timedwait`. It does not hardcode "sem_init fails here": it probes the
**host** `sem_init()` with an out-of-range value first, and only asserts the guest-visible failure
contract when the host call actually failed — so it explains itself and skips cleanly rather than
passing vacuously if some platform's libc happens to accept the probe value, and it is meaningful on
Linux (EINVAL, confirmed) and Darwin (ENOSYS on any value) without platform-specific code.

Also updated a stale comment in `test_kernel_sem_timedwait.cpp` that explicitly described its
`scePthreadSemInit reports success` check as "kept as a tripwire... the fix is #3068" — that
assertion now exercises a real forwarded result rather than an unconditional 0, and the comment
pointed at the new dedicated failure-path test instead of continuing to describe pre-fix behaviour.

## Build / test evidence (personally observed)

- `cmake --build` (Linux, distrobox `ps5ys`): clean, exit 0, at this PR's final commit.
- `ctest --no-tests=error`: **315/315 passed**, exit 0, at this PR's final commit
  (`f12609bf49926e7cc0dbd6a7b9274bd4566ed8d3` at push time).
- Mutation check (fix reverted, fix restored): described above, directly observed both states.

## Note on how this PR's branch was assembled

Mid-session, a `git stash pop` in this worktree picked up a **different concurrent agent's** stash
entry instead of mine (the stash ref is repo-wide, not worktree-scoped — filed as #3174). I did not
discard it: I re-stashed it intact with a note for its owner, never dropped anything from the shared
stack, and re-applied my own `hle_kernel.cpp` fix directly from my own record of the edit rather than
continuing to search the shared stash stack. `git diff --stat` on this branch is exactly the 4 files
listed above; nothing from that collision is in this PR.

