### PR TITLE
fix(gpu): distinguish an announced index size from a never-announced one (#3009)

### DIFF
--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -384,7 +384,20 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
   `index_buffer_is_unannounced_32bit_high`. **No further test over those two pointers can separate
   them** — do not try to tighten the pattern. The deciding evidence has to come from outside the
   buffer, and today that is the bound vertex buffer's record count. Residual, measured: a bound of
-  65,602 records still admits the case; #3009 is the real fix. Found by independent review of PR #3006.
+  65,602 records still admits the case. Found by independent review of PR #3006.
+  **#3009 has since bounded that residual from the other side**: `index_type == 0` no longer means
+  both "announced 16-bit" and "never announced", so a title that announced an index size never
+  reaches either detector at all. **This title's own exposure is unchanged, and that is now
+  established statically rather than inferred**: the 508,688 `index_type=0` draws never proved
+  "announces never" — that is exactly the reading `index_type == 0` cannot support — but the dump's
+  modules do not import `sceAgcDcbSetIndexSize` (NID `GIIW2J37e70`, `libSceAgc`) at all, so the
+  title **cannot** announce. Positive control on the same scan: `sceAgcDcbSetIndexBuffer`
+  (`l4fM9K-Lyks`) and `sceAgcDcbDrawIndexOffset` (`B+aG9DUnTKA`) ARE present in `eboot.bin`, so the
+  scan can see this dump's AGC NIDs and the absence is a real negative rather than a blind
+  instrument. (This title imports neither `DrawIndexAuto` nor `DrawIndex`: it draws through the Gen5
+  `SetIndexBuffer`/`SetIndexCount`/`DrawIndexOffset` path, which is why a control built from the
+  first two read as void on it.) The vertex-range bound therefore remains its only guard and the
+  period-2 residual above still stands for it.
 
 - **The renderer is not rejecting anything, and never was.** A full boot-to-gameplay run produces
   **zero** `[recompile-reject]` lines and **zero** `[compute] skip` lines. Neither the shattered

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -1290,6 +1290,40 @@ inline uint32_t index_elem_bytes(uint32_t index_type) {
     return index_type == 0 ? 2u : index_type == 1 ? 4u : 0u;
 }
 
+// May the two #304 detectors below speak for this draw at all (#3009)?
+//
+// Both are named for what they do: recover an element size the guest NEVER ANNOUNCED. They are
+// heuristics over guest bytes, and the second one carries a measured residual (see its own header) --
+// so running them against a title that DID announce lets a byte pattern overrule a fact prosper was
+// told by the guest, which is the one input that cannot be wrong. Hardware fetches indices at the
+// size VGT_INDEX_TYPE holds; a detector that overrides an announced size is emulating something the
+// hardware does not do.
+//
+// The reason they used to run everywhere is that `index_type == 0` meant two things at once -- "the
+// guest announced 16-bit" and "the guest never announced anything" -- so the executor could not tell
+// an announcement from a reset default. GpuState::index_type_announced now records that separately,
+// and this predicate is the only place the distinction is consumed.
+//
+// Neither known case regresses, and the evidence for that is deliberately NOT `index_type == 0` on a
+// live run -- that reading is the very thing this flag exists because it cannot support. Both dumps
+// were checked statically instead: neither PPSA17942 (DOLL) nor PPSA16901 (Tomb Raider I-III
+// Remastered) imports `sceAgcDcbSetIndexSize` (NID GIIW2J37e70, libSceAgc) in any module, so neither
+// CAN announce, and `announced` is false for them however they are routed. Positive control on the
+// same scan: other libSceAgc indexed-draw NIDs are present in both dumps, so the scan sees their
+// symbols and the absence is a real negative rather than a blind instrument. Corpus-wide, 21 of 55
+// local dumps import the entry point and 34 do not, with the control firing on all 34 (#3009).
+//
+// LIMIT, stated because its failure direction matters: this records announcements made through
+// IT_INDEX_TYPE, which is what sceAgcDcbSetIndexSize emits (hle_agc.cpp, agc_dcb_set_index_size). If
+// a title instead programs an index-type UCONFIG register directly, prosper does not read that
+// register for the element size ANYWHERE today, so such a title looks unannounced here -- and gets
+// exactly the pre-#3009 behaviour, detectors and all. Missing that path costs the fix, never
+// correctness. PROSPER_INDEXTYPE_LOG prints `announced` per indexed draw so the corpus question
+// ("how many titles announce at all?") is one run away.
+inline bool index_size_detection_permitted(uint32_t index_type, bool index_type_announced) {
+    return !index_type_announced && index_elem_bytes(index_type) == 2u;
+}
+
 // Detect an UNANNOUNCED 32-bit index buffer (#304). DOLL's UE4 Slate/UMG quad index buffers are
 // 32-bit, but the title never calls sceAgcDcbSetIndexSize and programs no VGT_INDEX_TYPE register,
 // so index_type defaults to 16-bit — which misreads each 32-bit index as TWO 16-bit ones (the low
@@ -1381,9 +1415,10 @@ inline bool index_buffer_is_unannounced_32bit(const uint16_t* p16, const uint32_
 // which is the point. The executor's
 // own clamp constant three lines above `vb_records_unclamped` is 65,536, i.e. vertex buffers of about
 // that size are routine, so a title with a modest pool AND fan/cone geometry whose apex index is small
-// can still satisfy every clause here. The real fix is knowing whether the guest ever announced an
-// index size at all -- today `index_type == 0` means "16-bit" and "never told" indistinguishably, and
-// that distinction would let both detectors decline outright for any title that announces (#3009).
+// can still satisfy every clause here. That residual is now bounded on the OTHER side by
+// index_size_detection_permitted() (#3009): a title that announced an index size never reaches this
+// function at all, so the exposure is titles that announce nothing -- which is still the exposure for
+// the two known cases, and the vertex-range bound remains their only guard.
 inline bool index_buffer_is_unannounced_32bit_high(const uint16_t* p16, const uint32_t* p32,
                                                    uint32_t n, uint32_t vertex_upper_bound) {
     constexpr uint32_t kMinSamples = 8;     // >= 4 words per parity before "all equal" means anything
@@ -2162,19 +2197,14 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         uint32_t esz = index_elem_bytes(ds.index_type);
         uint32_t n = std::min(draw->index_count, kMaxIndices);
         uint64_t index_addr = draw->index_addr;
-        // Auto-detect a 32-bit index buffer that the guest never announced (#304). DOLL's UE4 Slate/UMG
-        // quads use 32-bit index buffers but the title never calls sceAgcDcbSetIndexSize and sets no
-        // VGT_INDEX_TYPE register, so index_type defaults to 16-bit — misreading each 32-bit index as
-        // two 16-bit ones. The fingerprint is unmistakable: a 32-bit index buffer read as 16-bit has
-        // every ODD 16-bit word (the zero high half of a small index) == 0, while reading it as 32-bit
-        // yields small, valid indices. Genuine 16-bit buffers (DOLL's scene/text meshes, all of the
-        // Messenger's quads) have non-zero odd words and are left untouched. When detected, use the
-        // 32-bit element size AND recompute a DrawIndexOffset's address at that stride (index_base +
-        // index_offset*4) so it lands on the correct quad. CONFIDENCE: HIGH — the banner index buffer
-        // decodes to a clean [0,1,2,2,1,3] quad this way vs a degenerate [0,0,1,0,2,0] as 16-bit.
-        if (esz == 2 && n >= 2) {
-            uint64_t addr32 = draw->from_offset ? (draw->index_base + (uint64_t)draw->index_offset * 4u)
-                                                : draw->index_addr;
+        // The address the same buffer would be read from at a 4-byte stride. For a DrawIndexOffset
+        // the two differ (index_base + offset*2 against index_base + offset*4); otherwise they are
+        // the same bytes. Computed for every indexed draw so the instrument below can print both
+        // readings whatever the announced size says -- it is arithmetic, nothing is dereferenced.
+        const uint64_t addr32 = draw->from_offset
+                                    ? (draw->index_base + (uint64_t)draw->index_offset * 4u)
+                                    : draw->index_addr;
+        {
             // PROSPER_INDEXTYPE_LOG=1 -- what the guest ANNOUNCED against what its bytes actually
             // hold. Without it, "the title never set an index size" and "it set one and we dropped
             // it" produce identical evidence and point at different files; #304 and its part-two
@@ -2183,6 +2213,13 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             // hundreds of thousands of indexed draws (508,688 measured on one Tomb Raider run), and
             // an unbounded line-per-draw log is a multi-gigabyte file that fills the disk before it
             // answers anything. The cap is announced so a truncated log is never read as a count.
+            //
+            // #3009: prints `announced` (did an IT_INDEX_TYPE packet ever fold?) and runs for EVERY
+            // indexed draw, not only the ones the detectors may touch. Both halves are needed for
+            // the corpus census the gate's value depends on -- "how many titles announce an index
+            // size at all?" cannot be answered by an instrument that only fires on draws whose
+            // announced size is 16-bit, and gating the log alongside the detectors would have made
+            // the fix hide its own measurement. Widening it does spend the 64-line cap faster.
             static const bool indextype_log = getenv("PROSPER_INDEXTYPE_LOG") != nullptr;
             if (indextype_log) {
                 static std::atomic<uint32_t> printed{0};
@@ -2191,8 +2228,10 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 if (seq < kMaxLines) {
                     char line[512]; int off = 0;
                     off += snprintf(line + off, sizeof(line) - off,
-                                    "[idxtype] index_type=%u esz=%u n=%u from_offset=%u addr=0x%llx addr32=0x%llx",
-                                    ds.index_type, esz, n, (unsigned)draw->from_offset,
+                                    "[idxtype] index_type=%u announced=%u esz=%u n=%u from_offset=%u "
+                                    "addr=0x%llx addr32=0x%llx",
+                                    ds.index_type, (unsigned)ds.index_type_announced, esz, n,
+                                    (unsigned)draw->from_offset,
                                     (unsigned long long)draw->index_addr, (unsigned long long)addr32);
                     if (guest_readable(draw->index_addr, 16u)) {
                         off += snprintf(line + off, sizeof(line) - off, " u16=");
@@ -2214,6 +2253,22 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                                         "printed (this is a CAP, not a draw count)\n", kMaxLines);
                 }
             }
+        }
+        // Auto-detect a 32-bit index buffer that the guest never announced (#304). DOLL's UE4 Slate/UMG
+        // quads use 32-bit index buffers but the title never calls sceAgcDcbSetIndexSize and sets no
+        // VGT_INDEX_TYPE register, so index_type defaults to 16-bit — misreading each 32-bit index as
+        // two 16-bit ones. The fingerprint is unmistakable: a 32-bit index buffer read as 16-bit has
+        // every ODD 16-bit word (the zero high half of a small index) == 0, while reading it as 32-bit
+        // yields small, valid indices. Genuine 16-bit buffers (DOLL's scene/text meshes, all of the
+        // Messenger's quads) have non-zero odd words and are left untouched. When detected, use the
+        // 32-bit element size AND recompute a DrawIndexOffset's address at that stride (index_base +
+        // index_offset*4) so it lands on the correct quad. CONFIDENCE: HIGH — the banner index buffer
+        // decodes to a clean [0,1,2,2,1,3] quad this way vs a degenerate [0,0,1,0,2,0] as 16-bit.
+        //
+        // #3009 gates the whole thing on the guest NOT having announced a size. `esz == 2` used to
+        // stand in for that and could not: it is true both for an announced 16-bit buffer and for a
+        // title that never announced anything.
+        if (index_size_detection_permitted(ds.index_type, ds.index_type_announced) && n >= 2) {
             if (guest_readable(draw->index_addr, n * 2u) && guest_readable(addr32, n * 4u)) {
                 const uint16_t* p16 = (const uint16_t*)(uintptr_t)draw->index_addr;
                 const uint32_t* p32 = (const uint32_t*)(uintptr_t)addr32;

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -4174,6 +4174,21 @@ void apply_retained_dma_copies(std::vector<GpuState::DmaCopy>& copies) {
     copies.clear();
 }
 
+// State-at-draw snapshot (see the declaration). One snapshot is shared by consecutive work items
+// with no register write between them, so this is a pointer copy in the common case.
+const std::shared_ptr<const GpuState>& GpuState::refresh_state_snapshot() {
+    if (state_dirty_ || !last_snapshot_) {
+        auto snap = std::make_shared<GpuState>();
+        snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
+        snap->num_instances = num_instances;
+        snap->command_order = command_order;   // #305 instrument: order at snapshot
+        if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
+        last_snapshot_ = std::move(snap);
+        state_dirty_ = false;
+    }
+    return last_snapshot_;
+}
+
 void GpuState::apply(const Pm4Command& c) {
     using K = Pm4Command::Kind;
     command_order = c.stream_order ? c.stream_order : command_order + 1;
@@ -4528,15 +4543,7 @@ void GpuState::apply(const Pm4Command& c) {
                             g_fold_seq.load(std::memory_order_relaxed), jump_depth,
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
-            if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
-                snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
-                snap->num_instances = num_instances;
-                snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
-                last_snapshot_ = std::move(snap);
-                state_dirty_ = false;
-            }
+            refresh_state_snapshot();
             uint32_t elem = index_type ? 4u : 2u;
             Draw d;
             d.index_count = c.index_count ? c.index_count : index_num;
@@ -4579,15 +4586,7 @@ void GpuState::apply(const Pm4Command& c) {
                             g_fold_seq.load(std::memory_order_relaxed), jump_depth,
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
-            if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
-                snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
-                snap->num_instances = num_instances;
-                snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
-                last_snapshot_ = std::move(snap);
-                state_dirty_ = false;
-            }
+            refresh_state_snapshot();
             Draw d;
             d.index_count = c.index_count;
             d.instance_count = num_instances;
@@ -4622,15 +4621,7 @@ void GpuState::apply(const Pm4Command& c) {
                             g_fold_seq.load(std::memory_order_relaxed), jump_depth,
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
-            if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
-                snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
-                snap->num_instances = num_instances;
-                snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
-                last_snapshot_ = std::move(snap);
-                state_dirty_ = false;
-            }
+            refresh_state_snapshot();
             Draw d;
             d.state = last_snapshot_;
             d.indexed = true;
@@ -4874,15 +4865,7 @@ void GpuState::apply(const Pm4Command& c) {
                             g_fold_seq.load(std::memory_order_relaxed), jump_depth,
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
-            if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
-                snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
-                snap->num_instances = num_instances;
-                snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
-                last_snapshot_ = std::move(snap);
-                state_dirty_ = false;
-            }
+            refresh_state_snapshot();
             dispatches.push_back({c.threads_x, c.threads_y, c.threads_z,
                                   c.dispatch_modifier, last_snapshot_, command_order});
             dispatch_count++;
@@ -4906,15 +4889,7 @@ void GpuState::apply(const Pm4Command& c) {
                             g_fold_seq.load(std::memory_order_relaxed), jump_depth,
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
-            if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
-                snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
-                snap->num_instances = num_instances;
-                snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
-                last_snapshot_ = std::move(snap);
-                state_dirty_ = false;
-            }
+            refresh_state_snapshot();
             Dispatch d;
             d.modifier = c.dispatch_modifier;
             d.state = last_snapshot_;

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -4180,6 +4180,7 @@ const std::shared_ptr<const GpuState>& GpuState::refresh_state_snapshot() {
     if (state_dirty_ || !last_snapshot_) {
         auto snap = std::make_shared<GpuState>();
         snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
+        snap->index_type_announced = index_type_announced;
         snap->num_instances = num_instances;
         snap->command_order = command_order;   // #305 instrument: order at snapshot
         if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
@@ -4457,6 +4458,11 @@ void GpuState::apply(const Pm4Command& c) {
         }
         case K::SetIndexType:
             index_type = c.index_size;
+            // #3009: record the ANNOUNCEMENT, not just the value. A type-3 packet is at least two
+            // dwords (pm4_decode.cpp hdr_len adds 2), so a decoded SetIndexType always carried its
+            // payload dword and this is unconditional -- the `npl >= 1` guard on c.index_size is
+            // defensive, not a reachable "announced nothing" case.
+            index_type_announced = true;
             state_dirty_ = true;
             break;
         case K::SetNumInstances:

--- a/prosper/src/gpu/pm4/command_processor.hpp
+++ b/prosper/src/gpu/pm4/command_processor.hpp
@@ -323,6 +323,13 @@ struct GpuState {
     }
 
 private:
+    // Rebuild `last_snapshot_` if a register write has dirtied it, and hand the (possibly reused)
+    // snapshot to the caller. Every draw/dispatch packet case in apply() calls this instead of
+    // carrying its own copy of the field list: five identical copies used to sit inline, so adding a
+    // field to GpuState meant remembering all five, and a snapshot that silently omits one reports
+    // the RESET DEFAULT for it at every draw (#3009).
+    const std::shared_ptr<const GpuState>& refresh_state_snapshot();
+
     // Snapshot sharing: one snapshot is reused by consecutive draws until a register write dirties it.
     std::shared_ptr<const GpuState> last_snapshot_;
     bool state_dirty_ = true;

--- a/prosper/src/gpu/pm4/command_processor.hpp
+++ b/prosper/src/gpu/pm4/command_processor.hpp
@@ -139,7 +139,18 @@ struct GpuState {
     static uint64_t pack_prov_src(uint8_t origin, uint32_t jump_depth, uint32_t fold) {
         return (uint64_t)origin | ((uint64_t)(jump_depth & 0xFFu) << 8) | ((uint64_t)fold << 16);
     }
-    uint32_t index_type = 0;                             // last SetIndexType
+    uint32_t index_type = 0;                             // last SetIndexType (0 = 16-bit, 1 = 32-bit)
+    // Whether an IT_INDEX_TYPE packet was ever folded, i.e. whether the guest ANNOUNCED an index
+    // element size (#3009). `index_type` alone cannot say: 0 is simultaneously the announced 16-bit
+    // encoding and the reset default of a title that never announces anything, and the two demand
+    // opposite handling downstream. The #304 detectors exist only to recover a size the guest never
+    // announced -- run against a title that DID announce, they are free to overrule a fact prosper
+    // was told, on a byte pattern with a measured residual (gpu_execute.hpp,
+    // index_buffer_is_unannounced_32bit_high). Sticky for the process, like the register files:
+    // agc_graphics_state() is a process-lifetime fold, so "ever announced" is the question a draw
+    // in a later submit needs answered. Announcing 32-bit and then 16-bit leaves this true and
+    // index_type 0, which is exactly the state the sentinel could not express.
+    bool index_type_announced = false;
     uint32_t num_instances = 1;                          // default before SetNumInstances; zero discards
     // Gen5 indexed-draw binding state (issue #232, DOLL/UE4 geometry). SetIndexBuffer/SetIndexCount
     // set these; DrawIndexOffset consumes them to emit an indexed Draw. Persist across draws within a

--- a/prosper/tests/gpu/execute/test_gpu_execute.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_execute.cpp
@@ -849,6 +849,44 @@ int main() {
               "#1256: realize_draw_item records the raw indexed draw-packet count (3) + indexed flag");
     }
 
+    // #3009: the announcement gate, end to end through realize_draw_item.
+    //
+    // ONE buffer, ONE index_type (0), TWO announcement states. The bytes are the live DOLL banner
+    // quad stored 32-bit, so the #304 zero-high-half fingerprint matches them: read as 16-bit they
+    // are the degenerate [0,0,1,0,2,0], read as 32-bit the real [0,1,2,2,1,3].
+    //
+    // Before #3009 the executor had only `index_type == 0` to go on, so BOTH calls below produced
+    // the 32-bit reading -- an announced 16-bit buffer of this shape was silently reinterpreted, and
+    // no fixture could tell the two states apart because they were the same state. The arms are a
+    // matched pair on purpose: the unannounced one is the control proving the detector still fires,
+    // and without it the announced arm would pass just as well against a detector that never runs.
+    {
+        alignas(4) static const uint32_t kQuad32[6] = { 0, 1, 2, 2, 1, 3 };
+        auto realize_with = [&](bool announced, DrawItem& out) {
+            GpuState sq = st;
+            sq.index_type = 0;                       // 16-bit reading, both times
+            sq.index_type_announced = announced;
+            GpuState::Draw dq;
+            dq.index_count = 6; dq.indexed = true;
+            dq.index_addr = (uint64_t)(uintptr_t)kQuad32;
+            sq.draws.clear(); sq.draws.push_back(dq);
+            return realize_draw_item(sq, &sq.draws[0], 6u, 0x10000u, /*log*/false, out);
+        };
+        DrawItem unannounced_item, announced_item;
+        const bool made_unannounced = realize_with(/*announced*/false, unannounced_item);
+        const bool made_announced   = realize_with(/*announced*/true,  announced_item);
+        const std::vector<uint32_t> as32 = { 0, 1, 2, 2, 1, 3 };
+        const std::vector<uint32_t> as16 = { 0, 0, 1, 0, 2, 0 };
+        CHECK(made_unannounced && unannounced_item.indices == as32,
+              "#3009 control: with NO announcement the #304 detector still recovers the 32-bit quad");
+        CHECK(made_announced && announced_item.indices == as16,
+              "#3009: the SAME bytes at the SAME index_type are read as announced 16-bit once the "
+              "guest announced -- the heuristic no longer overrules what the guest said");
+        CHECK(made_unannounced && made_announced &&
+              unannounced_item.indices != announced_item.indices,
+              "#3009: the two previously-indistinguishable states now produce different index data");
+    }
+
     // The live-submit registry path — exactly what agc_driver_submit_dcb drives once a device is wired.
     // #189: production submit execution must realize an indexed draw only after a preceding DMA
     // supplies its index buffer. Callback ordering alone is insufficient because realization owns

--- a/prosper/tests/gpu/execute/test_index_size_detect.cpp
+++ b/prosper/tests/gpu/execute/test_index_size_detect.cpp
@@ -230,6 +230,46 @@ int main() {
     CHECK(!detect_hi({0, 0, 1, 0, 2, 0, 17, 0}, {0, 1, 2, 17, 0, 1, 2, 17}, 8, kTrPool),
           "DOLL zero-high-half quad -> declined here, still owned by the original detector");
 
+    // ---------------------------------------------------------------------------------------
+    // #3009: WHETHER either detector may be consulted at all.
+    //
+    // Both are named for what they do -- recover an element size the guest NEVER ANNOUNCED -- but the
+    // executor could not tell an announcement from a reset default, because `index_type == 0` was
+    // both "the guest announced 16-bit" and "the guest never announced anything". So every title got
+    // the heuristics, including titles that had already told prosper the answer.
+    printf("-- #3009: the announcement gate --\n");
+
+    CHECK(index_size_detection_permitted(0, /*announced*/false),
+          "never announced, reset default 16-bit -> the detectors may run (DOLL / Tomb Raider)");
+    CHECK(!index_size_detection_permitted(0, /*announced*/true),
+          "#3009: ANNOUNCED 16-bit -> declined, though index_type is byte-identical to the case above");
+    CHECK(!index_size_detection_permitted(1, /*announced*/true),
+          "announced 32-bit -> declined (already reading at 4 bytes)");
+    CHECK(!index_size_detection_permitted(1, /*announced*/false),
+          "a 32-bit reading is never a candidate, announced or not");
+    CHECK(!index_size_detection_permitted(7, /*announced*/false),
+          "an unknown encoding is not a 16-bit reading -> declined, as the loud fallback expects");
+
+    // The arm that carries the fix, and the reason the two above are not enough on their own: take
+    // a buffer whose BYTES both detectors accept, and show the gate is what decides. Before #3009
+    // the byte verdict WAS the decision, so an announcing title's genuine 16-bit buffer with this
+    // shape was silently re-read at 4 bytes.
+    {
+        const std::vector<uint32_t> quad = {0, 1, 2, 2, 1, 3};          // the live DOLL banner quad
+        CHECK(detect32(quad, 6), "control: the byte fingerprint still fires on the DOLL quad");
+        CHECK(index_size_detection_permitted(0, false) && detect32(quad, 6),
+              "#3009: unannounced + matching bytes -> re-read as 32-bit, exactly as before");
+        CHECK(!index_size_detection_permitted(0, true),
+              "#3009: the SAME bytes are left alone once the guest announced 16-bit");
+
+        std::vector<uint16_t> spokes;    // the period-2 residual named in the issue
+        for (uint16_t i = 0; i < 64; i++) { spokes.push_back(100 + i); spokes.push_back(7); }
+        CHECK(detect_alias(spokes, 64, 1u << 20),
+              "control: the period-2 residual is accepted by the byte fingerprint given a large pool");
+        CHECK(!index_size_detection_permitted(0, true),
+              "#3009: ...and is unreachable for a title that announced its index size");
+    }
+
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
     return fails ? 1 : 0;
 }

--- a/prosper/tests/gpu/pm4/test_command_processor.cpp
+++ b/prosper/tests/gpu/pm4/test_command_processor.cpp
@@ -306,6 +306,71 @@ int main() {
         }
     }
 
+    // #3009: "the guest announced 16-bit" and "the guest never announced anything" are BOTH
+    // index_type == 0, and before index_type_announced they were the same state. Downstream they
+    // are not: the #304 element-size detectors exist to recover a size the guest never announced,
+    // and running them against a title that DID announce lets a byte heuristic overrule a fact.
+    //
+    // Every arm here folds a REAL stream through the real sceAgcDcb builders, so what is asserted is
+    // what the command processor actually derives from guest bytes -- not a hand-set field.
+    if (auto drawi = Hle::lookup("q88lQ+GP5Yk")) {
+        static uint16_t indices[6] = { 0, 1, 2, 0, 2, 3 };
+        auto fold = [&](bool announce, uint32_t size, GpuState& out) {
+            uint32_t ibuf[64]; memset(ibuf, 0, sizeof ibuf);
+            Dcb id{}; id.bottom = ibuf; id.top = ibuf + 64; id.cursor_up = ibuf; id.cursor_down = ibuf + 64;
+            auto ID = (uint64_t)(uintptr_t)&id;
+            if (announce) idx(ID, size, 0, 0, 0, 0);
+            drawi(ID, 6, (uint64_t)(uintptr_t)indices, 0, 0, 0);
+            run_cb(ibuf, 64, out);
+        };
+
+        // (a) Never announced -- DOLL / Tomb Raider. index_type is the reset default.
+        GpuState quiet;
+        fold(/*announce*/false, 0, quiet);
+        CHECK(quiet.index_type == 0 && !quiet.index_type_announced,
+              "#3009: a stream with no SetIndexSize leaves index_type 0 and announced FALSE");
+        CHECK(quiet.draws.size() == 1 && quiet.draws[0].state &&
+              !quiet.draws[0].state->index_type_announced,
+              "#3009: the per-draw snapshot carries 'never announced' to the executor");
+
+        // (b) Announced 16-bit. IDENTICAL index_type to (a) -- this is the arm the sentinel could
+        // not express, and the ONLY thing that separates the two states.
+        GpuState announced16;
+        fold(/*announce*/true, 0, announced16);
+        CHECK(announced16.index_type == 0 && announced16.index_type_announced,
+              "#3009: sceAgcDcbSetIndexSize(0) leaves index_type 0 but announced TRUE");
+        CHECK(announced16.draws.size() == 1 && announced16.draws[0].state &&
+              announced16.draws[0].state->index_type_announced,
+              "#3009: the per-draw snapshot carries the announcement (not just its value)");
+        CHECK(quiet.index_type == announced16.index_type &&
+              quiet.index_type_announced != announced16.index_type_announced,
+              "#3009: the two states agree on index_type and DISAGREE on announced -- the whole point");
+
+        // (c) Announced 32-bit: the value still folds, and the flag is not a value.
+        GpuState announced32;
+        fold(/*announce*/true, 1, announced32);
+        CHECK(announced32.index_type == 1 && announced32.index_type_announced,
+              "#3009: an announced 32-bit size folds its value AND sets announced");
+
+        // (d) Sticky across a later re-announcement back to 16-bit, on ONE process-lifetime state
+        // (agc_graphics_state() is a static, so this is the shape the live fold has). "Ever
+        // announced" is the question a draw in a later submit needs answered, and a 32->16 sequence
+        // is precisely the state a non-zero sentinel on index_type could not have represented.
+        {
+            GpuState seq;
+            uint32_t b1[64]; memset(b1, 0, sizeof b1);
+            Dcb d1{}; d1.bottom = b1; d1.top = b1 + 64; d1.cursor_up = b1; d1.cursor_down = b1 + 64;
+            idx((uint64_t)(uintptr_t)&d1, 1, 0, 0, 0, 0);
+            run_cb(b1, 64, seq);
+            uint32_t b2[64]; memset(b2, 0, sizeof b2);
+            Dcb d2{}; d2.bottom = b2; d2.top = b2 + 64; d2.cursor_up = b2; d2.cursor_down = b2 + 64;
+            idx((uint64_t)(uintptr_t)&d2, 0, 0, 0, 0, 0);
+            run_cb(b2, 64, seq);
+            CHECK(seq.index_type == 0 && seq.index_type_announced,
+                  "#3009: announcing 32-bit then 16-bit ends at index_type 0 with announced still TRUE");
+        }
+    }
+
     // Per-draw register snapshots: each DrawIndexAuto captures the register state AT the draw, so a
     // register changed between two draws is visible in the first draw's snapshot at its old value.
     // (Consecutive draws with no writes in between share one snapshot.)


### PR DESCRIPTION
Fixes #3009.

## The failure

`GpuState::index_type` is a sentinel field: `0` means **both** "the guest announced 16-bit" and
"the guest never announced anything", and nothing else recorded the difference. The executor had
only that field to consult, so both #304 index-size detectors
(`index_buffer_is_unannounced_32bit`, `index_buffer_is_unannounced_32bit_high`) ran against every
title — including titles that had already told prosper the answer.

Both detectors are heuristics over guest bytes, and the second carries a measured residual (a
period-2 16-bit buffer — a fan or cone as a triangle strip, a line list radiating from one hub — is
byte-identical to a clustered 32-bit list when the guest supplies no `DrawIndexOffset`; the
vertex-range bound rejects the constructed cases only above ~65,602 records, and the executor's own
clamp constant is 65,536). Letting a byte pattern with that residual overrule a fact the guest
stated is the wrong precedence, whichever way the heuristic happens to land.

## The contract

Hardware fetches indices at the size `VGT_INDEX_TYPE` holds. A detector that overrides an announced
size is emulating something the hardware does not do — so an announcement, when there is one, wins
outright. The detectors exist only because prosper's default for a title that announces *nothing*
(16-bit) is a guess, and the two known cases are exactly that: titles that never announce.

Chain, all in-tree:
`sceAgcDcbSetIndexSize` → `IT_INDEX_TYPE` packet (`hle_agc.cpp:598-601`) → decode to
`K::SetIndexType` with `c.index_size = pl[0]` (`pm4_decode.cpp:50-52`) → fold
`index_type = c.index_size` (`command_processor.cpp`, `case K::SetIndexType`) → per-draw snapshot →
`index_elem_bytes(ds.index_type)` in `realize_draw_item` (`gpu_execute.hpp`).

## The fix

`GpuState::index_type_announced` — a bool beside `index_type`, set where `c.index_size` is
consumed, carried in the per-draw snapshot, and consumed at exactly one place:

```
inline bool index_size_detection_permitted(uint32_t index_type, bool index_type_announced) {
    return !index_type_announced && index_elem_bytes(index_type) == 2u;
}
```

A bool rather than `std::optional<uint32_t>` or a non-zero sentinel: `GpuState` already spells this
family of facts as plain flags (`indexed`, `from_offset`, `di_valid`), the field is copied into a
snapshot on every state-dirty draw, and a non-zero sentinel could not express "announced 32-bit,
then announced 16-bit" — which lands on `index_type == 0` with `announced == true`.

Lifetime matches `index_type`: `agc_graphics_state()` is a process-lifetime fold (only the per-submit
draw/dispatch lists are cleared), so "ever announced" is the question a draw in a later submit needs
answered, and it is the question the flag records.

### Separable first commit

Five packet cases in `GpuState::apply` carried a byte-identical copy of the snapshot block, so a new
field on `GpuState` had to be remembered in all five — and a snapshot that omits one reports the
field's *reset default* at every draw, which is indistinguishable from the guest having set it that
way. Commit 1 extracts `GpuState::refresh_state_snapshot()` (the same block verbatim, no behaviour
change); commit 2 is the fix. Mutation C below confirms the hazard is real and now caught.

### Instrument, not just the subject

`PROSPER_INDEXTYPE_LOG` now prints `announced=` and runs for **every** indexed draw rather than only
the ones whose announced size is 16-bit. Gating the log alongside the detectors would have made the
fix hide its own measurement: the corpus question the gate's value depends on ("how many titles
announce at all?") cannot be answered by an instrument that only fires on `index_type == 0`. The
64-line cap is unchanged and is spent faster.

## Corpus census — the issue's first "not yet established"

Answered statically, no GPU, no boot: does a dump import `sceAgcDcbSetIndexSize`
(NID `GIIW2J37e70`, `libSceAgc`, confirmed against the PS5 3.20 firmware symbol dump)? A title that
does not import it **cannot** announce; one that does **may** (linking is not calling, so IMPORTS is
an upper bound).

**21 of 55 local dumps import it; 34 do not.**

Positive control, because a clean zero from a scan that cannot see the dump's symbols is not a
negative: each no-import dump was re-scanned for other `libSceAgc` indexed-draw NIDs
(`DrawIndexAuto` `Yw0jKSqop+E`, `DrawIndex` `q88lQ+GP5Yk`, `SetIndexBuffer` `l4fM9K-Lyks`,
`DrawIndexOffset` `B+aG9DUnTKA`, `SetIndexCount` `8N2tmT3jmC8`). **The control fires on all 34**, so
every no-import verdict is a real negative.

That control earned its keep: a first pass using only `DrawIndexAuto`/`DrawIndex` read **void** on
PPSA16901 (Tomb Raider), which draws exclusively through the Gen5
`SetIndexBuffer`/`SetIndexCount`/`DrawIndexOffset` path. Had it not been run, that title's verdict
would have been recorded as a negative on an instrument that could not see it.

**Both known #304 cases are in the no-import set** — PPSA17942 (DOLL) and PPSA16901 (Tomb Raider) —
so neither can announce, and detection proceeds for them exactly as before. This replaces the
inference in `TOMB_RAIDER_STATUS.md` that "`index_type=0` across 508,688 draws" showed the title
never announces: that is precisely the reading `index_type == 0` cannot support, and the doc is
corrected in this PR to cite the import evidence instead.

## Affected / unaffected

- **Unaffected:** every title that never announces — the detectors run unchanged, same verdicts,
  same addresses. Both known #304 cases are here.
- **Affected:** a title that announces 16-bit and has an index buffer matching a detector's
  fingerprint now keeps its announced size. That is a latent-bug fix in the hardware-faithful
  direction (an announced size is a fact; a byte pattern is a guess), and the issue flags gating the
  original zero-high-half detector as a behaviour change beyond its original scope. Gating both was
  a deliberate call: both are *named* for recovering an element size the guest never announced, and
  the only way gating could regress a title is if the guest announced a size it does not use — which
  hardware would not tolerate either.
- **Unaffected:** announced 32-bit draws (already `esz == 4`), unknown encodings (still the loud
  non-indexed fallback), non-indexed draws, compute, and every address computation.

## Risk

The gate keys on `IT_INDEX_TYPE`, which is what `sceAgcDcbSetIndexSize` emits. If a title instead
programs an index-type UCONFIG register directly, prosper reads that register for the element size
**nowhere today**, so such a title looks unannounced and gets exactly the pre-#3009 behaviour.
Missing that path costs the fix, never correctness. Not asserted as absent — I did not verify which
register number that would be and deliberately did not guess one in the code.

Snapshots were **not** run (single-GPU policy for this session). From the census, **7 of the 17
guards in `snapshots.json` cover titles that import the announce entry point** and are therefore the
ones that could move: `alexkidd-gameplay` (PPSA02664), `gris-gameplay` (PPSA09804),
`evergate-title`/`evergate-gameplay` (PPSA01885), `greak-gameplay` (PPSA02849), `joe-mac-gameplay`
(PPSA02801), `asterix-gameplay` (PPSA08576), `summer-sports-gameplay` (PPSA03416). The other guarded
titles — Messenger PPSA24651, Dead Cells PPSA15552, Blasphemous 2 PPSA13579, Blue Prince PPSA25009,
Cobra PPSA17337, Terminator PPSA25872, Rugrats PPSA23396, Worms PPSA20052 — do not import it and
cannot be reached by this change.

## Verification

Built and tested in the `ps5ys` distrobox (a host build silently drops the Vulkan execution tests).

```
cmake -S prosper -B prosper/build-linux                       # rc 0
TMPDIR=<WORKTREE>/prosper/build-linux/tmpdir \
    cmake --build prosper/build-linux -j8                     # rc 0
ctest --test-dir prosper/build-linux --no-tests=error         # rc 0, 318/318 passed
```

One earlier full run showed `snapshot_guard_logic` (test 18) failing; it passed on re-run in
isolation and in the full re-run above, and it is a pure-Python unit test over `tools/snapshot/`
that this diff does not touch. Recorded as an observed flake, not dismissed.

### Mutation verification

Three mutations, each reverting one half of the fix, each rebuilt (build rc checked — a broken build
leaves the old binary and reports a false pass) and re-run.

| arm | build rc | index_size_detect | command_processor | gpu_execute |
| --- | --- | --- | --- | --- |
| baseline | 0 | 0 | 0 | 0 |
| **A** — `index_size_detection_permitted` ignores `announced` (pre-#3009 behaviour) | 0 | **1** (3 arms) | 0 | **1** (2 arms) |
| **B** — the fold no longer sets `index_type_announced` | 0 | 0 | **1** (5 arms) | 0 |
| **C** — `refresh_state_snapshot()` omits the new field | 0 | 0 | **1** (1 arm) | 0 |
| restored | 0 | 0 | 0 | 0 |

Each mutation fails a *different* set of arms, and the arms that stayed green under A are the
controls — "with no announcement the detector still recovers the 32-bit quad" passes under old and
new code alike, which is what makes the announced arm mean something rather than merely proving the
detector never runs.

### What the new arms assert

- `test_command_processor` — folds **real streams** through the real `sceAgcDcb` builders, so what is
  asserted is what the command processor derives from guest bytes, not a hand-set field: no
  `SetIndexSize` → `index_type == 0`, `announced == false`; `SetIndexSize(0)` → `index_type == 0`,
  `announced == true`; the two states **agree on `index_type` and disagree on `announced`**; the
  per-draw snapshot carries both; and 32-bit-then-16-bit ends at `index_type == 0` with `announced`
  still true.
- `test_index_size_detect` — the gate predicate across the four `(index_type, announced)` states,
  plus the arm that carries the fix: the DOLL banner quad's bytes still fire the fingerprint
  (control), and the *same bytes* are left alone once the guest announced.
- `test_gpu_execute` — end to end through `realize_draw_item`: one buffer, `index_type == 0` both
  times, two announcement states, and the resolved index vectors differ (`{0,1,2,2,1,3}` against
  `{0,0,1,0,2,0}`). Before this change no fixture could tell the two apart, because they were the
  same state.

```
git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'   # 0
git diff --check                                                       # clean
```
