### PR TITLE
fix(perf): warn about harness readback whenever it is a material share, not only when it wins classification

### DIFF
--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -329,21 +329,27 @@ def summarize(records):
     # different instrument that happens to share the mechanism.
     readback_note = None
     # Warn whenever readback is a LEADING component, not only when it wins the classification.
-    # A capture where readback is the largest single component but sits under the evidence
-    # threshold gets classified "inconclusive" -- and then prints the biggest number on the page
-    # with no warning attached, which is the exact shape that sends a reader chasing the harness.
-    # Measured on a Dragon Quest capture: readback=977.7ms was the top component, classification
-    # was "inconclusive", and the note stayed silent.
-    # Ranking is the wrong trigger: on the capture that motivated this, readback was 977.7ms and
-    # merely SECOND to compute's 1134.0ms, so a "is it the max" test stayed silent on a number a
-    # reader would still have chased. If the frontend is copying scanout frames at all, say so.
-    material_readback = False
-    try:
-        _c = components if isinstance(components, dict) else {}
-        _rb = _c.get("readback")
-        material_readback = isinstance(_rb, (int, float)) and _rb > 0.0
-    except Exception:
-        material_readback = False
+    # A capture where readback is large but sits under the 40% evidence threshold is classified
+    # "inconclusive" -- and then prints a big number with no warning attached, which is the exact
+    # shape that sends a reader chasing the harness instead of the title. Measured on a Dragon
+    # Quest VII capture: readback=977.7ms against compute=1134.0ms, classified "inconclusive",
+    # note silent.
+    #
+    # Ranking is the wrong trigger and was the first attempt: a "is readback the max component"
+    # test stays silent at 977.7 vs 1134.0, which is precisely the case that misleads. So the
+    # trigger is readback's SHARE of measured work, with a threshold deliberately well below the
+    # 40% classification bar -- the whole point is to cover the gap under that bar.
+    #
+    # The threshold is a judgement call and both ends of it are pinned by tests: a ~39% readback
+    # must warn (the motivating capture), and a 2%-of-total readback must stay silent, because a
+    # paragraph of warning attached to a rounding-level number is noise on every report and trains
+    # readers to skip the note in the cases that matter. Any nonzero readback is NOT the right
+    # trigger for that reason.
+    READBACK_NOTE_MIN_SHARE = 0.10
+    readback_ms = classification_components.get("readback")
+    material_readback = (
+        isinstance(readback_ms, (int, float)) and measured_total > 0 and
+        readback_ms / measured_total >= READBACK_NOTE_MIN_SHARE)
     if classification == "readback" or material_readback:
         adopted = _gpu_present_adopted(post)
         if adopted is None:

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -439,7 +439,7 @@ def summarize(records):
                 "GPU present WAS adopted, so scanout readback is skipped and this readback is real "
                 "work -- non-deferred colour-target readback, storage writeback, or a copy forced by "
                 "authoritative_readback (every ordered DMA copy sets it). Chase it rather than "
-                "dismissing it as a harness artifact")
+                "dismissing it as a harness artifact.")
 
     pacing_note = None
     if rates["guest_fps"] is not None and rates["rendered_fps"] is not None:

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -227,6 +227,45 @@ def _compute_program_groups(records, limit=10, address_limit=8):
     }
 
 
+# Readback must reach this share of measured work before the harness-readback note is emitted.
+#
+# ANCHOR: one quarter of the 0.40 classification evidence bar. The note exists to cover the gap
+# UNDER that bar -- a readback large enough to mislead but too small to win the verdict -- so the
+# threshold belongs well below it, and a quarter is the round fraction that is.
+#
+# WHAT THE TESTS ACTUALLY PIN, measured per-arm rather than by exit code, because the two are not
+# the same question and reading only the exit code gets this wrong:
+#
+#   threshold     failing arm
+#   <= 0.020      test_non_readback_verdict_carries_no_readback_note   (2 ms / 2%, PRE-EXISTING)
+#   0.021-0.200   none
+#   >  0.200      test_readback_note_threshold_is_a_share_not_a_ranking (its 20% assertion)
+#
+# So the pinned band is (0.020, 0.200] and 0.10 is NOT itself pinned -- it can move anywhere in a
+# 10x range with no test objecting. Two corrections worth keeping, because the obvious reading of
+# the arms is wrong in both directions:
+#   * the LOWER bound is held by the pre-existing 2% test, NOT by the 1% arm added alongside this
+#     threshold. That arm passes at 0.011 and at 0.020; it never binds.
+#   * the UPPER bound is held by the 20% assertion, NOT by the 31% motivating arm. That arm's share
+#     is 0.3120 and it does not fail anywhere in the swept range.
+# The 1% and 31% arms still earn their place -- they hold verdict and GPU-present state constant so
+# the only variable is share, and the 31% one reproduces the capture that motivated the change --
+# but neither is what fixes the band, and a comment claiming otherwise sends the next reader to the
+# wrong test when they want to tighten it.
+READBACK_NOTE_MIN_SHARE = 0.10
+
+
+# The note's closing advice depends on whether readback DECIDED the verdict. "before acting on this
+# verdict" is right when the verdict IS readback; on a capture whose verdict is a decisive compute or
+# renderer-resource share it is wrong advice attached to a correct conclusion, which is worse than no
+# advice -- the reader is told to discard a finding the readback had no part in.
+def _readback_note_tail(classification):
+    if classification == "readback":
+        return " before acting on this verdict"
+    return (" before reading the readback line below; it does not affect the "
+            + str(classification) + " verdict above")
+
+
 def summarize(records):
     header = records[0]
     footer = next(record for record in records if record.get("type") == "footer")
