### PR TITLE
feat(gpu): PROSPER_SKIP_DRAW_PROGRAM — decline graphics draws by shader program identity

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,19 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-01
 
+### Astro Bot's world map stops killing the GPU, and the draw that does it has a name
+
+No picture: what the world map renders is still the nebula backdrop we already published. What
+changed is that the run no longer dies there.
+
+Loading the world map took the whole GPU down — a driver-level hard recovery, after which every
+frame was the same frozen picture for the rest of the run. The message blamed a compute program,
+but that program was just the first thing to fail *after* the device was already gone. It was a
+single **draw**, and there was no way to ask which one: prosper could decline a compute program by
+name but not a graphics one. It can now, and bisecting thirty-two candidates took four runs — with
+one draw declined, a five-minute run has zero device losses and keeps producing new frames the whole
+way. ([#3193](https://github.com/mattias800/prosper/issues/3193))
+
 ### The three getenv calls the profiler pointed at were the three we could not fix
 
 No picture — this one is pure CPU time. `getenv` costs 1.24% of Blue Prince's gameplay frame

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1677,6 +1677,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_watch_list PRIVATE prosper_core)
   add_test(NAME watch_list COMMAND test_watch_list)
 
+  # PROSPER_SKIP_DRAW_PROGRAM: decline graphics draws by shader PROGRAM identity (the graphics
+  # counterpart of PROSPER_COMPUTE_SKIP_PROGRAM). Pure selector logic -- no Vulkan; the wiring into
+  # the live renderer is pinned separately by draw_program_skip_render below.
+  add_executable(test_draw_program_skip tests/gpu/diagnostics/test_draw_program_skip.cpp)
+  target_link_libraries(test_draw_program_skip PRIVATE prosper_core)
+  add_test(NAME draw_program_skip COMMAND test_draw_program_skip)
+
   add_executable(test_rdna2_decode tests/gpu/recompiler/test_rdna2_decode.cpp)
   target_link_libraries(test_rdna2_decode PRIVATE prosper_core)
   add_test(NAME rdna2_decode_walk COMMAND test_rdna2_decode)
@@ -2451,6 +2458,22 @@ if(TARGET prosper_core)
       target_include_directories(test_gpu_capture_render PRIVATE src tests tools/boot_trace)
       target_link_libraries(test_gpu_capture_render PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
       add_test(NAME gpu_capture_render_replay COMMAND test_gpu_capture_render)
+
+      # PROSPER_SKIP_DRAW_PROGRAM through the REAL live renderer: an unnamed program renders, the
+      # named one is withheld, and a mixed submit loses only the named draw. Needs the live renderer
+      # (and therefore Vulkan) because the wiring, not the selector logic, is what is under test.
+      add_executable(test_draw_program_skip_render tests/gpu/diagnostics/test_draw_program_skip_render.cpp)
+      target_include_directories(test_draw_program_skip_render PRIVATE frontends)
+      target_include_directories(test_draw_program_skip_render PRIVATE src tests tools/boot_trace)
+      target_link_libraries(test_draw_program_skip_render PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
+      add_test(NAME draw_program_skip_render COMMAND test_draw_program_skip_render)
+      # Armed from the ENVIRONMENT rather than by a setenv inside the test. The persistent-target
+      # opt-out is read through PROSPER_ENV_VALUE, which caches, so arming it from inside the process
+      # is exactly the vacuous-arm defect cached_env_arming_logic exists to catch; and the selector
+      # itself is read once into a function-local static, so environment arming removes the ordering
+      # argument for it too.
+      set_tests_properties(draw_program_skip_render PROPERTIES ENVIRONMENT
+        "PROSPER_SKIP_DRAW_PROGRAM=0x5006c6a00;PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS=1")
 
       add_executable(test_vulkan_offscreen tests/test_vulkan_offscreen.cpp)
       target_link_libraries(test_vulkan_offscreen PRIVATE Vulkan::Vulkan)

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4,6 +4,7 @@
 #include "diagnostics/env_cache.hpp"   // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
 #include "gpu/resources/metadata_kind_correlation.hpp"  // positive metadata-kind correlation (pure, tested)
 #include "gpu/diagnostics/watch_list.hpp"                 // strict 0x-only watch parsing
+#include "gpu/diagnostics/draw_program_skip.hpp"          // PROSPER_SKIP_DRAW_PROGRAM / census
 #include "shared/rtt/rtt_authority.hpp"
 #include "shared/rtt/rtt_injection.hpp"
 #include "shared/rtt/rtt_scale.hpp"
@@ -7222,6 +7223,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 }
                 return false;
             };
+            // PROSPER_SKIP_DRAW_PROGRAM / PROSPER_DRAW_PROGRAM_CENSUS: decline draws by shader
+            // PROGRAM identity, and enumerate the programs a title draws with. Both are process
+            // singletons configured once from the environment (see draw_program_skip.hpp for the
+            // contract and the four limits a reader of a skipped run cannot see in the output).
+            // Hoisted here for the same reason descriptor_validate_mode is: the accessor is one
+            // function-local-static test, but calling it per draw on a 2,100-draw submit is a
+            // measurable cost for a variable nobody set.
+            auto& program_skip = prosper::gpu::draw_program_skip_selector();
+            const bool program_skip_armed = program_skip.armed();
+            const bool program_census = prosper::gpu::draw_program_census_enabled();
             auto build_bds = [&](const std::vector<const prosper::gpu::DrawItem*>& group) {
                 std::vector<prosper::test::BackendDraw> bds;
                 // Once per call, not once per draw -- see the note on descriptor_validate_mode above
@@ -7354,6 +7365,57 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 fprintf(stderr, " tex@%u=0x%llx(%ux%u f%u)", r.binding,
                                         (unsigned long long)r.gpu_addr, r.width, r.height, (unsigned)r.format);
                         fprintf(stderr, "\n");
+                    }
+                    // PROSPER_DRAW_PROGRAM_CENSUS: which programs does this title actually draw
+                    // with? One line per distinct (vs, vs-chain, ps) triple, then powers of two --
+                    // bounded by the program count, not the draw count. This is the census that
+                    // supplies PROSPER_SKIP_DRAW_PROGRAM's input.
+                    if (program_census) {
+                        const auto sighting = prosper::gpu::draw_program_census().observe(
+                            it.vs_guest_addr, it.vs_chain_guest_addr, it.fs_guest_addr);
+                        if (sighting.print)
+                            fprintf(stderr, "[draw-program] %s vs=0x%llx chain=0x%llx ps=0x%llx "
+                                    "draws=%llu distinct=%llu vcount=%u nidx=%zu topo=%u tgt=0x%llx\n",
+                                    sighting.first ? "NEW " : "    ",
+                                    (unsigned long long)it.vs_guest_addr,
+                                    (unsigned long long)it.vs_chain_guest_addr,
+                                    (unsigned long long)it.fs_guest_addr,
+                                    (unsigned long long)sighting.ordinal,
+                                    (unsigned long long)sighting.distinct,
+                                    bd.vcount, bd.indices.size(), it.ps.topology,
+                                    (unsigned long long)it.color0_base);
+                    }
+                    // PROSPER_SKIP_DRAW_PROGRAM: withhold this draw from the GPU because one of its
+                    // programs is named. LAST in the per-draw build on purpose -- instrument trap
+                    // 166: a diagnostic skip ordered before the dump blinds every other instrument
+                    // to the thing under suspicion, and the program worth declining is precisely the
+                    // one that hangs the GPU. So the draw is fully realized, fully validated and
+                    // fully logged by [render]/[rtt]/[draw-program] first; only the Vulkan draw call
+                    // is withheld. Its CPU-side cost is therefore real, and the timing partition
+                    // above has already counted it in build_draws, which is arithmetically right --
+                    // it did spend build_R, validation, poison and indices.
+                    if (program_skip_armed) {
+                        const auto decision = program_skip.evaluate(
+                            it.vs_guest_addr, it.vs_chain_guest_addr, it.fs_guest_addr);
+                        if (decision.skip) {
+                            if (decision.print)
+                                fprintf(stderr,
+                                        "[draw-decline] program=0x%llx stage=%s "
+                                        "reason=skipped-by-selector count=%llu draw#%llu order=%llu "
+                                        "vs=0x%llx chain=0x%llx ps=0x%llx vcount=%u nidx=%zu "
+                                        "tgt=0x%llx\n",
+                                        (unsigned long long)decision.address,
+                                        prosper::gpu::draw_program_stage_name(decision.stage),
+                                        (unsigned long long)decision.ordinal,
+                                        (unsigned long long)it.draw_index,
+                                        (unsigned long long)it.command_order,
+                                        (unsigned long long)it.vs_guest_addr,
+                                        (unsigned long long)it.vs_chain_guest_addr,
+                                        (unsigned long long)it.fs_guest_addr,
+                                        bd.vcount, bd.indices.size(),
+                                        (unsigned long long)it.color0_base);
+                            continue;
+                        }
                     }
                     bds.push_back(std::move(bd));
                 }

