### PR TITLE
Extract sem_timedwait's deadline/slice arithmetic to clock-free helpers (#3069)

### DIFF
--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -3137,16 +3137,20 @@ HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem
 // fix the cadence and blunt the responsiveness in the same change. Short slices for the first few
 // milliseconds keep the wake tight where pacing lives; longer slices afterwards keep a guest parked
 // for seconds from spinning at 2 kHz for no benefit. (An earlier revision of this comment said
-// 5 kHz, which was the 200 us slice that revision used before the floor measurement below
-// replaced it.)
+// 5 kHz, which was the 200 us slice that revision used before the floor measurement replaced it --
+// that measurement, and the three constants it fixes, now live beside poll_slice_ns() in
+// precise_sleep.hpp.)
 HLE(k_sem_timedwait) {
     auto* s = ensure_sem(a0);
     if (!s) return prosper::hle::kSceKernelErrorEINVAL;
     // Saturating, matching guest_ns_from in hle_kernel_time.cpp (#3022): a1 is guest-controlled,
     // and a wrap here would turn a very long timeout into a short one. That file states the rule
     // for the whole family, so this member of it should not be the exception.
-    const uint64_t kNsMax = ~0ull;
-    const uint64_t timeout_ns = a1 > kNsMax / 1000ull ? kNsMax : (uint64_t)a1 * 1000ull;
+    // The arithmetic itself lives in precise_sleep.hpp, beside the deadline sleeper the Windows
+    // loop below calls, so it can be driven by a FAKE CLOCK instead of only by timing the real HLE
+    // -- which test_kernel_sem_timedwait.cpp's header explains at length cannot discriminate here
+    // (#3069). Behaviour is identical; this is an extraction, not a change.
+    const uint64_t timeout_ns = prosper::host::timeout_ns_from_us(a1);
     hle::WaitCensusScope c(hle::WaitKind::SemTimedwait, timeout_ns);
 #ifndef _WIN32
     timespec dl = abs_deadline_us(a1);
@@ -3160,19 +3164,7 @@ HLE(k_sem_timedwait) {
     // Saturating again on the addition: start_ns + timeout_ns can itself wrap for a huge timeout,
     // and a wrapped deadline lands in the past, which would turn a long wait into an instant
     // timeout -- the loud direction, but still wrong.
-    const uint64_t deadline_ns =
-        timeout_ns > kNsMax - start_ns ? kNsMax : start_ns + timeout_ns;
-    // 500 us while the wait is young, 2 ms after 8 ms have passed. The crossover is above one grain
-    // period so an audio pacing wait never leaves the tight regime.
-    //
-    // 500 us and not less, because that is the FLOOR of a short high-resolution-timer sleep on
-    // this host, measured rather than assumed: requests of 0.05, 0.10 and 0.20 ms all cost a
-    // median of 0.52 ms (200 samples each; 0.50 ms -> 1.02, 1.00 -> 1.51, 2.00 -> 2.07). An
-    // earlier revision asked for 200 us, which reads as a tighter loop than the machine can
-    // actually run and would mislead the next person tuning it. What the fine window buys is a
-    // poll interval about 4x shorter than the coarse one (0.52 ms against 2.07), not the 10x the
-    // constants implied.
-    const uint64_t kFineSliceNs = 500000ull, kCoarseSliceNs = 2000000ull, kFineWindowNs = 8000000ull;
+    const uint64_t deadline_ns = prosper::host::deadline_ns_from(start_ns, timeout_ns);
     for (;;) {
         if (sem_trywait(s) == 0) return 0;
         // EAGAIN means "not posted yet", which is the whole point of the loop. Anything else --
@@ -3182,10 +3174,13 @@ HLE(k_sem_timedwait) {
         if (errno != EAGAIN && errno != EINTR) return sce_pthread_rc(fbsd_errno(errno));
         const uint64_t now_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
                                     std::chrono::steady_clock::now().time_since_epoch()).count();
-        if (now_ns >= deadline_ns) { errno = ETIMEDOUT; return sce_pthread_rc(fbsd_errno(errno)); }
-        const uint64_t slice = (now_ns - start_ns) < kFineWindowNs ? kFineSliceNs : kCoarseSliceNs;
-        const uint64_t remaining = deadline_ns - now_ns;
-        prosper::host::sleep_until_steady_ns(now_ns + (remaining < slice ? remaining : slice));
+        // The deadline test, the adaptive slice and its clamp against the remaining time, as one
+        // pure decision -- see prosper::host::sem_poll_step for the cadence rationale and for the
+        // two invariants it guarantees (now_ns < sleep_until_ns <= deadline_ns).
+        const prosper::host::SemPollStep step =
+            prosper::host::sem_poll_step(start_ns, deadline_ns, now_ns);
+        if (step.expired) { errno = ETIMEDOUT; return sce_pthread_rc(fbsd_errno(errno)); }
+        prosper::host::sleep_until_steady_ns(step.sleep_until_ns);
     }
 #endif
 }

--- a/prosper/src/host/platform/precise_sleep.hpp
+++ b/prosper/src/host/platform/precise_sleep.hpp
@@ -97,4 +97,93 @@ constexpr uint64_t grid_boundaries_missed(uint64_t prev_deadline_ns, uint64_t ne
     return advanced > 0 ? advanced - 1 : 0;
 }
 
+// ---------------------------------------------------------------------------
+// scePthreadSemTimedwait's poll-loop arithmetic (#3069).
+//
+// Extracted UNCHANGED from the Windows poll loop in hle_kernel.cpp's k_sem_timedwait, for the same
+// reason next_grid_deadline_ns and sleep_until_deadline_retry above were extracted: it was inline in
+// an HLE() body, so the only way to reach it was to call the real HLE and time it -- and
+// test_kernel_sem_timedwait.cpp's own header records at length why a wall-clock duration cannot
+// discriminate anything here (a quantized wait returns at the next tick BOUNDARY, so the defect's
+// latency distribution overlaps the fix's, for any tick length, and no single-run bound separates
+// them). Two of the three pieces below are saturating arms guarding guest-controlled input, and no
+// test reached either.
+//
+// Everything here is pure and takes the clock reading as a PARAMETER, so a test drives the whole
+// loop with a fake clock: no _WIN32, no real sleep, no wall time. See test_precise_sleep.cpp.
+
+// Saturating microseconds -> nanoseconds. `timeout_us` arrives straight from the guest, and a wrap
+// here would turn a very long timeout into a short one. Matches guest_ns_from in
+// hle_kernel_time.cpp (#3022), which states the rule for the whole family.
+constexpr uint64_t timeout_ns_from_us(uint64_t timeout_us) {
+    constexpr uint64_t kNsMax = ~0ull;
+    return timeout_us > kNsMax / 1000ull ? kNsMax : timeout_us * 1000ull;
+}
+
+// Saturating start + timeout. A wrapped deadline lands in the PAST, which turns a long wait into an
+// instant timeout -- the loud direction, but still wrong.
+constexpr uint64_t deadline_ns_from(uint64_t start_ns, uint64_t timeout_ns) {
+    constexpr uint64_t kNsMax = ~0ull;
+    return timeout_ns > kNsMax - start_ns ? kNsMax : start_ns + timeout_ns;
+}
+
+// The poll cadence. 500 us while the wait is young, 2 ms after 8 ms have passed; the crossover is
+// above one 5.33 ms audio grain period so a pacing wait never leaves the tight regime.
+//
+// 500 us and not less, because that is the FLOOR of a short high-resolution-timer sleep on this
+// host, measured rather than assumed: requests of 0.05, 0.10 and 0.20 ms all cost a median of
+// 0.52 ms (200 samples each; 0.50 ms -> 1.02, 1.00 -> 1.51, 2.00 -> 2.07). An earlier revision asked
+// for 200 us, which reads as a tighter loop than the machine can actually run and would mislead the
+// next person tuning it. What the fine window buys is a poll interval about 4x shorter than the
+// coarse one (0.52 ms against 2.07), not the 10x the constants imply.
+constexpr uint64_t kSemPollFineSliceNs   =  500000ull;   // 500 us
+constexpr uint64_t kSemPollCoarseSliceNs = 2000000ull;   // 2 ms
+constexpr uint64_t kSemPollFineWindowNs  = 8000000ull;   // 8 ms
+
+// How long to sleep before polling the semaphore again, given how long the wait has already run and
+// how much of its timeout is left.
+//
+// THE CLAMP AGAINST `remaining_ns` IS THE LOAD-BEARING HALF. Without it the loop would sleep past
+// the deadline and report a timeout up to one coarse slice late; and near the representable maximum
+// the caller's `now_ns + slice` would wrap outright, landing the next wake in the past. With it the
+// result is always <= remaining_ns, so `now_ns + poll_slice_ns(...)` can never exceed the deadline
+// and therefore can never overflow.
+//
+// Exposed separately from sem_poll_step() below -- its only caller -- so the clamp can be
+// mutation-tested on its own rather than only through the composed step.
+constexpr uint64_t poll_slice_ns(uint64_t elapsed_ns, uint64_t remaining_ns) {
+    const uint64_t slice =
+        elapsed_ns < kSemPollFineWindowNs ? kSemPollFineSliceNs : kSemPollCoarseSliceNs;
+    return remaining_ns < slice ? remaining_ns : slice;
+}
+
+// One iteration of the poll loop's timing decision, taken after a trywait has already failed.
+struct SemPollStep {
+    bool expired;              // the deadline has passed; the caller reports ETIMEDOUT
+    uint64_t sleep_until_ns;   // otherwise sleep until here, then poll again. Unset if `expired`.
+};
+
+// Two invariants hold for every non-expired result, and they are what the tests assert:
+//
+//     now_ns < sleep_until_ns <= deadline_ns
+//
+// The LOWER bound is strict, so the loop can never busy-spin while time remains (a zero-length sleep
+// would poll at whatever rate the scheduler allows). The UPPER bound is the clamp, so it can never
+// overshoot the deadline nor overflow. Both survive an early wakeup: the decision is recomputed from
+// `now_ns` alone on each iteration and carries nothing forward, so a sleep that returns short simply
+// produces another step from wherever it actually landed.
+constexpr SemPollStep sem_poll_step(uint64_t start_ns, uint64_t deadline_ns, uint64_t now_ns) {
+    if (now_ns >= deadline_ns) return {true, 0};
+    // NOTE: on a clock that went BACKWARDS, `now_ns - start_ns` wraps to a huge value and so selects
+    // the coarse slice. That is the behaviour of the code this was extracted from, preserved
+    // deliberately rather than corrected, because #3069 is a pure extraction. It is unreachable
+    // through the real call site -- start_ns and now_ns are both steady_clock reads, which cannot go
+    // backwards -- and benign if it ever were: the loop polls at 2 ms instead of 500 us and STILL
+    // times out at exactly the right moment, because the deadline check above does not involve
+    // start_ns at all. Pinned by a test arm so a later change to the elapsed computation is a
+    // deliberate one.
+    const uint64_t elapsed_ns = now_ns - start_ns;
+    return {false, now_ns + poll_slice_ns(elapsed_ns, deadline_ns - now_ns)};
+}
+
 }  // namespace prosper::host

