### PR TITLE
host: give Win32SleepFallback the same deadline post-condition as its sibling (#3074)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2045,6 +2045,16 @@ if(TARGET prosper_core)
   target_link_libraries(test_videoout PRIVATE prosper_core)
   add_test(NAME videoout_queries COMMAND test_videoout)
 
+  # precise_sleep's deadline post-condition (#3074): every sleep_until_steady_ns() backend must
+  # never return before now_ns() >= deadline_ns. Win32SleepFallback did not re-check after its one
+  # OS sleep call, unlike the sibling high-resolution-timer path. CROSS-PLATFORM like test_videoout
+  # above and for the same reason: sleep_until_deadline_retry() is the pure-function loop the fix
+  # composes, deliberately extracted so its termination condition is testable with a fake clock and
+  # a fake sleep on any host, without executing the Windows-only code path or measuring wall time.
+  add_executable(test_precise_sleep tests/host/platform/test_precise_sleep.cpp)
+  target_link_libraries(test_precise_sleep PRIVATE prosper_core)
+  add_test(NAME precise_sleep_deadline_retry COMMAND test_precise_sleep)
+
   # Windows guest-execution substrate (exec_image_win.cpp): build boot_trace so the whole boot path
   # links (proves the substrate + SysV-ABI HLE boundary resolve). No evdev/Vulkan here. The guest boot
   # itself is not yet verified on Windows — see docs/PORTING.md "Windows".

--- a/prosper/src/host/platform/precise_sleep.cpp
+++ b/prosper/src/host/platform/precise_sleep.cpp
@@ -70,6 +70,20 @@ void sleep_until_with_std(uint64_t deadline_ns) {
             std::chrono::nanoseconds(deadline_ns))));
 }
 