@@ -340,14 +379,7 @@ def summarize(records):
     # trigger is readback's SHARE of measured work, with a threshold deliberately well below the
     # 40% classification bar -- the whole point is to cover the gap under that bar.
     #
-    # The threshold is a judgement call, and what the tests pin is a BAND, not this constant: a
-    # 31%-of-measured-work readback must warn and a 1% one must stay silent, so any value in
-    # (0.02, 0.20] passes. 0.10 sits in that band and is not itself pinned -- a later change may
-    # move it within the band without any test noticing, which is the honest limit of the coverage.
-    # The quiet end is the one that earns its keep: a paragraph of warning attached to a
-    # rounding-level number is noise on every report and trains readers to skip the note in the
-    # cases that matter. Any nonzero readback is NOT the right trigger, for that reason.
-    READBACK_NOTE_MIN_SHARE = 0.10
+    # See READBACK_NOTE_MIN_SHARE at module scope for the threshold and what pins it.
     readback_ms = classification_components.get("readback")
     material_readback = (
         isinstance(readback_ms, (int, float)) and measured_total > 0 and
@@ -358,13 +390,13 @@ def summarize(records):
             readback_note = (
                 "this capture cannot say whether GPU present was adopted, so it cannot say whether "
                 "the readback is real or the harness copying every scanout frame to the CPU. Check "
-                "the run log for a GPU-present surface failure before acting on this verdict")
+                "the run log for a GPU-present surface failure" + _readback_note_tail(classification))
         elif adopted is False:
             readback_note = (
                 "GPU present was NOT adopted for this capture, so the frontend copied every scanout "
                 "frame to the CPU -- most often prosper-app under SDL_VIDEODRIVER=offscreen, which "
                 "needs VK_EXT_headless_surface. This readback is the harness, not the title. "
-                "Re-measure through a real window before acting on this verdict")
+                "Re-measure through a real window" + _readback_note_tail(classification))
         else:
             readback_note = (
                 "GPU present WAS adopted, so scanout readback is skipped and this readback is real "

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -340,11 +340,13 @@ def summarize(records):
     # trigger is readback's SHARE of measured work, with a threshold deliberately well below the
     # 40% classification bar -- the whole point is to cover the gap under that bar.
     #
-    # The threshold is a judgement call and both ends of it are pinned by tests: a ~39% readback
-    # must warn (the motivating capture), and a 2%-of-total readback must stay silent, because a
-    # paragraph of warning attached to a rounding-level number is noise on every report and trains
-    # readers to skip the note in the cases that matter. Any nonzero readback is NOT the right
-    # trigger for that reason.
+    # The threshold is a judgement call, and what the tests pin is a BAND, not this constant: a
+    # 31%-of-measured-work readback must warn and a 1% one must stay silent, so any value in
+    # (0.02, 0.20] passes. 0.10 sits in that band and is not itself pinned -- a later change may
+    # move it within the band without any test noticing, which is the honest limit of the coverage.
+    # The quiet end is the one that earns its keep: a paragraph of warning attached to a
+    # rounding-level number is noise on every report and trains readers to skip the note in the
+    # cases that matter. Any nonzero readback is NOT the right trigger, for that reason.
     READBACK_NOTE_MIN_SHARE = 0.10
     readback_ms = classification_components.get("readback")
     material_readback = (

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -328,7 +328,23 @@ def summarize(records):
     # prosper-app arms one. The `PROSPER_TILECENSUS` readback trap (instrument trap 237) is a
     # different instrument that happens to share the mechanism.
     readback_note = None
-    if classification == "readback":
+    # Warn whenever readback is a LEADING component, not only when it wins the classification.
+    # A capture where readback is the largest single component but sits under the evidence
+    # threshold gets classified "inconclusive" -- and then prints the biggest number on the page
+    # with no warning attached, which is the exact shape that sends a reader chasing the harness.
+    # Measured on a Dragon Quest capture: readback=977.7ms was the top component, classification
+    # was "inconclusive", and the note stayed silent.
+    # Ranking is the wrong trigger: on the capture that motivated this, readback was 977.7ms and
+    # merely SECOND to compute's 1134.0ms, so a "is it the max" test stayed silent on a number a
+    # reader would still have chased. If the frontend is copying scanout frames at all, say so.
+    material_readback = False
+    try:
+        _c = components if isinstance(components, dict) else {}
+        _rb = _c.get("readback")
+        material_readback = isinstance(_rb, (int, float)) and _rb > 0.0
+    except Exception:
+        material_readback = False
+    if classification == "readback" or material_readback:
         adopted = _gpu_present_adopted(post)
         if adopted is None:
             readback_note = (

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -227,11 +227,21 @@ def _compute_program_groups(records, limit=10, address_limit=8):
     }
 
 
+# The share a component must reach to WIN the classification. Named because two things depend on
+# it and it was previously a bare literal in one of them, so neither the dependency nor the value
+# was pinned by anything -- moving it passed the whole suite.
+CLASSIFICATION_EVIDENCE_SHARE = 0.40
+
 # Readback must reach this share of measured work before the harness-readback note is emitted.
 #
-# ANCHOR: one quarter of the 0.40 classification evidence bar. The note exists to cover the gap
-# UNDER that bar -- a readback large enough to mislead but too small to win the verdict -- so the
-# threshold belongs well below it, and a quarter is the round fraction that is.
+# It sits BELOW the evidence bar by construction: the note exists to cover the gap under that bar,
+# a readback large enough to mislead but too small to win the verdict. That inequality is the real
+# invariant and is what the tests assert.
+#
+# One quarter of the bar is a CHOSEN fraction, not a derived one -- it came out of review as a
+# rationalisation for 0.10 rather than from anything about the data, and pinning it as an equality
+# would give a reviewer's off-hand ratio the authority of an invariant. Recorded as the reason the
+# value is what it is; the tests deliberately do not enforce the ratio.
 #
 # WHAT THE TESTS ACTUALLY PIN, measured per-arm rather than by exit code, because the two are not
 # the same question and reading only the exit code gets this wrong:
@@ -252,18 +262,36 @@ def _compute_program_groups(records, limit=10, address_limit=8):
 # the only variable is share, and the 31% one reproduces the capture that motivated the change --
 # but neither is what fixes the band, and a comment claiming otherwise sends the next reader to the
 # wrong test when they want to tighten it.
-READBACK_NOTE_MIN_SHARE = 0.10
+READBACK_NOTE_MIN_SHARE = CLASSIFICATION_EVIDENCE_SHARE / 4
 
 
 # The note's closing advice depends on whether readback DECIDED the verdict. "before acting on this
 # verdict" is right when the verdict IS readback; on a capture whose verdict is a decisive compute or
 # renderer-resource share it is wrong advice attached to a correct conclusion, which is worse than no
 # advice -- the reader is told to discard a finding the readback had no part in.
+# Verdicts that CANNOT flip when the readback is removed. Removing readback scales every other
+# component's share up by the same factor, so a component that already won still wins. A verdict
+# that exists precisely BECAUSE nothing won ("inconclusive"), or because measured work was small
+# against the wall window ("cpu-outside-renderer"), can and does flip -- measured on this change's
+# own motivating capture, where dropping the harness readback turns "inconclusive" into "compute
+# (1134.0 ms, 53%)". This module already records the same effect from hardware: #3152 saw a verdict
+# become renderer-resource with the graphics total halved once the capture ran through a real window.
+_VERDICTS_READBACK_CANNOT_FLIP = frozenset({
+    "compute", "renderer-resource", "gpu-device", "gpu-wait", "gpu-wait-overhead",
+})
+
+
 def _readback_note_tail(classification):
     if classification == "readback":
-        return " before acting on this verdict"
-    return (" before reading the readback line below; it does not affect the "
-            + str(classification) + " verdict above")
+        return " before acting on this verdict."
+    if classification in _VERDICTS_READBACK_CANNOT_FLIP:
+        # Safe to reassure: this verdict survives the readback being removed.
+        return (f" The {classification} verdict above does not depend on it: removing the readback "
+                "raises every other share, so a component that already won still wins.")
+    # Not safe. Saying "the verdict is unaffected" here would invite trust in a verdict the harness
+    # may have produced, which is the opposite of what this note exists to prevent.
+    return (f" The {classification} verdict above may itself be an artefact of that readback -- it "
+            "is not a verdict some component won, so removing the readback can change it.")
 
 
 def summarize(records):
@@ -333,7 +361,7 @@ def summarize(records):
     if measured_total > 0:
         largest, cost = max(classification_components.items(), key=lambda item: item[1])
         share = cost / measured_total
-        if share >= 0.40:
+        if share >= CLASSIFICATION_EVIDENCE_SHARE:
             classification = largest
             reason = f"{largest} is the largest measured component ({cost:.1f} ms, {share:.0%})"
         elif cpu_cores is not None and cpu_cores >= 0.80 and wall_ms and measured_total < wall_ms * 0.40:
@@ -341,7 +369,8 @@ def summarize(records):
             reason = (f"the process used {cpu_cores:.2f} CPU cores while measured renderer/compute "
                       f"work covered only {measured_total / wall_ms:.0%} of the sampled wall window")
         else:
-            reason = "measured work is split across components; no component reaches the 40% evidence threshold"
+            reason = ("measured work is split across components; no component reaches the "
+                      f"{CLASSIFICATION_EVIDENCE_SHARE:.0%} evidence threshold")
     elif cpu_cores is not None and cpu_cores >= 0.80:
         classification = "cpu-outside-renderer"
         reason = (f"the process used {cpu_cores:.2f} CPU cores with no retained renderer/compute "
@@ -390,13 +419,13 @@ def summarize(records):
             readback_note = (
                 "this capture cannot say whether GPU present was adopted, so it cannot say whether "
                 "the readback is real or the harness copying every scanout frame to the CPU. Check "
-                "the run log for a GPU-present surface failure" + _readback_note_tail(classification))
+                "the run log for a GPU-present surface failure." + _readback_note_tail(classification))
         elif adopted is False:
             readback_note = (
                 "GPU present was NOT adopted for this capture, so the frontend copied every scanout "
                 "frame to the CPU -- most often prosper-app under SDL_VIDEODRIVER=offscreen, which "
                 "needs VK_EXT_headless_surface. This readback is the harness, not the title. "
-                "Re-measure through a real window" + _readback_note_tail(classification))
+                "Re-measure through a real window." + _readback_note_tail(classification))
         else:
             readback_note = (
                 "GPU present WAS adopted, so scanout readback is skipped and this readback is real "

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -262,6 +262,10 @@ CLASSIFICATION_EVIDENCE_SHARE = 0.40
 # the only variable is share, and the 31% one reproduces the capture that motivated the change --
 # but neither is what fixes the band, and a comment claiming otherwise sends the next reader to the
 # wrong test when they want to tighten it.
+# Deriving this FROM the bar means a bar mutation is a COMPOUND mutation: the threshold moves with
+# it, so at a bar of 0.80 or more the threshold leaves the (0.020, 0.200] band its own arms pin and
+# readback tests start failing for reasons that have nothing to do with the bar. Harmless for any
+# plausible bar value, and worth knowing before reading a wide sweep's failures.
 READBACK_NOTE_MIN_SHARE = CLASSIFICATION_EVIDENCE_SHARE / 4
 
 
@@ -283,7 +287,11 @@ _VERDICTS_READBACK_CANNOT_FLIP = frozenset({
 
 def _readback_note_tail(classification):
     if classification == "readback":
-        return " before acting on this verdict."
+        # A full sentence, like the other four. It was a trailing subordinate clause until the
+        # callers grew their own terminating period, at which point it rendered as
+        # "...through a real window. before acting on this verdict." -- and no assertion could see
+        # it, because every arm used `assertIn` on a substring the break left intact.
+        return " Readback IS this capture's verdict, so there is nothing else here to act on."
     if classification in _VERDICTS_READBACK_CANNOT_FLIP:
         # Safe to reassure: this verdict survives the readback being removed.
         return (f" The {classification} verdict above does not depend on it: removing the readback "

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -180,6 +180,37 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         else:
             self.assertIsNone(summary["readback_note"])
 
+    def test_large_sub_threshold_readback_warns_even_though_it_lost_classification(self):
+        # The gap this closes, and the shape of the capture that motivated it (Dragon Quest VII):
+        # readback 977.7 ms against compute 1134.0 ms. Neither reaches the 40% evidence bar, so
+        # the verdict is "inconclusive" -- and the old trigger, which fired only on a readback
+        # VERDICT, printed the second-largest number on the page with nothing attached.
+        #
+        # Note the arm would also pass under a "is readback the max component" trigger only if
+        # readback won, which it does NOT here (977.7 < 1134.0). That is deliberate: ranking was
+        # the first attempt at this fix and is silent on exactly this capture.
+        summary = summarize(capture(
+            SAMPLES,
+            renderer=[{"total_ms": 2000, "readback_ms": 977.7}],
+            compute=[{"total_ms": 1134.0}]))
+        # Neither component clears 40% of the 3134 ms measured total: compute is 36%, readback 31%.
+        self.assertEqual(summary["classification"], "inconclusive")
+        self.assertIn("harness, not the title", summary["readback_note"])
+
+    def test_readback_note_threshold_is_a_share_not_a_ranking(self):
+        # Pins the quiet end against the loud one with the SAME verdict and the same GPU-present
+        # state, so the only variable is readback's share of measured work. Without this pair the
+        # threshold could drift to "any nonzero readback" -- which it briefly was -- and no test
+        # would notice, because every existing readback arm has a large readback.
+        def note_for(readback_ms):
+            return summarize(capture(
+                SAMPLES,
+                renderer=[{"total_ms": 1000, "readback_ms": readback_ms}],
+                compute=[{"total_ms": 1000.0}]))["readback_note"]
+
+        self.assertIsNone(note_for(20.0))        # 1% of measured work -- rounding, stays silent
+        self.assertIsNotNone(note_for(400.0))    # 20% -- a reader could mistake it for the answer
+
     def test_non_readback_verdict_carries_no_readback_note(self):
         # The note is specific to the readback verdict; on every report it would be noise.
         summary = summarize(capture(SAMPLES, renderer=[{

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -2,7 +2,8 @@
 
 import unittest
 
-from performance_capture_report import CaptureError, summarize, validate_capture
+from performance_capture_report import (CaptureError, READBACK_NOTE_MIN_SHARE,
+                                        summarize, validate_capture)
 
 
 def capture(post=None, renderer=None, compute=None, dropped=(0, 0)):
@@ -198,10 +199,14 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertIn("harness, not the title", summary["readback_note"])
 
     def test_readback_note_threshold_is_a_share_not_a_ranking(self):
-        # Pins the quiet end against the loud one with the SAME verdict and the same GPU-present
-        # state, so the only variable is readback's share of measured work. Without this pair the
-        # threshold could drift to "any nonzero readback" -- which it briefly was -- and no test
-        # would notice, because every existing readback arm has a large readback.
+        # Holds verdict and GPU-present state constant so the only variable is readback's SHARE.
+        #
+        # It does NOT pin the lower bound, and an earlier version of this comment wrongly claimed it
+        # did ("no test would notice" a drift to any-nonzero). Measured per-arm: a drift to
+        # any-nonzero is caught by the PRE-EXISTING 2% arm below, and this 1% assertion passes at
+        # every threshold down to 0.011. What binds above is this arm's 20% assertion. Keeping the
+        # 1% half is still right -- it is the only arm that varies share alone -- but the reason is
+        # isolation, not coverage of the quiet end.
         def note_for(readback_ms):
             return summarize(capture(
                 SAMPLES,
@@ -210,6 +215,36 @@ class PerformanceCaptureReportTests(unittest.TestCase):
 
         self.assertIsNone(note_for(20.0))        # 1% of measured work -- rounding, stays silent
         self.assertIsNotNone(note_for(400.0))    # 20% -- a reader could mistake it for the answer
+
+    def test_readback_note_threshold_constant_is_pinned_to_its_anchor(self):
+        # The constant is importable precisely so it can be pinned. Without this arm it can move
+        # anywhere inside the (0.020, 0.200] band the behavioural arms allow -- a 10x range -- with
+        # nothing objecting, which is the gap an independent review of this change identified.
+        #
+        # Asserts the ANCHOR, not the literal: the threshold is one quarter of the classification
+        # evidence bar, so a future change to that bar carries this along instead of silently
+        # decoupling from it. A bare `== 0.10` would pass while the relationship it stands for broke.
+        self.assertAlmostEqual(READBACK_NOTE_MIN_SHARE, 0.40 / 4)
+        self.assertLess(READBACK_NOTE_MIN_SHARE, 0.40)
+
+    def test_readback_note_tail_does_not_disown_a_verdict_readback_did_not_decide(self):
+        # A decisive compute verdict with a material readback used to close "...before acting on
+        # this verdict" -- telling the reader to discard a conclusion the readback had no part in.
+        decisive = summarize(capture(
+            SAMPLES,
+            renderer=[{"total_ms": 1000, "readback_ms": 600}],
+            compute=[{"total_ms": 4000.0}]))
+        # readback 600 / 5000 measured = 12%, over the threshold; compute 4000 / 5000 = 80%, a
+        # decisive verdict readback played no part in. That combination is the whole point.
+        self.assertEqual(decisive["classification"], "compute")
+        self.assertIsNotNone(decisive["readback_note"])
+        self.assertNotIn("before acting on this verdict", decisive["readback_note"])
+        self.assertIn("does not affect the compute verdict", decisive["readback_note"])
+
+        # ...while a readback VERDICT still says exactly that, because there it is correct.
+        owned = summarize(capture(SAMPLES, renderer=[self.READBACK_RENDERER[0]]))
+        self.assertEqual(owned["classification"], "readback")
+        self.assertIn("before acting on this verdict", owned["readback_note"])
 
     def test_non_readback_verdict_carries_no_readback_note(self):
         # The note is specific to the readback verdict; on every report it would be noise.

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -173,6 +173,28 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertIn("real", summary["readback_note"])
         self.assertNotIn("harness, not the title", summary["readback_note"])
 
+    def test_every_readback_note_is_well_formed_prose(self):
+        # A structural guard, added because the previous commit shipped a visible break that every
+        # existing arm was blind to: the tails became full sentences while one branch stayed a
+        # trailing clause, rendering "...through a real window. before acting on this verdict."
+        # `assertIn` on a substring cannot see a break OUTSIDE that substring, so no amount of
+        # content assertions would have caught it -- this checks the joins instead of the content.
+        cases = {
+            "readback": capture(SAMPLES, renderer=[self.READBACK_RENDERER[0]]),
+            "compute": capture(SAMPLES, renderer=[{"total_ms": 1500, "readback_ms": 1400}],
+                               compute=[{"total_ms": 3500.0}]),
+            "inconclusive": capture(SAMPLES, renderer=[{"total_ms": 2000, "readback_ms": 977.7}],
+                                    compute=[{"total_ms": 1134.0}]),
+            "cannot-say": capture([], renderer=self.READBACK_RENDERER),
+        }
+        for name, records in cases.items():
+            note = summarize(records)["readback_note"]
+            self.assertIsNotNone(note, name)
+            self.assertNotRegex(note, r"\.\s+[a-z]", f"{name}: lowercase clause after a period")
+            self.assertNotRegex(note, r"\s\.", f"{name}: space before a period")
+            self.assertNotRegex(note, r"\.\.", f"{name}: doubled period")
+            self.assertTrue(note.endswith("."), f"{name}: note does not end in a period")
+
     def test_no_post_samples_cannot_determine_gpu_present(self):
         # The one uncovered line in the helper. With no post population there is nothing to read the
         # field from, so the honest answer is the third state rather than either branch.
@@ -238,8 +260,19 @@ class PerformanceCaptureReportTests(unittest.TestCase):
 
     def test_classification_evidence_bar_is_pinned(self):
         # Nothing pinned this at all: moving the tool's primary classification threshold from 0.40
-        # to 0.50 passed the entire suite. Both arms below fail if it moves, so the bar is now held
-        # by behaviour and not only by a literal.
+        # to 0.50 passed the entire suite.
+        #
+        # The two halves below are COMPLEMENTARY, not redundant, and the measured split is not what
+        # "both arms fail if it moves" would suggest -- swept with the literal assert neutralised,
+        # the behavioural pair alone tolerates (0.375, 0.4444]:
+        #
+        #   bar        0.375   0.376   0.42   0.4444   0.445   0.50
+        #   behavioural  FAIL    pass   pass     pass    FAIL   FAIL
+        #
+        # So inside that window only the literal catches a value change -- while reverting the USE
+        # SITE to an inline literal (decoupling the constant from the code it governs) is caught
+        # only by the behavioural pair, which is the failure the whole finding was about. Each
+        # covers what the other cannot.
         self.assertAlmostEqual(CLASSIFICATION_EVIDENCE_SHARE, 0.40)
         # Totals are scaled so measured work clears 40% of the 1000 ms wall window in SAMPLES --
         # otherwise both arms land in `cpu-outside-renderer` and neither exercises the bar at all,
@@ -266,10 +299,12 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertNotIn("before acting on this verdict", decisive["readback_note"])
         self.assertIn("does not depend on it", decisive["readback_note"])
 
-        # ...while a readback VERDICT still says exactly that, because there it is correct.
+        # ...while a readback VERDICT says the strongest thing of the five, because there the
+        # readback is not a caveat on the verdict -- it IS the verdict.
         owned = summarize(capture(SAMPLES, renderer=[self.READBACK_RENDERER[0]]))
         self.assertEqual(owned["classification"], "readback")
-        self.assertIn("before acting on this verdict", owned["readback_note"])
+        self.assertIn("nothing else here to act on", owned["readback_note"])
+        self.assertNotIn("does not depend on it", owned["readback_note"])
 
     def test_readback_note_does_not_vouch_for_a_verdict_the_readback_can_flip(self):
         # The case the previous version got WRONG, and it is this change's own motivating capture:

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -2,8 +2,9 @@
 
 import unittest
 
-from performance_capture_report import (CaptureError, READBACK_NOTE_MIN_SHARE,
-                                        summarize, validate_capture)
+from performance_capture_report import (CaptureError, CLASSIFICATION_EVIDENCE_SHARE,
+                                        READBACK_NOTE_MIN_SHARE, summarize,
+                                        validate_capture)
 
 
 def capture(post=None, renderer=None, compute=None, dropped=(0, 0)):
@@ -175,11 +176,15 @@ class PerformanceCaptureReportTests(unittest.TestCase):
     def test_no_post_samples_cannot_determine_gpu_present(self):
         # The one uncovered line in the helper. With no post population there is nothing to read the
         # field from, so the honest answer is the third state rather than either branch.
+        #
+        # The note assertion is UNCONDITIONAL: this fixture's readback share clears the trigger, so
+        # the note fires whatever the verdict turns out to be. Only the classification is left
+        # tolerant, because that is the part this arm does not care about. The previous shape had a
+        # defensive `else` asserting the note is None -- which became both unreachable and false
+        # once the trigger stopped depending on the verdict, i.e. a branch that would have silently
+        # stopped testing anything.
         summary = summarize(capture([], renderer=self.READBACK_RENDERER))
-        if summary["classification"] == "readback":
-            self.assertIn("cannot say", summary["readback_note"])
-        else:
-            self.assertIsNone(summary["readback_note"])
+        self.assertIn("cannot say", summary["readback_note"])
 
     def test_large_sub_threshold_readback_warns_even_though_it_lost_classification(self):
         # The gap this closes, and the shape of the capture that motivated it (Dragon Quest VII):
@@ -216,35 +221,76 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertIsNone(note_for(20.0))        # 1% of measured work -- rounding, stays silent
         self.assertIsNotNone(note_for(400.0))    # 20% -- a reader could mistake it for the answer
 
-    def test_readback_note_threshold_constant_is_pinned_to_its_anchor(self):
-        # The constant is importable precisely so it can be pinned. Without this arm it can move
-        # anywhere inside the (0.020, 0.200] band the behavioural arms allow -- a 10x range -- with
-        # nothing objecting, which is the gap an independent review of this change identified.
+    def test_readback_note_threshold_stays_under_the_evidence_bar(self):
+        # The INEQUALITY is the invariant, and it is all this asserts. The note exists to cover the
+        # gap under the classification bar, so a threshold at or above the bar would make it
+        # unreachable in exactly the cases it is for.
         #
-        # Asserts the ANCHOR, not the literal: the threshold is one quarter of the classification
-        # evidence bar, so a future change to that bar carries this along instead of silently
-        # decoupling from it. A bare `== 0.10` would pass while the relationship it stands for broke.
-        self.assertAlmostEqual(READBACK_NOTE_MIN_SHARE, 0.40 / 4)
-        self.assertLess(READBACK_NOTE_MIN_SHARE, 0.40)
+        # It deliberately does NOT assert the one-quarter ratio. A previous version did, on the
+        # grounds that a future change to the bar would then "carry the threshold along" -- but the
+        # bar was a bare inline literal, so `0.40 / 4` in the test was a second disconnected copy
+        # and the assert only ever pinned `== 0.1` in longer notation. The mutation offered as proof
+        # (moving the threshold) was drawn from the same source as the claim and could not have
+        # failed: it showed the assert fires when the CONSTANT moves, never in doubt, not when the
+        # BAR moves, which was the claim. One quarter is a chosen fraction, not a derived one.
+        self.assertGreater(READBACK_NOTE_MIN_SHARE, 0)
+        self.assertLess(READBACK_NOTE_MIN_SHARE, CLASSIFICATION_EVIDENCE_SHARE)
+
+    def test_classification_evidence_bar_is_pinned(self):
+        # Nothing pinned this at all: moving the tool's primary classification threshold from 0.40
+        # to 0.50 passed the entire suite. Both arms below fail if it moves, so the bar is now held
+        # by behaviour and not only by a literal.
+        self.assertAlmostEqual(CLASSIFICATION_EVIDENCE_SHARE, 0.40)
+        # Totals are scaled so measured work clears 40% of the 1000 ms wall window in SAMPLES --
+        # otherwise both arms land in `cpu-outside-renderer` and neither exercises the bar at all,
+        # which is what a first draft of this test did.
+        just_under = summarize(capture(SAMPLES, renderer=[{"total_ms": 1000}],
+                                       compute=[{"total_ms": 600}]))         # 37.5% -- under
+        self.assertEqual(just_under["classification"], "inconclusive")
+        just_over = summarize(capture(SAMPLES, renderer=[{"total_ms": 1000}],
+                                      compute=[{"total_ms": 800}]))          # 44.4% -- over
+        self.assertEqual(just_over["classification"], "compute")
 
     def test_readback_note_tail_does_not_disown_a_verdict_readback_did_not_decide(self):
         # A decisive compute verdict with a material readback used to close "...before acting on
         # this verdict" -- telling the reader to discard a conclusion the readback had no part in.
+        # readback 1400 / 5000 measured = 28%, comfortably over the 10% threshold rather than the
+        # 2 points of headroom a first draft had -- a fixture that only just clears the trigger
+        # fails for a threshold reason under any threshold mutation, which is not what it tests.
         decisive = summarize(capture(
             SAMPLES,
-            renderer=[{"total_ms": 1000, "readback_ms": 600}],
-            compute=[{"total_ms": 4000.0}]))
-        # readback 600 / 5000 measured = 12%, over the threshold; compute 4000 / 5000 = 80%, a
-        # decisive verdict readback played no part in. That combination is the whole point.
-        self.assertEqual(decisive["classification"], "compute")
+            renderer=[{"total_ms": 1500, "readback_ms": 1400}],
+            compute=[{"total_ms": 3500.0}]))
+        self.assertEqual(decisive["classification"], "compute")          # 70%, decisive
         self.assertIsNotNone(decisive["readback_note"])
         self.assertNotIn("before acting on this verdict", decisive["readback_note"])
-        self.assertIn("does not affect the compute verdict", decisive["readback_note"])
+        self.assertIn("does not depend on it", decisive["readback_note"])
 
         # ...while a readback VERDICT still says exactly that, because there it is correct.
         owned = summarize(capture(SAMPLES, renderer=[self.READBACK_RENDERER[0]]))
         self.assertEqual(owned["classification"], "readback")
         self.assertIn("before acting on this verdict", owned["readback_note"])
+
+    def test_readback_note_does_not_vouch_for_a_verdict_the_readback_can_flip(self):
+        # The case the previous version got WRONG, and it is this change's own motivating capture:
+        # readback 977.7 against compute 1134.0 with a 2000 ms renderer total is "inconclusive"
+        # only because nothing reaches the bar. Remove the readback and compute wins outright at
+        # 53% -- so "the verdict above does not depend on it" would be a false statement printed on
+        # the exact capture this feature exists for, inviting trust in a verdict the harness made.
+        contaminated = summarize(capture(
+            SAMPLES,
+            renderer=[{"total_ms": 2000, "readback_ms": 977.7}],
+            compute=[{"total_ms": 1134.0}]))
+        self.assertEqual(contaminated["classification"], "inconclusive")
+        self.assertIn("may itself be an artefact", contaminated["readback_note"])
+        self.assertNotIn("does not depend on it", contaminated["readback_note"])
+
+        # And the flip is real, not asserted: drop the readback and the verdict changes.
+        without = summarize(capture(
+            SAMPLES,
+            renderer=[{"total_ms": 2000 - 977.7}],
+            compute=[{"total_ms": 1134.0}]))
+        self.assertEqual(without["classification"], "compute")
 
     def test_non_readback_verdict_carries_no_readback_note(self):
         # The note is specific to the readback verdict; on every report it would be noise.

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -179,14 +179,24 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         # trailing clause, rendering "...through a real window. before acting on this verdict."
         # `assertIn` on a substring cannot see a break OUTSIDE that substring, so no amount of
         # content assertions would have caught it -- this checks the joins instead of the content.
-        cases = {
-            "readback": capture(SAMPLES, renderer=[self.READBACK_RENDERER[0]]),
-            "compute": capture(SAMPLES, renderer=[{"total_ms": 1500, "readback_ms": 1400}],
-                               compute=[{"total_ms": 3500.0}]),
-            "inconclusive": capture(SAMPLES, renderer=[{"total_ms": 2000, "readback_ms": 977.7}],
-                                    compute=[{"total_ms": 1134.0}]),
-            "cannot-say": capture([], renderer=self.READBACK_RENDERER),
+        # The FULL product of reachable joins: three GPU-present states (each selecting a different
+        # note body) x three verdicts (each selecting a different tail). Enumerated as a product
+        # rather than hand-listed because a hand-listed set is exactly how an arm named "every" ends
+        # up excluding the one case that fails it -- which a first version of this arm did, missing
+        # the `adopted is True` body, the only reachable note that lacked a terminating period.
+        posts = {
+            "not-adopted": SAMPLES,                                            # harness readback
+            "adopted": [{**s, "rendered_frames": None} for s in SAMPLES],      # real readback
+            "cannot-say": [],                                                  # no post population
         }
+        verdicts = {
+            "readback": (self.READBACK_RENDERER, []),
+            "compute": ([{"total_ms": 1500, "readback_ms": 1400}], [{"total_ms": 3500.0}]),
+            "inconclusive": ([{"total_ms": 2000, "readback_ms": 977.7}], [{"total_ms": 1134.0}]),
+        }
+        cases = {f"{pn}/{vn}": capture(post, renderer=r, compute=c)
+                 for pn, post in posts.items() for vn, (r, c) in verdicts.items()}
+        self.assertEqual(len(cases), 9)
         for name, records in cases.items():
             note = summarize(records)["readback_note"]
             self.assertIsNotNone(note, name)
@@ -296,7 +306,9 @@ class PerformanceCaptureReportTests(unittest.TestCase):
             compute=[{"total_ms": 3500.0}]))
         self.assertEqual(decisive["classification"], "compute")          # 70%, decisive
         self.assertIsNotNone(decisive["readback_note"])
-        self.assertNotIn("before acting on this verdict", decisive["readback_note"])
+        # The live discriminator, not the retired phrase: `assertNotIn` on a string that no
+        # longer exists anywhere in the module cannot fail, so it asserts nothing.
+        self.assertNotIn("nothing else here to act on", decisive["readback_note"])
         self.assertIn("does not depend on it", decisive["readback_note"])
 
         # ...while a readback VERDICT says the strongest thing of the five, because there the


### PR DESCRIPTION
Split out of #3160 on review recommendation — it shares no code with the alias census, it is its own
judgement call, and it can merge independently.

## Failure scenario

`tools/perf/performance_capture_report.py` printed its harness-readback warning **only when readback
won the classification**. A capture where readback is large but under the 40% evidence threshold is
classified `inconclusive` and then prints a large readback number **with no warning attached** — the
exact shape that sends a reader optimising the harness instead of the title.

Measured on a Dragon Quest VII capture: `readback=977.7ms` against `compute=1134.0ms`, classified
`inconclusive`, note silent. GPU present was not adopted, so that 977.7 ms was `prosper-app` under
`SDL_VIDEODRIVER=offscreen` copying every scanout frame to the CPU — not the title's work, and the
second-largest number on the page.

## Why not a ranking trigger

"Is readback the largest component" was the first attempt and is **silent on exactly this capture**
(977.7 < 1134.0). The trigger is readback's *share of measured work* instead.

## The threshold, and its honest limits

I first shipped `readback_ms > 0.0` under a variable named `material_readback` — a name that
described the intent and a predicate that did not implement it. A **pre-existing test**
(`test_non_readback_verdict_carries_no_readback_note`) caught it, and that test was right: a
paragraph of warning attached to a 2 ms readback is noise on every report, and noise trains readers
to skip the note in the cases that matter.

Two arms now pin it from both sides. Swept rather than asserted (cache cleared per iteration, `-B`):

| threshold | 0.005 | 0.020 | **0.021** | **0.100** | **0.200** | 0.201 | 0.310 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| suite rc | 1 | 1 | **0** | **0** | **0** | 1 | 1 |

**The pinned band is (0.020, 0.200] — a 10x range, and `0.10` is not itself pinned.** The code
comment now says so. This is the part I want a reader to know: someone who believes the constant is
pinned will never add the arm that would pin it.

An earlier revision of that comment claimed "a ~39% readback must warn (the motivating capture)".
That figure was never computed — the arm that exists is 31%. Corrected.

## Mutation evidence

| mutation | result |
| --- | --- |
| threshold → `0.0` (any nonzero readback — the bug) | `rc=1` |
| trigger → `classification == "readback"` only (the original narrow behaviour) | `rc=1` |
| baseline / restored | `rc=0` |

Both directions are load-bearing: the arms catch a trigger that is too loose *and* one that is too
narrow.

## The arms

- **A ~31% readback that lost classification still warns** — the motivating shape reproduced:
  readback 977.7 ms, compute 1134.0 ms, neither reaching 40% of the 3134 ms measured total, verdict
  `inconclusive`. Readback is deliberately *not* the largest component here, so this arm also stays
  red under a ranking trigger.
- **A 1%-of-total readback stays silent**, with the same verdict and the same GPU-present state, so
  the only variable is the share. Without this arm the threshold could drift back toward "any
  nonzero" unnoticed, because every other readback arm in the file has a large readback.

## Affected / deliberately unaffected

Affects only `readback_note` in the report's summary. Classification, reasons, pacing notes and every
other component are untouched; the two-case split between "GPU present adopted" (real work, chase it)
and "not adopted" (harness, ignore it) is unchanged, and still decides what the note *says*.

## Verification

`ctest --no-tests=error -R performance_capture_report_logic` → **1/1**, exit 0. Full suite green on
the branch this was split from (319 registered, 100% passed, exit 0).

A note on method: an intermediate run of the sweep reported a false `restored_rc=1` from a stale
`__pycache__`. The sweep above clears it per iteration and runs `python3 -B`; the band is unchanged
from the contaminated run, but the restore check only passes on the clean one.
