### PR TITLE
perf(render): take getenv off 44 per-draw guards, screened against runtime arming

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -19,6 +19,26 @@ from the tracker issues, and still gated, because it is a projection of state ra
 > title's current state — for that, read the tracker. Nothing is ever removed when a title moves on,
 > because the point of a blog is that it records *when* things happened.
 
+## 2026-09-01
+
+### The three getenv calls the profiler pointed at were the three we could not fix
+
+No picture — this one is pure CPU time. `getenv` costs 1.24% of Blue Prince's gameplay frame
+because a per-draw guard like `if (getenv("PROSPER_GFXLOG"))` rescans the whole environment block
+for every draw, to answer a question whose answer never changes.
+
+The interesting part is what the sweep found. Every one of the four call sites [#3094][i3094]
+nominated as the obvious fix turns out to be unsafe to cache: three are armed at runtime by tests
+that toggle them between phases, and caching those does not make a test fail — it makes it go
+*vacuous*, still printing `[ok]` against a stale value. A fourth class is worse, because no gate
+can currently see it: `gpu_replay` re-applies a whole allowlist of renderer switches once per
+bundle submit, through a variable rather than a literal. So the sweep became a screening problem
+rather than a mechanical one. Forty-two sites across the renderer backend, the draw executor and
+the live frontend now read once instead of per draw, measured at 30% fewer `getenv` calls across
+the render test suite, and the sites are pinned so they cannot quietly grow back.
+
+[i3094]: https://github.com/mattias800/prosper/issues/3094
+
 ## 2026-08-31
 
 ### Stray's splash runs 66% faster, and the title screen now holds 65 fps

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1362,6 +1362,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_boot_phase_log PRIVATE prosper_core)
   add_test(NAME diagnostics_boot_phase_log COMMAND test_boot_phase_log)
 
+  # PROSPER_ENV_ON / PROSPER_ENV_VALUE sample getenv exactly once (#3094). Header-only, so this
+  # needs no library: it mutates the environment between two evaluations of the same macro and
+  # asserts the second still reports the first value -- the one behaviour a live getenv cannot
+  # produce, so the arms go red if the caching is ever removed.
+  add_executable(test_env_cache tests/diagnostics/test_env_cache.cpp)
+  target_include_directories(test_env_cache PRIVATE src)
+  add_test(NAME diagnostics_env_cache COMMAND test_env_cache)
+
   # Diagnostics: enabled-path and JSON tests (only when feature is built).
   if(PROSPER_DIAGNOSTICS)
     add_executable(test_diagnostics_enabled tests/diagnostics/test_diagnostics_enabled.cpp)

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -1,7 +1,7 @@
 // live_renderer.cpp — see live_renderer.hpp. Extracted from boot_trace's PROSPER_RENDER lambda
 // (behavior-preserving); Vulkan-backed, so this unit links Vulkan::Vulkan.
 #include "shared/live/live_renderer.hpp"
-#include "hle/dispatch/dispatch.hpp"   // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
+#include "diagnostics/env_cache.hpp"   // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
 #include "gpu/resources/metadata_kind_correlation.hpp"  // positive metadata-kind correlation (pure, tested)
 #include "gpu/diagnostics/watch_list.hpp"                 // strict 0x-only watch parsing
 #include "shared/rtt/rtt_authority.hpp"
@@ -2368,7 +2368,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // colour with no content -- which is exactly Little Nightmares III's
                         // uniform-yellow presents (#2014). Deduped per (address, decoded colour) so a
                         // run costs a handful of lines.