+}  // namespace
+
+// Defined OUTSIDE the anonymous namespace and outside every #ifdef _WIN32 block: this is the
+// pure-function half of the #3074 fix; see its declaration in precise_sleep.hpp for why it takes
+// function pointers rather than calling steady_now_ns()/sleep_until_with_std() directly, and
+// test_precise_sleep.cpp for the platform-neutral test that exercises it.
+void sleep_until_deadline_retry(uint64_t deadline_ns,
+                                 uint64_t (*now_ns)(),
+                                 void (*sleep_once)(uint64_t deadline_ns)) {
+    while (now_ns() < deadline_ns) sleep_once(deadline_ns);
+}
+
+namespace {
+
 #ifdef _WIN32
 // One auto-reset timer per waiting thread. Auto-reset so the wait itself consumes the signal and no
 // stale signalled state can make the NEXT wait return instantly.
@@ -124,7 +138,11 @@ void sleep_until_steady_ns(uint64_t deadline_ns) {
     // Anything above that did not work out lands here — no worse than master's behaviour, and
     // reported distinctly so a test can tell the two apart rather than silently pacing at ~32 Hz.
     if (steady_now_ns() >= deadline_ns) return;
-    sleep_until_with_std(deadline_ns);
+    // #3074: sleep_until_with_std() is ONE OS sleep call with no post-condition re-check of its
+    // own -- unlike the high-resolution loop above, which re-reads the clock after every timer
+    // signal -- so calling it once and returning let this path come back before deadline_ns.
+    // sleep_until_deadline_retry() re-checks and, if the sleep returned early, sleeps again.
+    sleep_until_deadline_retry(deadline_ns, steady_now_ns, sleep_until_with_std);
     g_backend = SleepBackend::Win32SleepFallback;
 #else
     // glibc: sleep_until -> sleep_for -> a nanosleep loop that also restarts on EINTR, which matters

--- a/prosper/src/host/platform/precise_sleep.hpp
+++ b/prosper/src/host/platform/precise_sleep.hpp
@@ -22,6 +22,23 @@ enum class SleepBackend {
 // immediately if the deadline has already passed.
 void sleep_until_steady_ns(uint64_t deadline_ns);
 
+// The post-condition sleep_until_steady_ns() promises on EVERY backend: never return before
+// `now_ns() >= deadline_ns`. A single OS sleep primitive is not trusted to hit this on its own -- a
+// waitable timer can signal marginally early, and so can the ::Sleep()-backed fallback used when no
+// waitable timer is available (#3074) -- so a backend that cannot prove its own precision composes
+// this retry loop instead of calling its one-shot sleep directly and returning.
+//
+// `now_ns` and `sleep_once` are function pointers rather than the real clock/sleep calls so the
+// LOOP'S TERMINATION CONDITION is a pure function, testable on any host platform without executing
+// a real sleep or depending on _WIN32: a test supplies a fake clock and a fake "sleep" that just
+// advances it by a fixed amount, and asserts the loop keeps calling sleep_once until the fake clock
+// reaches the deadline -- never a wall-clock duration, which is a flake by construction on a loaded
+// host (see test_videoout.cpp's note on #1770/#1793, and next_grid_deadline_ns above for the same
+// pure-function-over-real-time precedent from #3075).
+void sleep_until_deadline_retry(uint64_t deadline_ns,
+                                 uint64_t (*now_ns)(),
+                                 void (*sleep_once)(uint64_t deadline_ns));
+
 SleepBackend sleep_backend();
 
 // A stable spelling of sleep_backend() for assertions and logs. Never null.

--- a/prosper/tests/host/platform/test_precise_sleep.cpp
+++ b/prosper/tests/host/platform/test_precise_sleep.cpp
@@ -1,0 +1,106 @@
+// test_precise_sleep (#3074) — the post-condition every sleep_until_steady_ns() backend must
+// satisfy: never return before `now_ns() >= deadline_ns`. The high-resolution Windows path already
+// re-checked the clock after every timer signal; Win32SleepFallback did not, so a single early
+// ::Sleep() return let the whole function come back before its documented deadline.
+//
+// That fallback only runs under _WIN32, so on this platform it cannot be driven directly (and even
+// on Windows a wall-clock test would flake with host scheduling, which this project has already been
+// burned by twice — see test_videoout.cpp's note on #1770/#1793). The fix is therefore split into a
+// PURE FUNCTION, sleep_until_deadline_retry(), compiled and linked on every platform: it takes the
+// clock read and the one-shot sleep as function pointers, so this test can supply a fake clock and a
+// fake "sleep" that just advances it, and assert the loop's TERMINATION CONDITION — never a duration.
+//
+// Mutation-checked (see the PR): reverting sleep_until_deadline_retry()'s body from
+// `while (now_ns() < deadline_ns) sleep_once(deadline_ns);` to the pre-fix single-call shape
+// `if (now_ns() < deadline_ns) sleep_once(deadline_ns);` reddens arm 1 below — the fake sleep step is
+// deliberately smaller than the deadline gap, so one call cannot reach it and the post-condition
+// check catches exactly the #3074 defect.
+#include "host/platform/precise_sleep.hpp"
+
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// A fake clock/sleeper pair, file-scope so they can be plain function pointers (the API
+// sleep_until_deadline_retry() takes, matching the real steady_now_ns()/sleep_until_with_std()
+// signatures it is called with in precise_sleep.cpp). Reset at the top of each arm.
+static uint64_t g_fake_now_ns = 0;
+static int g_sleep_calls = 0;
+static uint64_t g_sleep_step_ns = 0;   // how far one fake "sleep" advances the fake clock
+
+static uint64_t fake_now_ns() { return g_fake_now_ns; }
+
+// Simulates an OS sleep primitive that does not itself guarantee reaching the deadline — exactly
+// what ::Sleep()'s ~15.6 ms tick quantization can do relative to a 16.68 ms vblank deadline (or,
+// more generally, what any single OS wait is allowed to do: return marginally early). Ignores the
+// deadline it is passed and always advances by the fixed step, so a caller that does not re-check
+// and retry will return however far short of the deadline that leaves it.
+static void fake_sleep_fixed_step(uint64_t /*deadline_ns*/) {
+    ++g_sleep_calls;
+    g_fake_now_ns += g_sleep_step_ns;
+}
+
+int main() {
+    printf("== test_precise_sleep ==\n");
+
+    // 1. THE #3074 CASE: each fake sleep advances less than the full gap to the deadline, so a
+    //    single call cannot satisfy the post-condition. This is the arm the mutation check reddens.
+    {
+        g_fake_now_ns = 0;
+        g_sleep_calls = 0;
+        g_sleep_step_ns = 1000;                    // ten calls needed to cover the 10000 ns deadline
+        constexpr uint64_t kDeadlineNs = 10000;
+        host::sleep_until_deadline_retry(kDeadlineNs, fake_now_ns, fake_sleep_fixed_step);
+        CHECK(g_fake_now_ns >= kDeadlineNs,
+              "retry loop never returns before the deadline, even when each sleep undershoots it");
+        CHECK(g_sleep_calls > 1,
+              "reaching the deadline took more than one sleep call (proves it looped, not just "
+              "called once)");
+        CHECK(g_sleep_calls == 10,
+              "it retried exactly as many times as the fixed step requires, not more (no busy spin "
+              "past the deadline)");
+    }
+
+    // 2. A sleep that reaches the deadline in one call: the loop must not call again after the
+    //    post-condition already holds (no extra, unnecessary sleep).
+    {
+        g_fake_now_ns = 0;
+        g_sleep_calls = 0;
+        g_sleep_step_ns = 10000;                   // exactly the deadline gap
+        constexpr uint64_t kDeadlineNs = 10000;
+        host::sleep_until_deadline_retry(kDeadlineNs, fake_now_ns, fake_sleep_fixed_step);
+        CHECK(g_fake_now_ns >= kDeadlineNs, "the single-call case still satisfies the post-condition");
+        CHECK(g_sleep_calls == 1, "a sleep that already reaches the deadline is not retried again");
+    }
+
+    // 3. A sleep that overshoots the deadline in one call: same as (2), one call is enough.
+    {
+        g_fake_now_ns = 0;
+        g_sleep_calls = 0;
+        g_sleep_step_ns = 50000;                   // far past the deadline
+        constexpr uint64_t kDeadlineNs = 10000;
+        host::sleep_until_deadline_retry(kDeadlineNs, fake_now_ns, fake_sleep_fixed_step);
+        CHECK(g_fake_now_ns >= kDeadlineNs, "an overshooting sleep satisfies the post-condition");
+        CHECK(g_sleep_calls == 1, "an overshooting sleep is not called a second time");
+    }
+
+    // 4. The deadline has ALREADY passed when the loop is entered: it must not sleep at all. This is
+    //    the same early-out precise_sleep.cpp keeps before calling the retry loop, pinned here as a
+    //    property of the loop itself.
+    {
+        g_fake_now_ns = 12345;
+        g_sleep_calls = 0;
+        g_sleep_step_ns = 1000;
+        constexpr uint64_t kDeadlineNs = 10000;    // already behind g_fake_now_ns
+        host::sleep_until_deadline_retry(kDeadlineNs, fake_now_ns, fake_sleep_fixed_step);
+        CHECK(g_sleep_calls == 0, "a deadline already in the past is not slept on at all");
+    }
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Issue

Fixes #3074.

`precise_sleep`'s `sleep_until_steady_ns()` on Windows has two backends: the high-resolution
waitable-timer path and, when the timer is unavailable, a fallback that goes through
`std::this_thread::sleep_until()`. The high-resolution path loops and re-reads the clock after
every timer signal, explicitly because a waitable timer can be released marginally early and the
function's contract ("do not come back before the deadline") has to be enforced rather than
trusted to the primitive's precision. `Win32SleepFallback` did not do the same: it called the one
OS sleep primitive exactly once and returned, so it could come back before `deadline_ns` while the
sibling path (and the header's own doc comment) both promise it cannot.

## Behavioral contract

`sleep_until_steady_ns(deadline_ns)` must never return before
`steady_clock::now() >= deadline_ns`, on every backend it can select. That is the property every
caller relies on -- the vblank kevent pump (`hle_kernel_time.cpp`, after #3064) and the audio grain
pacer (`audio_sink_sdl3.cpp`) both assume it, and an early return from the fallback can post a
duplicate vblank kevent for the same tick or deliver an audio grain early.

## Approach

The fix (`prosper/src/host/platform/precise_sleep.cpp`, `.hpp`) extracts the re-check-and-retry
loop into a new, platform-neutral function:

```cpp
void sleep_until_deadline_retry(uint64_t deadline_ns,
                                 uint64_t (*now_ns)(),
                                 void (*sleep_once)(uint64_t deadline_ns));
```

It is compiled and linked unconditionally (outside every `#ifdef _WIN32` block), and takes the
clock read and the one-shot sleep as function pointers rather than calling
`steady_now_ns()`/`sleep_until_with_std()` directly. `Win32SleepFallback` now calls
`sleep_until_deadline_retry(deadline_ns, steady_now_ns, sleep_until_with_std)` instead of calling
`sleep_until_with_std()` once and returning. The high-resolution timer path is unchanged -- it
already re-checks correctly and this PR does not touch it. The POSIX path is also unchanged
(deliberately a single call; see the existing comment in the file).

Making the retry loop a pure function taking function pointers is what makes this testable off
Windows at all: `tests/host/platform/test_precise_sleep.cpp` supplies a fake clock and a fake
"sleep" that just advances it by a fixed step, and asserts the loop's **termination condition**
(never a wall-clock duration, which would flake under host scheduling -- this project has been
burned by that twice already, per the comments in `test_videoout.cpp` on #1770/#1793). This follows
the same pure-function-over-real-time approach #3170 used for `grid_boundaries_missed()`.

Test arms:
1. The #3074 case itself: each fake sleep undershoots the deadline (mirroring what `::Sleep()`'s
   tick quantization can do), so a single call cannot satisfy the post-condition -- the loop must
   retry. Asserts the post-condition holds and that it took more than one call.
2. A sleep that reaches the deadline in exactly one call: no extra retry.
3. A sleep that overshoots the deadline in one call: same, no extra retry.
4. A deadline already in the past on entry: zero sleep calls.

## What is verified vs. reasoned

- **Verified, on Linux:** `sleep_until_deadline_retry()` itself -- its loop, its termination
  condition, and every test arm above -- builds and runs correctly on this platform, since it is
  platform-neutral. Verified the test **reddens without the fix**: temporarily reverted the
  function's body to the pre-fix single-call shape
  (`if (now_ns() < deadline_ns) sleep_once(deadline_ns);`) and rebuilt -- the undershoot arm failed
  3 assertions exactly as expected, confirming the test catches the #3074 defect. Reverted back
  before this commit (verified via `git diff`/rebuild that the working tree matches the intended
  fix).
- **Reasoned, not executed:** the actual `Win32SleepFallback` branch of `sleep_until_steady_ns()`
  (the `#ifdef _WIN32` code path that now calls `sleep_until_deadline_retry`) does not compile or
  run on this machine. I did not build or execute it on Windows. The change there is a
  three-argument call-site substitution with the same arguments' types and order as the function it
  replaces (`sleep_until_with_std(deadline_ns)` -> `sleep_until_deadline_retry(deadline_ns,
  steady_now_ns, sleep_until_with_std)`); `steady_now_ns` and `sleep_until_with_std` are the same
  free functions the high-resolution path above it already uses, unchanged. CI's Windows MinGW job
  will build this; I have not run it myself.

## Affected / unaffected behavior

- Affected: `sleep_until_steady_ns()`'s `Win32SleepFallback` branch (Windows only, and only taken
  when `CREATE_WAITABLE_TIMER_HIGH_RESOLUTION` is unavailable).
- Unaffected: the `Win32HighResolutionTimer` branch (unchanged), the POSIX branch (unchanged),
  `next_grid_deadline_ns()`/`grid_boundaries_missed()` (untouched, from #3170).

## Risk

Low. The change is additive (a new pure function) plus a one-line call-site substitution at the
one place identified in the issue. The new function has no side effects of its own -- it only
calls the function pointers it is given -- so its worst case on a still-buggy `sleep_once` is
identical to today's behavior (return once `now_ns()` first reports past the deadline, same as
before, just via a loop that would also retry if given the chance).

## Build / test

```
cmake -S prosper -B prosper/build-linux
cmake --build prosper/build-linux -j6
ctest --no-tests=error   # 315 tests, 100% passed (baseline 314 + the 1 new precise_sleep_deadline_retry)
```

`ctest --no-tests=error -R precise_sleep` -> 1/1 passed.