--- a/prosper/src/gpu/diagnostics/AGENTS.md
+++ b/prosper/src/gpu/diagnostics/AGENTS.md
@@ -4,7 +4,7 @@
 with nothing armed, code in this folder can be removed or rate-limited without changing a single
 rendered pixel.
 
-**One entry breaks the stronger form of that rule and you must know about it.**
+**Two entries break the stronger form of that rule and you must know about them.**
 `compute_parent_walk_suspicious()` in `compute_parent_walk.cpp` reaches the site in
 `execute/gpu_executor.cpp` that prints `[compute-parent-walk] DIAGNOSTIC-ONLY skip suspicious`
 and then **does not run the dispatch** — grep `DIAGNOSTIC-ONLY skip suspicious`, which is unique
@@ -13,11 +13,21 @@ there, so the longer form matches nothing. It is env-gated, so a default boot is
 merely observing. `compute_parent_walk.hpp` states this boundary; do not read the folder name as a
 guarantee.
 
+`draw_program_skip` is the second, and it is deliberate rather than incidental: armed with
+`PROSPER_SKIP_DRAW_PROGRAM=0xADDR`, the live renderer withholds every draw using that shader program
+from the GPU. It is the graphics counterpart of `PROSPER_COMPUTE_SKIP_PROGRAM`, and it exists
+because a draw that hangs the device cannot be studied any other way — the context is gone before
+any other instrument reports. Unset, it costs one `empty()` test per draw and changes nothing.
+`draw_program_skip.hpp` states the four limits a reader of a skipped run cannot see in the output;
+read them before quoting a result. Its companion `PROSPER_DRAW_PROGRAM_CENSUS` is observation only.
+
 - `diagnostic_selectors` — choosing what to observe.
 - `diag_ratelimit` — rate limiting. **Check a diagnostic's rate limit before quoting its volume as a
   frequency**; several phantom findings came from reading a capped count as a real one.
 - `watch_list`, `compute_tree_watch`, `compute_parent_walk` — watching addresses and walking compute
   parentage.
+- `draw_program_skip` — naming a graphics shader program, to census it or to decline every draw
+  that uses it.
 
 Two standing cautions, both learned expensively:
 