--- a/prosper/tests/host/platform/test_precise_sleep.cpp
+++ b/prosper/tests/host/platform/test_precise_sleep.cpp
@@ -15,6 +15,17 @@
 // `if (now_ns() < deadline_ns) sleep_once(deadline_ns);` reddens arm 1 below — the fake sleep step is
 // deliberately smaller than the deadline gap, so one call cannot reach it and the post-condition
 // check catches exactly the #3074 defect.
+//
+// ARMS 5-11 (#3069) cover a SECOND set of pure functions in the same header, extracted from
+// scePthreadSemTimedwait's Windows poll loop for the same reason and testable the same way:
+// timeout_ns_from_us(), deadline_ns_from(), poll_slice_ns() and sem_poll_step(). Two of them are
+// saturating arms guarding a guest-controlled timeout, and before the extraction nothing reached
+// them -- the only handle on that arithmetic was to call the real HLE and time it, which
+// test_kernel_sem_timedwait.cpp's header records at length cannot discriminate anything here.
+//
+// The cases the fake clock buys, none of which a wall-clock test can produce on demand: an early
+// wakeup, a deadline already in the past, a clock that runs backwards, the slice clamp binding, and
+// arithmetic within a few nanoseconds of UINT64_MAX. Mutation results are in the PR.
 #include "host/platform/precise_sleep.hpp"
 
 #include <cstdint>
