### PR TITLE
render_runner: check vkCreateImage's result before using the image handle

### DIFF
--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2650,6 +2650,28 @@ inline const char* render_buffer_upload_failure_name(RenderBufferUploadFailureSt
     }
 }
 
+// Deterministic one-shot injection for the #3045 regression check: simulate the NEXT sampled-
+// texture vkCreateImage call failing, without depending on any real device's limits. A real
+// over-large arrayLayers request cannot be relied on to fail here -- this box's RADV reports
+// maxImageArrayLayers=8192, well above the backend's own kBackendMaxArrayLayers ceiling of 2048,
+// so the array-layer path never actually reaches the driver's own rejection. The production path
+// never arms this state.
+inline bool& render_texture_create_failure_once_storage() {
+    static thread_local bool armed = false;
+    return armed;
+}
+
+inline void inject_render_texture_create_failure_once() {
+    render_texture_create_failure_once_storage() = true;
+}
+
+inline bool consume_render_texture_create_failure_once() {
+    bool& armed = render_texture_create_failure_once_storage();
+    if (!armed) return false;
+    armed = false;
+    return true;
+}
+
 // Create, populate, and unmap one transient storage buffer. Every partial failure tears down in
 // Vulkan lifetime order (buffer before any bound memory) and leaves both outputs null. Returning the
 // exact failed step lets the caller report the binding before substituting a safe zero-word buffer.
@@ -5205,7 +5227,24 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         dci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
                     VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
                     VK_IMAGE_USAGE_SAMPLED_BIT;   // sampled depth bridge (#1275)
-        vkCreateImage(dev, &dci, nullptr, &dimg);
+        // #3045: same class of defect as the sampled-texture upload path, and found while
+        // auditing this function's other vkCreateImage sites for the same review. Unlike the
+        // color-target sites above (which discard the VkResult but do check `!img`/`!img1`/
+        // `!extra_images[slot]` before touching the handle further), this one had NO guard at
+        // all -- a real failure fed a definitely-null `dimg` straight into
+        // vkGetImageMemoryRequirements, the exact undefined behaviour #3045 reports. Match the
+        // sibling return-out-on-failure convention instead.
+        const VkResult ds_image_result = vkCreateImage(dev, &dci, nullptr, &dimg);
+        if (ds_image_result != VK_SUCCESS || !dimg) {
+            dimg = VK_NULL_HANDLE;
+            static std::atomic<uint32_t> ds_create_failure_logs{0};
+            if (ds_create_failure_logs.fetch_add(1, std::memory_order_relaxed) < 32)
+                std::fprintf(stderr,
+                    "[ds-create-failed] vkCreateImage result=%d extent=%ux%u fmt=%d\n",
+                    (int)ds_image_result, W, H, (int)DFMT);
+            if (cached_ds) persistent_ds_cache().erase(ds_key);
+            return out;
+        }
         VkMemoryRequirements dr; vkGetImageMemoryRequirements(dev, dimg, &dr);
         VkMemoryAllocateInfo dai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
         dai.allocationSize = dr.size; dai.memoryTypeIndex = pick(dr.memoryTypeBits, 0);
@@ -6953,7 +6992,36 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                  ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0u) |
                                             (upload.key.mip_levels > 1
                                                  ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0u);