--- a/prosper/src/gpu/diagnostics/draw_program_skip.cpp
+++ b/prosper/src/gpu/diagnostics/draw_program_skip.cpp
@@ -1,0 +1,149 @@
+#include "gpu/diagnostics/draw_program_skip.hpp"
+
+#include "gpu/diagnostics/diag_ratelimit.hpp"
+#include "gpu/diagnostics/watch_list.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace prosper::gpu {
+namespace {
+
+// First 8 occurrences of each (program, stage), then every power of two. The ordinal is on every
+// line, so the tail stays readable without the cap ever masquerading as the rate
+// (diag_ratelimit.hpp).
+constexpr uint64_t kFirstN = 8;
+
+}  // namespace
+
+const char* draw_program_stage_name(DrawProgramStage stage) {
+    switch (stage) {
+        case DrawProgramStage::Vertex:      return "vs";
+        case DrawProgramStage::VertexChain: return "vs-chain";
+        case DrawProgramStage::Fragment:    return "ps";
+        case DrawProgramStage::None:        break;
+    }
+    return "none";
+}
+
+DrawProgramSkipSelector::ConfigureResult DrawProgramSkipSelector::configure(const char* spec) {
+    addresses_.clear();
+    if (!spec || !*spec) return ConfigureResult::Unset;
+    std::vector<uint64_t> parsed;
+    if (!parse_hex_watch_list(spec, parsed)) return ConfigureResult::Malformed;
+    addresses_ = std::move(parsed);
+    return ConfigureResult::Armed;
+}
+
+DrawSkipDecision DrawProgramSkipSelector::evaluate(uint64_t vs_addr, uint64_t vs_chain_addr,
+                                                  uint64_t fs_addr) {
+    DrawSkipDecision decision;
+    // The disarmed fast path: one empty() test, no lock, no allocation. This runs per draw on every
+    // default boot, so it must cost nothing measurable when nothing is selected.
+    if (addresses_.empty()) return decision;
+
+    // Ordered vertex, chain, pixel. A guest address names exactly one program, so at most one of
+    // these can match and the order only decides which name is reported when a caller passes the
+    // same address twice (a chained NGG program whose ES and main addresses coincide).
+    const auto matches = [this](uint64_t address) {
+        return address != 0 &&
+               std::find(addresses_.begin(), addresses_.end(), address) != addresses_.end();
+    };
+    if (matches(vs_addr)) {
+        decision.stage = DrawProgramStage::Vertex;
+        decision.address = vs_addr;
+    } else if (matches(vs_chain_addr)) {
+        decision.stage = DrawProgramStage::VertexChain;
+        decision.address = vs_chain_addr;
+    } else if (matches(fs_addr)) {
+        decision.stage = DrawProgramStage::Fragment;
+        decision.address = fs_addr;
+    } else {
+        return decision;
+    }
+    decision.skip = true;
+
+    std::lock_guard lock(mutex_);
+    const uint64_t ordinal =
+        ++counts_[{decision.address, static_cast<uint8_t>(decision.stage)}];
+    ++total_;
+    decision.ordinal = ordinal;
+    decision.print = diag_should_print(ordinal, kFirstN);
+    return decision;
+}
+
+uint64_t DrawProgramSkipSelector::skipped_total() const {
+    std::lock_guard lock(mutex_);
+    return total_;
+}
+
+DrawProgramCensus::Sighting DrawProgramCensus::observe(uint64_t vs_addr, uint64_t vs_chain_addr,
+                                                      uint64_t fs_addr) {
+    Sighting sighting;
+    std::lock_guard lock(mutex_);
+    const Key key{vs_addr, vs_chain_addr, fs_addr};
+    const auto [it, inserted] = counts_.emplace(key, 0u);
+    sighting.ordinal = ++it->second;
+    sighting.first = inserted;
+    sighting.distinct = counts_.size();
+    // First sighting always prints — that is the census. Recurrences print at powers of two so a
+    // program that suddenly dominates a frame is still visible without a per-draw firehose.
+    sighting.print = inserted || diag_should_print(sighting.ordinal, 1);
+    return sighting;
+}
+
+uint64_t DrawProgramCensus::distinct_programs() const {
+    std::lock_guard lock(mutex_);
+    return static_cast<uint64_t>(counts_.size());
+}
+
+DrawProgramSkipSelector& draw_program_skip_selector() {
+    // Two statics rather than one initialized from a lambda's return: the selector holds a mutex, so
+    // it is neither copyable nor movable and cannot be returned by value. Both initializations are
+    // still thread-safe (magic statics), and the second runs exactly once.
+    static DrawProgramSkipSelector selector;
+    [[maybe_unused]] static const bool configured_once = [] {
+        DrawProgramSkipSelector& s = selector;
+        const char* spec = std::getenv("PROSPER_SKIP_DRAW_PROGRAM");
+        switch (s.configure(spec)) {
+            case DrawProgramSkipSelector::ConfigureResult::Unset:
+                break;   // silence is correct here: the default boot must not print
+            case DrawProgramSkipSelector::ConfigureResult::Malformed:
+                std::fprintf(stderr,
+                             "[draw-skip] ignoring malformed PROSPER_SKIP_DRAW_PROGRAM=\"%s\" "
+                             "(expected 0x-prefixed hex program addresses, comma separated) "
+                             "-- NOT armed, every draw runs\n", spec);
+                break;
+            case DrawProgramSkipSelector::ConfigureResult::Armed:
+                std::fprintf(stderr,
+                             "[draw-skip] PROSPER_SKIP_DRAW_PROGRAM=%s -> %zu program(s) will be "
+                             "declined; every draw using one is withheld from the GPU\n",
+                             spec, s.size());
+                break;
+        }
+        return true;
+    }();
+    return selector;
+}
+
+DrawProgramCensus& draw_program_census() {
+    static DrawProgramCensus census;
+    return census;
+}
+
+bool draw_program_census_enabled() {
+    static const bool enabled = [] {
+        const char* spec = std::getenv("PROSPER_DRAW_PROGRAM_CENSUS");
+        const bool on = spec && *spec && std::strcmp(spec, "0") != 0;
+        if (on)
+            std::fprintf(stderr,
+                         "[draw-program] PROSPER_DRAW_PROGRAM_CENSUS armed -- one line per distinct "
+                         "(vs, vs-chain, ps) program triple, then powers of two\n");
+        return on;
+    }();
+    return enabled;
+}
+
+}  // namespace prosper::gpu