-                        if (const char* dcclog = std::getenv("PROSPER_DCCLOG")) {
+                        if (const char* dcclog = PROSPER_ENV_VALUE("PROSPER_DCCLOG")) {
                             if (dcclog[0] == '1' && dcclog[1] == '\0') {
                                 static std::mutex dcc_mutex;
                                 static std::set<std::pair<uint64_t, uint32_t>> dcc_seen;
@@ -5431,7 +5431,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // measures, and a diagnostic that prints a field a different switch
                             // decided is one whose output cannot be trusted on its own -- which
                             // check_diag_gates.py enforces (TWO-GATE).
-                            if (!is_cube && getenv("PROSPER_SLICESTRIDE")) {
+                            if (!is_cube && PROSPER_ENV_ON("PROSPER_SLICESTRIDE")) {
                                 static std::unordered_set<uint64_t> reported;
                                 if (reported.insert(r.gpu_addr).second)
                                     fprintf(stderr,
@@ -9532,7 +9532,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // substitution happened, not what was substituted or where it came from.
                             // Sampled, not exhaustive: a full uniformity scan of a 33 MB frame on the
                             // present path would cost more than the render.
-                            if (const char* uni = std::getenv("PROSPER_UNIFORMLOG")) {
+                            if (const char* uni = PROSPER_ENV_VALUE("PROSPER_UNIFORMLOG")) {
                                 if (uni[0] == '1' && uni[1] == '\0' && selected_pixels &&
                                     selected_pixels->size() >= 4) {
                                     const uint8_t* px = selected_pixels->data();

--- a/prosper/src/diagnostics/AGENTS.md
+++ b/prosper/src/diagnostics/AGENTS.md
@@ -44,3 +44,22 @@ published conclusion on #3142. `diag_now_us()` gives them a common monotonic rea
 is process-wide, so independently taken values in unrelated translation units compare directly with
 no anchor or registry. Anything that needs to be time-ordered against a diagnostic in another
 subsystem should stamp it rather than grow a private clock.
+
+`env_cache.hpp` is the third always-reachable file, and it is here for the same reason as
+`diag_clock.hpp`: it is shared, and it belongs to no one subsystem. It holds `PROSPER_ENV_ON` /
+`PROSPER_ENV_VALUE`, the one-shot reads of a `PROSPER_*` switch. They lived in
+`hle/dispatch/dispatch.hpp` until #3094, which is where they were first needed and not where they
+belong — the renderer backend, the draw executor and the live frontend all evaluate diagnostic
+gates on per-draw and per-resource paths, and none of them should pull in the HLE dispatch
+registry to ask whether a switch is on. `dispatch.hpp` includes this header, so its existing users
+did not change.
+
+The thing to know before using them: **caching a diagnostic switch changes its semantics**, and it
+fails in the quiet direction. The variable is sampled at first use, so a process that arms it later
+never observes the write — and a test that arms a diagnostic and then asserts on the behaviour does
+not go red when the read is cached, it goes **vacuous** and keeps printing `[ok]` (#2214).
+`tools/env/check_cached_env.py` is the gate: it refuses any name something in the tree arms at
+runtime, and separately pins the hot sites #3094 converted so they cannot regrow a live `getenv`.
+Run it before caching a new name. Note it can only see arming through a *literal* name —
+`tools/gpu_replay` re-applies `render_env[]` (`gpu/capture/gpu_capture.cpp`) per bundle submit
+through a variable, which is invisible to it; that comment lives in `env_cache.hpp` itself.

--- a/prosper/src/diagnostics/env_cache.hpp
+++ b/prosper/src/diagnostics/env_cache.hpp
@@ -1,0 +1,73 @@
+// env_cache.hpp — one-shot reads of PROSPER_* diagnostic switches, for HOT paths.
+//
+// These two macros used to live in hle/dispatch/dispatch.hpp, which is where they were first
+// needed. They are not an HLE concept: the renderer backend, the draw executor and the live
+// frontend all evaluate diagnostic gates on per-draw and per-resource paths, and none of them
+// should have to pull in the HLE dispatch registry (self/module.hpp, the NID tables, the import
+// slot types) to ask "is this switch on?". dispatch.hpp includes this header, so every existing
+// user keeps compiling unchanged.
+//
+// WHY THEY EXIST
+//
+// getenv() is not free: it walks the environment block comparing each entry, on EVERY call. A
+// diagnostic that is switched OFF therefore still costs that scan every time its guard is
+// evaluated -- and some of these guards sit on per-draw and per-RESOURCE paths, so the cost scales
+// with scene complexity rather than with logging.
+//
+// Measured on Blue Prince (native Windows), sampling the guest primary thread with every
+// diagnostic disabled: 97 of 331 samples -- ~30% of that thread's wall time -- were inside
+// getenv's strlen loop. On Linux/AMD a 15 s perf record of the gameplay frame put getenv at 1.24%
+// of the whole frame (#3094, decomposition in #1284).
+//
+// THE UNIT IS THE CALL SITE, NOT THE NAME. Each textual expansion declares its own
+// function-local static inside its own lambda, so one site reads once however many times it is
+// evaluated -- which is the case that matters, since a per-draw guard is a single site evaluated
+// thousands of times -- while two sites reading the SAME name each read once, independently. Do
+// not reason as though caching a name anywhere caches it everywhere; tests/diagnostics/
+// test_env_cache.cpp pins both halves.
+//
+// A function-local static is initialized thread-safely under C++11 and later, which is why the
+// storage is inside the lambda rather than at namespace scope. Namespace-scope storage would also
+// be exposed to static-initialization order across translation units; this is not.
+//
+// THIS CHANGES SEMANTICS, and that is why it is not applied everywhere: the variable is sampled at
+// first use, so a caller that sets it LATER never sees it. Several tests arm diagnostics at runtime
+// with setenv/_putenv_s and then assert on the behaviour -- and such a test does not FAIL when the
+// read is cached, it goes VACUOUS and keeps printing [ok], because the assertion still holds for
+// the stale value (#2214). tools/env/check_cached_env.py is the gate that refuses any name
+// something in the tree arms at runtime; run it before caching a new name.
+//
+// The historical record, because it is easy to misread as a blanket prohibition: an early sweep
+// that applied these macros to hle_kernel.cpp, gpu_executor and the command processor broke
+// win_exception_delivery, eop_write and dynfetch_fold. That was never a property of those FILES --
+// it was the specific names they read (PROSPER_WIN_*_EXC, PROSPER_GDSLOG / PROSPER_WRITE_TRAP,
+// PROSPER_DYNTRACE_FAIL*), every one of which a test arms between phases, and every one of which
+// check_cached_env.py now refuses by name. #3094 cached sixteen names in gpu_execute.hpp -- on the
+// same per-draw path, reached from gpu_executor.cpp -- with the suite green, because the gate
+// separates the two questions. Screen by NAME, not by file.
+//
+// A SECOND ARMING MECHANISM THE GATE CANNOT SEE, recorded here because it is invisible at the call
+// site: tools/gpu_replay re-applies `GpuCaptureMetadata::renderer_env` -- the allowlist at
+// gpu_capture.cpp's `render_env[]` -- through set_environment() with a NON-literal name, once per
+// bundle submit. check_cached_env.py matches on literal first arguments, so it cannot see those.
+// Their values come from the capturing process's own (constant) environment, so no defect is
+// demonstrated today; the names are nonetheless left as live reads, because a bundle replay is the
+// project's primary offline debugging tool and a diagnostic silently frozen across submits would
+// be a trap. Do not cache a name in render_env[] without re-deriving that argument.
+//
+// Use these only where the flag is a pure boot-time diagnostic switch AND the path is hot, and run
+// the suite after.
+#pragma once
+#include <cstdlib>
+
+// Cached presence check: "is this diagnostic switched on?"
+#define PROSPER_ENV_ON(name) ([]() -> bool { static const bool prosper_env_on_v = std::getenv(name) != nullptr; return prosper_env_on_v; }())
+
+// The same, for a diagnostic that reads a VALUE rather than just presence. Same one-shot read and
+// the same consequence: sampled at first use, so a caller that sets it later never sees it.
+//
+// Worth its own macro because the value form is the one that hides: `const char* m = getenv(...)`
+// does not look like a flag check, so a boolean-guard sweep skips it -- and in live_renderer.cpp
+// the single hottest getenv site was exactly that shape, on a per-RESOURCE path, calling getenv up
+// to three times per resource.
+#define PROSPER_ENV_VALUE(name) ([]() -> const char* { static const char* prosper_env_value_v = std::getenv(name); return prosper_env_value_v; }())

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <atomic>
 #include <string>
+#include "diagnostics/env_cache.hpp"        // PROSPER_ENV_ON / _VALUE: cached reads on the per-draw path
 #include "gpu/pm4/command_processor.hpp"   // GpuState
 #include "gpu/state/render_state.hpp"        // extract_render_state / resolve_pipeline_state / ResolvedPipelineState
 #include "gpu/pm4/pm4_registers.hpp"        // CB_COLOR_CONTROL operation decode
@@ -1654,7 +1655,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         resolved_pipeline.color_targets.begin(), resolved_pipeline.color_targets.end(),
         [](const auto& target) { return target.write_mask != 0; });
     if (!preexport_color_effect && !has_depth_stencil_side_effect(resolved_pipeline) &&
-        !getenv("PROSPER_FORCE_COLORWRITE") && !getenv("PROSPER_NO_EARLY_NO_EFFECT")) {
+        !PROSPER_ENV_ON("PROSPER_FORCE_COLORWRITE") && !PROSPER_ENV_ON("PROSPER_NO_EARLY_NO_EFFECT")) {
         // PROSPER_DROPPED_DRAW_CENSUS=1 — which colour targets lose draws before they ever reach the
         // renderer, and why. A target census counts draws that ARRIVE; a surface whose draws are all
         // discarded here reads as "written by nothing" in that census and in every write-path watch,
@@ -1683,7 +1684,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // a whole route in ONE run. Painting one shader at a time answers the same question one
     // candidate per run; on a title with 66 fragment stages that is the difference between one run
     // and a bisect. It is what identified Stray's full-screen composite (#3126).
-    if (getenv("PROSPER_DRAWMAP")) {
+    if (PROSPER_ENV_ON("PROSPER_DRAWMAP")) {
         static std::mutex dmx; static std::map<std::string, uint64_t> dseen;
         char k[192];
         snprintf(k, sizeof k, "ps=0x%llx target=0x%llx %ux%u scissor=%u,%u..%u,%u tm=0x%x",
@@ -1772,7 +1773,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // Keep this diagnostic narrow enough for a routed title run.  PROSPER_DBG/GFXLOG both perturb
     // GTA V heavily and generate enormous logs; this switch proves that the post-VS RectList path
     // actually armed, and names the exact producer/consumer pair, without changing execution.
-    if (rect_list_synthesis && getenv("PROSPER_RECTLOG")) {
+    if (rect_list_synthesis && PROSPER_ENV_ON("PROSPER_RECTLOG")) {
         static std::atomic<uint32_t> logged{0};
         const uint32_t ordinal = logged.fetch_add(1, std::memory_order_relaxed);
         if (ordinal < 64u)
@@ -1787,7 +1788,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // PROSPER_RTLOG: correlate this draw's render-target address (CB_COLOR0_BASE) with the addresses of
     // the textures it SAMPLES. If a sampled texture's base equals some draw's color0_base, that surface is
     // a GPU render target (the game renders into it then samples it) -> render-to-texture (#83/#101).
-    if (getenv("PROSPER_RTLOG")) {
+    if (PROSPER_ENV_ON("PROSPER_RTLOG")) {
         fprintf(stderr, "[rt] color0=0x%llx %ux%u cf=0x%x nt=%u cs=%u",
                 (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height,
                 rs.color0_format, rs.color0_number_type, rs.color0_comp_swap);
@@ -1817,7 +1818,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         pixel_inputs = resolve_pixel_input_mapping(
             pixel_inputs, metadata_inputs, &interpolants_from_metadata);
     }
-    if (getenv("PROSPER_INTERPLOG")) {
+    if (PROSPER_ENV_ON("PROSPER_INTERPLOG")) {
         fprintf(stderr, "[interp] es=0x%llx ps=0x%llx source=%s valid=%08x ena=%08x addr=%08x",
                 (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
                 interpolants_from_metadata ? "metadata" : "registers",
@@ -1853,7 +1854,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     const FragmentInterpolationLayout interpolation = fragment_interpolation_layout_cached(
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
         max_shader_dwords, system_input_ptr, pixel_input_ptr);
-    const bool capture_vertex_position = getenv("PROSPER_GEOM_PROBE") != nullptr &&
+    const bool capture_vertex_position = PROSPER_ENV_ON("PROSPER_GEOM_PROBE") &&
                                          !interpolation.requires_geometry &&
                                          !rect_list_synthesis;
     uint64_t vs_identity = 0, fs_identity = 0;
@@ -1932,7 +1933,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                                        resolved_pipeline.topology <= 5u;
         if (triangle_topology)
             gs = recompile_interpolation_geometry(
-                interpolation, getenv("PROSPER_GEOM_PROBE") != nullptr,
+                interpolation, PROSPER_ENV_ON("PROSPER_GEOM_PROBE"),
                 rect_list_synthesis);
     }
     if (phase_timing) {
@@ -1948,7 +1949,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     if (vertex_chain)
         add_stage_diagnostic(ShaderProgramStage::Vertex, chain_addr, vrt, vs_words);
     add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, prt, fs_words);
-    if (const char* dd = getenv("PROSPER_VS_DUMP")) {   // diag: dump successful VS SPIR-V + raw RDNA2 for inspection
+    if (const char* dd = PROSPER_ENV_VALUE("PROSPER_VS_DUMP")) {   // diag: dump successful VS SPIR-V + raw RDNA2 for inspection
         static int nd = 0;
         if (nd < 3 && !vs_words.empty()) {
             char fn[512];
@@ -1964,7 +1965,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     if (vs_words.empty() || fs_words.empty() ||
         ((interpolation.requires_geometry || rect_list_synthesis) && gs.empty())) {
-        if (getenv("PROSPER_PROLOGLOG")) {
+        if (PROSPER_ENV_ON("PROSPER_PROLOGLOG")) {
             // #3126: name the FAILING program by the same content hash the prolog recogniser uses,
             // so the reject and the chain decision can be joined inside ONE run.
             const uint32_t* fc = reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.es_addr));
@@ -2020,7 +2021,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                     rs.ps_input_ena, rs.ps_input_addr,
                     (unsigned long long)(draw ? draw->command_order : 0),
                     (unsigned long long)reject_occurrence);
-        if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
+        if (const char* dd = PROSPER_ENV_VALUE("PROSPER_SHADER_DUMP")) {
             for (auto [tag, addr] : {std::pair{"vs", vs_program_addr}, std::pair{"ps", rs.ps_addr}}) {
                 if (!addr || !guest_readable(addr, sizeof(uint32_t))) continue;
                 const size_t dump_dwords = rdna2_recompile_code_span(
@@ -2108,7 +2109,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     const bool color_effect = std::any_of(
         ps.color_targets.begin(), ps.color_targets.end(),
         [](const auto& target) { return target.write_mask != 0; });
-    if (!color_effect && !ds_effect && !getenv("PROSPER_FORCE_COLORWRITE")) {
+    if (!color_effect && !ds_effect && !PROSPER_ENV_ON("PROSPER_FORCE_COLORWRITE")) {
         report_dropped_draw_target(rs.color0_base, "no-effect", rs.cb_target_mask,
                                    rs.cb_shader_mask);
         if (failure) failure->reason = RealizationFailureReason::NoEffect;
@@ -2119,10 +2120,10 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // PROSPER_FORCE_COLORWRITE: diagnostic — render color_write_mask==0 draws anyway (force mask to RGBA).
     // The cutscene submits ~66 draws/frame that resolve to mask==0; if that is a mis-decode (not a genuine
     // depth-only pass), rendering them reveals whether they are the cutscene content.
-    if (ps.color_write_mask == 0 && getenv("PROSPER_FORCE_COLORWRITE")) ps.color_write_mask = 0xf;
+    if (ps.color_write_mask == 0 && PROSPER_ENV_ON("PROSPER_FORCE_COLORWRITE")) ps.color_write_mask = 0xf;
     // PROSPER_DRAWDIAG: per-RENDERED-draw geometry/position/texture — to LOCATE specific draws (e.g. the
     // cutscene caption text: small indexed quads, bottom viewport, blended, sampling a font atlas).
-    if (getenv("PROSPER_DRAWDIAG")) {
+    if (PROSPER_ENV_ON("PROSPER_DRAWDIAG")) {
         uint32_t ic = (draw && draw->indexed) ? draw->index_count : vcount_hint;
         fprintf(stderr, "[draw] idx=%u vp=%d y=%.0f h=%.0f blend=%d cwm=0x%x "
                         "target=0x%x shader=0x%x exp=0x%x es=0x%llx ps=0x%llx", ic,
@@ -2322,7 +2323,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // PROSPER_ONLY_ATLAS: render ONLY the caption text draw (samples the 2048x1024 font atlas), skipping
     // every other draw — so the caption geometry renders alone onto a clear frame. With TESTPS this shows
     // whether the caption rasterizes at all (magenta glyphs) or is culled/degenerate/clipped. #257.
-    if (getenv("PROSPER_ONLY_ATLAS")) {
+    if (PROSPER_ENV_ON("PROSPER_ONLY_ATLAS")) {
         bool sa = false;
         if (prt) for (const auto& r : prt->resources)
             if (r.cls == ResourceClass::Texture && r.width == 2048 && r.height == 1024) sa = true;
@@ -2332,7 +2333,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
         // PROSPER_ONLY_IC=<n>: further restrict to draws whose index count == n (isolate one atlas mesh,
         // e.g. the main glyph batch idx=1566 vs a fullscreen atlas draw).
-        if (const char* ic_s = getenv("PROSPER_ONLY_IC")) {
+        if (const char* ic_s = PROSPER_ENV_VALUE("PROSPER_ONLY_IC")) {
             uint32_t want = (uint32_t)atoi(ic_s);
             uint32_t ic = (draw && draw->indexed) ? draw->index_count : vcount_hint;
             if (ic != want) {
@@ -2341,7 +2342,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
     }
-    if (getenv("PROSPER_CAPTION_DIAG") && prt) {
+    if (PROSPER_ENV_ON("PROSPER_CAPTION_DIAG") && prt) {
         bool samples_atlas = false;
         for (const auto& r : prt->resources)
             if (r.cls == ResourceClass::Texture && r.width == 2048 && r.height == 1024) samples_atlas = true;
@@ -2467,7 +2468,7 @@ inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
     // PROSPER_EXECLOG: just the per-draw bail-point/skip logs, without PROSPER_GFXLOG's per-packet
     // firehose (which is GBs over a minutes-long run) — for "which draws skip and why" surveys (#319).
     const bool log = getenv("PROSPER_GFXLOG") != nullptr ||
-                     getenv("PROSPER_EXECLOG") != nullptr;   // bail-point visibility (why no frame?)
+                     PROSPER_ENV_ON("PROSPER_EXECLOG");   // bail-point visibility (why no frame?)
     // Render each draw from its OWN register snapshot when the submit has MULTIPLE draws — a real
     // multi-geometry scene (the game's in-game/cutscene submits carry 8-11 distinct draws with per-draw
     // shaders/textures/blends). Folding those to just the last draw drops the rest and the frame comes out
@@ -2537,7 +2538,7 @@ inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
             failures->push_back(std::move(failure));
         }
     }
-    if (getenv("PROSPER_DRAWLOG")) { fprintf(stderr, "[exec] draws=%zu perdraw=%d -> %zu item(s): raw index_counts=[",
+    if (PROSPER_ENV_ON("PROSPER_DRAWLOG")) { fprintf(stderr, "[exec] draws=%zu perdraw=%d -> %zu item(s): raw index_counts=[",
         st.draws.size(), (int)perdraw, items.size());
         for (size_t i = 0; i < st.draws.size(); i++) fprintf(stderr, "%s%u%s", i?",":"", st.draws[i].index_count,
                                                              st.draws[i].indexed ? "i" : "");

--- a/prosper/src/hle/dispatch/dispatch.hpp
+++ b/prosper/src/hle/dispatch/dispatch.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include "self/module.hpp"
 #include "hle/dispatch/nid.hpp"
+#include "diagnostics/env_cache.hpp"   // PROSPER_ENV_ON / PROSPER_ENV_VALUE
 #include <cstdint>
 #include <cstdlib>
 #include <cstdio>
@@ -29,35 +30,10 @@ namespace prosper {
 // marker of the boundary in case a future toolchain makes the attribute viable.
 #define PROSPER_SYSV_ABI
 
-// Cached diagnostic-flag read, for HOT paths.
-//
-// getenv() is not free: the UCRT walks a locked environment block, strlen-ing and comparing each
-// entry, on EVERY call. A diagnostic that is switched OFF therefore still costs that scan every
-// time its guard is evaluated -- and some of these guards sit on per-draw and per-RESOURCE paths,
-// so the cost scales with scene complexity rather than with logging.
-//
-// Measured on Blue Prince (native Windows), sampling the guest primary thread with every
-// diagnostic disabled: 97 of 331 samples -- ~30% of that thread's wall time -- were inside
-// getenv's strlen loop.
-//
-// Each use site gets its own function-local static, so the read happens exactly once.
-//
-// THIS CHANGES SEMANTICS, and that is why it is not applied everywhere: the variable is sampled at
-// first use, so a caller that sets it LATER never sees it. Several tests arm diagnostics at runtime
-// with _putenv_s and then assert on the behaviour -- applying this to hle_kernel.cpp, gpu_executor
-// or the command processor broke win_exception_delivery, eop_write and dynfetch_fold for exactly
-// that reason. Use it only where the flag is a pure boot-time diagnostic switch AND the path is
-// hot, and run the suite after.
-#define PROSPER_ENV_ON(name) ([]() -> bool { static const bool prosper_env_on_v = std::getenv(name) != nullptr; return prosper_env_on_v; }())
-
-// The same, for a diagnostic that reads a VALUE rather than just presence. Same one-shot read and
-// the same consequence: sampled at first use, so a caller that sets it later never sees it.
-//
-// Worth its own macro because the value form is the one that hides: `const char* m = getenv(...)`
-// does not look like a flag check, so a boolean-guard sweep skips it -- and in live_renderer.cpp
-// the single hottest getenv site was exactly that shape, on a per-RESOURCE path, calling getenv up
-// to three times per resource.
-#define PROSPER_ENV_VALUE(name) ([]() -> const char* { static const char* prosper_env_value_v = std::getenv(name); return prosper_env_value_v; }())
+// Cached diagnostic-flag reads for HOT paths (PROSPER_ENV_ON / PROSPER_ENV_VALUE) moved to
+// diagnostics/env_cache.hpp: the renderer backend and the draw executor need them too, and
+// should not have to include the HLE dispatch registry to ask whether a switch is on. Included
+// here so every existing user of dispatch.hpp keeps compiling unchanged.
 
 // Generic HLE handler signature (up to 6 integer/pointer args, SysV).
 using HleFn = PROSPER_SYSV_ABI uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);

--- a/prosper/tests/diagnostics/test_env_cache.cpp
+++ b/prosper/tests/diagnostics/test_env_cache.cpp
@@ -1,0 +1,101 @@
+// test_env_cache — the one-shot semantics of PROSPER_ENV_ON / PROSPER_ENV_VALUE.
+//
+// WHY THIS SHAPE. These macros exist to take getenv off per-draw paths (#3094), and the whole point
+// of the optimisation is that a given guard reads the environment EXACTLY ONCE no matter how many
+// times it is evaluated. That property is not observable in the ordinary case -- a diagnostic
+// nobody re-arms behaves identically cached or not -- so a test that merely evaluates a macro and
+// checks the answer would pass just as well against a plain getenv. It would confirm the assertion
+// without exercising the mechanism.
+//
+// So each case below evaluates ONE call site twice with the environment MUTATED in between, and
+// asserts the second evaluation still reports the first value. That is the one behaviour a live
+// getenv cannot produce, so these arms go red if the caching is ever removed.
+//
+// THE CALL SITE IS THE UNIT, AND IT IS EASY TO GET WRONG. Each textual expansion of the macro
+// declares its own function-local static inside its own lambda, so two expansions of
+// PROSPER_ENV_ON("X") on two different source lines are two independent caches -- the second one
+// performs its own live read. The first draft of this test asserted across two separate expansions
+// and failed for exactly that reason. That is not a defect: a per-draw guard is a single site
+// evaluated thousands of times, which is the case the optimisation targets. It does mean the
+// contract is "once per site", never "once per name", so each case here routes both evaluations
+// through the SAME site by calling a helper twice.
+//
+// The names below deliberately do NOT carry the PROSPER_ prefix. This file is the one place in the
+// tree that arms a variable and caches it on purpose -- it asserts the staleness rather than being
+// made vacuous by it -- which is exactly the shape tools/env/check_cached_env.py fails on. That
+// gate scans for PROSPER_* names only, so an unprefixed name keeps this test outside its scope
+// without adding an exception to it. (The macros are name-agnostic, so nothing is lost.)
+#include "diagnostics/env_cache.hpp"
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#ifdef _WIN32
+#include <stdlib.h>
+static void put_env(const char* n, const char* v) { _putenv_s(n, v ? v : ""); }
+#else
+static void put_env(const char* n, const char* v) { if (v) setenv(n, v, 1); else unsetenv(n); }
+#endif
+
+// One call site each. Every evaluation below goes through these, so the "same site" condition the
+// contract is stated in terms of is structural here rather than a property of how the test is laid
+// out. NOINLINE keeps them distinguishable in a disassembly if this ever needs debugging; it has no
+// bearing on the semantics, which come from the function-local static.
+#if defined(_MSC_VER)
+#define ENVCACHE_NOINLINE __declspec(noinline)
+#else
+#define ENVCACHE_NOINLINE __attribute__((noinline))
+#endif
+static ENVCACHE_NOINLINE bool site_on()       { return PROSPER_ENV_ON("ENVCACHE_TEST_ON"); }
+static ENVCACHE_NOINLINE bool site_off()      { return PROSPER_ENV_ON("ENVCACHE_TEST_OFF"); }
+static ENVCACHE_NOINLINE const char* site_v() { return PROSPER_ENV_VALUE("ENVCACHE_TEST_VAL"); }
+
+static int fails = 0;
+static void check(bool ok, const char* what) {
+    printf("%s %s\n", ok ? "[ok]  " : "[FAIL]", what);
+    if (!ok) ++fails;
+}
+
+int main() {
+    // --- armed BEFORE first use, then disarmed --------------------------------------------------
+    put_env("ENVCACHE_TEST_ON", "1");
+    check(site_on(), "PROSPER_ENV_ON reports a variable set before the site's first evaluation");
+    put_env("ENVCACHE_TEST_ON", nullptr);
+    check(std::getenv("ENVCACHE_TEST_ON") == nullptr,
+          "control: the variable really is gone from the environment now");
+    check(site_on(),
+          "...and the same site still reports it, because its read was cached (a live getenv "
+          "would now say false)");
+
+    // --- unset BEFORE first use, then armed -----------------------------------------------------
+    // The mirror arm. Without it, "still true" above could be satisfied by a macro that simply
+    // always returns true.
+    put_env("ENVCACHE_TEST_OFF", nullptr);
+    check(!site_off(), "PROSPER_ENV_ON reports false for a variable unset at first evaluation");
+    put_env("ENVCACHE_TEST_OFF", "1");
+    check(std::getenv("ENVCACHE_TEST_OFF") != nullptr,
+          "control: the variable really is set in the environment now");
+    check(!site_off(),
+          "...and the same site still reports false -- arming AFTER first use is never observed");
+
+    // --- the value form -------------------------------------------------------------------------
+    put_env("ENVCACHE_TEST_VAL", "first");
+    const char* v1 = site_v();
+    check(v1 && std::strcmp(v1, "first") == 0, "PROSPER_ENV_VALUE returns the value at first use");
+    put_env("ENVCACHE_TEST_VAL", "second");
+    const char* live = std::getenv("ENVCACHE_TEST_VAL");
+    check(live && std::strcmp(live, "second") == 0,
+          "control: a live getenv sees the new value, so the mutation did take effect");
+    check(site_v() == v1,
+          "...and the same site returns the identical cached pointer, not the new value");
+
+    // --- distinct sites keep independent storage ------------------------------------------------
+    // Stated as a positive property rather than left implicit: if a refactor ever hoisted the
+    // storage to one shared slot, the first name evaluated would answer for every other name --
+    // silently, and only on paths that read more than one switch. site_on() is cached true and
+    // site_off() cached false above, so a shared slot collapses them to one value.
+    check(site_on() && !site_off(),
+          "two different sites keep independent cached storage (true and false coexist)");
+
+    printf(fails ? "== FAILURES: %d ==\n" : "== all passed (%d failures) ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -7,6 +7,7 @@
 #include <vulkan/vulkan.h>
 #include "gpu/capture/gpu_capture.hpp"
 #include "gpu/diagnostics/diagnostic_selectors.hpp"
+#include "diagnostics/env_cache.hpp"       // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
 #include "gpu/state/render_state.hpp"
 #include "gpu/resources/shader_resources.hpp"
 #include "shared/rtt/rtt_scale.hpp"
@@ -3016,7 +3017,7 @@ inline PersistentDsKey persistent_ds_key_for(const prosper::gpu::ResolvedPipelin
     // exists to answer is whether any title programs 0x17 at all on a gfx10 part, and a decode
     // printed beside the raw value would pre-judge exactly that. Observation is evidence; a decode
     // is a claim. (#2669)
-    if (getenv("PROSPER_DS_SLICE_CENSUS")) {
+    if (PROSPER_ENV_ON("PROSPER_DS_SLICE_CENSUS")) {
         static std::mutex mutex;
         // (base, width, HEIGHT, raw) -- height was missing, so two surfaces sharing a base and width
         // but differing in height collapsed to one line and the second never printed. A census that
@@ -3527,7 +3528,7 @@ inline size_t invalidate_persistent_ds_guest_write(uint64_t addr, uint64_t size)
         if (stencil_overlap || htile_kill) image.stencil_valid = false;
         ++invalidated;
     }
-    if (invalidated && getenv("PROSPER_DSLOG"))
+    if (invalidated && PROSPER_ENV_ON("PROSPER_DSLOG"))
         fprintf(stderr, "[ds] guest-write addr=%llx size=%llu invalidated=%zu\n",
                 (unsigned long long)addr, (unsigned long long)size, invalidated);
     return invalidated;
@@ -4440,7 +4441,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // real work is supporting writable portable-uvec4 storage images. It exists to make the blast
     // radius measurable.
     const bool drop_only_unproven_draw =
-        getenv("PROSPER_RENDER_DROP_UNPROVEN_DRAW") != nullptr;
+        PROSPER_ENV_ON("PROSPER_RENDER_DROP_UNPROVEN_DRAW");
     std::vector<const BackendDraw*> proven_draws;
     proven_draws.reserve(draws.size());
     for (const BackendDraw& draw : draws) {
@@ -4640,7 +4641,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // wrong reverse-Z depth value); this reports whether it is happening again on the depth side,
     // which the derived float alone cannot show. A pass whose draws are predominantly GREATER but
     // whose value came out 1.0 is rejecting its own geometry.
-    if (getenv("PROSPER_DEPTH_CLEAR_WHY") && use_depth) {
+    if (PROSPER_ENV_ON("PROSPER_DEPTH_CLEAR_WHY") && use_depth) {
         uint32_t greater = 0, less = 0, other = 0, explicit_clear = 0;
         uint32_t greater_colour = 0, less_colour = 0;
         uint32_t reversed_viewports = 0, forward_viewports = 0;
@@ -4701,7 +4702,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     greater_colour, less_colour, vp_min, vp_max, reversed_viewports,
                     forward_viewports, logical_draws.size(), (unsigned long long)n);
     }
-    if (const char* v = getenv("PROSPER_DEPTH_CLEAR"))
+    if (const char* v = PROSPER_ENV_VALUE("PROSPER_DEPTH_CLEAR"))
         depth_clear = strtof(v, nullptr);
     if (getenv("PROSPER_NO_DEPTH"))   use_depth = false;     // diag: isolate depth-test rejection
     if (getenv("PROSPER_NO_STENCIL")) use_stencil = false;   // diag: isolate stencil masking
@@ -4820,7 +4821,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     const VkImageLayout self_depth_layout = format_has_stencil && stencil_may_be_written
         ? VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
         : VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-    if (getenv("PROSPER_DSLOG")) {
+    if (PROSPER_ENV_ON("PROSPER_DSLOG")) {
         static uint64_t call_id = 0;
         const uint64_t id = ++call_id;
         fprintf(stderr,
@@ -4974,7 +4975,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         ++color_target_stats.writes;
         color_target_stats.write_hits = load_cached_color ? 1 : 0;
     }
-    if (color_target && color_target->persistent_id && getenv("PROSPER_BACKEND_LOAD_LOG"))
+    if (color_target && color_target->persistent_id && PROSPER_ENV_ON("PROSPER_BACKEND_LOAD_LOG"))
         fprintf(stderr,
                 "[backend-load] id=0x%llx %ux%u fmt=%d cached=%d valid=%d load_existing=%d "
                 "seed=%d readback=%d -> load=%d\n",
@@ -5197,7 +5198,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     for (uint32_t slot = 2; slot < color_count; ++slot)
         load_extra[slot] = cached_extra[slot] && cached_extra[slot]->valid &&
                            color_target && color_target->load_existing_slots[slot];
-    if (color_target && getenv("PROSPER_BACKEND_LOAD_LOG")) {
+    if (color_target && PROSPER_ENV_ON("PROSPER_BACKEND_LOAD_LOG")) {
         if (use_color1)
             fprintf(stderr,
                     "[backend-load] slot=1 id=0x%llx %ux%u fmt=%d cached=%d valid=%d "
@@ -5662,7 +5663,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     const uint32_t zero_buffer_word = 0;
     const VkDeviceSize storage_buffer_alignment = ctx.storage_buffer_alignment;
     const bool use_buffer_arena = reuse_host_buffers &&
-        getenv("PROSPER_NO_BACKEND_BUFFER_ARENA") == nullptr;
+        !PROSPER_ENV_ON("PROSPER_NO_BACKEND_BUFFER_ARENA");
     auto align_storage_offset = [storage_buffer_alignment](VkDeviceSize value) {
         const VkDeviceSize remainder = value % storage_buffer_alignment;
         if (!remainder) return value;
@@ -5861,7 +5862,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
     }
     // Pass 1: create each draw's shader modules, descriptors (with texture staging upload), and pipeline.
-    const bool backend_trace = getenv("PROSPER_BACKEND_TRACE") != nullptr;
+    const bool backend_trace = PROSPER_ENV_ON("PROSPER_BACKEND_TRACE");
     // PROSPER_WAVE64_SKIP_CENSUS=1 -- which DRAWS the required-subgroup-size gate drops, at which
     // render target, and WHY (#2429, #2448). The existing "requires subgroup size 64" line sits inside
     // a dedupe guard keyed on shader identity while the `continue` that drops the draw is outside it,
@@ -6308,7 +6309,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // acne. Clamp requires the depthBiasClamp device feature; without it a non-zero clamp is
         // dropped to 0 (bias still applies, unclamped — the safe direction). PROSPER_NO_DEPTH_BIAS
         // is the A/B diagnostic, symmetric with PROSPER_NO_CULL above.
-        if (ps && ps->depth_bias_enable && !getenv("PROSPER_NO_DEPTH_BIAS")) {
+        if (ps && ps->depth_bias_enable && !PROSPER_ENV_ON("PROSPER_NO_DEPTH_BIAS")) {
             rs.depthBiasEnable         = VK_TRUE;
             rs.depthBiasConstantFactor = ps->depth_bias_constant;
             rs.depthBiasSlopeFactor    = ps->depth_bias_slope;
@@ -6394,7 +6395,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 ps->has_depth_clear && ps->depth_clear_value <= 0.5f;
             if (reverse_z_equal_compat) {
                 dss.depthCompareOp = VK_COMPARE_OP_GREATER_OR_EQUAL;
-                if (getenv("PROSPER_DSLOG"))
+                if (PROSPER_ENV_ON("PROSPER_DSLOG"))
                     fprintf(stderr, "[ds] reverse-Z read-only EQUAL -> GEQUAL compatibility\n");
             }
         }
@@ -6415,7 +6416,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 // from hardware — its use is isolating whether a suspect draw's coverage is
                 // stencil-gated (flipping GREATER<->LESS suppresses/expands it) without touching
                 // any other state. Symmetric ops (EQUAL/NOTEQUAL/ALWAYS/NEVER) are unaffected.
-                if (getenv("PROSPER_STENCIL_MIRROR")) {
+                if (PROSPER_ENV_ON("PROSPER_STENCIL_MIRROR")) {
                     switch (s.compareOp) {
                         case VK_COMPARE_OP_LESS:             s.compareOp = VK_COMPARE_OP_GREATER; break;
                         case VK_COMPARE_OP_GREATER:          s.compareOp = VK_COMPARE_OP_LESS; break;
@@ -6442,7 +6443,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 return s;
             };
             dss.front = mkop(0); dss.back = mkop(1);
-            if (getenv("PROSPER_STENCILLOG"))
+            if (PROSPER_ENV_ON("PROSPER_STENCILLOG"))
                 fprintf(stderr, "[stencil] front{cmp=%u ref=%u opval=%u cmask=0x%x wmask=0x%x fail=%u pass=%u zfail=%u} back{cmp=%u ref=%u fail=%u pass=%u zfail=%u} vkref=%u/%u cull=%u depth_test=%d\n",
                         ps->stencil_compare_op[0], ps->stencil_ref[0], ps->stencil_op_val[0], ps->stencil_compare_mask[0], ps->stencil_write_mask[0],
                         ps->stencil_fail_op[0], ps->stencil_pass_op[0], ps->stencil_depth_fail_op[0],
@@ -7250,7 +7251,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         SharedTextureBinding binding;
                         const bool persistent_bindings_enabled = share_backend_resources &&
                             persistent_textures_enabled &&
-                            getenv("PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS") == nullptr;
+                            !PROSPER_ENV_ON("PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS");
                         auto persistent_image = persistent_texture_images.end();
                         if (persistent_bindings_enabled &&
                             (upload.persistent_hit || upload.persistent_refresh) &&
@@ -8364,7 +8365,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     rpbi.renderPass = rp; rpbi.framebuffer = fb; rpbi.renderArea = {{0, 0}, {W, H}};
     rpbi.clearValueCount = color_count + (use_ds ? 1u : 0u);
     rpbi.pClearValues = clear.data();
-    if (getenv("PROSPER_PIPELOG")) {   // diag: how many draws' pipelines built + will be recorded
+    if (PROSPER_ENV_ON("PROSPER_PIPELOG")) {   // diag: how many draws' pipelines built + will be recorded
         int nok = 0; for (auto& v : dv) if (v.ok) nok++;
         fprintf(stderr, "[pipe] %zu draws, %d pipelines OK, use_depth=%d use_stencil=%d; counts:", dv.size(), nok, (int)use_depth, (int)use_stencil);
         for (auto& v : dv) fprintf(stderr, " %s%u", v.ok ? "" : "SKIP", v.icount ? v.icount : v.vcount);
@@ -8376,7 +8377,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // only active with the env var AND a real flush in THIS call (so the results are ready to read back).
     // Query-pool RESET must be recorded outside a render pass, so it happens here.
     const RenderVkCtx& ds_ctx = render_vk_ctx();
-    const bool draw_stats = getenv("PROSPER_DRAW_STATS") && ds_ctx.pipeline_stats_enabled &&
+    const bool draw_stats = PROSPER_ENV_ON("PROSPER_DRAW_STATS") && ds_ctx.pipeline_stats_enabled &&
                             !dv.empty() && flush_now;
     VkQueryPool ds_stats_pool = VK_NULL_HANDLE, ds_occ_pool = VK_NULL_HANDLE;
     if (draw_stats) {
@@ -8405,7 +8406,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // transform feedback and report where they land (degenerate / off-screen / behind-camera / NaN).
     // Requires VK_EXT_transform_feedback + the last pre-rasterization shader xfb-decorated (gated on
     // the same env var in gpu_executor). Only active with the env var, TF support, AND a flush here.
-    const char* geom_env = getenv("PROSPER_GEOM_PROBE");
+    const char* geom_env = PROSPER_ENV_VALUE("PROSPER_GEOM_PROBE");
     uint64_t geom_target = 0;
     const bool geom_target_valid = geom_env && gpu::parse_diagnostic_draw_id(geom_env, geom_target);
     const auto geom_target_label = static_cast<unsigned long long>(geom_target);
@@ -8894,7 +8895,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // valid is either never really written or is having its write disclaimed here, and those
         // are different defects. GTA V's cube shadows show exactly that shape: every face has a
         // cache entry, and slice 0 is never valid.
-        if (getenv("PROSPER_DS_SLICE_CENSUS")) {
+        if (PROSPER_ENV_ON("PROSPER_DS_SLICE_CENSUS")) {
             static std::mutex mutex;
             struct SliceTally { uint64_t passes = 0, claimed = 0, used_depth = 0, meaningful = 0; };
             static std::map<std::pair<uint64_t, uint32_t>, SliceTally> tally;
@@ -9082,7 +9083,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 // `[shader-tap] NOT APPLIED ...` naming the PC in that case, so the two lines
                 // must be read together: this header states what was ASKED FOR, and the ABSENCE
                 // of a NOT APPLIED line is what says it was delivered.
-                const bool is_tap = getenv("PROSPER_SHADER_TAP") != nullptr;
+                const bool is_tap = PROSPER_ENV_ON("PROSPER_SHADER_TAP");
                 if (is_tap)
                     fprintf(stderr, "[geom-probe] draw=%llu SHADER-TAP REQUESTED (see any [shader-tap] NOT APPLIED line for this shader, which means these are the REAL clip positions -- #2064): values below are the tapped VGPR "
                                     "(dst+3) at that PC, not clip positions (bbox/tags meaningless)\n",
@@ -9176,7 +9177,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 // (x,y,z,w in primitive-assembly order — for a triangle list, consecutive triples are the
                 // rasterized triangles) as CSV, so per-triangle overlap/degeneracy can be analyzed offline
                 // (e.g. GTA #1163's stencil over-count from self-overlapping mask triangles).
-                if (const char* dp = getenv("PROSPER_GEOM_PROBE_DUMP")) {
+                if (const char* dp = PROSPER_ENV_VALUE("PROSPER_GEOM_PROBE_DUMP")) {
                     if (FILE* f = fopen(dp, "w")) {
                         fprintf(f, "i,x,y,z,w\n");
                         for (uint32_t i = 0; i < written; i++)

--- a/prosper/tools/env/check_cached_env.py
+++ b/prosper/tools/env/check_cached_env.py
@@ -89,6 +89,86 @@ def scan(root: Path):
     return cached, armed
 
 
+# --- tier 3: the hot sites must not REGROW a live getenv ----------------------------------------
+#
+# #3094 took getenv off the per-draw and per-resource paths of the three files below. Nothing about
+# a bare getenv looks wrong at the call site, so the only thing that noticed the cost in the first
+# place was a perf profile -- which means the next edit to any of these guards can silently put it
+# back and no build, test or review would go red. This table is the standing statement that these
+# particular reads are hot, so that reintroducing getenv for one of them fails here instead.
+#
+# Adding a name is cheap; removing one needs a reason. A name here must ALSO survive the tier-1 and
+# tier-2 checks above -- being hot is never a licence to cache something that is armed at runtime.
+HOT_SITES = {
+    "tests/fixtures/render_runner.h": [
+        "PROSPER_BACKEND_LOAD_LOG", "PROSPER_GEOM_PROBE", "PROSPER_DSLOG",
+        "PROSPER_RENDER_DROP_UNPROVEN_DRAW", "PROSPER_DRAW_STATS", "PROSPER_DEPTH_CLEAR",
+        "PROSPER_DEPTH_CLEAR_WHY", "PROSPER_PIPELOG", "PROSPER_BACKEND_TRACE",
+        "PROSPER_NO_BACKEND_BUFFER_ARENA", "PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS",
+        "PROSPER_DS_SLICE_CENSUS", "PROSPER_STENCIL_MIRROR", "PROSPER_STENCILLOG",
+        "PROSPER_SHADER_TAP", "PROSPER_GEOM_PROBE_DUMP", "PROSPER_NO_DEPTH_BIAS",
+    ],
+    "src/gpu/execute/gpu_execute.hpp": [
+        "PROSPER_FORCE_COLORWRITE", "PROSPER_NO_EARLY_NO_EFFECT", "PROSPER_DRAWDIAG",
+        "PROSPER_DRAWLOG", "PROSPER_EXECLOG", "PROSPER_RECTLOG", "PROSPER_RTLOG",
+        "PROSPER_INTERPLOG", "PROSPER_GEOM_PROBE", "PROSPER_ONLY_ATLAS", "PROSPER_ONLY_IC",
+        "PROSPER_CAPTION_DIAG", "PROSPER_PROLOGLOG", "PROSPER_VS_DUMP", "PROSPER_SHADER_DUMP",
+        "PROSPER_DRAWMAP",
+    ],
+    "frontends/shared/live/live_renderer.cpp": [
+        "PROSPER_DCCLOG", "PROSPER_SLICESTRIDE", "PROSPER_UNIFORMLOG",
+    ],
+}
+
+
+def live_getenv_names(line: str):
+    """PROSPER_* names this line reads with a LIVE getenv.
+
+    A line carrying `static` is excluded: `static const bool x = getenv("N") != nullptr;` is a
+    one-shot read already -- the older hand-rolled spelling of the same fix, still present in the
+    tree and not something this gate should push people off.
+    """
+    if "static" in line:
+        return []
+    return LIVE_GETENV_RE.findall(line)
+
+
+LIVE_GETENV_RE = re.compile(r'(?:std::)?getenv\s*\(\s*"(PROSPER_[A-Z_0-9]+)"\s*\)')
+CACHED_USE_RE = re.compile(r'PROSPER_ENV_(?:ON|VALUE)\(\s*"(PROSPER_[A-Z_0-9]+)"\s*\)')
+
+
+def check_hot_sites(root) -> int:
+    """Every HOT_SITES name must be read through PROSPER_ENV_* and never through a live getenv."""
+    bad = 0
+    for relpath, names in sorted(HOT_SITES.items()):
+        path = root / relpath
+        if not path.is_file():
+            print(f"  [FAIL] hot-site file missing: {relpath}")
+            print( "         the guard cannot see the sites it is meant to protect -- if the file")
+            print( "         moved, move this entry with it rather than deleting it")
+            bad += 1
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        cached_here = set(CACHED_USE_RE.findall(text))
+        live_here = {}
+        for lineno, line in enumerate(text.split("\n"), 1):
+            for nm in live_getenv_names(line):
+                live_here.setdefault(nm, []).append(lineno)
+        for name in sorted(names):
+            if name in live_here:
+                print(f"  [FAIL] {relpath}: {name} is read with a live getenv at "
+                      f"line(s) {', '.join(str(n) for n in live_here[name][:4])}")
+                bad += 1
+            elif name not in cached_here:
+                print(f"  [FAIL] {relpath}: {name} is in HOT_SITES but the file reads it neither")
+                print( "         cached nor live -- the guard is stale, so fix or drop the entry")
+                bad += 1
+    if not bad:
+        total = sum(len(v) for v in HOT_SITES.values())
+        print(f"  [ok]   {total} hot site(s) across {len(HOT_SITES)} file(s) still read cached")
+    return bad
+
+
 def scan_line(line: str):
     """The per-line half of scan(), exposed so the self-test exercises the real code path."""
     return ([m.group(1) for m in CACHED_RE.finditer(line)],
@@ -126,8 +206,29 @@ SELF_TESTS = [
 ]
 
 
+# Shapes the hot-site scanner must and must not treat as a LIVE read. Without these, a regex that
+# stops matching turns tier 3 into a permanent [ok] -- the same silent-clean failure the tier-1
+# self-tests above exist to prevent.
+HOT_SELF_TESTS = [
+    ('if (getenv("PROSPER_HOT")) {', ["PROSPER_HOT"]),
+    ('const char* v = std::getenv("PROSPER_HOT");', ["PROSPER_HOT"]),
+    ('x = getenv("PROSPER_HOT") != nullptr;', ["PROSPER_HOT"]),
+    # MUST NOT match: already a one-shot read, in the older hand-rolled spelling.
+    ('static const bool on = getenv("PROSPER_HOT") != nullptr;', []),
+    # MUST NOT match: the cached macro is the fix.
+    ('if (PROSPER_ENV_ON("PROSPER_HOT")) {', []),
+    # MUST NOT match: prose naming the variable reads nothing.
+    ('// PROSPER_HOT is evaluated per draw', []),
+]
+
+
 def self_test() -> int:
     bad = 0
+    for snippet, want in HOT_SELF_TESTS:
+        got = live_getenv_names(snippet)
+        if got != want:
+            print(f"  [FAIL] hot-site self-test: {snippet!r} want={want} got={got}")
+            bad += 1
     for snippet, want_cached, want_armed in SELF_TESTS:
         got_cached, got_armed = scan_line(snippet)
         if got_cached != want_cached or got_armed != want_armed:
@@ -138,7 +239,7 @@ def self_test() -> int:
     if bad:
         print(f"  the scanner's own patterns are broken -- a tree scan would report a false CLEAN")
     else:
-        print(f"  [ok]   scanner self-test: {len(SELF_TESTS)} cases")
+        print(f"  [ok]   scanner self-test: {len(SELF_TESTS) + len(HOT_SELF_TESTS)} cases")
     return bad
 
 
@@ -182,6 +283,12 @@ def main() -> int:
 
     if not fails:
         print(f"  [ok]   no cached variable is armed by a test ({len(notes)} ordering note(s) above)")
+        if check_hot_sites(root):
+            print("  A hot site regrew a live getenv. #3094 measured these on per-draw and")
+            print("  per-resource paths; restore the PROSPER_ENV_ON/VALUE read, or if the site is")
+            print("  genuinely no longer hot, remove its entry from HOT_SITES in this file.")
+            print("== 1 failure(s) ==")
+            return 1
         print("== all checks passed ==")
         return 0
 


### PR DESCRIPTION
## What this fixes

`getenv` is 1.24% of Blue Prince's gameplay frame (#3094, decomposition in #1284). It is a linear
scan of the environment block, and prosper evaluates diagnostic guards like
`if (getenv("PROSPER_PIPELOG"))` on per-draw and per-resource paths — thousands of scans a second to
answer a question whose answer cannot change. No wrong behaviour, just wasted time, which is why
nothing had ever flagged it.

Fixes #3094.

## Failure scenario

A title rendering at a normal draw rate. Every draw evaluates a set of diagnostic gates; each gate
that is still a live `getenv` walks the whole environment block comparing entries, whether or not
the variable is set. Cost scales with scene complexity rather than with logging.

## The contract, and why this is not a regex sweep

Caching changes semantics: the variable is sampled at first use, so a process that arms it later
never observes the write. The dangerous part is the failure mode — a test that arms a diagnostic
with `setenv` and asserts on the behaviour does **not** go red when the read is cached, it goes
**vacuous** and keeps printing `[ok]` against the stale value (#2214).

**All four call sites the issue nominated as the obvious fix are unsafe, and are deliberately left
as live `getenv`:**

| site | name | why it must stay live |
| --- | --- | --- |
| `render_runner.h:1285`, `:1288` | `PROSPER_GFXLOG` | armed by `tests/gpu/test_eop_write.cpp:254` and 9 other sites |
| `render_runner.h:714` | `PROSPER_NO_BACKEND_PIPELINE_CACHE` | armed by `tests/gpu/state/test_multidraw_render.cpp:248` |
| `render_runner.h:759` | `PROSPER_NO_BACKEND_PIPELINE_LAYOUT_CACHE` | armed by `tests/gpu/state/test_multidraw_render.cpp:390` |

So each site was screened rather than rewritten. Screening used two filters:

1. **`tools/env/check_cached_env.py`'s arming scan** — 128 `PROSPER_*` names are written at runtime
   somewhere in the tree. None of them are cached here.
2. **A blind spot in that gate, found while doing this.** `tools/gpu_replay` re-applies
   `GpuCaptureMetadata::renderer_env` — the `render_env[]` allowlist at `gpu_capture.cpp:6237`, 37
   names — through `set_environment(name, value)` with a **non-literal** name, once per bundle
   submit. `check_cached_env.py` matches on literal first arguments, so it cannot see any of them.
   Those 37 names are excluded from this change too.

   To be precise about what that blind spot is and is not: **no defect is demonstrated.** Those
   values are captured from the capturing process's own environment, which is constant for that
   run, so all submits in a bundle carry identical values; and the one genuinely submit-local entry,
   `PROSPER_GPU_REPLAY_SCANOUT_ADDR`, is not cached anywhere. 17 of the 37 are already cached on
   master and I am **not** calling those a bug. They are excluded here because a bundle replay is
   the project's primary offline debugging tool, and a diagnostic silently frozen across submits
   would be a trap for a future reader — not because anything is known to be broken. The reasoning
   is recorded in `env_cache.hpp` so the next person does not have to re-derive it.

## Approach

- **`src/diagnostics/env_cache.hpp` (new).** `PROSPER_ENV_ON` / `PROSPER_ENV_VALUE` moved verbatim
  out of `hle/dispatch/dispatch.hpp`, which is where they were first needed and not where they
  belong — the renderer backend and the draw executor should not include the HLE dispatch registry
  (`self/module.hpp`, the NID tables) to ask whether a switch is on. `dispatch.hpp` includes the new
  header, so its ~150 existing macro users are untouched. `live_renderer.cpp` now includes the small
  header instead of the HLE one.
- **44 call sites converted** across `tests/fixtures/render_runner.h` (21),
  `src/gpu/execute/gpu_execute.hpp` (20) and `frontends/shared/live/live_renderer.cpp` (3). Boolean
  guards became `PROSPER_ENV_ON`; sites binding the pointer became `PROSPER_ENV_VALUE`.
  Note `render_runner.h` is the shared renderer backend despite its path — it is included by
  `live_renderer.cpp`, `gpu_executor.cpp`, `live_compute.cpp` and `gpu_replay`.
- **The historical warning is corrected, not dropped.** The old comment said applying these macros
  to `hle_kernel.cpp`, `gpu_executor` or the command processor broke `win_exception_delivery`,
  `eop_write` and `dynfetch_fold`. That was never a property of those *files* — it was the specific
  names they read, all of which the gate now refuses. This PR caches 16 names in `gpu_execute.hpp`,
  on the same per-draw path reached from `gpu_executor.cpp`, with the suite green. Screen by name.

## Invariants

- No name written at runtime anywhere in the tree is cached (gate tier 1/2).
- No `render_env[]` name is cached.
- The cache unit is the **call site**, not the name: each expansion has its own function-local
  static. Two sites reading one name read once each. C++11+ makes function-local static init
  thread-safe; storage is deliberately not at namespace scope, which would also expose it to
  cross-TU static-init order.

## Regression tests (both mutation-verified)

**`diagnostics_env_cache`** (new, `tests/diagnostics/test_env_cache.cpp`) — behavioural. Each case
evaluates **one** call site twice with the environment mutated in between and asserts the second
evaluation still reports the first value. That is the one behaviour a live `getenv` cannot produce.
Both directions are covered (armed-then-disarmed, and unset-then-armed, so "always true" cannot
pass), each with a live-`getenv` control arm proving the mutation actually took effect.

This test found a real subtlety while being written: the first draft asserted across two *different*
macro expansions and failed, because those are two independent caches. The contract is "once per
site", never "once per name", and the header now says so.

**`cached_env_arming_logic` tier 3** (extends `tools/env/check_cached_env.py`) — a `HOT_SITES` table
naming the 36 (file, name) pairs converted here. It fails if any of them regrows a live `getenv`,
and also fails if an entry goes stale. Six self-test cases cover the shapes it must and must not
match, including `static const bool x = getenv(...)` — the older hand-rolled one-shot spelling still
in the tree, which must not be flagged. Without those the tier could silently report a clean tree
forever.

## Measurement — honest scope

I did **not** re-measure the 1.24% frame share; that number stays the issue's, not mine. What I did
measure is the mechanism directly, with an `LD_PRELOAD` shim counting `getenv` calls by name across
eight render/execute tests, same binaries and same command before and after:

```
getenv calls  BEFORE 29539   AFTER 20626   delta -8913 (-30.2%)
```

Per-name, the converted guards drop to exactly **8 calls each — one per process across 8 test
processes**, which is the reachable floor and confirms one read per site per run:

```
PROSPER_BACKEND_LOAD_LOG          1240 ->  8
PROSPER_GEOM_PROBE                 836 ->  9
PROSPER_DSLOG                      819 -> 13
PROSPER_RENDER_DROP_UNPROVEN_DRAW  815 ->  8
PROSPER_DEPTH_CLEAR / _WHY         812 ->  8   (each)
PROSPER_DRAW_STATS                 812 ->  8
PROSPER_PIPELOG                    812 ->  8
PROSPER_BACKEND_TRACE              812 ->  8
PROSPER_NO_BACKEND_BUFFER_ARENA    807 ->  8
```
No name increased.

**What this is not:** eight render tests are a proxy for a Blue Prince gameplay frame, not that
frame. The call-count reduction is measured and reproducible; the resulting *frame-time* improvement
on a real title is **unverified here**. Roughly half the per-draw `getenv` volume in these tests
(`PROSPER_NO_STENCIL`, `PROSPER_NO_BLEND`, `PROSPER_NO_CULL`, `PROSPER_FLIP_FRONT_FACE`,
`PROSPER_STENCIL_CLEAR`, `PROSPER_NO_DEPTH`, `PROSPER_DRAW_ISO` — ~7,000 calls) is deliberately left
live because those are the `render_env[]` names, so a further win exists behind the question above.

## Affected / unaffected

- **Affected:** 44 diagnostic guards now read once per call site per process instead of per
  draw/resource. If any of these is armed *after* first evaluation, it is no longer observed — that
  is the intended trade and no test or tool in the tree does it.
- **Unaffected:** every armed name, every `render_env[]` name, all ~150 existing `PROSPER_ENV_*`
  users, and the two macros' definitions (moved verbatim, byte-identical bodies). No rendering
  behaviour changes when no diagnostic is set.

## Risks

- A future contributor arms one of the 44 cached names at runtime and gets a vacuous test rather
  than a failure. Mitigated by gate tier 1/2, which fails on exactly that.
- `HOT_SITES` goes stale if a file is renamed. The check fails loudly (missing file / entry present
  but unread) rather than passing quietly.
- The `render_env[]` blind spot remains unguarded in the gate. Deliberate: encoding it would flag 17
  existing cached names for which no defect is demonstrated, and a gate with standing false
  positives is one people learn to skip. Recorded in `env_cache.hpp` and `src/diagnostics/AGENTS.md`
  instead.

## Commands and results

```
cmake -S prosper -B prosper/build-linux -DCMAKE_BUILD_TYPE=RelWithDebInfo   # rc 0
TMPDIR=$PWD/prosper/build-linux/tmpdir cmake --build prosper/build-linux -j8   # rc 0
ctest --test-dir prosper/build-linux --no-tests=error
      -> 100% tests passed, 319 tests, 0 failed, exit code 0
python3 prosper/tools/env/check_cached_env.py    # rc 0; "36 hot site(s) across 3 file(s)"
python3 prosper/tools/docs/check_numbered_table.py BLOG.md prosper/src/diagnostics/AGENTS.md  # rc 0
git diff --check   # rc 0
```

Built and tested in the project distrobox (Linux/AMD, Vulkan present — the offscreen graphics
harness is enabled, so the Vulkan execution tests really ran).

### Mutation evidence

**1. Remove the caching** — drop `static` from both macro bodies in `env_cache.hpp`:

```
baseline_rc 0  /  mutant_rc 1  (5 assertions failed)  /  restored_rc 0
mutant build rc 0   <- the mutant binary really was rebuilt, so the failure is the code, not a stale build
```

**2. Regrow a live getenv** — revert `render_runner.h:8368` to `if (getenv("PROSPER_PIPELOG"))`:

```
baseline_rc 0  /  mutant_rc 1  /  restored_rc 0
mutant output: [FAIL] tests/fixtures/render_runner.h: PROSPER_PIPELOG is read with a live getenv at line(s) 8368
```

## Docs

`src/diagnostics/AGENTS.md` gains a paragraph on `env_cache.hpp` — why it lives there, and the
caching-changes-semantics warning with the gate that enforces it. `BLOG.md` gets a short entry (no
screenshot: this is CPU time, nothing new renders).