-                                vkCreateImage(dev, &tci, nullptr, &upload.image);
+                                // #3045: the result used to be discarded here, so a device
+                                // rejecting the request (VK_ERROR_OUT_OF_DEVICE_MEMORY, or an
+                                // extent/array-layer count past a real device's limits -- Vulkan
+                                // Core only guarantees maxImageArrayLayers >= 256, well under the
+                                // 2048 backend ceiling in #3043) left upload.image as
+                                // VK_NULL_HANDLE and fed straight into vkGetImageMemoryRequirements,
+                                // which is undefined behaviour on a null image. Check the result and
+                                // skip this draw the same way a fatal buffer-upload failure does
+                                // above (buffer_resources_ready = false; break;) instead of
+                                // propagating the null handle.
+                                const VkResult image_create_result =
+                                    consume_render_texture_create_failure_once()
+                                        ? VK_ERROR_OUT_OF_DEVICE_MEMORY
+                                        : vkCreateImage(dev, &tci, nullptr, &upload.image);
+                                if (image_create_result != VK_SUCCESS || !upload.image) {
+                                    upload.image = VK_NULL_HANDLE;
+                                    static std::atomic<uint32_t> texture_create_failure_logs{0};
+                                    if (texture_create_failure_logs.fetch_add(
+                                            1, std::memory_order_relaxed) < 32)
+                                        std::fprintf(
+                                            stderr,
+                                            "[texture-upload-failed] set=%u binding=%u "
+                                            "vkCreateImage result=%d extent=%ux%ux%u mips=%u "
+                                            "layers=%u fmt=%d -- skipping draw\n",
+                                            r.set, r.binding, (int)image_create_result,
+                                            tci.extent.width, tci.extent.height, tci.extent.depth,
+                                            tci.mipLevels, tci.arrayLayers, (int)tci.format);
+                                    buffer_resources_ready = false;
+                                    break;
+                                }
                                 VkMemoryRequirements tr;
                                 vkGetImageMemoryRequirements(dev, upload.image, &tr);
                                 upload.image_bytes = tr.size;

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -139,6 +139,26 @@ int main() {
     printf("  (0.75,0.25) center=(%u,%u,%u)\n", ok1?rgb[0]:0, ok1?rgb[1]:0, ok1?rgb[2]:0);
     CHECK(ok1 && rgb[1] > 0x80 && rgb[0] < 0x40 && rgb[2] < 0x40, "sampling texel (1,0) yields GREEN (proves u routing)");
 
+    // #3045: vkCreateImage's result used to be discarded in the texture-upload path and fed
+    // straight into vkGetImageMemoryRequirements, so any real allocation failure handed the
+    // Vulkan loader a VK_NULL_HANDLE. inject_render_texture_create_failure_once() simulates that
+    // exact failure deterministically for the next texture upload -- a real over-large request
+    // can't be relied on to fail here, since this box's RADV reports maxImageArrayLayers=8192,
+    // well above the backend's own 2048 ceiling (#3043), so it never actually reaches the driver.
+    // A fixed backend must skip the draw carrying the unmaterializable texture rather than use
+    // the null handle: the pass still renders (blue clear, per this file's header), but the texel
+    // that WOULD have been GREEN never gets drawn.
+    {
+        prosper::test::inject_render_texture_create_failure_once();
+        uint8_t frgb[3];
+        bool okFail = sample_center(C075, C025, frgb);
+        printf("  vkCreateImage-failure (0.75,0.25) center=(%u,%u,%u)\n",
+               okFail?frgb[0]:0, okFail?frgb[1]:0, okFail?frgb[2]:0);
+        CHECK(okFail && frgb[2] > 0x80 && frgb[0] < 0x40 && frgb[1] < 0x40,
+              "vkCreateImage failure skips the draw (blue clear survives) instead of using the "
+              "null image handle (#3045)");
+    }
+
     // Dynamic single-channel textures (notably Astro Bot's FMV planes) stay R8 through upload. The
     // component mapping reproduces the live frontend's historical coverage broadcast without a 4x
     // CPU expansion to RGBA8.


### PR DESCRIPTION
## Summary

Fixes #3045: `render_draw_pass_rgba`'s sampled-texture upload path called
`vkCreateImage(dev, &tci, nullptr, &upload.image)` and discarded the `VkResult`, then
unconditionally called `vkGetImageMemoryRequirements(dev, upload.image, &tr)`. On any real
`vkCreateImage` failure (`VK_ERROR_OUT_OF_DEVICE_MEMORY`, or a device rejecting the requested
extent/array-layer count), `upload.image` stayed `VK_NULL_HANDLE` and was passed straight into
that call -- undefined behaviour.

While auditing this function's other `vkCreateImage` sites for the same defect, I found a second
one with the identical shape: the depth/stencil target creation path had **no guard at all**
(not even the weaker `if (!img)` handle check the color-target sites use) before calling
`vkGetImageMemoryRequirements(dev, dimg, &dr)`. Fixed both.

## Failure scenario

Any `vkCreateImage` failure on the sampled-texture or depth/stencil target path fed a
`VK_NULL_HANDLE` into `vkGetImageMemoryRequirements` and onward. Verified this is not
theoretical: with the fix removed and a real failure forced (see Verification), the process
segfaults inside the Vulkan call, on this box's RADV driver.

## Fix

Both sites now check the `VkResult` (and the handle, matching the sibling color-target
convention), log a rate-limited diagnostic naming the real Vulkan error code and the requested
image parameters, and fail visibly instead of propagating the null handle:

- **Sampled-texture upload** (`tests/fixtures/render_runner.h`, the site #3045 names): on
  failure, sets `buffer_resources_ready = false; break;` -- the exact mechanism this function
  already uses for a fatal storage-buffer upload failure, which the per-draw loop turns into
  `continue` (skip this one draw; the render pass still executes for every other draw and still
  produces its clear).
- **Depth/stencil target creation**: on failure, `return out;` -- matching the sibling
  color-target/MRT creation sites in this same function, which already bail this way on a
  (weaker, handle-only) creation failure.

### Deliberately out of scope

The color-target and MRT creation sites (`img`, `img1`, `extra_images[slot]`, four call sites)
also discard the `VkResult`, but each already checks `!img` before using the handle further, so
there is no UB today -- just reliance on the (universally true in practice, but spec-unguaranteed)
convention that a failed `vkCreateImage` leaves the output handle null. Filed as #3180 rather than
folding into this PR, since it's a different-severity issue (robustness/diagnosability, not UB)
and touches four more call sites.

Also out of scope: `tests/fixtures/render_runner.h:426-437`'s comment (added by #3043, which is
what surfaced this issue) notes that prosper reads no `VkPhysicalDeviceLimits` for image creation
at all, and that deriving the real `maxImageArrayLayers`/`maxImageDimension2D` would let the
backend reject at the contract boundary rather than at the driver. That's a real improvement but
a materially bigger change (threading device limits through); this PR is scoped to the reported
defect -- checking the result and failing visibly.

## Verification

Added `inject_render_texture_create_failure_once()` (mirrors the existing
`inject_render_buffer_upload_failure_once` pattern in the same file) -- a deterministic one-shot
injection that simulates the *next* texture-upload `vkCreateImage` call failing, without depending
on any real device's limits. A real over-large request can't be relied on to fail on every
device: this box's RADV reports `maxImageArrayLayers=8192`, well above the backend's own
`kBackendMaxArrayLayers` ceiling of 2048 from #3043, so an over-large-arrayLayers request never
actually reaches the driver here.

New regression check in `tests/gpu/test_texture_sample_render.cpp`: arm the injection, render the
same textured triangle the file's existing GREEN-texel check uses, and assert the pass still
completes and shows the blue clear (not the GREEN texel, not garbage, not a crash) -- proving the
draw was skipped rather than the null handle being used.

**Proved the test fails without the fix:** temporarily reverted just the
check-and-bail block (kept the injection call itself, since that's test scaffolding, not the fix)
back to the original unconditional `vkCreateImage(...); vkGetImageMemoryRequirements(dev,
upload.image, &tr);`, rebuilt, and ran `test_texture_sample_render`:

```
[render] Vulkan device: AMD Radeon 8060S Graphics (RADV STRIX_HALO) (integrated GPU)
== test_texture_sample_render ==
  ...
  [ok]   sampling texel (1,0) yields GREEN (proves u routing)
Segmentation fault (core dumped)
```

(stdout is fully buffered when redirected to a file, so later `[ok]`/`[FAIL]` lines never reached
disk; a `stdbuf -oL` rerun confirmed the crash lands immediately after that last printed line --
i.e. inside my new check block, calling `vkGetImageMemoryRequirements` on the injected-failure's
null handle.) Restored the fix, rebuilt, reran: `== PASS ==`, exit 0, the new check passes.

## Build / test

```
cmake --build prosper/build-linux -j6      # clean, both before and after merging master
ctest --no-tests=error                     # 314/314 passed, exit 0 (before and after merging master)
python3 tools/output/check_ascii_output.py prosper   # all checks passed
```

314 is the unchanged full count -- the new regression check lives inside the existing
`test_texture_sample_render` binary rather than registering a new ctest case.

## Follow-up filed

#3180 -- the four milder sibling `vkCreateImage` sites (color-target/MRT creation) that discard
`VkResult` but already guard the handle.