--- a/prosper/src/gpu/diagnostics/draw_program_skip.hpp
+++ b/prosper/src/gpu/diagnostics/draw_program_skip.hpp
@@ -1,0 +1,138 @@
+#pragma once
+// `PROSPER_SKIP_DRAW_PROGRAM` — decline GRAPHICS draws by shader PROGRAM identity, and the
+// first-sighting census that supplies its input.
+//
+// This is the graphics counterpart of `PROSPER_COMPUTE_SKIP_PROGRAM` (live_compute.cpp). The
+// motivating case is the same one that instrument made answerable on compute: a single draw can
+// hang the GPU, RADV then cancels the whole context, and every later submit fails with
+// `VK_ERROR_DEVICE_LOST` naming a *victim* rather than the cause. Astro Bot's world-map reset was
+// misattributed to compute for exactly that reason; the RADV `hang` dump puts the last reached
+// command-processor trace point immediately before a `DRAW_INDEX_2`. "Which draw is responsible?"
+// therefore has to be askable directly.
+//
+// The pre-existing `PROSPER_SKIP_DRAW` cannot ask it. It selects by the submit-local semantic
+// `draw_index`, which is an ordinal within one submit and is not stable from frame to frame, so it
+// cannot name "every draw that runs this shader" — which is what a hanging *program* is.
+//
+// Contract, mirroring the compute selector deliberately:
+//   * Default OFF. Unset, `evaluate()` returns "do not skip" after one `empty()` test and nothing
+//     about the run changes.
+//   * Impossible to arm by accident. The spec is parsed by the STRICT hex parser in
+//     `watch_list.hpp`, so a bare decimal, a stray comma, trailing junk, an overflow or a zero
+//     address arms NOTHING and says so. A selector whose null is meaningless is worse than none.
+//   * It reports itself. The arming line names the variable and the count; every skip prints a
+//     rate-limited `[draw-decline] ... reason=skipped-by-selector` line carrying its 1-based
+//     ordinal (`diag_ratelimit.hpp`'s contract). A log from a run made with this set can never
+//     later be read as a default run.
+//
+// FOUR LIMITS A READER OF THE RESULT CANNOT SEE IN THE OUTPUT. The compute selector documents two;
+// the graphics analogue has more, because a draw's product is an image other draws then read.
+//
+//   1. **A skipped draw's TARGET still loses its contribution, and later passes sample the hole.**
+//      The live renderer caches each pass's rendered pixels under `CB_COLOR0_BASE` and injects them
+//      when a later draw samples a texture at that address. Decline the draw that fills a render
+//      target and the composite that samples it does not fail — it succeeds against stale or empty
+//      pixels. What you get is not "the frame minus that draw"; it is that frame minus the draw
+//      minus every later draw's dependence on what it would have written.
+//   2. **A pass whose every draw is declined renders NOTHING — not even its clear.**
+//      `render_draw_pass_rgba` returns an empty image on an empty draw list, and the group's clear
+//      colour is taken from the group's FIRST item regardless of whether that item was declined. So
+//      naming a program that owns a whole pass removes the pass, and naming the first draw of a
+//      pass does not change what the pass clears to.
+//   3. **Only draws that reach the live renderer can be declined.** A draw whose shader the
+//      recompiler rejected, or whose descriptor contract failed validation, never gets here, so
+//      naming its program has no effect and produces no line. Silence is not proof the selector
+//      matched — check the arming line and the census.
+//   4. **An address names a PROGRAM, not a draw.** Every draw using that program is declined,
+//      which on a real title is routinely thousands per frame across unrelated objects.
+//
+// And one that IS visible but is easy to misread: the decline is ordered LAST in the per-draw
+// build, after resource resolution and after the `[render]`/`[rtt]` per-draw census lines
+// (instrument trap 166 — a diagnostic skip ordered before the dump blinds every other instrument to
+// the thing under suspicion). So a declined draw still costs its full CPU-side realization and is
+// still fully observable; only the Vulkan draw call is withheld.
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace prosper::gpu {
+
+// Which of a draw's programs the selector matched. A guest address identifies one program, and a
+// program is a vertex/ES program, its NGG main continuation, or a pixel program — never two of
+// them — so the stage is reported rather than chosen by the caller.
+enum class DrawProgramStage : uint8_t { None = 0, Vertex, VertexChain, Fragment };
+
+// "vs", "vs-chain", "ps", or "none". Stable strings — they appear in logs that get grepped.
+const char* draw_program_stage_name(DrawProgramStage stage);
+
+struct DrawSkipDecision {
+    bool skip = false;
+    DrawProgramStage stage = DrawProgramStage::None;
+    uint64_t address = 0;   // the matched address, not the draw's other programs
+    // 1-based occurrence count for this (address, stage), carried on every printed line so the last
+    // line's ordinal is a lower bound on the population. The line COUNT never is.
+    uint64_t ordinal = 0;
+    bool print = false;     // rate-limit verdict for this ordinal
+};
+
+class DrawProgramSkipSelector {
+public:
+    enum class ConfigureResult { Unset, Armed, Malformed };
+
+    // Parse `spec` (the raw environment value; null or empty means "unset"). Arms only on a
+    // completely valid list. On Malformed the selector is left disarmed — never partially armed.
+    ConfigureResult configure(const char* spec);
+
+    bool armed() const { return !addresses_.empty(); }
+    std::size_t size() const { return addresses_.size(); }
+
+    // The hot path. Cheap and lock-free when disarmed. When armed and matching, counts the skip and
+    // returns the rate-limit verdict for the caller to print.
+    DrawSkipDecision evaluate(uint64_t vs_addr, uint64_t vs_chain_addr, uint64_t fs_addr);
+
+    uint64_t skipped_total() const;
+
+private:
+    std::vector<uint64_t> addresses_;
+    mutable std::mutex mutex_;
+    std::map<std::pair<uint64_t, uint8_t>, uint64_t> counts_;
+    uint64_t total_ = 0;
+};
+
+// The census that supplies the selector's input: which graphics programs does this title actually
+// draw with? Reports the FIRST sighting of each distinct (vs, vs-chain, ps) triple and then that
+// triple's count at powers of two, so the number of lines is bounded by the number of distinct
+// programs rather than by the number of draws. Deliberately not a teardown report: the run this
+// exists for ends in a device loss, and a teardown report would not survive it.
+class DrawProgramCensus {
+public:
+    struct Sighting {
+        bool print = false;   // first sighting, or a power-of-two recurrence
+        bool first = false;   // true only on the very first sighting of this triple
+        uint64_t ordinal = 0; // 1-based count of draws with this triple
+        uint64_t distinct = 0;// how many distinct triples have been seen, including this one
+    };
+
+    Sighting observe(uint64_t vs_addr, uint64_t vs_chain_addr, uint64_t fs_addr);
+    uint64_t distinct_programs() const;
+
+private:
+    using Key = std::tuple<uint64_t, uint64_t, uint64_t>;
+    mutable std::mutex mutex_;
+    std::map<Key, uint64_t> counts_;
+};
+
+// Process-wide instances, configured once from the environment on first use:
+//   PROSPER_SKIP_DRAW_PROGRAM=0xADDR[,0xADDR...]
+//   PROSPER_DRAW_PROGRAM_CENSUS=1
+// Both print their arming state to stderr exactly once.
+DrawProgramSkipSelector& draw_program_skip_selector();
+DrawProgramCensus& draw_program_census();
+bool draw_program_census_enabled();
+
+}  // namespace prosper::gpu