@@ -43,6 +54,69 @@ static uint64_t fake_now_ns() { return g_fake_now_ns; }
 static void fake_sleep_fixed_step(uint64_t /*deadline_ns*/) {
     ++g_sleep_calls;
     g_fake_now_ns += g_sleep_step_ns;
+}
+
+// ---------------------------------------------------------------------------
+// A driver for sem_poll_step() (#3069) that reproduces the real poll loop's structure exactly --
+// read the clock, take a step, "sleep", repeat -- with the clock replaced by a variable. The one
+// thing it varies is WHERE THE SLEEP ACTUALLY LANDS relative to the step's requested target, which
+// is the seam a real host has and a test otherwise cannot control.
+enum class Wake {
+    Exact,       // the sleep returns precisely at the requested target
+    Early,       // it returns roughly halfway there -- the #3074 shape, seen from this side
+    Overshoot,   // it returns late, as ::Sleep()'s tick quantization does by 14-30 ms
+};
+
+struct LoopStats {
+    int steps = 0;
+    int fine_steps = 0;      // steps taken while inside the 8 ms fine window
+    int coarse_steps = 0;    // steps taken after it
+    int clamped_steps = 0;   // steps where the remaining time, not the slice, set the target
+    bool invariants_ok = true;
+    bool terminated = false;
+    uint64_t last_now_ns = 0;
+};
+
+// Runs the loop to its timeout, asserting sem_poll_step()'s two invariants at EVERY step:
+//     now_ns < sleep_until_ns <= deadline_ns
+// and that the fake clock advances strictly, so a violation cannot hide behind a stalled loop.
+static LoopStats drive_poll_loop(uint64_t start_ns, uint64_t timeout_us, Wake wake,
+                                 int max_steps = 100000) {
+    LoopStats st;
+    const uint64_t timeout_ns = host::timeout_ns_from_us(timeout_us);
+    const uint64_t deadline_ns = host::deadline_ns_from(start_ns, timeout_ns);
+    uint64_t now_ns = start_ns;
+    st.last_now_ns = now_ns;
+    for (int i = 0; i < max_steps; ++i) {
+        const host::SemPollStep step = host::sem_poll_step(start_ns, deadline_ns, now_ns);
+        if (step.expired) { st.terminated = true; break; }
+        ++st.steps;
+        // THE INVARIANTS. The strict lower bound is what forbids a zero-length sleep (a busy spin
+        // while time remains); the upper bound is the clamp, and it is also what keeps
+        // `now_ns + slice` from wrapping when the deadline is near UINT64_MAX.
+        if (!(step.sleep_until_ns > now_ns)) st.invariants_ok = false;
+        if (!(step.sleep_until_ns <= deadline_ns)) st.invariants_ok = false;
+        // Which regime this step was in, and whether the clamp bound it. Counted so the arms below
+        // can assert that the branch they claim to cover was actually REACHED -- a step count alone
+        // cannot tell a loop that exercised both regimes from one that never left the first.
+        if ((now_ns - start_ns) < host::kSemPollFineWindowNs) ++st.fine_steps; else ++st.coarse_steps;
+        if (step.sleep_until_ns == deadline_ns) ++st.clamped_steps;
+
+        uint64_t next_ns = step.sleep_until_ns;
+        if (wake == Wake::Early) {
+            // Land strictly between now and the target. `+ 1` keeps it strictly ahead of `now_ns`
+            // even when the gap is 1 ns, so the driver itself can never stall.
+            next_ns = now_ns + (step.sleep_until_ns - now_ns) / 2 + 1;
+            if (next_ns > step.sleep_until_ns) next_ns = step.sleep_until_ns;
+        } else if (wake == Wake::Overshoot) {
+            // Saturating, so an overshoot near UINT64_MAX does not wrap the DRIVER and fake a pass.
+            next_ns = step.sleep_until_ns > ~0ull - 137000ull ? ~0ull : step.sleep_until_ns + 137000ull;
+        }
+        if (!(next_ns > now_ns)) { st.invariants_ok = false; break; }   // the driver must progress
+        now_ns = next_ns;
+        st.last_now_ns = now_ns;
+    }
+    return st;
 }
 
 int main() {
@@ -99,6 +173,218 @@ int main() {
         constexpr uint64_t kDeadlineNs = 10000;    // already behind g_fake_now_ns
         host::sleep_until_deadline_retry(kDeadlineNs, fake_now_ns, fake_sleep_fixed_step);
         CHECK(g_sleep_calls == 0, "a deadline already in the past is not slept on at all");
+    }
+
+    // =======================================================================
+    // #3069: scePthreadSemTimedwait's poll-loop arithmetic, driven by a fake clock.
+    // =======================================================================
+    constexpr uint64_t kNsMax = ~0ull;
+
+    // 5. SATURATING us -> ns. `timeout_us` is guest-controlled; a wrap turns a 584-year timeout
+    //    into a few hundred nanoseconds. The naive `us * 1000` gives 384 for the first input past
+    //    the boundary, which is why the property arm below is stated as "never less than its own
+    //    input" rather than as a magic number.
+    {
+        CHECK(host::timeout_ns_from_us(0) == 0, "a zero timeout converts to zero");
+        CHECK(host::timeout_ns_from_us(1) == 1000, "1 us is 1000 ns");
+        CHECK(host::timeout_ns_from_us(5000) == 5000000,
+              "the 5 ms timeout test_kernel_sem_timedwait uses converts exactly");
+        // THE BOUNDARY, both sides of it. kNsMax/1000 is the largest input that does NOT saturate.
+        constexpr uint64_t kLastExact = kNsMax / 1000ull;
+        CHECK(host::timeout_ns_from_us(kLastExact) == kLastExact * 1000ull,
+              "the largest non-saturating input converts exactly (no premature clamping)");
+        CHECK(host::timeout_ns_from_us(kLastExact + 1) == kNsMax,
+              "one microsecond past it saturates instead of wrapping");
+        CHECK(host::timeout_ns_from_us(kNsMax) == kNsMax, "UINT64_MAX microseconds saturates");
+        // The property, swept across the boundary: a saturating conversion is non-decreasing and
+        // never returns less than its input. A wrap violates both, and this arm does not need to
+        // know what the wrapped value would be.
+        bool monotonic = true, never_shrinks = true;
+        uint64_t prev = 0;
+        for (uint64_t d = 0; d <= 8; ++d) {
+            const uint64_t u = kLastExact - 4 + d;
+            const uint64_t got = host::timeout_ns_from_us(u);
+            if (got < prev) monotonic = false;
+            if (got < u) never_shrinks = false;
+            prev = got;
+        }
+        CHECK(monotonic, "the conversion is non-decreasing across the saturation boundary");
+        CHECK(never_shrinks, "...and never returns a timeout SHORTER than the microseconds asked for");
+    }
+
+    // 6. SATURATING deadline addition. A wrapped deadline lands in the PAST, which turns a long
+    //    wait into an instant timeout.
+    {
+        CHECK(host::deadline_ns_from(0, 0) == 0, "a zero start and zero timeout give a zero deadline");
+        CHECK(host::deadline_ns_from(1000, 5000) == 6000, "the ordinary case is a plain addition");
+        // The boundary, both sides. With start = kNsMax - 5, a timeout of exactly 5 still fits.
+        CHECK(host::deadline_ns_from(kNsMax - 5, 5) == kNsMax,
+              "a timeout that exactly reaches the maximum is not clamped early");
+        CHECK(host::deadline_ns_from(kNsMax - 5, 6) == kNsMax,
+              "one nanosecond past it saturates instead of wrapping into the past");
+        CHECK(host::deadline_ns_from(kNsMax, 1) == kNsMax, "a start already at the maximum saturates");
+        CHECK(host::deadline_ns_from(100, kNsMax) == kNsMax, "a maximal timeout saturates");
+        // The property: the deadline is never BEHIND the start. That is the whole point of the
+        // saturation, and the naive `start + timeout` fails it (kNsMax - 5 + 6 wraps to 0).
+        bool never_in_past = true;
+        for (uint64_t d = 0; d <= 8; ++d) {
+            const uint64_t start = kNsMax - 4;   // fixed, near the top; `d` sweeps the TIMEOUT
+            const uint64_t got = host::deadline_ns_from(start, d);
+            if (got < start) never_in_past = false;
+        }
+        CHECK(never_in_past, "a saturated deadline never lands BEHIND its own start");
+    }
+
+    // 7. THE ADAPTIVE SLICE AND ITS CLAMP, tested directly rather than only through sem_poll_step,
+    //    so a clamp regression is attributable to one function.
+    {
+        const uint64_t kFine = host::kSemPollFineSliceNs;
+        const uint64_t kCoarse = host::kSemPollCoarseSliceNs;
+        const uint64_t kWindow = host::kSemPollFineWindowNs;
+        const uint64_t kPlenty = 1000ull * 1000ull * 1000ull;   // 1 s remaining: never the binding constraint
+
+        // The three constants themselves, as LITERALS. Every other assertion in this arm reads them
+        // SYMBOLICALLY -- which is right for testing the selection logic, but means a change to a
+        // constant's VALUE cannot redden any of them. Mutation-checked, and it is not hypothetical:
+        // swapping the fine slice to 2 ms survived every other assertion in this file. The triple is
+        // a measured tuning decision (see the sleep-floor measurement above poll_slice_ns), so this
+        // is a tripwire making a retune deliberate -- not a claim that these values are optimal.
+        CHECK(kFine == 500000ull && kCoarse == 2000000ull && kWindow == 8000000ull,
+              "the measured poll cadence is 500 us / 2 ms / 8 ms (tripwire on an accidental retune)");
+
+        CHECK(host::poll_slice_ns(0, kPlenty) == kFine, "a young wait polls on the 500 us slice");
+        CHECK(host::poll_slice_ns(kWindow - 1, kPlenty) == kFine,
+              "...right up to the last nanosecond inside the 8 ms window");
+        CHECK(host::poll_slice_ns(kWindow, kPlenty) == kCoarse,
+              "at exactly 8 ms elapsed it switches to the 2 ms slice (the boundary is `<`, not `<=`)");
+        CHECK(host::poll_slice_ns(kWindow + 1, kPlenty) == kCoarse, "...and stays there afterwards");
+
+        // THE CLAMP. Each of these fails if the `remaining_ns < slice` clamp is removed.
+        CHECK(host::poll_slice_ns(0, 1) == 1,
+              "one nanosecond of remaining time clamps the fine slice to 1 ns, not 500 us");
+        CHECK(host::poll_slice_ns(kWindow, 1) == 1, "...and clamps the coarse slice just the same");
+        CHECK(host::poll_slice_ns(0, kFine - 1) == kFine - 1,
+              "remaining just under the fine slice binds");
+        CHECK(host::poll_slice_ns(0, kFine) == kFine,
+              "remaining exactly equal to the slice is NOT clamped (the boundary is `<`, not `<=`)");
+        CHECK(host::poll_slice_ns(kWindow, kCoarse - 1) == kCoarse - 1,
+              "remaining just under the coarse slice binds");
+        // The property that makes the clamp the anti-overflow guard, swept: the slice never exceeds
+        // the remaining time, in either regime.
+        bool never_exceeds = true;
+        for (uint64_t rem = 0; rem <= 12; ++rem) {
+            if (host::poll_slice_ns(0, rem) > rem) never_exceeds = false;
+            if (host::poll_slice_ns(kWindow, rem) > rem) never_exceeds = false;
+        }
+        CHECK(never_exceeds, "the slice never exceeds the time remaining, in either regime");
+    }
+
+    // 8. A DEADLINE ALREADY IN THE PAST, and the exact instant it becomes one. The real loop cannot
+    //    be asked for this: it would need a semaphore that stays unposted and a clock the test owns.
+    {
+        constexpr uint64_t kStart = 1000000ull, kDeadline = 1005000ull;
+        CHECK(host::sem_poll_step(kStart, kDeadline, kDeadline).expired,
+              "a clock exactly ON the deadline has expired (the test is `>=`, not `>`)");
+        CHECK(host::sem_poll_step(kStart, kDeadline, kDeadline + 1).expired,
+              "a clock past the deadline has expired");
+        CHECK(host::sem_poll_step(kStart, kDeadline, kDeadline + 999999999ull).expired,
+              "a wildly overshot wake still reports expiry rather than computing a slice");
+        CHECK(!host::sem_poll_step(kStart, kDeadline, kDeadline - 1).expired,
+              "one nanosecond short of the deadline has NOT expired");
+        // ...and that last nanosecond is slept on, not skipped or spun through.
+        const host::SemPollStep last = host::sem_poll_step(kStart, kDeadline, kDeadline - 1);
+        CHECK(last.sleep_until_ns == kDeadline,
+              "...and the final nanosecond is slept to the deadline exactly, never past it");
+        // A zero-length timeout: expired on the very first look, without a single sleep.
+        CHECK(host::sem_poll_step(kStart, kStart, kStart).expired,
+              "a zero timeout expires immediately (deadline == start)");
+    }
+
+    // 9. THE FULL LOOP under three wake behaviours, including an EARLY wakeup. Every arm asserts
+    //    both regimes were actually entered -- otherwise a loop that never left the fine window
+    //    would pass while claiming to cover the crossover.
+    {
+        constexpr uint64_t kStart = 5000000000ull;   // an arbitrary, non-zero clock epoch
+        constexpr uint64_t kTimeoutUs = 50000;       // 50 ms: well past the 8 ms fine window
+
+        for (int w = 0; w < 3; ++w) {
+            const Wake wake = w == 0 ? Wake::Exact : (w == 1 ? Wake::Early : Wake::Overshoot);
+            const char* name = w == 0 ? "exact" : (w == 1 ? "early" : "overshooting");
+            const LoopStats st = drive_poll_loop(kStart, kTimeoutUs, wake);
+            printf("         (%s wakes: %d steps, %d fine, %d coarse, %d clamped)\n",
+                   name, st.steps, st.fine_steps, st.coarse_steps, st.clamped_steps);
+            CHECK(st.terminated, "the poll loop terminates");
+            CHECK(st.invariants_ok, "now_ns < sleep_until_ns <= deadline_ns held at every step");
+            // The lever moved: both regimes were reached, so the crossover really was crossed.
+            CHECK(st.fine_steps > 0, "...and the fine (500 us) regime was actually entered");
+            CHECK(st.coarse_steps > 0, "...and the coarse (2 ms) regime was actually entered");
+            CHECK(st.clamped_steps > 0,
+                  "...and the clamp bound at least once, on the final approach to the deadline");
+            CHECK(st.last_now_ns >= kStart, "the fake clock never wrapped");
+        }
+
+        // An early wakeup costs strictly MORE iterations than an exact one for the same timeout --
+        // which is the observable consequence of the loop recomputing from `now_ns` rather than
+        // carrying a target forward. If these were equal the "early" arm would be exercising
+        // nothing the "exact" arm does not.
+        const LoopStats exact = drive_poll_loop(kStart, kTimeoutUs, Wake::Exact);
+        const LoopStats early = drive_poll_loop(kStart, kTimeoutUs, Wake::Early);
+        CHECK(early.steps > exact.steps,
+              "an early-returning sleep really does drive more iterations (the arm is not a no-op)");
+    }
+
+    // 10. A CLOCK THAT RUNS BACKWARDS. steady_clock cannot do this, so the real call site cannot
+    //     reach it -- but the arithmetic is expressible and this pins what it currently does, so a
+    //     later change to the elapsed computation is a DELIBERATE one rather than a silent one.
+    //
+    //     Current behaviour, preserved unchanged by #3069's extraction: `now_ns - start_ns` wraps to
+    //     a huge value, so the coarse slice is selected. Benign -- the loop polls at 2 ms instead of
+    //     500 us and still times out at exactly the right moment, because the deadline test does not
+    //     involve start_ns at all. THIS ARM ASSERTS THE STATUS QUO, NOT THAT THE STATUS QUO IS IDEAL.
+    {
+        constexpr uint64_t kStart = 5000000000ull;
+        const uint64_t deadline = host::deadline_ns_from(kStart, host::timeout_ns_from_us(50000));
+        const uint64_t now_behind = kStart - 1000000ull;   // the clock jumped 1 ms backwards
+        const host::SemPollStep step = host::sem_poll_step(kStart, deadline, now_behind);
+        CHECK(!step.expired, "a backwards clock before the deadline has not expired");
+        CHECK(step.sleep_until_ns == now_behind + host::kSemPollCoarseSliceNs,
+              "a backwards clock currently selects the COARSE slice (wrapped elapsed) -- pinned, "
+              "not endorsed");
+        CHECK(step.sleep_until_ns > now_behind && step.sleep_until_ns <= deadline,
+              "...and the invariants still hold, so the loop is still correct, just slower");
+        // The termination guarantee survives it: the deadline test reads only now_ns and
+        // deadline_ns, so a backwards jump cannot make the loop run forever.
+        CHECK(host::sem_poll_step(kStart, deadline, deadline).expired,
+              "...and expiry is still decided by the deadline alone, never by the elapsed time");
+    }
+
+    // 11. ARITHMETIC WITHIN A FEW NANOSECONDS OF UINT64_MAX -- the case the clamp exists for, and
+    //     the one a wall-clock test can never construct. Without the clamp, `now_ns + 500000` wraps
+    //     here and the next wake lands in the PAST.
+    {
+        const uint64_t start = kNsMax - 10;
+        const uint64_t deadline = host::deadline_ns_from(start, host::timeout_ns_from_us(kNsMax));
+        CHECK(deadline == kNsMax, "a maximal timeout from a near-maximal start saturates to the max");
+
+        const uint64_t now = kNsMax - 1;                 // one nanosecond of remaining time
+        const host::SemPollStep step = host::sem_poll_step(start, deadline, now);
+        CHECK(!step.expired, "one nanosecond short of a maximal deadline has not expired");
+        CHECK(step.sleep_until_ns == kNsMax,
+              "...and the wake target is clamped to the deadline itself, not wrapped past zero");
+        CHECK(step.sleep_until_ns > now, "...so it is still strictly in the future (no wrap)");
+        CHECK(step.sleep_until_ns <= deadline, "...and still no later than the deadline");
+
+        // Walk the last few nanoseconds one at a time: every one must stay ordered and terminate.
+        bool ok = true;
+        for (uint64_t back = 8; back >= 1; --back) {
+            const uint64_t n = kNsMax - back;
+            const host::SemPollStep s2 = host::sem_poll_step(start, deadline, n);
+            if (s2.expired) { ok = false; break; }
+            if (!(s2.sleep_until_ns > n && s2.sleep_until_ns <= deadline)) { ok = false; break; }
+        }
+        CHECK(ok, "every step through the last 8 ns before UINT64_MAX stays ordered and bounded");
+        CHECK(host::sem_poll_step(start, deadline, kNsMax).expired,
+              "and the maximum itself is the timeout, reached rather than overshot into a wrap");
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);


### PR DESCRIPTION
Fixes #3069. Refs #3067. Refs #3066. Refs #3044. Refs #3064. Refs #3074.

## Why

`scePthreadSemTimedwait`'s Windows poll loop carried three pieces of arithmetic that **no test reached**, two of them saturating arms guarding a **guest-controlled** timeout:

1. saturating microsecond -> nanosecond conversion — a wrap turns a 584-year timeout into a few hundred nanoseconds;
2. saturating deadline addition — a wrapped deadline lands in the **past**, turning a long wait into an instant timeout;
3. the adaptive poll slice and its clamp against the remaining time.

They were unreachable by construction. The arithmetic sat inline in an `HLE()` body, so the only handle on it was to call the real HLE and observe a duration — and `test_kernel_sem_timedwait.cpp`'s own header records at length why that cannot discriminate anything here: a quantized wait returns at the next tick **boundary**, so the defect's latency distribution overlaps the fix's for any tick length, and no single-run wall-clock bound separates them.

This is the same shape, and the same argument, as #3064 (`next_grid_deadline_ns`) and #3074 (`sleep_until_deadline_retry`).

## The helper's contract

Added to `prosper/src/host/platform/precise_sleep.hpp`, beside the two existing pure functions and beside the deadline sleeper the loop actually calls:

| function | contract |
| --- | --- |
| `timeout_ns_from_us(us)` | saturating us -> ns; never returns fewer nanoseconds than the microseconds asked for |
| `deadline_ns_from(start_ns, timeout_ns)` | saturating add; the deadline never lands **behind** its own start |
| `poll_slice_ns(elapsed_ns, remaining_ns)` | 500 us inside the 8 ms fine window, 2 ms after; never exceeds `remaining_ns` |
| `sem_poll_step(start_ns, deadline_ns, now_ns)` | the whole per-iteration decision: `{expired, sleep_until_ns}` |

All pure, all `constexpr`, all taking the clock reading as a **parameter** — so a test drives the entire loop with a fake clock: no `_WIN32`, no real sleep, no wall time.

`sem_poll_step` guarantees, for every live step:

    now_ns < sleep_until_ns <= deadline_ns

The **strict** lower bound forbids a zero-length sleep (a busy spin while time remains). The upper bound is both the clamp and the reason `now_ns + slice` cannot wrap near `UINT64_MAX`.

`poll_slice_ns` is exposed separately from its only caller so the clamp is attributable to one function under mutation.

## What is provably unchanged

**Pure extraction — no behaviour change**, and that is measured rather than asserted. A differential harness transcribed the original inline expressions verbatim from `origin/master` and compared them against the helpers over **12,011,237** input triples — both saturation boundaries, the fine/coarse crossover, backwards clocks, and the last nanoseconds before `UINT64_MAX`:

    checked=12011237 mismatches=0
    DIFFERENTIAL PASSED (extraction is behaviour-identical)

**The zero is not vacuous.** Positive control: perturbing the slice by **1 ns** yields `mismatches=5480686` and `DIFFERENTIAL FAILED`. The harness is scratch, not committed.

The only prose that moved is the sleep-floor measurement and the three cadence constants, which now live beside `poll_slice_ns`; the call-site comment that referred to them "below" now points at the header instead.

## Affected / unaffected

- **Affected:** the Windows (`_WIN32`) poll loop's spelling only. Same values, same order, same branches.
- **Unaffected:** the POSIX branch keeps the native `sem_timedwait` and its exact semantics. The `WaitCensusScope` census value is byte-identical (covered by the differential sweep).
- **Not touched, deliberately:** `abs_deadline_us(a1)` on the POSIX path still takes the raw `a1` rather than the saturated `timeout_ns`. Checked — for `UINT64_MAX` it yields `tv_sec` ~1.8e13 (year ~586,000), i.e. an effectively infinite wait, which agrees with the saturating intent. Pre-existing on master and out of scope for a pure extraction.

## The backwards clock is PINNED, NOT FIXED

`now_ns - start_ns` on a clock that ran backwards wraps to a huge value and so selects the **coarse** slice. That is master's behaviour, preserved deliberately rather than corrected, because this PR is an extraction.

It is unreachable through the real call site — both reads are `steady_clock`, which cannot go backwards — and benign if it ever were reached: the loop polls at 2 ms instead of 500 us and **still times out at exactly the right moment**, because the expiry test does not involve `start_ns` at all. A test arm asserts the status quo and says in as many words that it pins it rather than endorses it, so a later change there is a deliberate one.

**No arithmetic bug was found** while extracting. Both saturating arms are correct at their boundaries, which the tests now pin on both sides.

## Fake-clock cases covered

Arms 5-11 of `test_precise_sleep.cpp`, none of which a wall-clock test can produce on demand:

- **early wakeup** — a sleep returning roughly halfway, driven to termination;
- **deadline already past**, and the exact instant it becomes one (`>=` vs `>`);
- **clock running backwards**;
- **slice clamping**, in both regimes and at both `<` boundaries;
- **overflow near the representable maximum** — start at `UINT64_MAX - 10`, walked one nanosecond at a time.

The loop-driving arms **count which regime each step used** and assert both were entered, so an arm cannot pass while never reaching the branch it claims to cover. Observed: `exact wakes: 37 steps, 16 fine, 21 coarse, 1 clamped` / `early wakes: 92 steps, 32 fine, 60 coarse, 20 clamped`. A separate arm asserts `early.steps > exact.steps`, so the early arm is provably not a duplicate of the exact one.

## Commands and results

Configure + build (in the distrobox; a host build silently drops the Vulkan execution tests):

    cmake -S prosper -B prosper/build-linux                      # rc=0
    TMPDIR=$PWD/prosper/build-linux/tmpdir cmake --build prosper/build-linux -j8    # rc=0
    ctest --test-dir prosper/build-linux --no-tests=error        # rc=0, 100% tests passed out of 318

`kernel_sem_timedwait` (test 53) passes in 0.01 s; `precise_sleep_deadline_retry` (test 258) passes.

**The Windows branch is the one actually rewired, and Linux never compiles it**, so it was compile-verified separately with MinGW:

    x86_64-w64-mingw32-g++ -std=gnu++20 -Iprosper/src ... -fsyntax-only \
        prosper/src/hle/kernel/hle_kernel.cpp                    # rc=0, 0 errors

With a positive control proving that check is real — injecting an undeclared identifier **inside** the `#else` branch gives MinGW `rc=1` (`error: 'PROSPER_I3069_POSITIVE_CONTROL' was not declared in this scope`, at the rewired line) while native `g++` still returns **rc=0** on the same broken file, confirming Linux preprocesses that branch out entirely.

## Mutation evidence

Each mutation was applied to the helper, rebuilt, and run; `build_rc` is reported alongside because a failed build leaves the old binary and reports a false pass. **All builds succeeded, so every result below is a real test verdict.**

    baseline_rc=0   restored_rc=0

    M1  drop the clamp in poll_slice_ns                  mutant_rc=1  (build_rc=0)
    M2  flip the expiry test >= to > in sem_poll_step    mutant_rc=1  (build_rc=0)
    M3  drop the saturation in timeout_ns_from_us        mutant_rc=1  (build_rc=0)
    M4  drop the saturation in deadline_ns_from          mutant_rc=1  (build_rc=0)
    M5  fine-window boundary < becomes <=                mutant_rc=1  (build_rc=0)
    M6  swap the fine slice to 2 ms (cadence inversion)  mutant_rc=1  (build_rc=0)

**M6 initially SURVIVED** and is reported because it was a real gap, not because it was found by design: every other assertion read the cadence constants *symbolically*, so changing a constant's value could not redden any of them. An arm pinning the three literals closes it, commented as a tripwire on a measured tuning decision rather than a claim the values are optimal.

## Risks

- Low. The extracted expressions are identical (12M-case differential), the call site is a mechanical substitution, and the only platform whose code path changed shape was compile-verified under MinGW with a positive control.
- The **runtime** Windows path is not exercised here — no Windows host in this session. Mitigated by the differential (the values are identical) and the MinGW syntax check (the code compiles), but stated plainly rather than glossed.
- `sem_poll_step` returns `sleep_until_ns = 0` when expired; the field is documented as unset in that case and the call site never reads it.

## Note for #3067

#3067 remains open, undiagnosed, and untouched by this PR -- no claim is made on it here. What this does remove is the reason its arithmetic was untestable, which was the stated purpose of #3069.

One observation, offered as a **lead rather than a finding**: `kernel_sem_timedwait` takes **0.01 s** on Linux here, while #3067 records the macOS/Rosetta failures at **1.02 s and 1.22 s**. ARM 4 of that test grants a **one second** timeout and asserts the posted acquire returns nowhere near it, so a runtime of ~1.0 s is what waiting that timeout out would look like. That is consistent with the failure being ARM 4 rather than the timing bounds in ARM 3 — untested, and it does not distinguish #3067's two candidates (a loaded runner vs. something environmental). Whoever picks it up should confirm against the job's own per-arm output before believing it.