--- a/prosper/tests/gpu/diagnostics/test_draw_program_skip.cpp
+++ b/prosper/tests/gpu/diagnostics/test_draw_program_skip.cpp
@@ -1,0 +1,182 @@
+// PROSPER_SKIP_DRAW_PROGRAM — decline graphics draws by shader PROGRAM identity.
+//
+// The gap this closes: PROSPER_COMPUTE_SKIP_PROGRAM can name a compute program, and that is what
+// isolated GTA V's hanging dispatch. The graphics side had only PROSPER_SKIP_DRAW, which selects a
+// submit-local `draw_index` ordinal — not stable frame to frame, so it cannot name "every draw that
+// runs this shader". Astro Bot's world-map GPU reset is a DRAW_INDEX_2, so that is exactly the
+// question that had no instrument.
+//
+// What is pinned here is the part a wrong answer would be invisible in: the selector must never arm
+// on a spec it did not fully understand (a partially-armed selector produces a confident negative
+// about a program nobody selected), it must report which stage matched, and its rate limit must
+// carry the ordinal so the cap can never be read as the rate.
+#include "gpu/diagnostics/draw_program_skip.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+using Configure = DrawProgramSkipSelector::ConfigureResult;
+
+// A draw's three program addresses, in the order evaluate() takes them.
+constexpr uint64_t kVs    = 0x5006c6a00ull;
+constexpr uint64_t kChain = 0x5006c7100ull;
+constexpr uint64_t kPs    = 0x5002af200ull;
+
+}  // namespace
+
+int main() {
+    printf("== test_draw_program_skip ==\n");
+
+    // ---- default OFF -------------------------------------------------------------------------
+    {
+        DrawProgramSkipSelector selector;
+        CHECK(selector.configure(nullptr) == Configure::Unset && !selector.armed() &&
+                  selector.size() == 0,
+              "an unset variable leaves the selector disarmed");
+        CHECK(selector.configure("") == Configure::Unset && !selector.armed(),
+              "an empty variable leaves the selector disarmed");
+        const auto decision = selector.evaluate(kVs, kChain, kPs);
+        CHECK(!decision.skip && decision.stage == DrawProgramStage::None &&
+                  decision.ordinal == 0 && !decision.print && selector.skipped_total() == 0,
+              "a disarmed selector skips nothing and counts nothing");
+    }
+
+    // ---- impossible to arm by accident -------------------------------------------------------
+    // Strict parsing is delegated to parse_hex_watch_list (pinned in test_watch_list), so what is
+    // asserted here is the CONSEQUENCE: a rejected spec must leave the selector inert, not
+    // partially armed. A selector holding half a list answers "this program is not responsible"
+    // about programs it never examined.
+    {
+        const char* const bad[] = {
+            "21474836480",                 // bare decimal — the base-0 trap
+            "0x5006c6a00,",                // trailing comma
+            "0x5006c6a00,,0x5002af200",    // empty token
+            "0x5006c6a00 junk",            // trailing junk
+            "0x0",                         // zero is never a program
+            "0x5006c6a00,21474836480",     // one bad token in an otherwise valid list
+            "5006c6a00",                   // hex digits without the 0x prefix
+        };
+        for (const char* spec : bad) {
+            DrawProgramSkipSelector selector;
+            const bool rejected = selector.configure(spec) == Configure::Malformed &&
+                                  !selector.armed() && selector.size() == 0 &&
+                                  !selector.evaluate(kVs, kChain, kPs).skip;
+            std::string message = "malformed spec \"";
+            message += spec;
+            message += "\" arms NOTHING and skips nothing";
+            CHECK(rejected, message.c_str());
+        }
+    }
+
+    // ---- a re-configure never leaves the previous list behind --------------------------------
+    {
+        DrawProgramSkipSelector selector;
+        CHECK(selector.configure("0x5006c6a00") == Configure::Armed && selector.armed(),
+              "a single 0x-prefixed program address arms the selector");
+        CHECK(selector.configure("0x5006c6a00,bogus") == Configure::Malformed &&
+                  !selector.armed() && !selector.evaluate(kVs, kChain, kPs).skip,
+              "re-configuring with a malformed spec DISARMS rather than keeping the old list");
+    }
+
+    // ---- which stage matched -----------------------------------------------------------------
+    {
+        DrawProgramSkipSelector vs_only;
+        vs_only.configure("0x5006c6a00");
+        const auto d = vs_only.evaluate(kVs, kChain, kPs);
+        CHECK(d.skip && d.stage == DrawProgramStage::Vertex && d.address == kVs &&
+                  std::strcmp(draw_program_stage_name(d.stage), "vs") == 0,
+              "a named VERTEX program declines the draw and reports stage=vs");
+
+        DrawProgramSkipSelector chain_only;
+        chain_only.configure("0x5006c7100");
+        const auto c = chain_only.evaluate(kVs, kChain, kPs);
+        CHECK(c.skip && c.stage == DrawProgramStage::VertexChain && c.address == kChain &&
+                  std::strcmp(draw_program_stage_name(c.stage), "vs-chain") == 0,
+              "a named NGG CHAIN continuation declines the draw and reports stage=vs-chain");
+
+        DrawProgramSkipSelector ps_only;
+        ps_only.configure("0x5002af200");
+        const auto p = ps_only.evaluate(kVs, kChain, kPs);
+        CHECK(p.skip && p.stage == DrawProgramStage::Fragment && p.address == kPs &&
+                  std::strcmp(draw_program_stage_name(p.stage), "ps") == 0,
+              "a named PIXEL program declines the draw and reports stage=ps");
+    }
+
+    // ---- a draw that uses none of the named programs is untouched ----------------------------
+    {
+        DrawProgramSkipSelector selector;
+        selector.configure("0x5006c6a00,0x5002af200");
+        CHECK(!selector.evaluate(0x400000000ull, 0, 0x400001000ull).skip &&
+                  selector.skipped_total() == 0,
+              "a draw using none of the named programs is not declined");
+        CHECK(!selector.evaluate(0, 0, 0).skip,
+              "a draw whose program addresses are all zero never matches an armed selector");
+        CHECK(selector.evaluate(kVs, 0, 0).skip && selector.evaluate(0, 0, kPs).skip &&
+                  selector.skipped_total() == 2,
+              "a comma list declines a draw matching EITHER named program, and both are counted");
+    }
+
+    // ---- the rate limit carries its ordinal --------------------------------------------------
+    // diag_ratelimit's contract: first 8, then powers of two, with the 1-based ordinal on every
+    // line. The ordinal is what makes the last printed line a lower bound on the population; the
+    // line COUNT never is, and reading a cap as a rate has cost this project multiple sessions.
+    {
+        DrawProgramSkipSelector selector;
+        selector.configure("0x5006c6a00");
+        bool ordinals_dense = true, printed_first_eight = true, quiet_between = true;
+        for (uint64_t n = 1; n <= 16; ++n) {
+            const auto d = selector.evaluate(kVs, 0, 0);
+            if (d.ordinal != n) ordinals_dense = false;
+            if (n <= 8 && !d.print) printed_first_eight = false;
+            if (n > 8 && n < 16 && d.print) quiet_between = false;
+        }
+        CHECK(ordinals_dense, "every decline carries a dense 1-based ordinal, printed or not");
+        CHECK(printed_first_eight, "the first eight declines of a program print");
+        CHECK(quiet_between, "declines 9..15 are suppressed");
+        CHECK(selector.evaluate(kVs, 0, 0).ordinal == 17 && selector.skipped_total() == 17,
+              "the running total counts suppressed declines too");
+
+        // Per (program, stage) budget: a program declined thousands of times must not exhaust the
+        // log before a second, rarer program gets a line at all.
+        DrawProgramSkipSelector both;
+        both.configure("0x5006c6a00,0x5002af200");
+        for (int i = 0; i < 100; ++i) both.evaluate(kVs, 0, 0);
+        const auto rare = both.evaluate(0, 0, kPs);
+        CHECK(rare.skip && rare.ordinal == 1 && rare.print,
+              "a second program's first decline still prints after 100 declines of another");
+    }
+
+    // ---- the census that supplies the selector's input ---------------------------------------
+    {
+        DrawProgramCensus census;
+        const auto a = census.observe(kVs, kChain, kPs);
+        CHECK(a.print && a.first && a.ordinal == 1 && a.distinct == 1,
+              "the first sighting of a program triple prints and is marked NEW");
+        const auto b = census.observe(kVs, kChain, kPs);
+        CHECK(b.print && !b.first && b.ordinal == 2 && b.distinct == 1,
+              "a recurrence is not NEW and does not grow the distinct count");
+        const auto c = census.observe(kVs, kChain, 0x400002000ull);
+        CHECK(c.print && c.first && c.ordinal == 1 && c.distinct == 2,
+              "the SAME vertex program with a different pixel program is a distinct triple");
+        for (int i = 0; i < 5; ++i) census.observe(kVs, kChain, kPs);   // ordinals 3..7
+        const auto eight = census.observe(kVs, kChain, kPs);
+        CHECK(eight.ordinal == 8 && eight.print, "a recurrence prints again at a power of two");
+        const auto nine = census.observe(kVs, kChain, kPs);
+        CHECK(nine.ordinal == 9 && !nine.print, "an ordinary recurrence is suppressed");
+        CHECK(census.distinct_programs() == 2,
+              "the census reports how many distinct program triples it has seen");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/gpu/diagnostics/test_draw_program_skip_render.cpp
+++ b/prosper/tests/gpu/diagnostics/test_draw_program_skip_render.cpp
@@ -1,0 +1,187 @@
+// PROSPER_SKIP_DRAW_PROGRAM, end to end through the REAL live renderer.
+//
+// test_draw_program_skip pins the selector's logic. This pins the WIRING: that the live renderer
+// actually consults it, that a named program's draws are withheld from the GPU, and — the half that
+// a logic test cannot show — that an unnamed draw submitted in the same process still renders.
+//
+// The wiring is the part that can be silently wrong. The renderer already carries three per-draw
+// substitution switches (REFVS, TESTPS, FS_SPV) whose exact-match gates fail closed, plus a
+// draw_index skip; a program skip placed in the wrong branch, or short-circuited by the shared-words
+// accessor trap in DrawItem (#1434), would leave every draw rendering while the log claimed
+// otherwise. So the assertion is on the rendered pixels and on the selector's own skip counter, in
+// one process, with one submit per arm.
+#include "gpu/diagnostics/draw_program_skip.hpp"
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/present/videoout_present.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "hle/dispatch/dispatch.hpp"
+#include "shared/live/live_renderer.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+namespace {
+
+constexpr uint32_t W = 64, H = 64;
+// A guest presentation surface LARGER than the render extent, exactly as test_gpu_capture_render
+// does: render_submit_items then consumes the last pass at its own extent rather than under a
+// present-extent contract it was never given.
+constexpr uint32_t PRESENT_W = 128, PRESENT_H = 128;
+// Two program addresses in the shape a real title uses. Only the first is named by the selector.
+constexpr uint64_t kDeclinedVs = 0x5006c6a00ull;
+constexpr uint64_t kKeptVs     = 0x5006c7100ull;
+
+using Hle8Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t, uint64_t, uint64_t);
+
+// A fullscreen-ish triangle from constants, and a solid magenta pixel shader — the same synthetic
+// pair the renderer's own PROSPER_RENDER_TESTPS override uses, so neither stage depends on a
+// resource table, a vertex buffer or guest memory being mapped.
+DrawItem make_draw(uint64_t vs_addr) {
+    static const uint32_t vs_rdna[] = {
+        0x36020081u, 0x2C040081u, 0x7E020D01u, 0x7E040D02u, 0x7E0A02F6u, 0x7E0C02F2u, 0x10020B01u,
+        0x08020D01u, 0x10040B02u, 0x08040D02u, 0x7E060280u, 0x7E0802F2u, 0xF80008CFu, 0x04030201u,
+        0xBF810000u,
+    };
+    static const uint32_t magenta_ps[] = {
+        0x7E0002F2u, 0x7E020280u, 0x7E0402F2u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u,
+    };
+    DrawItem item;
+    item.vs = recompile_vertex(vs_rdna, std::size(vs_rdna));
+    item.fs = recompile_fragment(magenta_ps, std::size(magenta_ps), nullptr);
+    item.vertex_count = 3;
+    item.ps.topology = 3;              // triangle list
+    item.ps.color_write_mask = 0xF;
+    item.color0_base = 0x200000;
+    item.color0_width = W;
+    item.color0_height = H;
+    item.vs_guest_addr = vs_addr;
+    item.fs_guest_addr = vs_addr + 0x1000ull;
+    return item;
+}
+
+// The magenta the test PS writes, sampled at the frame centre.
+bool centre_is_magenta(const std::vector<uint8_t>& rgba) {
+    if (rgba.size() != static_cast<size_t>(W) * H * 4) return false;
+    const uint8_t* px = &rgba[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+    return px[0] > 0xC0 && px[1] < 0x40 && px[2] > 0xC0;
+}
+
+}  // namespace
+
+int main() {
+    std::printf("== test_draw_program_skip_render ==\n");
+
+    // Armed BEFORE the first render: the selector is a process singleton read once, which is what
+    // makes a run's log unambiguous. A test that armed it later would be asserting on a disarmed
+    // selector and passing for the wrong reason.
+    // BOTH variables come from the ctest ENVIRONMENT property, not from a setenv here, and that is
+    // deliberate rather than incidental:
+    //
+    //   * PROSPER_SKIP_DRAW_PROGRAM is read once into a function-local static on first use. Arming
+    //     it from the environment the process starts with removes the ordering argument entirely.
+    //   * PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS is read through PROSPER_ENV_VALUE, which CACHES.
+    //     A test that setenv'd it would trip cached_env_arming_logic — correctly, because a cached
+    //     read that ran first would make every pixel assertion below vacuous while printing [ok].
+    //
+    // The renderer keeps intermediate colour targets GPU-resident and defers readback by default, so
+    // without that opt-out a pass's pixels are simply not on the CPU for this test to assert on. It
+    // does not change the thing under test: the decline happens while the backend draw list is being
+    // assembled, upstream of where the pixels end up living. It does mean the pixel arms below cover
+    // the CPU-readback path only; the selector's effect on the persistent-target path is covered by
+    // the skip counter, which is path-independent.
+    const char* skip_spec = std::getenv("PROSPER_SKIP_DRAW_PROGRAM");
+    const char* no_persistent = std::getenv("PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS");
+    if (!skip_spec || !no_persistent) {
+        std::printf("  [FAIL] run me through ctest, or with:\n"
+                    "         PROSPER_SKIP_DRAW_PROGRAM=0x5006c6a00 "
+                    "PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS=1 %s\n",
+                    "test_draw_program_skip_render");
+        return 1;
+    }
+    CHECK(std::strcmp(skip_spec, "0x5006c6a00") == 0,
+          "the environment names the program this test expects to be declined");
+
+    // The live renderer publishes through the present layer, so it needs a guest presentation
+    // surface to publish INTO. Without one it renders and then reports "Vulkan render FAILED",
+    // which would make every arm below vacuously true for a reason that has nothing to do with the
+    // selector -- the exact shape the positive control exists to catch.
+    prosper::register_builtin_hle();
+    present_reset();
+    auto open = prosper::Hle::lookup(prosper::nid_hash("sceVideoOutOpen"));
+    auto set_buffer_attribute2 = reinterpret_cast<Hle8Fn>(prosper::Hle::lookup("PjS5uASwcV8"));
+    auto register_buffers2 = prosper::Hle::lookup("rKBUtgRrtbk");
+    std::vector<uint8_t> scanout0(static_cast<size_t>(PRESENT_W) * PRESENT_H * 4u);
+    std::vector<uint8_t> scanout1(static_cast<size_t>(PRESENT_W) * PRESENT_H * 4u);
+    std::vector<uint8_t> scanout2(static_cast<size_t>(PRESENT_W) * PRESENT_H * 4u);
+    uint8_t scanout_attr[0x50]{};
+    struct VideoBuffer { const void* data; const void* metadata; const void* reserved[2]; };
+    VideoBuffer scanouts[3] = {
+        {scanout0.data(), nullptr, {nullptr, nullptr}},
+        {scanout1.data(), nullptr, {nullptr, nullptr}},
+        {scanout2.data(), nullptr, {nullptr, nullptr}},
+    };
+    const uint64_t video_handle = open ? open(0, 0, 0, 0, 0, 0) : 0;
+    if (set_buffer_attribute2)
+        set_buffer_attribute2(reinterpret_cast<uint64_t>(scanout_attr), 0x8000000000000000ull,
+                              0, PRESENT_W, PRESENT_H, 0, 0, 0);
+    const uint64_t register_result = register_buffers2
+        ? register_buffers2(video_handle, 0, 0, reinterpret_cast<uint64_t>(scanouts), 3,
+                            reinterpret_cast<uint64_t>(scanout_attr))
+        : UINT64_MAX;
+    CHECK(open && set_buffer_attribute2 && register_buffers2 && register_result == 0 &&
+              present_width() == PRESENT_W && present_height() == PRESENT_H,
+          "the test registers a presentation surface for the live renderer to publish into");
+
+    prosper::frontend::register_live_renderer(".", false);
+
+    const DrawItem kept = make_draw(kKeptVs);
+    CHECK(!kept.vs.empty() && !kept.fs.empty(), "the synthetic VS/PS pair recompiles to SPIR-V");
+
+    // The named program FIRST, before anything has rendered. Order matters: the present layer serves
+    // the last retained frame when a submit publishes nothing, so a declined submit run after a
+    // successful one shows the PREVIOUS frame's pixels and looks like it rendered. That is real
+    // behaviour and one of the documented limits of this instrument — it is asserted here in the one
+    // arrangement where the retained frame cannot supply the answer.
+    const std::vector<uint8_t> declined_pixels = render_submit_items({make_draw(kDeclinedVs)}, W, H);
+    CHECK(draw_program_skip_selector().armed() && draw_program_skip_selector().size() == 1,
+          "the selector armed from the environment on exactly one program");
+    CHECK(draw_program_skip_selector().skipped_total() == 1,
+          "the named program's draw is declined exactly once");
+    CHECK(!centre_is_magenta(declined_pixels),
+          "the declined draw paints nothing -- its pixels never reach the target");
+
+    // POSITIVE CONTROL, and the arm that makes the one above mean anything: the same shaders, the
+    // same submit shape, one different program address. Without it, "the named program produced no
+    // pixels" is equally consistent with this environment producing no pixels for anything — which
+    // is precisely how a skip instrument reports a clean result it never earned.
+    const std::vector<uint8_t> kept_pixels = render_submit_items({kept}, W, H);
+    CHECK(centre_is_magenta(kept_pixels),
+          "a draw whose program is NOT named renders through the live backend");
+    CHECK(draw_program_skip_selector().skipped_total() == 1,
+          "the unnamed draw was not declined");
+
+    // A mixed submit: naming a program must decline THAT draw, not the batch. This separates a
+    // working selector from one that poisons the whole submit — which is how a renderer-side
+    // rejection already behaves, and would look identical in a screenshot.
+    const std::vector<uint8_t> mixed_pixels =
+        render_submit_items({make_draw(kDeclinedVs), kept}, W, H);
+    CHECK(draw_program_skip_selector().skipped_total() == 2,
+          "the mixed submit declines only the named draw");
+    CHECK(centre_is_magenta(mixed_pixels),
+          "the unnamed draw in a mixed submit still renders");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -1183,6 +1183,49 @@ It is ordered **after** `trace_compute_item` and `maybe_dump_traced_compute_spir
 a program that hangs the GPU without losing the device. Combined with `PROSPER_COMPUTELOG_CODE` /
 `PROSPER_COMPUTELOG_SPIRV`, a recompiler change can be A/B'd by module hash at zero device cost.
 
+**`PROSPER_SKIP_DRAW_PROGRAM=0xADDR[,0xADDR...]` — decline GRAPHICS draws by shader PROGRAM
+identity.** The counterpart of the compute selector above, and it exists for the same reason: one
+draw can hang the GPU, RADV then cancels the whole context, and every later submit fails with
+`VK_ERROR_DEVICE_LOST` naming a *victim*. Astro Bot's world-map reset was misattributed to compute
+for exactly that reason — the `RADV_DEBUG=hang` dump puts the last command-processor trace point
+immediately before a `DRAW_INDEX_2`.
+
+An address is matched against a draw's vertex/ES program, its NGG main continuation, and its pixel
+program, and the matched stage is reported. Parsing is the strict `0x`-only list parser, so a bare
+decimal or a stray comma arms **nothing** and says so rather than producing a confident negative
+about a program nobody selected. Armed, it announces itself once and prints each decline as
+`[draw-decline] program=0x… stage=vs|vs-chain|ps reason=skipped-by-selector count=N …` — first eight
+per (program, stage), then powers of two, with the ordinal on every line.
+
+**Do not read a skipped run as "the frame minus that draw".** Four limits, none visible in the
+output:
+
+- **Later passes sample the hole.** The renderer caches a pass's pixels under `CB_COLOR0_BASE` and
+  injects them when a later draw samples that address. Decline the draw that fills a target and the
+  composite that reads it does not fail — it succeeds against stale or empty pixels.
+- **A pass whose every draw is declined renders nothing, not even its clear.** The backend returns
+  an empty image for an empty draw list, and a group's clear colour comes from its first item
+  whether or not that item was declined. The present layer then serves the previously retained
+  frame, which on screen looks like the frame rendered.
+- **Only draws that reach the live renderer can be declined** — not one the recompiler rejected or
+  whose descriptor contract failed. Naming such a program produces no line, and silence is not proof
+  the selector matched.
+- **An address names a PROGRAM, not a draw.** Every draw using it goes, routinely thousands a frame.
+
+It is ordered **last** in the per-draw build — after resource resolution and after the
+`[render]`/`[rtt]`/`[draw-program]` per-draw lines (instrument trap 166). A declined draw is
+therefore still fully realized, validated and logged; only the Vulkan draw call is withheld.
+
+**`PROSPER_DRAW_PROGRAM_CENSUS=1` is where its input comes from.** One `[draw-program] NEW …` line
+per distinct (vs, vs-chain, ps) triple, then that triple at powers of two — bounded by the program
+count rather than the draw count, so it is usable on a 4K title where `PROSPER_RTTLOG` is a
+firehose. It is not a teardown report on purpose: the run it exists for ends in a device loss.
+
+The older **`PROSPER_SKIP_DRAW="N[,N...]"`** drops draws by the submit-local semantic `draw_index`.
+That ordinal is not stable across frames, so it cannot name "every draw that runs this shader" —
+use it to test a specific suspected draw within one captured submit, and the program selector above
+for anything that has to hold across frames.
+
 `PROSPER_PROVENANCE_DIM=WxH` retains every decoded `CB_COLOR0_BASE` write across submits, then reports
 the last matching writer whenever a draw samples an image of that size. Descriptor resolution can be
 limited to likely target submits with `PROSPER_PROVENANCE_MIN_DRAWS=N`; color-target history is still


### PR DESCRIPTION
## What this adds

`PROSPER_COMPUTE_SKIP_PROGRAM` can name a **compute** program, and that is what isolated GTA V's
hanging dispatch. Graphics had no equivalent. `PROSPER_SKIP_DRAW` selects a submit-local semantic
`draw_index` — an ordinal within one submit, not stable frame to frame — so it cannot express
"every draw that runs this shader", which is what a hanging *program* is.

This adds the counterpart:

- **`PROSPER_SKIP_DRAW_PROGRAM=0xADDR[,0xADDR...]`** — decline every draw whose vertex/ES program,
  NGG main continuation, or pixel program is at a named guest address, and report which stage
  matched.
- **`PROSPER_DRAW_PROGRAM_CENSUS=1`** — one line per distinct `(vs, vs-chain, ps)` triple, then
  powers of two. This is where the selector's input comes from; it is bounded by the *program*
  count rather than the draw count, so it is usable on a 4K title where `PROSPER_RTTLOG` is a
  firehose.

New module `prosper/src/gpu/diagnostics/draw_program_skip.{hpp,cpp}`, consulted from
`build_bds()` in the live renderer.

## Why now

Astro Bot's world-map GPU reset. The `VK_ERROR_DEVICE_LOST` line names a compute program, but that
program is the first submit to fail *after* the context was already lost; the `RADV_DEBUG=hang` dump
puts the last reached command-processor trace point immediately before a `DRAW_INDEX_2` (#1809,
2026-08-31). So the question "which draw?" had to be askable directly, and was not.

## Contract

Mirrored from the compute selector deliberately:

- **Default OFF.** Unset, the hot path is one `empty()` test per draw and nothing about the run
  changes.
- **Impossible to arm by accident.** Parsed by the strict `0x`-only list parser in
  `watch_list.hpp`, so a bare decimal, a stray comma, trailing junk, an overflow or a zero address
  arms **nothing** and says so. A partially-armed selector would produce a confident negative about
  a program nobody selected.
- **It reports itself.** An arming line, then
  `[draw-decline] program=… stage=vs|vs-chain|ps reason=skipped-by-selector count=…` per skip —
  first eight per `(program, stage)`, then powers of two, with the 1-based ordinal on every line
  (`diag_ratelimit.hpp`'s contract, so the cap can never be read as the rate). A log from an armed
  run cannot later be mistaken for a default run.

### Ordering — instrument trap 166

The decline is **last** in the per-draw build: after `build_R`, after descriptor-contract
validation, and after the `[render]` / `[rtt]` / `[draw-program]` per-draw census lines. A
diagnostic skip ordered before the dump blinds every other instrument to the thing under suspicion,
and the program worth declining is precisely the one that hangs the GPU. A declined draw is
therefore still fully realized, validated and logged; only the Vulkan draw call is withheld, and its
CPU cost is still counted in the timing partition's `build_draws` (it did spend that work).

### Four limits a reader of a skipped run cannot see in the output

Stated in `draw_program_skip.hpp`, `tools/AGENTS.md` and `src/gpu/diagnostics/AGENTS.md`, because
none of them show up in the log or the picture:

1. **Later passes sample the hole.** The renderer caches a pass's pixels under `CB_COLOR0_BASE` and
   injects them when a later draw samples that address. Decline the draw that fills a target and the
   composite that reads it does not fail — it succeeds against stale or empty pixels. The result is
   not "the frame minus that draw".
2. **A pass whose every draw is declined renders nothing, not even its clear.**
   `render_draw_pass_rgba` returns an empty image for an empty draw list, and a group's clear colour
   comes from its first item whether or not that item was declined. The present layer then serves the
   previously retained frame, which on screen looks like the frame rendered.
3. **Only draws that reach the live renderer can be declined** — not one the recompiler rejected or
   whose descriptor contract failed. Naming such a program produces no line; silence is not proof
   the selector matched.
4. **An address names a PROGRAM, not a draw.** Every draw using it goes, routinely thousands a
   frame.

## Result on Astro Bot (PPSA21564)

Full table, controls and caveats in **#3193**. Summary: bisection over the 32 distinct program
triples live at the moment of the loss took four runs and lands on **one** draw —
vertex/ES program `0x5008efd00`, pixel program `0x5008f1400`, an indexed triangle list first sighted
at the `worldmap` level load.

| run | `PROSPER_SKIP_DRAW_PROGRAM` | wall | `GRAPHICS submission failed` | distinct frames | max pixel stale |
| --- | --- | --- | --- | --- | --- |
| control | *(unset)* | 300 s | 37,377 | 381 / 9,777 | 210.0 s |
| control | *(unset)* | 150 s | 56 | 382 / 4,385 | 60.0 s |
| **skip** | **`0x5008efd00`** | 150 s | **0** | 607 / 3,297 | 0.0 s |
| **skip** | **`0x5008efd00`** (replication) | 300 s | **0** | 1,233 / 6,666 | 0.0 s |
| complement | `0x5008be700,0x5008cd600` | 150 s | 106 | 1 / 5,034 | 120.0 s |

Both controls fail at the identical `submit=6151 dispatch=16 order=1740980`, so the default failure
is deterministic and 150 s is well past it. The rung does not move: declining a draw is an
instrument, not a fix, and the world map still shows only its nebula backdrop (#1459).

## Tests

- **`draw_program_skip`** (new, no Vulkan) — 29 arms over the selector and the census: the disarmed
  fast path, seven malformed specs that must arm *nothing*, re-configure disarming rather than
  keeping the old list, each of the three stages, non-matching and all-zero draws, the rate limit's
  dense ordinal and its per-`(program, stage)` budget, and the census's NEW/recurrence/distinct
  accounting.
- **`draw_program_skip_render`** (new, Vulkan) — the wiring, through the real live renderer: the
  named program's draw paints nothing, an unnamed draw with the *same shaders* renders (the positive
  control), and a mixed submit loses only the named draw. The declined arm runs **first**, before
  anything has rendered, because the present layer serves the last retained frame when a submit
  publishes nothing — run second it would show the previous frame's pixels and look like it
  rendered.
  Both variables come from the ctest `ENVIRONMENT` property rather than a `setenv` in the test: the
  persistent-target opt-out it needs is a cached read, and arming it in-process is exactly the
  vacuous-arm defect `cached_env_arming_logic` exists to catch (it fails the gate if you try).

### Verification, exact head

```
cmake -S prosper -B prosper/build-linux -DPROSPER_APP=ON -DGAME_DUMP=<DUMP_ROOT>/PPSA21564-app0
cmake --build prosper/build-linux -j8                      # exit 0
ctest --test-dir prosper/build-linux --no-tests=error -j4  # exit 0, 321 tests, 100% passed
```

4 skipped (`module_loads_eboot`, `plugin_autolink`, `boot_reaches_first_syscall`,
`real_shader_render`) — expected, the dump is configured at `PPSA21564` rather than `PPSA24651`
(#1573).

**Mutation-verified, both halves, each with a green build so the old binary cannot report a false
pass:**

- `if (decision.skip)` → `if (false && decision.skip)` in `live_renderer.cpp` (drop the withholding,
  keep the counting): `draw_program_skip_render` fails on exactly *"the declined draw paints
  nothing"*, 1/9. Restored → 9/9.
- `matches(fs_addr)` → `false && matches(fs_addr)` in `draw_program_skip.cpp`:
  `draw_program_skip` fails 3 arms. Restored → 29/29.

No snapshots run — this adds an env-gated diagnostic that is inert unset, and the GPU was needed for
the Astro runs above.

## Risk

The only default-path change is one `addresses_.empty()` test per draw inside `build_bds`, on a
reference hoisted once per submit. Everything else is behind an unset environment variable. The new
module is in `src/gpu/diagnostics/`, whose `AGENTS.md` is updated to say this is now the **second**
entry there that is not observation-only when armed.

Refs #1809, #3193
