### PR TITLE
gpu: compute images carry the T#-declared mip chain, so image_load_mip is implemented (#3048)

### DIFF
--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -586,8 +586,12 @@ changes nothing.
   `[compute-mip-chain] declined …` on a geometric schedule (`skip_image` alone warns once per
   address for the whole process while the dispatch is dropped every frame, which reads as a
   one-off when it is not).
-* **The LOD is clamped** to the materialized level count, which is what hardware does with a T#'s
-  `LAST_LEVEL`.
+* **The LOD is clamped** to the materialized level count. Half of that is certain and half is
+  inference, and the code says so at the site (`CONFIDENCE: MED`): an out-of-range `Lod` operand is
+  UNDEFINED in SPIR-V, so *some* clamp is mandatory whatever the hardware does — but *saturating to
+  the last level* is read from doc 70648's BASE_LEVEL/LAST_LEVEL fields, whose MIMG section does not
+  spell out the out-of-range behaviour, and no capture here exercises one. Returning zeros is the
+  other candidate.
 
 **Not yet measured on this title.** The change is covered by a registered execution test — a real
 tiled nine-level guest chain, dispatched through the production compute backend, asserting the

--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -570,11 +570,21 @@ changes nothing.
   `BASE_LEVEL` (`mip_chain_*`), because `gpu_addr`/`width`/`height` have already been shifted onto
   the selected level and nothing downstream could recover the rest. Captures serialize them at
   format v57; a pre-v57 file reads as "not modelled" and fails closed to one level.
+  **`gpu_replay` still declines this op**, and v57 does not change that: a replayed resource is
+  `host_data`-backed and its blob covers only the selected level, so the derivation fails closed
+  there. Materializing the chain on replay needs the capture to own the whole allocation's bytes —
+  a separate change. Do not take a capsule expecting to study the fetch offline yet.
 * **Reject-by-default.** Linear chains, a selected level packed in the tail, layered or volume
   views, DCC, block-compressed and converting formats, a shifted `BASE_LEVEL`, and `host_data`
   backing all keep the historical single-level image. A binding whose shape cannot carry the chain
   (imported/renderer-owned surfaces above all) is declined **fail-visibly** rather than silently
-  built with fewer levels than its compiled module addresses.
+  built with fewer levels than its compiled module addresses. **That decline is wider than it
+  needs to be** — it does not depend on the module actually issuing `IMAGE_LOAD_MIP`, because the
+  backend cannot see which ops a compiled module contains, so a sampling-only use of such a
+  resource on an RTT-aliased binding would be dropped for nothing. It reports as
+  `[compute-mip-chain] declined …` on a geometric schedule (`skip_image` alone warns once per
+  address for the whole process while the dispatch is dropped every frame, which reads as a
+  one-off when it is not).
 * **The LOD is clamped** to the materialized level count, which is what hardware does with a T#'s
   `LAST_LEVEL`.
 

--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -535,8 +535,9 @@ investigation to the wrong file:
   (`tests/fixtures/render_runner.h:6044-6055` — that file is the live offscreen Vulkan backend,
   included by `frontends/shared/live/live_renderer.cpp:39`). `tests/gpu/test_texture_mip_render.cpp`
   is a registered ctest asserting a declared 3-level chain samples level 2.
-* The **compute** path does not: its single `VkImageCreateInfo` for guest images sets
-  `ici.mipLevels = 1` unconditionally (`frontends/shared/live/live_compute.cpp:7089`).
+* The **compute** path did not: its single `VkImageCreateInfo` for guest images set
+  `ici.mipLevels = 1` unconditionally. **Fixed by #3048** — see the next section; the sentence is
+  kept because everything else in this bullet list is still current.
 * **And the graphics chain is GENERATED, not uploaded.** Staging carries level 0 only; levels
   1..N-1 come from a linear-filtered `vkCmdBlitImage` cascade at upload time
   (`render_runner.h:6257-6259`, `:7245`).
@@ -549,6 +550,43 @@ rule exists to prevent.
 
 **The census did not move when the MUST defect was fixed** — 14 programs, all `executed=0`, before
 and after at the same denominator — and neither did the composite. Both were measured, not assumed.
+
+### Compute images now carry the declared chain, and the LOD operand is emitted (#3048)
+
+Both halves of #3048 landed together, because neither works alone: emitting a `Lod` against a
+one-level image fetches a level that does not exist, and materializing levels nobody addresses
+changes nothing.
+
+* **One derivation, two consumers.** `src/gpu/resources/mip_chain_plan.{hpp,cpp}` answers "how many
+  levels does this resource's compute image have, and where does each level's guest data live".
+  `live_compute`'s image creation and the recompiler's MIMG lowering both call
+  `shader_resource_compute_mip_chain_levels`, so they cannot disagree — the drift that #2265
+  recorded (three copies of one predicate) is what this shape exists to prevent.
+* **Real guest bytes, not a generated cascade.** Each level is detiled from the guest's own
+  `tiled_mip_level_layout` offset, tail levels included, straight into the staging buffer. The
+  graphics path's blit cascade is deliberately not reused here: this section's own analysis is why.
+* **The provenance the placement needs is now carried.** `ShaderResource` gained the allocation's
+  level-zero element extent, its bytes-per-block, its effective `MAX_MIP` and the view's
+  `BASE_LEVEL` (`mip_chain_*`), because `gpu_addr`/`width`/`height` have already been shifted onto
+  the selected level and nothing downstream could recover the rest. Captures serialize them at
+  format v57; a pre-v57 file reads as "not modelled" and fails closed to one level.
+* **Reject-by-default.** Linear chains, a selected level packed in the tail, layered or volume
+  views, DCC, block-compressed and converting formats, a shifted `BASE_LEVEL`, and `host_data`
+  backing all keep the historical single-level image. A binding whose shape cannot carry the chain
+  (imported/renderer-owned surfaces above all) is declined **fail-visibly** rather than silently
+  built with fewer levels than its compiled module addresses.
+* **The LOD is clamped** to the materialized level count, which is what hardware does with a T#'s
+  `LAST_LEVEL`.
+
+**Not yet measured on this title.** The change is covered by a registered execution test — a real
+tiled nine-level guest chain, dispatched through the production compute backend, asserting the
+result is *level one's own texels* — but no routed arm has been run since, so nothing here claims
+the Cyber Space world renders. Two things are worth measuring next, in this order: whether the three
+scene-width programs now leave the census skip list on a **default** build (they did on the
+measurement-only LOD-0 build, which is a weaker statement), and only then the composite's non-black
+percentage and bounding box. The `## Ruled out` row above — "fixing a recompiler decline that
+unblocks these programs will change the frame" — is **not established**, and has now failed four
+times; do not assume the fifth.
 
 ## Ruled out
 

--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -573,7 +573,8 @@ changes nothing.
   **`gpu_replay` still declines this op**, and v57 does not change that: a replayed resource is
   `host_data`-backed and its blob covers only the selected level, so the derivation fails closed
   there. Materializing the chain on replay needs the capture to own the whole allocation's bytes —
-  a separate change. Do not take a capsule expecting to study the fetch offline yet.
+  a separate change, tracked as **#3202**. Do not take a capsule expecting to study the fetch
+  offline yet.
 * **Reject-by-default.** Linear chains, a selected level packed in the tail, layered or volume
   views, DCC, block-compressed and converting formats, a shifted `BASE_LEVEL`, and `host_data`
   backing all keep the historical single-level image. A binding whose shape cannot carry the chain

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6826,6 +6826,31 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     volume_texels == static_cast<uint64_t>(r->width) * r->height &&
                     texel_bytes == r->mip_chain_bytes_per_block;
                 if (!chain_binding_shape) {
+                    // BLAST RADIUS, stated plainly: this decline is NOT conditional on the module
+                    // actually issuing IMAGE_LOAD_MIP. A module that only samples this resource
+                    // behaves identically at one level or N, so declining it is pure loss -- but
+                    // the backend cannot see which ops the compiled module contains, and the
+                    // alternative (build one level while the module may address N) is SPIR-V
+                    // undefined behaviour. The reachable case is a guest texture that declares a
+                    // placeable chain AND aliases a live render target, which the imported/
+                    // renderer-owned terms above exclude.
+                    //
+                    // `skip_image` warns once per address for the whole process while this drops
+                    // the dispatch EVERY frame, so a lane reading a black frame would find one
+                    // line from an hour ago and nothing since. Count it and re-report on a
+                    // geometric schedule: loud early, bounded later.
+                    static std::atomic<uint64_t> chain_shape_declines{0};
+                    const uint64_t occurrence =
+                        chain_shape_declines.fetch_add(1, std::memory_order_relaxed) + 1u;
+                    if ((occurrence & (occurrence - 1u)) == 0u)
+                        std::fprintf(stderr,
+                                     "[compute-mip-chain] declined binding=%u addr=0x%llx "
+                                     "levels=%u imported=%u rtt=%u (occurrence %llu; this "
+                                     "dispatch is dropped every frame)\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     declared_chain_levels, bi.imported ? 1u : 0u,
+                                     renderer_owned ? 1u : 0u,
+                                     (unsigned long long)occurrence);
                     skip_image(r, "declared mip chain not materializable for this binding shape");
                     break;
                 }
@@ -7877,6 +7902,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         // could not see B's read at all, so that pair scored as no alias.
                         alias_seeds.push_back({r->gpu_addr, need});
                     }
+                    // Set only by the native straight-copy branch below, which is the only one that
+                    // can produce levels 1..N-1. See the detector after the conversion chain.
+                    bool mip_chain_levels_written = false;
                     const bool needs_sampled_upload = !bi.upload_skipped &&
                         !bi.compute_transfer_seed_borrowed;
                     if (needs_sampled_upload && sampled_dcc_fast_clear) {
@@ -8037,11 +8065,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             sampled_uint32_native || sampled_float32_native ||
                             sampled_float16_native || sampled_depth) {  // Native sampled texels
                             std::memcpy(upload, sampled_source, linear_bytes);
-                            if (bi.mip_levels > 1u)
+                            if (bi.mip_levels > 1u) {
                                 upload_guest_mip_chain_levels(
                                     mip_chain, bi.mip_staging_offsets,
                                     src - mip_chain.levels[0].byte_offset, r->tile_mode,
                                     bpt, upload);
+                                mip_chain_levels_written = true;
+                            }
                         } else if (f32) {                           // Native float channels + default fill
                             parallel_compute_texels(texels, linear_bytes + texels * 16u,
                                 [&](size_t begin, size_t end) {
@@ -8071,6 +8101,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         } else {                                    // Float16: half -> UNORM8 + default fill
                             sampled_float16_to_unorm8_range(
                                 sampled_source, nc, texels, upload);
+                        }
+                        // Two predicates decide "is this upload a straight per-texel copy": the
+                        // whitelist inside `shader_resource_compute_mip_chain_levels`, which chose
+                        // the level COUNT, and the branch condition above, which does the copying.
+                        // They agree today, and a one-line widening of either would leave levels
+                        // 1..N-1 as whatever the staging allocation happened to contain -- copied
+                        // into the image and sampled as if it were guest data. So rather than a
+                        // third copy of the predicate, this is a detector: the branch that can
+                        // write those levels is the only one that sets the flag, and a chain that
+                        // reaches here unwritten declines instead of uploading garbage.
+                        if (bi.mip_levels > 1u && !mip_chain_levels_written) {
+                            skip_image(r,
+                                       "declared mip chain levels not written by the sampled "
+                                       "conversion that ran (straight-copy predicates disagree)");
+                            break;
                         }
                     }
                 }

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -19,6 +19,7 @@
 #include "gpu/recompiler/gta5/rdna2_gta5_cf9200_contract.hpp"
 #include "gpu/resources/shader_resources.hpp"
 #include "gpu/recompiler/spirv_builder.hpp"
+#include "gpu/resources/mip_chain_plan.hpp"
 #include "gpu/texture/tile.hpp"
 #include "gpu/capture/writer_provenance.hpp"
 #include "host/memory/guest_write_watch.hpp"
@@ -881,6 +882,11 @@ struct ComputeImageCacheKey {
     bool in_mip_tail = false;
     bool srgb = false;
     bool depth_compare = false;
+    // #3048: a cached image is created with exactly this many mip levels. Two T#s over the same
+    // allocation can agree on every field above and declare different chain lengths, and handing a
+    // one-level image to a binding whose module fetches level three is not a miss but a fault.
+    // Appended LAST so `storage_image_cache_key`'s positional aggregate init keeps its meaning.
+    uint32_t mip_levels = 1;
 
     bool operator==(const ComputeImageCacheKey& other) const = default;
 };
@@ -899,13 +905,15 @@ struct ComputeImageCacheKeyHash {
         mix(key.mip_tail_offset); mix(key.mip_tail_bytes);
         mix(key.mip_tail_x); mix(key.mip_tail_y); mix(key.vk_format);
         mix(key.storage); mix(key.in_mip_tail); mix(key.srgb); mix(key.depth_compare);
+        mix(key.mip_levels);
         return result;
     }
 };
 
 ComputeImageCacheKey storage_image_cache_key(const prosper::gpu::ShaderResource& resource,
                                               uint32_t guest_bytes,
-                                              VkFormat native_format) {
+                                              VkFormat native_format,
+                                              uint32_t mip_levels = 1) {
     return {
         resource.gpu_addr, reinterpret_cast<uintptr_t>(resource.host_data),
         guest_bytes, resource.size,
@@ -917,7 +925,7 @@ ComputeImageCacheKey storage_image_cache_key(const prosper::gpu::ShaderResource&
         resource.mip_tail_offset, resource.mip_tail_bytes,
         resource.mip_tail_x, resource.mip_tail_y,
         static_cast<uint32_t>(native_format), true, resource.in_mip_tail,
-        resource.srgb, resource.depth_compare};
+        resource.srgb, resource.depth_compare, mip_levels};
 }
 
 struct CachedComputeImage {
@@ -2988,6 +2996,11 @@ struct BoundImage {
     }
     uint32_t texel_depth = 1;           // logical Z/layer count represented in the staging buffer
     uint32_t array_layers = 1;           // Vulkan array-layer count (3D depth remains one layer)
+    // #3048: the guest-declared mip chain this image materializes, and where each level past zero
+    // begins in the staging buffer. 1 (with an empty offset table) is the historical single-level
+    // image; the recompiler reads the same derivation before emitting an explicit LOD.
+    uint32_t mip_levels = 1;
+    std::vector<VkDeviceSize> mip_staging_offsets;
     bool arrayed_2d = false;            // SPIR-V requires a real 2D-array view (not base-slice fallback)
     bool stacked_cube = false;          // cube lowering addresses six faces as one w x 6h 2D image
     bool depth_view = false;             // reflected SPIR-V uses a true depth image/sampler contract
@@ -4951,6 +4964,31 @@ void parent_scan_dump_pair(uint64_t addr, const uint8_t* after, size_t count,
     }
 }
 
+// Detile levels 1..N-1 of a guest mip chain straight into the staging buffer (#3048). Level zero is
+// written by the ordinary single-level path and is deliberately not touched here, so a resource that
+// gains a chain keeps producing byte-identical level-zero texels.
+//
+// `allocation_base` is the FIRST byte of the guest allocation, which sits below the resource's own
+// `gpu_addr` whenever the selected level is not the allocation's first stored byte -- tiled GFX10
+// chains store the shared mip-tail block first and then the remaining levels smallest-to-largest.
+void upload_guest_mip_chain_levels(const prosper::gpu::MipChainPlan& plan,
+                                   const std::vector<VkDeviceSize>& staging_offsets,
+                                   const uint8_t* allocation_base, uint32_t tile_mode,
+                                   uint32_t texel_bytes, uint8_t* upload) {
+    for (uint32_t level = 1; level < plan.level_count; ++level) {
+        const prosper::gpu::MipChainLevel& source = plan.levels[level];
+        uint8_t* destination = upload + staging_offsets[level];
+        const uint8_t* bytes = allocation_base + source.byte_offset;
+        if (source.in_tail)
+            prosper::gpu::detile_surface_level(destination, bytes, source.byte_size,
+                                               source.width, source.height, tile_mode,
+                                               texel_bytes, source.tail_x, source.tail_y);
+        else
+            prosper::gpu::detile_surface(destination, bytes, source.width, source.height,
+                                         tile_mode, 0, texel_bytes);
+    }
+}
+
 bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
     using namespace prosper::gpu;
     using ComputeClock = std::chrono::steady_clock;
@@ -6562,6 +6600,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     p->layer_mip_offset_bytes == r->layer_mip_offset_bytes &&
                     p->in_mip_tail == r->in_mip_tail &&
                     p->mip_tail_x == r->mip_tail_x && p->mip_tail_y == r->mip_tail_y &&
+                    // The chain length is derived from these six fields (#3048); two descriptors
+                    // that disagree on any of them materialize different images.
+                    p->declared_mip_levels == r->declared_mip_levels &&
+                    p->mip_chain_element_width == r->mip_chain_element_width &&
+                    p->mip_chain_element_height == r->mip_chain_element_height &&
+                    p->mip_chain_bytes_per_block == r->mip_chain_bytes_per_block &&
+                    p->mip_chain_max_level == r->mip_chain_max_level &&
+                    p->mip_chain_base_level == r->mip_chain_base_level &&
                     p->srgb == r->srgb && same_host_backing &&
                     p->host_data_size == r->host_data_size && same_dcc_identity;
                 bool same_sampler = true;
@@ -6585,6 +6631,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.sampler = owner.sampler; bi.guest_bytes = owner.guest_bytes;
                 bi.texel_depth = owner.texel_depth;
                 bi.array_layers = owner.array_layers;
+                bi.mip_levels = owner.mip_levels;
+                bi.mip_staging_offsets = owner.mip_staging_offsets;
                 bi.dcc_metadata = owner.dcc_metadata;
                 bi.dcc_metadata_bytes = owner.dcc_metadata_bytes;
                 staging_bytes[i] = staging_bytes[bi.alias_of];
@@ -6758,7 +6806,46 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                   : VK_FORMAT_R8G8B8A8_UNORM;
             // Most storage images use raw uvec4 channels; reflected exact paths keep native-width
             // bytes. Most sampled formats normalize to RGBA8, while HDR/integer formats stay native.
-            const VkDeviceSize sbytes = volume_texels * texel_bytes;
+            // #3048: the T#-declared mip chain. `shader_resource_compute_mip_chain_levels` is the
+            // ONE derivation the recompiler also reads before it lowers IMAGE_LOAD_MIP with an
+            // explicit LOD, so this backend must materialize exactly what that function reports.
+            // A binding shape that cannot carry the chain is declined fail-visibly rather than
+            // quietly creating fewer levels than the compiled module addresses.
+            const uint32_t declared_chain_levels =
+                prosper::gpu::shader_resource_compute_mip_chain_levels(*r);
+            prosper::gpu::MipChainPlan mip_chain;
+            VkDeviceSize mip_chain_extra_bytes = 0;
+            if (declared_chain_levels > 1u) {
+                mip_chain = prosper::gpu::shader_resource_mip_chain_plan(*r);
+                const bool chain_binding_shape =
+                    mip_chain.valid && mip_chain.level_count == declared_chain_levels &&
+                    !bi.storage && !bi.imported && !renderer_owned &&
+                    !bi.depth_bits_source && !bi.unorm_rtt_value_reuse && !bi.depth_view &&
+                    !dim_1d && !dim_3d && !dim_cube_stacked && !cube_face_as_2d &&
+                    sampled_layers == 1u && bi.array_layers == 1u && !bi.stacked_cube &&
+                    volume_texels == static_cast<uint64_t>(r->width) * r->height &&
+                    texel_bytes == r->mip_chain_bytes_per_block;
+                if (!chain_binding_shape) {
+                    skip_image(r, "declared mip chain not materializable for this binding shape");
+                    break;
+                }
+                // Vulkan requires each region's bufferOffset to be a multiple of four AND of the
+                // texel block size; every width here is a power of two, so one alignment covers both.
+                const VkDeviceSize alignment = texel_bytes < 4u ? 4u : texel_bytes;
+                const VkDeviceSize level_zero_bytes = volume_texels * texel_bytes;
+                bi.mip_staging_offsets.assign(mip_chain.level_count, 0);
+                VkDeviceSize offset = (level_zero_bytes + alignment - 1u) / alignment * alignment;
+                for (uint32_t level = 1; level < mip_chain.level_count; ++level) {
+                    bi.mip_staging_offsets[level] = offset;
+                    const VkDeviceSize level_bytes =
+                        static_cast<VkDeviceSize>(mip_chain.levels[level].width) *
+                        mip_chain.levels[level].height * texel_bytes;
+                    offset = (offset + level_bytes + alignment - 1u) / alignment * alignment;
+                }
+                mip_chain_extra_bytes = offset - level_zero_bytes;
+                bi.mip_levels = mip_chain.level_count;
+            }
+            const VkDeviceSize sbytes = volume_texels * texel_bytes + mip_chain_extra_bytes;
             if (!sbytes || sbytes > kMaxComputeImageBytes) {
                 skip_image(r, "expanded image exceeds the 512 MiB backend bound"); break;
             }
@@ -6930,6 +7017,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         (r->host_data && r->host_data_size >= sampled_guest_need) ||
                         guest_readable(r->gpu_addr, static_cast<uint32_t>(sampled_guest_need));
                     if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
+                    // The chain's other levels live in the SAME allocation, below and above the
+                    // selected level. Bound the whole span before any of it is dereferenced.
+                    if (bi.mip_levels > 1u) {
+                        const uint64_t level_zero_offset = mip_chain.levels[0].byte_offset;
+                        if (r->host_data || level_zero_offset > r->gpu_addr ||
+                            mip_chain.allocation_bytes > UINT32_MAX ||
+                            !guest_readable(r->gpu_addr - level_zero_offset,
+                                            static_cast<uint32_t>(mip_chain.allocation_bytes))) {
+                            skip_image(r, "declared mip chain allocation unreadable");
+                            break;
+                        }
+                    }
                 }
 
                 static const bool dcc_cache_disabled =
@@ -7004,6 +7103,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     .persistent_enabled = persistent_compute_image_enabled(
                         sbytes, ComputeImageCacheClass::sampled),
                 });
+                // #3048: a cached sampled image is revalidated against the SELECTED level's guest
+                // bytes only. A multi-level image's higher levels live elsewhere in the same
+                // allocation, so an unchanged level zero would wrongly certify a stale level three.
+                // Fail closed and re-upload every dispatch until the validated span covers the whole
+                // chain; this costs upload time, never correctness.
+                if (bi.mip_levels > 1u) bi.cache_candidate = false;
                 const VkFormat transfer_native_format =
                     compute_transfer_storage_vk_format(r->format, sampled_components);
                 const bool float32_uint32_transfer_alias =
@@ -7055,7 +7160,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         r->mip_tail_offset, r->mip_tail_bytes,
                         r->mip_tail_x, r->mip_tail_y,
                         static_cast<uint32_t>(image_format), bi.storage, r->in_mip_tail,
-                        r->srgb, r->depth_compare};
+                        r->srgb, r->depth_compare, bi.mip_levels};
                     // An ordinary native typed 2D image or native typed 3D volume is byte- and
                     // format-identical to the sampled upload that follows it. Borrow that retained
                     // result only as a TRANSFER source: the sampled cache remains a separate image so
@@ -7932,6 +8037,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             sampled_uint32_native || sampled_float32_native ||
                             sampled_float16_native || sampled_depth) {  // Native sampled texels
                             std::memcpy(upload, sampled_source, linear_bytes);
+                            if (bi.mip_levels > 1u)
+                                upload_guest_mip_chain_levels(
+                                    mip_chain, bi.mip_staging_offsets,
+                                    src - mip_chain.levels[0].byte_offset, r->tile_mode,
+                                    bpt, upload);
                         } else if (f32) {                           // Native float channels + default fill
                             parallel_compute_texels(texels, linear_bytes + texels * 16u,
                                 [&](size_t begin, size_t end) {
@@ -7991,7 +8101,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             ici.format = image_format;
             ici.extent = {r->width, dim_cube_stacked ? r->height * 6u : r->height,
                           dim_3d ? bi.texel_depth : 1u};
-            ici.mipLevels = 1;
+            ici.mipLevels = bi.mip_levels;
             ici.arrayLayers = bi.array_layers;
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
             ici.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -8045,7 +8155,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             const VkImageAspectFlags image_aspect = (sampled_depth || bi.imported_depth)
                 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
-            vci.subresourceRange = {image_aspect, 0, 1, 0, ici.arrayLayers};
+            vci.subresourceRange = {image_aspect, 0, ici.mipLevels, 0, ici.arrayLayers};
             const auto view_start = ComputeClock::now();
             if (!vk_ok(vkCreateImageView(ctx.device, &vci, nullptr, &bi.view),
                        "image-view")) { images_ready = false; break; }
@@ -8791,17 +8901,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             to_dst.image = bi.image;
             const VkImageAspectFlags aspect = bi.depth_view
                 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
-            to_dst.subresourceRange = {aspect, 0, 1, 0, bi.array_layers};
+            to_dst.subresourceRange = {aspect, 0, bi.mip_levels, 0, bi.array_layers};
             vkCmdPipelineBarrier(command,
                                  bi.persistent ? VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
                                                : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_dst);
-            VkBufferImageCopy region{};
-            region.imageSubresource = {aspect, 0, 0, bi.array_layers};
-            region.imageExtent = {r->width, bi.stacked_cube ? r->height * 6u : r->height,
-                                  bi.array_layers > 1 ? 1u : bi.texel_depth};
+            // One region per materialized level. Level zero keeps the exact extent and offset the
+            // single-level path always used; levels above it read the staging offsets computed
+            // beside the chain plan (#3048).
+            std::vector<VkBufferImageCopy> mip_regions(bi.mip_levels);
+            for (uint32_t level = 0; level < bi.mip_levels; ++level) {
+                VkBufferImageCopy& region = mip_regions[level];
+                region = {};
+                region.bufferOffset = level ? bi.mip_staging_offsets[level] : VkDeviceSize{0};
+                region.imageSubresource = {aspect, level, 0, bi.array_layers};
+                region.imageExtent = level
+                    ? VkExtent3D{r->width >> level ? r->width >> level : 1u,
+                                 r->height >> level ? r->height >> level : 1u, 1u}
+                    : VkExtent3D{r->width, bi.stacked_cube ? r->height * 6u : r->height,
+                                 bi.array_layers > 1 ? 1u : bi.texel_depth};
+            }
             vkCmdCopyBufferToImage(command, staging[i], bi.image,
-                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                   static_cast<uint32_t>(mip_regions.size()), mip_regions.data());
             VkImageMemoryBarrier to_general = to_dst;
             to_general.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |

--- a/prosper/src/gpu/agc/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.cpp
@@ -512,6 +512,11 @@ DecodedImageView image_base_level_view(const DecodedImageDescriptor& d,
         view.supported = unshifted_view_supported();
         return view;
     }
+    view.chain_element_width = element_width;
+    view.chain_element_height = element_height;
+    view.chain_bytes_per_block = fi.bytes_per_block;
+    view.chain_max_mip = effective_max_mip;
+    view.chain_base_level = d.base_level;
     view.mip_offset = layout.byte_offset;
     view.in_mip_tail = layout.in_tail;
     view.mip_tail_bytes = layout.tail_block_bytes;
@@ -1185,6 +1190,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.sample_count  = d.sample_count;
             r.declared_mip_levels = d.sample_count > 1u ? 1u :
                 (d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u);
+            shader_resource_apply_mip_chain_provenance(r, view);
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
             r.in_mip_tail   = view.in_mip_tail;
             r.mip_tail_offset = view.in_mip_tail

--- a/prosper/src/gpu/agc/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.hpp
@@ -227,10 +227,31 @@ struct DecodedImageView {
     // base + layer*layer_stride + layer_mip_offset (or use the tail coordinates for a packed tail).
     size_t layer_stride = 0;
     size_t layer_mip_offset = 0;
+    // The exact inputs tiled_mip_level_layout needs to place ANY level of this allocation, kept
+    // beside the selected level's own placement so a backend that must materialize the declared
+    // chain does not have to re-decode the T#. Zero element extent = not modelled (#3048).
+    uint32_t chain_element_width = 0;
+    uint32_t chain_element_height = 0;
+    uint32_t chain_bytes_per_block = 0;
+    uint32_t chain_max_mip = 0;
+    uint32_t chain_base_level = 0;
     // False when BASE_LEVEL selects a mip whose layout this helper cannot prove. Callers must reject
     // the binding instead of silently sampling the allocation's base level with the wrong dimensions.
     bool supported = true;
 };
+// Copy the allocation-wide mip placement from a decoded view onto the resource it produced. Three
+// separate sites build a Texture/StorageImage ShaderResource from a (descriptor, view) pair; they
+// have drifted before (#2265), so the provenance travels through one function rather than three
+// copies of five assignments.
+inline void shader_resource_apply_mip_chain_provenance(ShaderResource& r,
+                                                       const DecodedImageView& view) {
+    r.mip_chain_element_width = view.chain_element_width;
+    r.mip_chain_element_height = view.chain_element_height;
+    r.mip_chain_bytes_per_block = view.chain_bytes_per_block;
+    r.mip_chain_max_level = view.chain_max_mip;
+    r.mip_chain_base_level = view.chain_base_level;
+}
+
 DecodedImageView image_base_level_view(const DecodedImageDescriptor& descriptor,
                                        const Gen5ImageFormatInfo& format);
 // Emit one diagnostic per unsupported layout signature. Callers use this immediately before

--- a/prosper/src/gpu/agc/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.hpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace prosper::gpu {
 
@@ -214,6 +215,18 @@ struct Gen5ImageFormatInfo {
 // The single mip level Prosper uploads for a T# view. GFX10 descriptor BASE_ADDRESS names the
 // entire allocation, whose mip-tail-first layout can put BASE_LEVEL at a non-zero byte offset.
 struct DecodedImageView {
+    // NOT redundant, and do not delete it as noise. A user-declared default constructor makes this
+    // a non-aggregate under C++20 (P1008R1), which turns every POSITIONAL braced initialization of
+    // it into a compile error while `V v;`, `V v{};` and `return {};` keep working. That is the
+    // point: this struct grew five fields in #3048, and the tree's one positional initializer
+    // silently re-bound its last value onto a new field -- leaving `supported` at its default
+    // `true` and killing a BASE_ARRAY guard with no diagnostic, because `bool -> uint32_t` is a
+    // promotion rather than a narrowing. A test can pin the function that used to hold that
+    // initializer; only this line stops the same shape appearing at a NEW call site. Verified on
+    // gcc 16 -Wall -Wextra: named/value/`{}` initialization compiles, `DecodedImageView{a, b, ...}`
+    // does not. Assign by name, or add designators.
+    DecodedImageView() = default;
+
     uint64_t base = 0;
     uint32_t width = 0, height = 0;
     size_t mip_offset = 0;
@@ -239,6 +252,12 @@ struct DecodedImageView {
     // the binding instead of silently sampling the allocation's base level with the wrong dimensions.
     bool supported = true;
 };
+// The guard above, made self-defending: deleting the defaulted constructor to "tidy up" would make
+// this an aggregate again and silently re-open positional initialization. This fails the build
+// instead.
+static_assert(!std::is_aggregate_v<DecodedImageView>,
+              "DecodedImageView must stay a non-aggregate so positional braced initialization "
+              "cannot silently re-bind its fields when the struct grows (#3048/#3197)");
 // The view for a descriptor whose Gen5 format prosper cannot map. Such a binding can still
 // recompile as a format-free storage image, but no mip or slice placement is derivable for it, so
 // this builds the allocation base by hand and fails closed on any descriptor that selects something

--- a/prosper/src/gpu/agc/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.hpp
@@ -239,6 +239,29 @@ struct DecodedImageView {
     // the binding instead of silently sampling the allocation's base level with the wrong dimensions.
     bool supported = true;
 };
+// The view for a descriptor whose Gen5 format prosper cannot map. Such a binding can still
+// recompile as a format-free storage image, but no mip or slice placement is derivable for it, so
+// this builds the allocation base by hand and fails closed on any descriptor that selects something
+// other than level zero of slice zero: an unshifted base under a selected slice binds slice ZERO's
+// texels silently, and for a STORAGE image it also writes slice N's results into slice zero's guest
+// bytes.
+//
+// This exists as a function, rather than as a braced initializer at its one call site, because that
+// initializer was POSITIONAL: adding a field to DecodedImageView re-bound its last value and made
+// `supported` fall back to its default `true`, killing the guard with no compiler diagnostic
+// (`bool -> uint32_t` is a promotion, not a narrowing). Every field below is named. Do not convert
+// this back to an aggregate initializer, and do not add a positional one elsewhere.
+inline DecodedImageView unmapped_format_image_view(const DecodedImageDescriptor& d) {
+    DecodedImageView view;
+    view.base = d.base;
+    view.width = d.width;
+    view.height = d.height;
+    view.supported = d.base_level == 0 && d.base_array == 0;
+    // Everything else stays at its default: no mip offset, no tail, no layer stride, and no
+    // allocation-wide mip placement (zero element extent = not modelled, #3048).
+    return view;
+}
+
 // Copy the allocation-wide mip placement from a decoded view onto the resource it produced. Three
 // separate sites build a Texture/StorageImage ShaderResource from a (descriptor, view) pair; they
 // have drifted before (#2265), so the provenance travels through one function rather than three

--- a/prosper/src/gpu/capture/gpu_capture.cpp
+++ b/prosper/src/gpu/capture/gpu_capture.cpp
@@ -137,10 +137,16 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v56: extend the append-only RTT-seed format enum with native RGBA32F surfaces.
 // v57 (#3048): each resource's allocation-wide mip placement -- the level-zero element extent, the
 // bytes per block, the effective MAX_MIP, and the view's BASE_LEVEL. `declared_mip_levels` says how
-// MANY levels a T# declares; without these a replayed capture cannot say WHERE any level but the
-// selected one lives, so the compute backend would build a single-level image where the live run
-// built the declared chain and the recompiler would decline the very IMAGE_LOAD_MIP the capture was
-// taken to study. Pre-v57 files leave all five zero, read everywhere as "not modelled".
+// MANY levels a T# declares; these say WHERE they are, which nothing else preserves once
+// image_base_level_view has shifted gpu_addr/width/height onto the SELECTED level.
+//
+// What this does NOT yet do, so nobody plans around it: a replayed resource is host_data-backed and
+// its blob covers only the selected level's footprint, and the chain derivation declines any
+// host_data resource -- so gpu_replay still refuses IMAGE_LOAD_MIP exactly as it did before v57.
+// Making replay materialize the chain needs the capture to own the whole ALLOCATION's bytes, which
+// is a separate change. This tail is the descriptor half of it, recorded now so the placement is
+// not lost from every capsule taken in the meantime. Pre-v57 files leave all five zero, read
+// everywhere as "not modelled".
 constexpr uint32_t kVersion = 57;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;

--- a/prosper/src/gpu/capture/gpu_capture.cpp
+++ b/prosper/src/gpu/capture/gpu_capture.cpp
@@ -135,7 +135,13 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // independent vector footprint; replay cannot reconstruct one from the other when STRIDE < 4.
 // v55: append each depth/stencil seed's optional stencil bytes and stencil-presence marker.
 // v56: extend the append-only RTT-seed format enum with native RGBA32F surfaces.
-constexpr uint32_t kVersion = 56;
+// v57 (#3048): each resource's allocation-wide mip placement -- the level-zero element extent, the
+// bytes per block, the effective MAX_MIP, and the view's BASE_LEVEL. `declared_mip_levels` says how
+// MANY levels a T# declares; without these a replayed capture cannot say WHERE any level but the
+// selected one lives, so the compute backend would build a single-level image where the live run
+// built the declared chain and the recompiler would decline the very IMAGE_LOAD_MIP the capture was
+// taken to study. Pre-v57 files leave all five zero, read everywhere as "not modelled".
+constexpr uint32_t kVersion = 57;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobDefaultBytes = 1ull << 30;
@@ -3607,6 +3613,26 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     // the version is downgraded -- eleven legacy-reopen assertions failed that way when this field
     // was first placed next to the seed records.
     for (const auto& seed : c.ds_seeds) w.u32(seed.slice);
+    // v57 tail: allocation-wide mip placement per resource, in the same table order every other
+    // per-resource tail uses (#3048).
+    auto write_mip_chain_provenance = [&](const GpuCapturedTable& table) {
+        for (const GpuCapturedResource& captured : table.resources) {
+            const ShaderResource& resource = captured.resource;
+            w.u32(resource.mip_chain_element_width);
+            w.u32(resource.mip_chain_element_height);
+            w.u32(resource.mip_chain_bytes_per_block);
+            w.u32(resource.mip_chain_max_level);
+            w.u32(resource.mip_chain_base_level);
+        }
+    };
+    for (const auto& draw : c.draws) {
+        write_mip_chain_provenance(draw.vrt);
+        write_mip_chain_provenance(draw.prt);
+    }
+    for (const auto& compute : c.computes) write_mip_chain_provenance(compute.resources);
+    for (const auto& diagnostic : c.failure_diagnostics)
+        for (const auto& stage : diagnostic.stages)
+            write_mip_chain_provenance(stage.resource_table);
     // Re-check the ceiling AFTER the final tail. The bound above was enforced before this tail
     // existed, so a capture sitting just under the maximum could serialize successfully into a file
     // that read_gpu_capture then rejects as oversized -- a write that reports success and produces
@@ -5006,6 +5032,49 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
     if (version >= 55)
         for (auto& seed : c.ds_seeds)
             if (!r.u32(seed.slice)) return false;
+    // v57 trailing tail: allocation-wide mip placement per resource (#3048). See the writer.
+    if (version >= 57) {
+        auto read_mip_chain_provenance = [&](GpuCapturedTable& table) {
+            for (GpuCapturedResource& captured : table.resources) {
+                ShaderResource& resource = captured.resource;
+                if (!r.u32(resource.mip_chain_element_width) ||
+                    !r.u32(resource.mip_chain_element_height) ||
+                    !r.u32(resource.mip_chain_bytes_per_block) ||
+                    !r.u32(resource.mip_chain_max_level) ||
+                    !r.u32(resource.mip_chain_base_level))
+                    return false;
+                // A modelled placement is completely present or completely absent. A partial record
+                // cannot place a level, and reading one as if it could is exactly the silent
+                // wrong-offset failure this provenance exists to prevent.
+                const bool any = resource.mip_chain_element_width ||
+                                 resource.mip_chain_element_height ||
+                                 resource.mip_chain_bytes_per_block;
+                if (any && (!resource.mip_chain_element_width ||
+                            !resource.mip_chain_element_height ||
+                            !resource.mip_chain_bytes_per_block ||
+                            resource.mip_chain_max_level >= 16u))
+                    return false;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_mip_chain_provenance(draw.vrt) ||
+                !read_mip_chain_provenance(draw.prt)) {
+                error = "invalid mip-chain placement state";
+                return false;
+            }
+        for (auto& compute : c.computes)
+            if (!read_mip_chain_provenance(compute.resources)) {
+                error = "invalid mip-chain placement state";
+                return false;
+            }
+        for (auto& diagnostic : c.failure_diagnostics)
+            for (auto& stage : diagnostic.stages)
+                if (!read_mip_chain_provenance(stage.resource_table)) {
+                    error = "invalid mip-chain placement state";
+                    return false;
+                }
+    }
     // DS seed identity is checked HERE, not in the record loop, because the slice arrives in the
     // tail above: a per-record check would compare incomplete identities and reject two faces of one
     // cube that differ only in slice -- which is exactly the capture this version exists to allow.

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -7806,8 +7806,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     // consumer here — a sampled use with an unmapped format was already dropped.)
                     const DecodedImageView view = mapped_fmt
                         ? image_base_level_view(d, fi)
-                        : DecodedImageView{d.base, d.width, d.height, 0, false, 0, 0, 0,
-                                           0, 0, d.base_level == 0 && d.base_array == 0};
+                        : unmapped_format_image_view(d);
                     if (!view.supported) {
                         warn_unsupported_image_view(d);
                         continue;

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -13,6 +13,7 @@
 #include "gpu/diagnostics/compute_tree_watch.hpp"
 #include "gpu/present/videoout_present.hpp"   // present_write_frame
 #include "gpu/agc/agc_shader_layout.hpp"  // AgcShaderHeader + build_shader_resources
+#include "gpu/resources/mip_chain_plan.hpp"  // shader_resource_compute_mip_chain_levels (#3048)
 #include "gpu/pm4/pm4_registers.hpp"      // SPI_SHADER_USER_DATA_* offsets
 #include "gpu/recompiler/rdna2_decode.hpp"       // rdna2_walk (for the vertex-fetch const-eval)
 #include "gpu/recompiler/gta5/rdna2_gta5_cf9200_contract.hpp"
@@ -565,6 +566,10 @@ struct ShaderResourceCompileKey {
     uint32_t img_dim = 0;
     uint32_t sample_count = 1;
     uint32_t declared_mip_levels = 1;
+    // #3048: how many levels the compute backend materializes for this resource. The emitted module
+    // bakes it in (the IMAGE_LOAD_MIP LOD clamp is a literal), so two descriptors that differ only
+    // in their allocation-wide mip placement must not share a compiled module.
+    uint32_t materialized_mip_levels = 1;
     bool in_mip_tail = false;
     bool compression_enabled = false;
     bool proven_zero_mip = false;
@@ -803,6 +808,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.img_dim);
             hash = hash_mix(hash, resource.sample_count);
             hash = hash_mix(hash, resource.declared_mip_levels);
+            hash = hash_mix(hash, resource.materialized_mip_levels);
             hash = hash_mix(hash, resource.in_mip_tail);
             hash = hash_mix(hash, resource.compression_enabled);
             hash = hash_mix(hash, resource.proven_zero_mip);
@@ -1563,6 +1569,8 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.sample_count = (texture || storage_image) ? resource.sample_count : 1u;
             compiled.declared_mip_levels = (texture || storage_image)
                 ? resource.declared_mip_levels : 1u;
+            compiled.materialized_mip_levels = texture
+                ? shader_resource_compute_mip_chain_levels(resource) : 1u;
             compiled.in_mip_tail = (texture || storage_image) && resource.in_mip_tail;
             compiled.compression_enabled =
                 (texture || storage_image) && resource.compression_enabled;
@@ -7316,6 +7324,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.declared_mip_levels = d.sample_count > 1u ? 1u :
                         (d.last_level >= d.base_level ?
                             (uint32_t)(d.last_level - d.base_level) + 1u : 1u);
+                    shader_resource_apply_mip_chain_provenance(r, view);
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
                     r.in_mip_tail = view.in_mip_tail;
                     r.mip_tail_offset = view.in_mip_tail
@@ -7866,6 +7875,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     }
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
                     r.sample_count = d.sample_count;
+                    shader_resource_apply_mip_chain_provenance(r, view);
                     r.tile_mode = d.tile_mode;
                     r.declared_mip_levels = d.sample_count > 1u ? 1u :
                         (d.last_level >= d.base_level ?

--- a/prosper/src/gpu/recompiler/rdna2_decode.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_decode.cpp
@@ -1263,6 +1263,22 @@ bool rdna2_mimg_zero_mip_shape(const Rdna2Inst& in, uint32_t* mip_vgpr) {
     return true;
 }
 
+bool rdna2_mimg_dynamic_mip_shape(const Rdna2Inst& in, uint32_t* mip_vgpr) {
+    if (in.fmt != Rdna2Format::MIMG || in.opcode != 0x01u) return false;
+    // Every modifier here changes the ADDRESS or DATA layout, so the mip operand would not be where
+    // this function says it is. GLC/SLC/DLC and UNRM do not, and are admitted.
+    if (in.mimg_r128 || in.mimg_tfe || in.mimg_lwe || in.mimg_a16 || in.mimg_d16 ||
+        in.mimg_reserved)
+        return false;
+    if (in.mimg_nsa != 0u || in.len_dwords != 2u) return false;
+    if (in.mimg_dim != 1u && in.mimg_dim != 5u) return false;
+    if (in.src[0].kind != OperandKind::VGPR || in.src[0].value < 0) return false;
+    const uint32_t reg = static_cast<uint32_t>(in.src[0].value) + (in.mimg_dim == 5u ? 3u : 2u);
+    if (reg >= 256u) return false;
+    if (mip_vgpr) *mip_vgpr = reg;
+    return true;
+}
+
 uint32_t rdna2_sload_required_bytes(const uint32_t* code, size_t dwords, uint32_t sgpr_base) {
     std::vector<Rdna2Inst> instructions;
     rdna2_walk(code, dwords, instructions);

--- a/prosper/src/gpu/recompiler/rdna2_decode.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_decode.hpp
@@ -479,6 +479,15 @@ bool rdna2_program_is_terminator_only(const uint32_t* code, size_t dwords);
 // materialized, uncompressed mip.
 bool rdna2_mimg_zero_mip_shape(const Rdna2Inst& in, uint32_t* mip_vgpr = nullptr);
 
+// The GENERAL IMAGE_LOAD_MIP address shape, whose mip operand is a real runtime value rather than
+// something a proof may discard: consecutive (non-NSA) 2D [x,y,mip] or 2D_ARRAY [x,y,slice,mip],
+// any DMASK, and no operand-shape modifier (A16/D16/R128/TFE/LWE). Unlike
+// `rdna2_mimg_zero_mip_shape` this deliberately does NOT require UNRM/GLC: those are addressing and
+// cache hints, and Sonic Frontiers' stage kernels issue the op with both clear (#3048). Returns the
+// dimension-specific mip VGPR when requested. The caller must still establish that the resource's
+// image is materialized with the levels that operand can select.
+bool rdna2_mimg_dynamic_mip_shape(const Rdna2Inst& in, uint32_t* mip_vgpr = nullptr);
+
 // Minimum byte range touched by immediate s_load_dword[xN] operations whose 64-bit SBASE begins at
 // `sgpr_base`. Unlike s_buffer_load, s_load consumes an address pair rather than a bounded V#; callers
 // use this to size pointer-backed user-data tables from the shader's actual accesses.

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -7913,10 +7913,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     else if (is_sample_l)  b.image_sample_lod_2d(res->binding, cu, cv,
                         vread(cvg(in.mimg_dim == 5u && res->img_dim == 5u ? 3u : 2u)), out);
                     else if (dynamic_mip_load) {
-                        // Hardware clamps a MIMG mip selector to the descriptor's LAST_LEVEL. The
-                        // host image carries `materialized_mip_levels` of them, so clamp to that:
-                        // an out-of-range Lod in SPIR-V is undefined, and the guest is entitled to
-                        // the same saturating answer the console gives it.
+                        // Clamp the selector to the levels the host image actually has.
+                        //
+                        // The half that is certain: an out-of-range `Lod` operand is UNDEFINED in
+                        // SPIR-V, so some clamp is mandatory whatever the hardware does.
+                        //
+                        // The half that is inference: RDNA 2 ISA doc 70648 gives the image
+                        // descriptor BASE_LEVEL/LAST_LEVEL fields as the addressable level range,
+                        // and prosper reads `declared_mip_levels` off exactly that pair -- but the
+                        // guide's MIMG section does not spell out the saturating behaviour for an
+                        // out-of-range IMAGE_LOAD_MIP operand, and no live capture here exercises
+                        // one. Saturating to the last level is the reading consistent with the
+                        // field's purpose; returning zeros would be the other candidate.
+                        // CONFIDENCE: MED -- revisit if a title is measured issuing an
+                        // out-of-range mip.
                         // The register the shape predicate itself identified, not a second
                         // derivation of it: for this packet family they are the same VGPR, and
                         // reading it from one place keeps them that way.

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -11,6 +11,7 @@
 #include "gpu/recompiler/gta5/rdna2_gta5_packed_pointer.hpp"
 #include "gpu/recompiler/indirect/rdna2_indirect_buffer_shadow.hpp"
 #include "gpu/recompiler/indirect/rdna2_indirect_pointer_analysis.hpp"
+#include "gpu/resources/mip_chain_plan.hpp"
 #include "gpu/resources/shader_resources.hpp"
 #include <algorithm>
 #include <bit>
@@ -7527,10 +7528,32 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                  !is_gather_lz_o && !is_sample_lz_o && !is_sample_d) ||
                 (!dim2d && !dim3d && !dimcube && !dim_msaa)) { ok = false; return true; }
             if (res->cls != ResourceClass::Texture) { ok = false; return true; }
+            // #3048: the guest's mip selector no longer has to be discarded. When the compute
+            // backend materializes this resource's whole declared chain -- one derivation,
+            // `shader_resource_compute_mip_chain_levels`, read by BOTH this lowering and
+            // live_compute's image creation so the two cannot disagree about how many levels exist
+            // -- the operand reaches OpImageFetch's Lod. This is the only honest answer for the
+            // dynamic case: Sonic Frontiers' three scene-width stage kernels issue IMAGE_LOAD_MIP
+            // against a 12-level 2048x2048 R32G32_FLOAT surface with the mip NOT provably zero, so
+            // the specialization below can never admit them.
+            //
+            // Compute only, deliberately: the graphics texture path still uploads one level (its
+            // generated-chain gate in the render backend is narrower than this one), so a fragment
+            // stage reaching here would fetch a level that does not exist.
+            uint32_t dynamic_mip_vgpr = 0;
+            const uint32_t materialized_mip_levels =
+                prosper::gpu::shader_resource_compute_mip_chain_levels(*res);
+            const bool dynamic_mip_load =
+                is_zero_mip_load && b.is_compute && materialized_mip_levels > 1u &&
+                rdna2_mimg_dynamic_mip_shape(in, &dynamic_mip_vgpr) &&
+                in.mimg_dim == SQ_DIM_2D &&
+                prosper::gpu::shader_resource_uses_ordinary_2d_image(*res, true, false, false) &&
+                !res->unnormalized && !res->depth_compare && !res->in_mip_tail &&
+                res->sample_count == 1u && !res->compression_enabled;
             // IMAGE_LOAD_MIP's final address is a real guest mip selector. Specialize it away only
             // after the per-use fold and the materialized-resource checks agree. The 2D_ARRAY form
             // retains its slice coordinate; only the separately proven mip operand is discarded.
-            if (is_zero_mip_load &&
+            if (is_zero_mip_load && !dynamic_mip_load &&
                 (!rdna2_mimg_zero_mip_shape(in) || !res->proven_zero_mip ||
                  res->img_dim != in.mimg_dim || res->sample_count != 1u ||
                  res->declared_mip_levels != 1u || res->in_mip_tail ||
@@ -7889,6 +7912,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // base-slice view for DIM=5, whose address is [u,v,slice,lod].
                     else if (is_sample_l)  b.image_sample_lod_2d(res->binding, cu, cv,
                         vread(cvg(in.mimg_dim == 5u && res->img_dim == 5u ? 3u : 2u)), out);
+                    else if (dynamic_mip_load) {
+                        // Hardware clamps a MIMG mip selector to the descriptor's LAST_LEVEL. The
+                        // host image carries `materialized_mip_levels` of them, so clamp to that:
+                        // an out-of-range Lod in SPIR-V is undefined, and the guest is entitled to
+                        // the same saturating answer the console gives it.
+                        // The register the shape predicate itself identified, not a second
+                        // derivation of it: for this packet family they are the same VGPR, and
+                        // reading it from one place keeps them that way.
+                        const uint32_t requested = vread(static_cast<int>(dynamic_mip_vgpr));
+                        const uint32_t lod = b.uext2(
+                            Glsl_UMin, requested, b.uconst(materialized_mip_levels - 1u));
+                        b.image_fetch_2d_lod(res->binding, cu, cv, lod, out);
+                    }
                     else                   b.image_fetch_2d (res->binding, cu, cv, out);
                 }
             }

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -2240,6 +2240,24 @@ struct SpirvCompute {
     // Exact sampled IMAGE_LOAD representation for guest 2D_MSAA: the host image is single-sample
     // 2D-array, with each guest sample plane in one layer. The guest's explicit sample coordinate is
     // therefore the third integer coordinate; LOD remains zero because the host view has one level.
+    // IMAGE_LOAD_MIP lowering: the guest's own mip selector reaches OpImageFetch's Lod operand.
+    // Identical to image_fetch_2d except that the level is a value rather than the constant zero,
+    // so it is valid only against a binding whose image really carries that many levels (#3048).
+    void image_fetch_2d_lod(uint32_t binding, uint32_t x_bits, uint32_t y_bits,
+                            uint32_t lod_bits, uint32_t out[4]) {
+        uint32_t si    = id(); put(code, Op_Load,  {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t img   = id(); put(code, Op_Image, {tex_binding_img[binding], img, si});
+        uint32_t coord = id();
+        if (tex_is_arrayed(binding))
+            put(code, Op_CompositeConstruct, {t_v3u_fetch(), coord, x_bits, y_bits, uconst(0)});
+        else
+            put(code, Op_CompositeConstruct, {t_v2u(), coord, x_bits, y_bits});
+        uint32_t res   = id();
+        put(code, Op_ImageFetch,
+            {texture_vec4(binding), res, img, coord, ImgOp_Lod, lod_bits});
+        unpack_texture_result(binding, res, out);
+    }
+
     void image_fetch_2d_array(uint32_t binding, uint32_t x_bits, uint32_t y_bits,
                               uint32_t layer_bits, uint32_t out[4]) {
         uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});

--- a/prosper/src/gpu/resources/AGENTS.md
+++ b/prosper/src/gpu/resources/AGENTS.md
@@ -16,6 +16,12 @@ Turns descriptors into resolved, bindable resources, and answers questions about
   them live — `grep -rn by_fetch_pc src/gpu/recompiler/` finds the call sites, including the
   `by_fetch_pc(153u)` selected-descriptor lookup. `by_binding` matches anything in the table at
   all.
+- `mip_chain_plan` — where every level of a declared mip chain lives, and how many of them a
+  compute image materializes. `ShaderResource` describes the SELECTED level (`image_base_level_view`
+  shifts `gpu_addr`/`width`/`height` onto it), so the other levels have no placement anywhere else;
+  this is the one derivation that recovers them. It is deliberately read by **both** the backend
+  that creates the image and the recompiler that lowers `IMAGE_LOAD_MIP` — if those two ever answer
+  the level count differently, a shader fetches a level that was never created.
 - `gpu_resources` — the resolved resource layer over guest memory.
 - `compressed_source_authority` — who is authoritative for a compressed surface's bytes.
 - `metadata_kind_correlation` — correlating a surface's metadata kind with how it is used.

--- a/prosper/src/gpu/resources/mip_chain_plan.cpp
+++ b/prosper/src/gpu/resources/mip_chain_plan.cpp
@@ -20,6 +20,16 @@ namespace {
 // narrowing of FP16, packed R11G11B10, block-compressed decode, a depth view) is deliberately not
 // here: a per-level upload would have to reproduce that conversion at every extent, and this first
 // landing keeps the level-0 bytes byte-identical to what the single-level path already produces.
+//
+// IF YOU WIDEN THIS LIST, read `live_compute.cpp`'s conversion cascade first. This whitelist picks
+// the level COUNT; a separate branch condition there does the copying, and only that branch can
+// write levels 1..N-1. Adding a format here that the branch does not take would otherwise leave
+// those levels as whatever the staging allocation held. That case is caught -- the cascade ends in
+// a drift detector that declines instead of uploading it -- so the failure is a declined dispatch,
+// not corrupt texels; but the fix is to teach the cascade, not to widen only this list. The two are
+// deliberately NOT collapsed: this function has callers (the emitter, the compile key) that have no
+// BoundImage, no reflected descriptor and no live target, so the count must stay derivable from the
+// descriptor alone.
 bool native_straight_copy_sampled_format(DataFormat format, uint32_t components) {
     switch (format) {
         case DataFormat::Float32:

--- a/prosper/src/gpu/resources/mip_chain_plan.cpp
+++ b/prosper/src/gpu/resources/mip_chain_plan.cpp
@@ -1,0 +1,139 @@
+#include "gpu/resources/mip_chain_plan.hpp"
+
+#include "gpu/texture/tile.hpp"
+
+#include <algorithm>
+
+namespace prosper::gpu {
+
+uint32_t full_mip_chain_levels(uint32_t width, uint32_t height) {
+    if (!width || !height) return 0;
+    uint32_t levels = 1;
+    for (uint32_t extent = std::max(width, height); extent > 1u; extent >>= 1) ++levels;
+    return levels;
+}
+
+namespace {
+
+// The sampled formats whose compute upload is a straight per-texel copy. Anything that widens,
+// broadcasts or repacks on the way to the staging buffer (R8 coverage broadcast, the RGBA8
+// narrowing of FP16, packed R11G11B10, block-compressed decode, a depth view) is deliberately not
+// here: a per-level upload would have to reproduce that conversion at every extent, and this first
+// landing keeps the level-0 bytes byte-identical to what the single-level path already produces.
+bool native_straight_copy_sampled_format(DataFormat format, uint32_t components) {
+    switch (format) {
+        case DataFormat::Float32:
+            return components == 1 || components == 2 || components == 4;
+        case DataFormat::Uint32:
+        case DataFormat::Uint16:
+        case DataFormat::Unorm16:
+        case DataFormat::Uint8:
+            return components == 1 || components == 2 || components == 4;
+        case DataFormat::Unorm8:
+            return components == 2 || components == 4;
+        default:
+            return false;
+    }
+}
+
+} // namespace
+
+MipChainPlan shader_resource_mip_chain_plan(const ShaderResource& resource) {
+    MipChainPlan plan;
+    if (resource.cls != ResourceClass::Texture) return plan;
+    if (resource.declared_mip_levels < 2u || resource.sample_count != 1u) return plan;
+    // A selected level that is itself packed in the shared tail leaves `gpu_addr` at the allocation
+    // base while every sibling level shares that same block; the offsets below assume the ordinary
+    // "selected level owns a disjoint byte range" form and must not be applied to it.
+    if (resource.in_mip_tail) return plan;
+    // A layered or volume view selects one slice of a per-slice chain, and a compressed base is not
+    // ordinary tiled texels at any level. Both remain fail-closed.
+    if (resource.depth != 1u || resource.layer_stride_bytes || resource.layer_mip_offset_bytes)
+        return plan;
+    if (resource.compression_enabled || resource.metadata_addr) return plan;
+    if (resource.img_dim != 1u && resource.img_dim != 5u) return plan;
+
+    const uint32_t element_width = resource.mip_chain_element_width;
+    const uint32_t element_height = resource.mip_chain_element_height;
+    const uint32_t bytes_per_block = resource.mip_chain_bytes_per_block;
+    const uint32_t max_mip = resource.mip_chain_max_level;
+    if (!element_width || !element_height || !bytes_per_block || max_mip >= 16u) return plan;
+    // Only the view that starts at the allocation's own level zero is modelled. A shifted BASE_LEVEL
+    // would need every offset rebased onto the selected level, and no measured title issues one
+    // alongside a dynamic mip operand.
+    if (resource.mip_chain_base_level != 0u) return plan;
+    // Uncompressed only: for a block format the element grid is smaller than the texel extent, and
+    // this equality is what proves the two agree.
+    if (element_width != resource.width || element_height != resource.height) return plan;
+    if (resource.declared_mip_levels > max_mip + 1u) return plan;
+    // Linear chains place each level on a 256-byte-aligned pitch, which the per-level copy below
+    // does not yet reproduce; every measured multi-level guest texture here is tiled.
+    if (!tile_mode_is_tiled(resource.tile_mode)) return plan;
+
+    const uint32_t full = full_mip_chain_levels(resource.width, resource.height);
+    if (!full) return plan;
+    const uint32_t level_count = std::min(resource.declared_mip_levels, full);
+    if (level_count < 2u) return plan;
+
+    const size_t allocation_bytes = tiled_mip_chain_bytes(
+        element_width, element_height, bytes_per_block, resource.tile_mode, max_mip);
+    if (!allocation_bytes) return plan;
+
+    plan.levels.resize(level_count);
+    for (uint32_t level = 0; level < level_count; ++level) {
+        const TiledMipLevelLayout layout = tiled_mip_level_layout(
+            element_width, element_height, bytes_per_block, resource.tile_mode, max_mip, level);
+        if (!layout.supported) return {};
+        MipChainLevel& out = plan.levels[level];
+        out.width = std::max(resource.width >> level, 1u);
+        out.height = std::max(resource.height >> level, 1u);
+        out.in_tail = layout.in_tail;
+        if (layout.in_tail) {
+            // Tail levels are addressed by element coordinate inside the allocation's first block.
+            if (!layout.tail_block_bytes) return {};
+            out.byte_offset = 0;
+            out.byte_size = layout.tail_block_bytes;
+            out.tail_x = layout.tail_x;
+            out.tail_y = layout.tail_y;
+            out.tail_block_bytes = layout.tail_block_bytes;
+        } else {
+            out.byte_offset = layout.byte_offset;
+            out.byte_size = tiled_surface_bytes(
+                out.width, out.height, resource.tile_mode, 0, bytes_per_block);
+            if (!out.byte_size) return {};
+        }
+        if (out.byte_offset > allocation_bytes ||
+            out.byte_size > allocation_bytes - out.byte_offset)
+            return {};
+    }
+    // The selected level must be the one the resource's own fields describe, or `gpu_addr` and
+    // `levels[0]` name different bytes.
+    if (plan.levels[0].in_tail) return {};
+    plan.valid = true;
+    plan.level_count = level_count;
+    plan.allocation_bytes = allocation_bytes;
+    return plan;
+}
+
+uint32_t shader_resource_compute_mip_chain_levels(const ShaderResource& resource) {
+    // Cheapest possible rejection first. This is called per resource on the compile-key path, which
+    // runs for every dispatch, and almost every texture declares a single level -- so the common
+    // answer must not reach the plan's allocation.
+    if (resource.declared_mip_levels < 2u ||
+        resource.cls != ResourceClass::Texture) return 1u;
+    const uint32_t components = resource.num_components ? resource.num_components : 1u;
+    if (!native_straight_copy_sampled_format(resource.format, components)) return 1u;
+    if (resource.depth_compare) return 1u;
+    // The allocation base sits BELOW gpu_addr, so the source must be ordinary guest memory. A
+    // host_data-backed resource (capture replay, synthetic fixtures) exposes only the selected
+    // level's span and cannot answer for the rest of the chain.
+    if (resource.host_data) return 1u;
+    const uint32_t component_bytes = data_format_bytes(resource.format);
+    if (!component_bytes ||
+        component_bytes * components != resource.mip_chain_bytes_per_block)
+        return 1u;
+    const MipChainPlan plan = shader_resource_mip_chain_plan(resource);
+    return plan.valid ? plan.level_count : 1u;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/resources/mip_chain_plan.hpp
+++ b/prosper/src/gpu/resources/mip_chain_plan.hpp
@@ -1,0 +1,59 @@
+// mip_chain_plan.hpp — where every level of a guest texture's declared mip chain lives, and whether
+// the compute backend materializes that chain.
+//
+// The T# declares a chain length (`declared_mip_levels`); `image_base_level_view` resolves the
+// SELECTED level and shifts `gpu_addr`/`width`/`height` onto it. Nothing downstream could place the
+// OTHER levels, so the compute backend created every image with `mipLevels = 1` and the recompiler
+// declined IMAGE_LOAD_MIP whenever the descriptor declared more than one level — an operation the
+// guest genuinely issues (#3048, Sonic Frontiers' three scene-width stage kernels).
+//
+// This header answers both halves from ONE derivation so they cannot disagree: the backend asks how
+// many levels to create and where each level's guest bytes are, and the recompiler asks whether an
+// explicit LOD may be emitted at all. Reject-by-default — an unmodelled shape yields `level_count 1`
+// and the historical single-level behaviour, never a guessed offset.
+#pragma once
+#include "gpu/resources/shader_resources.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace prosper::gpu {
+
+// One level's source placement inside the guest allocation. `byte_offset` is measured from the
+// ALLOCATION base (which is below `ShaderResource::gpu_addr` whenever the selected level is not the
+// allocation's first stored byte). A packed-tail level shares the allocation's first macroblock, so
+// it reports `byte_offset 0` plus the element coordinates the tail-aware detile helpers consume.
+struct MipChainLevel {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint64_t byte_offset = 0;
+    uint64_t byte_size = 0;
+    uint32_t tail_x = 0;
+    uint32_t tail_y = 0;
+    uint32_t tail_block_bytes = 0;
+    bool in_tail = false;
+};
+
+struct MipChainPlan {
+    bool valid = false;
+    uint32_t level_count = 1;
+    // levels[0] is the resource's own selected level, so `allocation_base` is
+    // `gpu_addr - levels[0].byte_offset` and `allocation_bytes` bounds the readable span.
+    uint64_t allocation_bytes = 0;
+    std::vector<MipChainLevel> levels;
+};
+
+// Geometry only: where each declared level lives. Valid only when EVERY level of the chain resolves
+// through the modelled GFX10 thin-2D placement.
+MipChainPlan shader_resource_mip_chain_plan(const ShaderResource& resource);
+
+// The number of mip levels the COMPUTE backend materializes for this resource. 1 means the
+// historical single-level image. Called by `live_compute`'s image creation and by the recompiler's
+// MIMG lowering; a divergence between the two would emit an explicit LOD against a level that does
+// not exist, so both must read this one function (the #2265 lesson).
+uint32_t shader_resource_compute_mip_chain_levels(const ShaderResource& resource);
+
+// The complete chain implied by a level-zero extent (floor(log2(max(w,h))) + 1).
+uint32_t full_mip_chain_levels(uint32_t width, uint32_t height);
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/resources/shader_resources.hpp
+++ b/prosper/src/gpu/resources/shader_resources.hpp
@@ -361,6 +361,17 @@ struct ShaderResource {
     // WORD3 [19:16]/[15:12]). 1 = single level (the historical behavior). The backend uses this to
     // bound generated-mip uploads (#1272) — it never invents levels a T# does not declare.
     uint32_t      declared_mip_levels = 1;
+    // Placement provenance for the WHOLE allocation this view selects from, not just the selected
+    // level. `declared_mip_levels` says how many levels the T# declares; these four say where each
+    // of them lives, because tiled_mip_level_layout needs the allocation's own level-zero element
+    // extent and its final mip -- neither of which is recoverable from the fields above once
+    // gpu_addr/width/height have been shifted to the selected base level. Zero element extent means
+    // "not modelled"; every consumer must fail closed on it (#3048).
+    uint32_t      mip_chain_element_width  = 0;
+    uint32_t      mip_chain_element_height = 0;
+    uint32_t      mip_chain_bytes_per_block = 0;
+    uint32_t      mip_chain_max_level      = 0;   // effective MAX_MIP of the allocation
+    uint32_t      mip_chain_base_level     = 0;   // the T#'s BASE_LEVEL for this view
     bool          in_mip_tail       = false;
     uint32_t      mip_tail_offset   = 0;
     uint32_t      mip_tail_bytes    = 0;

--- a/prosper/tests/gpu/agc/test_build_shader_resources.cpp
+++ b/prosper/tests/gpu/agc/test_build_shader_resources.cpp
@@ -1007,6 +1007,49 @@ int main() {
               "S# FORCE_UNNORMALIZED survives paired-sampler decode");
     }
 
+    // ---- unmapped_format_image_view: the fail-closed fallback for a format prosper cannot map --
+    // This is the view that used to be built by a POSITIONAL DecodedImageView aggregate at its one
+    // call site. Growing the struct re-bound its last initializer, so `supported` silently took its
+    // default `true` and the guard below stopped rejecting anything -- with no compiler diagnostic,
+    // because `bool -> uint32_t` is a promotion. These arms pin the contract at the function the
+    // production path now calls, so the same mistake reddens here instead of binding slice zero.
+    {
+        DecodedImageDescriptor unmapped{};
+        unmapped.base = 0x2026900000ull;
+        unmapped.width = 1920;
+        unmapped.height = 1080;
+        unmapped.depth = 1;
+
+        const DecodedImageView plain = unmapped_format_image_view(unmapped);
+        CHECK(plain.supported && plain.base == unmapped.base &&
+                  plain.width == 1920u && plain.height == 1080u,
+              "unmapped format at level zero of slice zero yields a supported allocation-base view");
+        CHECK(plain.mip_offset == 0 && !plain.in_mip_tail && plain.mip_tail_bytes == 0 &&
+                  plain.mip_tail_x == 0 && plain.mip_tail_y == 0 &&
+                  plain.layer_stride == 0 && plain.layer_mip_offset == 0,
+              "the unmapped-format view claims no mip or layer placement");
+        CHECK(plain.chain_element_width == 0 && plain.chain_element_height == 0 &&
+                  plain.chain_bytes_per_block == 0 && plain.chain_max_mip == 0 &&
+                  plain.chain_base_level == 0,
+              "the unmapped-format view reports its mip chain as NOT MODELLED (#3048)");
+
+        DecodedImageDescriptor shifted_level = unmapped;
+        shifted_level.base_level = 1;
+        CHECK(!unmapped_format_image_view(shifted_level).supported,
+              "unmapped format with a selected BASE_LEVEL fails closed (no mip offset is derivable)");
+
+        DecodedImageDescriptor shifted_slice = unmapped;
+        shifted_slice.base_array = 1;
+        CHECK(!unmapped_format_image_view(shifted_slice).supported,
+              "unmapped format with a selected BASE_ARRAY fails closed (it would bind slice ZERO)");
+
+        DecodedImageDescriptor shifted_both = unmapped;
+        shifted_both.base_level = 2;
+        shifted_both.base_array = 3;
+        CHECK(!unmapped_format_image_view(shifted_both).supported,
+              "unmapped format with both selectors set fails closed");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/gpu/capture/test_gpu_capture.cpp
+++ b/prosper/tests/gpu/capture/test_gpu_capture.cpp
@@ -1177,6 +1177,14 @@ int main(int argc, char** argv) {
     tail_resource.mip_tail_bytes = 65536; tail_resource.mip_tail_x = 64;
     tail_resource.mip_tail_y = 0;
     tail_resource.declared_mip_levels = 5;   // #1280: a non-default T#-declared mip-chain length
+    // #3048 v57: five DISTINCT, non-default values, so a transposition inside the tail is caught
+    // rather than merely a missing tail. Finding a field-ordering defect in this very change is why
+    // "the version constant round-trips" is not coverage.
+    tail_resource.mip_chain_element_width = 60;
+    tail_resource.mip_chain_element_height = 33;
+    tail_resource.mip_chain_bytes_per_block = 4;
+    tail_resource.mip_chain_max_level = 5;
+    tail_resource.mip_chain_base_level = 2;
     auto tail_table = std::make_shared<ShaderResourceTable>();
     tail_table->resources = {tail_resource};
     DrawItem tail_draw = draw; tail_draw.vrt = tail_table;
@@ -1196,6 +1204,51 @@ int main(int argc, char** argv) {
           "v16 capture round-trips packed-tail byte and coordinate placement exactly");
     CHECK(tail_loaded.draws[0].vrt.resources[0].resource.declared_mip_levels == 5,
           "#1280: v24 capture round-trips the T#-declared mip-chain length (was silently defaulting to 1)");
+    {
+        const ShaderResource& tail_chain = tail_loaded.draws[0].vrt.resources[0].resource;
+        CHECK(tail_chain.mip_chain_element_width == 60 &&
+                  tail_chain.mip_chain_element_height == 33 &&
+                  tail_chain.mip_chain_bytes_per_block == 4 &&
+                  tail_chain.mip_chain_max_level == 5 &&
+                  tail_chain.mip_chain_base_level == 2,
+              "#3048: v57 capture round-trips each allocation-wide mip placement field in order");
+        // A pre-v57 file has no placement at all, and every consumer must read that as "not
+        // modelled" rather than as a zero-extent allocation it could try to place levels in.
+        std::vector<uint8_t> v56_tail_bytes = tail_bytes;
+        const size_t v57_bytes = tail_loaded.draws[0].vrt.resources.size() * 5u * sizeof(uint32_t);
+        GpuCaptureFile v56_tail_loaded;
+        CHECK(v56_tail_bytes.size() > v57_bytes, "v57 mip-placement tail is removable");
+        if (v56_tail_bytes.size() > v57_bytes) {
+            v56_tail_bytes.resize(v56_tail_bytes.size() - v57_bytes);
+            v56_tail_bytes[8] = 56u;
+            v56_tail_bytes[9] = v56_tail_bytes[10] = v56_tail_bytes[11] = 0u;
+        }
+        CHECK(deserialize_gpu_capture(v56_tail_bytes, v56_tail_loaded, error) &&
+                  v56_tail_loaded.format_version == 56u &&
+                  v56_tail_loaded.draws[0].vrt.resources[0].resource
+                          .mip_chain_element_width == 0u &&
+                  v56_tail_loaded.draws[0].vrt.resources[0].resource
+                          .mip_chain_bytes_per_block == 0u &&
+                  v56_tail_loaded.draws[0].vrt.resources[0].resource
+                          .mip_chain_base_level == 0u,
+              "#3048: a v56 capture reopens with its mip placement explicitly not modelled");
+        // A half-written placement cannot locate a level, and reading one as if it could is the
+        // silent wrong-offset failure the provenance exists to prevent.
+        std::vector<uint8_t> partial_tail_bytes = tail_bytes;
+        CHECK(partial_tail_bytes.size() >= v57_bytes,
+              "v57 partial-placement fixture has a tail to corrupt");
+        if (partial_tail_bytes.size() >= v57_bytes) {
+            const size_t element_width_offset = partial_tail_bytes.size() - v57_bytes;
+            partial_tail_bytes[element_width_offset] = 0u;      // width 60 -> 0, height still 33
+            partial_tail_bytes[element_width_offset + 1u] = 0u;
+            partial_tail_bytes[element_width_offset + 2u] = 0u;
+            partial_tail_bytes[element_width_offset + 3u] = 0u;
+        }
+        GpuCaptureFile partial_tail_loaded;
+        CHECK(!deserialize_gpu_capture(partial_tail_bytes, partial_tail_loaded, error) &&
+                  error == "invalid mip-chain placement state",
+              "#3048: v57 reader rejects a partially present mip placement");
+    }
 
     ShaderResource msaa_resource{};
     msaa_resource.cls = ResourceClass::Texture; msaa_resource.binding = 4;

--- a/prosper/tests/gpu/capture/test_gpu_capture.cpp
+++ b/prosper/tests/gpu/capture/test_gpu_capture.cpp
@@ -471,6 +471,19 @@ int main(int argc, char** argv) {
                 resources += stage.resource_table.resources.size();
         return 4u + resources * sizeof(uint32_t);
     };
+    // v57 appends five dwords per resource (the allocation-wide mip placement, #3048) with no
+    // count prefix. Every offset measured backwards from the end of the stream has to skip it.
+    auto v57_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t resources = 0;
+        for (const auto& draw : f.draws)
+            resources += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : f.computes)
+            resources += compute.resources.resources.size();
+        for (const auto& diagnostic : f.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                resources += stage.resource_table.resources.size();
+        return resources * 5u * sizeof(uint32_t);
+    };
     // Every fixture that truncates "the v50 tail" is recovering a pre-v50 prefix from a CURRENT
     // file. Include the later v52/v54 suffixes so the downgrade arithmetic stays exact.
     auto v50_tail = [&](const GpuCaptureFile& f) -> size_t {
@@ -480,7 +493,7 @@ int main(int argc, char** argv) {
         for (const auto& diagnostic : f.failure_diagnostics)
             for (const auto& stage : diagnostic.stages)
                 configs += stage.recompile_config_available;
-        return 4u + configs * sizeof(uint32_t) + v52_tail(f) + v54_tail(f);
+        return 4u + configs * sizeof(uint32_t) + v52_tail(f) + v54_tail(f) + v57_tail(f);
     };
 
     // The fixed v46 tail is 4 bytes of count plus 100 bytes per selected witness. Mutate the
@@ -844,7 +857,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame descriptor_array_replay;
     CHECK(serialize_gpu_capture(descriptor_array_capture, descriptor_array_bytes, error) &&
               deserialize_gpu_capture(descriptor_array_bytes, descriptor_array_loaded, error) &&
-              descriptor_array_loaded.format_version == 56 &&
+              descriptor_array_loaded.format_version == 57 &&
               materialize_gpu_replay(descriptor_array_loaded, descriptor_array_replay, error) &&
               descriptor_array_replay.computes.size() == 1 &&
               descriptor_array_replay.computes[0].resources &&
@@ -877,7 +890,8 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> malformed_descriptor_array = descriptor_array_bytes;
     if (malformed_descriptor_array.size() >= descriptor_array_v52_tail + 28u) {
         const size_t entry_count_offset =
-            malformed_descriptor_array.size() - v54_tail(descriptor_array_capture) -
+            malformed_descriptor_array.size() - v57_tail(descriptor_array_capture) -
+            v54_tail(descriptor_array_capture) -
             descriptor_array_v52_tail + 24u;
         malformed_descriptor_array[entry_count_offset] = 1u;
         malformed_descriptor_array[entry_count_offset + 1u] = 0u;
@@ -891,9 +905,10 @@ int main(int argc, char** argv) {
 
     std::vector<uint8_t> legacy_scalar_array = descriptor_array_bytes;
     if (legacy_scalar_array.size() >= descriptor_array_v52_tail +
-            v54_tail(descriptor_array_capture) + 12u) {
+            v54_tail(descriptor_array_capture) + v57_tail(descriptor_array_capture) + 12u) {
         legacy_scalar_array.resize(
-            legacy_scalar_array.size() - v54_tail(descriptor_array_capture) -
+            legacy_scalar_array.size() - v57_tail(descriptor_array_capture) -
+            v54_tail(descriptor_array_capture) -
             descriptor_array_v52_tail);
         legacy_scalar_array[8] = 51u;
         legacy_scalar_array[9] = legacy_scalar_array[10] = legacy_scalar_array[11] = 0u;
@@ -1226,7 +1241,7 @@ int main(int argc, char** argv) {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 56 &&
+              msaa_loaded.format_version == 57 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -1352,7 +1367,7 @@ int main(int argc, char** argv) {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 56 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 57 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -1363,7 +1378,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 56 &&
+              video_loaded.format_version == 57 &&
               video_loaded.draws[0].prt.resources[0].resource.proven_zero_mip &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
@@ -1407,7 +1422,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 56 &&
+              upgraded_video.format_version == 57 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -1489,7 +1504,7 @@ int main(int argc, char** argv) {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 56 &&
+              array_layout_loaded.format_version == 57 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -1717,7 +1732,7 @@ int main(int argc, char** argv) {
     CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
     GpuCaptureFile loaded;
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
-    CHECK(loaded.format_version == 56 &&
+    CHECK(loaded.format_version == 57 &&
               loaded.draws[0].vrt.resources[1].resource.size == 16u &&
               loaded.draws[0].vrt.resources[1].resource.scalar_buffer_dword_count == 4u &&
               shader_resource_buffer_binding_bytes(
@@ -1726,9 +1741,10 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> v53_scalar_bytes;
     GpuCaptureFile v53_scalar_loaded;
     CHECK(serialize_gpu_capture(captured, v53_scalar_bytes, error) &&
-              v53_scalar_bytes.size() >= v54_tail(captured) + 12u,
+              v53_scalar_bytes.size() >= v54_tail(captured) + v57_tail(captured) + 12u,
           "v54 scalar-buffer tail is removable for a v53 compatibility fixture");
-    if (v53_scalar_bytes.size() >= v54_tail(captured) + 12u) {
+    if (v53_scalar_bytes.size() >= v54_tail(captured) + v57_tail(captured) + 12u) {
+        v53_scalar_bytes.resize(v53_scalar_bytes.size() - v57_tail(captured));  // v57 mip placement
         v53_scalar_bytes.resize(v53_scalar_bytes.size() - v55_ds_slice_tail(captured));  // v55 DS-seed slices
         v53_scalar_bytes.resize(v53_scalar_bytes.size() - v54_tail(captured));
         v53_scalar_bytes[8] = 53u;
@@ -1807,7 +1823,8 @@ int main(int argc, char** argv) {
           "v54 stale scalar-buffer bound fixture serializes");
     // v55 appends the DS-seed slices AFTER the v54 tail, so an offset measured from the end of the
     // stream must skip them to land on the v54 records.
-    const size_t stale_tail = v54_tail(captured) + v55_ds_slice_tail(captured);
+    const size_t stale_tail =
+        v54_tail(captured) + v55_ds_slice_tail(captured) + v57_tail(captured);
     bool stale_patched = false;
     if (stale_bound_bytes.size() >= stale_tail) {
         // The v54 tail is `count` followed by one dword per resource, in table order; resource 1 of
@@ -1832,8 +1849,10 @@ int main(int argc, char** argv) {
     CHECK(serialize_gpu_capture(captured, malformed_scalar_bytes, error) &&
               !malformed_scalar_bytes.empty(),
           "v54 scalar-buffer truncation fixture serializes");
-    // Drop the v55 DS-seed slice tail first, so popping a byte truncates the V54 tail this
-    // assertion is about rather than the newer one appended after it.
+    // Drop every tail appended AFTER v54 first, so popping a byte truncates the v54 tail this
+    // assertion is about rather than a newer one appended after it.
+    if (malformed_scalar_bytes.size() >= v57_tail(captured))
+        malformed_scalar_bytes.resize(malformed_scalar_bytes.size() - v57_tail(captured));
     if (malformed_scalar_bytes.size() >= v55_ds_slice_tail(captured))
         malformed_scalar_bytes.resize(malformed_scalar_bytes.size() -
                                       v55_ds_slice_tail(captured));
@@ -3307,7 +3326,7 @@ int main(int argc, char** argv) {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 56 &&
+              failed_compute_loaded.format_version == 57 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -3546,7 +3565,7 @@ int main(int argc, char** argv) {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 56 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 57 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -3834,9 +3853,9 @@ int main(int argc, char** argv) {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 57;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 58;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 57",
+          error == "unsupported capture version 58",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -2413,10 +2413,15 @@ int main() {
                   "live backend executes a dynamic-mip IMAGE_LOAD_MIP dispatch");
             CHECK(std::equal(chain_dst.begin(), chain_dst.end(), chain_level1_linear.begin()),
                   "IMAGE_LOAD_MIP at a runtime mip returns LEVEL ONE's own guest texels");
-            // The real anti-coincidence guard is that recompilation only succeeds through the
-            // dynamic-LOD path at all: with the backend reverted to one level the assertion above
-            // reddens while this one stays green, because an UNWRITTEN destination also differs
-            // from level zero. Keep both, and do not read the second as the discriminator.
+            // The two arms below are FIXTURE-VALIDITY guards, not discriminators, and the
+            // difference is measured rather than argued: with the backend reverted to
+            // `ici.mipLevels = 1` the assertion above reddens while BOTH of these stay green.
+            // So the destination is not left unwritten under that mutant -- it is written with
+            // something that is neither level one nor the sentinel. What they rule out is a
+            // fixture that could pass vacuously: level one being byte-identical to level zero,
+            // and the dispatch never running at all. The discriminator is the level-one equality
+            // itself, and behind it the fact that this program only recompiles through the
+            // dynamic-LOD path. Do not read either arm as evidence about the mutant.
             CHECK(!std::equal(chain_dst.begin(), chain_dst.end(), chain_level0_linear.begin()),
                   "level one is distinguishable from level zero in this fixture");
             CHECK(std::none_of(chain_dst.begin(), chain_dst.end(),

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -2413,8 +2413,120 @@ int main() {
                   "live backend executes a dynamic-mip IMAGE_LOAD_MIP dispatch");
             CHECK(std::equal(chain_dst.begin(), chain_dst.end(), chain_level1_linear.begin()),
                   "IMAGE_LOAD_MIP at a runtime mip returns LEVEL ONE's own guest texels");
+            // The real anti-coincidence guard is that recompilation only succeeds through the
+            // dynamic-LOD path at all: with the backend reverted to one level the assertion above
+            // reddens while this one stays green, because an UNWRITTEN destination also differs
+            // from level zero. Keep both, and do not read the second as the discriminator.
             CHECK(!std::equal(chain_dst.begin(), chain_dst.end(), chain_level0_linear.begin()),
                   "level one is distinguishable from level zero in this fixture");
+            CHECK(std::none_of(chain_dst.begin(), chain_dst.end(),
+                               [](uint32_t value) { return value == 0x77777777u; }),
+                  "every destination texel was actually written by the dispatch");
+        }
+    }
+
+    // #3048: the SAME dynamic-mip lowering at DMASK 0x3. `rdna2_mimg_dynamic_mip_shape` widened
+    // DMASK from the zero-mip shape's {0x1, 0xf} to anything, and Sonic Frontiers' kernels issue
+    // exactly 0x3 against a two-channel surface -- so the two-component result mask, and the
+    // register the second component lands in, need their own executed arm. Word0 here is byte-equal
+    // to the word the [mimg-mip] diagnostic reports for `0x2005714000`: `f0040308`.
+    {
+        constexpr uint32_t RG_W = 256, RG_H = 256, RG_BPE = 8, RG_MAX_MIP = 8;
+        const uint32_t rg_tile = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        const TiledMipLevelLayout rg_level0 = tiled_mip_level_layout(
+            RG_W, RG_H, RG_BPE, rg_tile, RG_MAX_MIP, 0);
+        const TiledMipLevelLayout rg_level1 = tiled_mip_level_layout(
+            RG_W, RG_H, RG_BPE, rg_tile, RG_MAX_MIP, 1);
+        const size_t rg_bytes = tiled_mip_chain_bytes(
+            RG_W, RG_H, RG_BPE, rg_tile, RG_MAX_MIP);
+        CHECK(rg_level0.supported && !rg_level0.in_tail && rg_level1.supported &&
+                  !rg_level1.in_tail && rg_bytes != 0,
+              "the dmask:0x3 fixture places levels zero and one outside the shared mip tail");
+
+        std::vector<uint8_t> rg_allocation(rg_bytes, 0x3c);
+        std::vector<uint32_t> rg_level0_linear(static_cast<size_t>(RG_W) * RG_H * 2u);
+        std::vector<uint32_t> rg_level1_linear(
+            static_cast<size_t>(RG_W / 2u) * (RG_H / 2u) * 2u);
+        for (size_t i = 0; i < rg_level0_linear.size(); ++i)
+            rg_level0_linear[i] = static_cast<uint32_t>(i * 2246822519u + 0x22222222u);
+        for (size_t i = 0; i < rg_level1_linear.size(); ++i)
+            rg_level1_linear[i] = static_cast<uint32_t>(i * 668265263u + 0x5c5c0000u);
+        tile_surface(rg_allocation.data() + rg_level0.byte_offset,
+                     reinterpret_cast<const uint8_t*>(rg_level0_linear.data()),
+                     RG_W, RG_H, rg_tile, 0, RG_BPE);
+        tile_surface(rg_allocation.data() + rg_level1.byte_offset,
+                     reinterpret_cast<const uint8_t*>(rg_level1_linear.data()),
+                     RG_W / 2u, RG_H / 2u, rg_tile, 0, RG_BPE);
+
+        // VDATA is v[0:1] for dmask 0x3, so the coordinates live at v2 upward and the store reads
+        // the SECOND returned component -- the one a dmask-0x1 arm can never observe.
+        const uint32_t dmask3_program[] = {
+            0x7e040300u,                     // v2 = x (VADDR base)
+            0x7e060280u,                     // v3 = y = 0
+            0x7e080281u,                     // v4 = mip = inline constant 1
+            0x7e0a0300u,                     // v5 = destination x
+            0x7e0c0280u,                     // v6 = destination y = 0
+            0xf0040308u, 0x00050002u,        // IMAGE_LOAD_MIP dmask:0x3 v[0:1], [v2,v3,v4], s[20:27]
+            0xbf8c3f70u,                     // s_waitcnt
+            0xf0200108u, 0x00020105u,        // IMAGE_STORE dmask:0x1 v1, [v5,v6], s[8:15]
+            0xbf810000u,                     // s_endpgm
+        };
+        std::vector<uint32_t> rg_dst(W, 0x66666666u);
+        ShaderResourceTable rg_rt = irt;
+        for (ShaderResource& resource : rg_rt.resources) {
+            if (resource.binding == 4) {
+                resource.cls = ResourceClass::Texture;
+                resource.sgpr_base = 20;
+                resource.fetch_pc = 5;
+                resource.img_dim = 1;
+                resource.format = DataFormat::Uint32;
+                resource.num_components = 2;      // Sonic's surface is two-channel at 8 B/texel
+                resource.width = RG_W;
+                resource.height = RG_H;
+                resource.depth = 1;
+                resource.tile_mode = rg_tile;
+                resource.declared_mip_levels = RG_MAX_MIP + 1u;
+                resource.mip_chain_element_width = RG_W;
+                resource.mip_chain_element_height = RG_H;
+                resource.mip_chain_bytes_per_block = RG_BPE;
+                resource.mip_chain_max_level = RG_MAX_MIP;
+                resource.mip_chain_base_level = 0;
+                resource.proven_zero_mip = false;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(
+                    rg_allocation.data() + rg_level0.byte_offset);
+                resource.size = static_cast<uint32_t>(
+                    tiled_surface_bytes(RG_W, RG_H, rg_tile, 0, RG_BPE));
+            } else if (resource.binding == 5) {
+                resource.img_dim = 1;
+                resource.format = DataFormat::Uint32;
+                resource.num_components = 1;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(rg_dst.data());
+                resource.size = static_cast<uint32_t>(rg_dst.size() * sizeof(uint32_t));
+            }
+        }
+        const std::vector<uint32_t> rg_spirv = recompile_valu(
+            dmask3_program, std::size(dmask3_program), 1, 0, &rg_rt);
+        CHECK(!rg_spirv.empty(),
+              "#3048: a dmask:0x3 IMAGE_LOAD_MIP with a runtime mip recompiles");
+        if (!rg_spirv.empty()) {
+            ComputeItem item;
+            item.spirv = rg_spirv;
+            item.resources = std::make_shared<ShaderResourceTable>(rg_rt);
+            item.launch.threads_x = W; item.launch.local_x = 64; item.launch.groups_x = 1;
+            item.launch.local_y = item.launch.local_z = 1;
+            item.launch.groups_y = item.launch.groups_z = 1;
+            item.code_addr = 0x200571bd00ull;
+            CHECK(prosper::frontend::execute_live_compute_items({item}),
+                  "#3048: live backend executes the dmask:0x3 dynamic-mip dispatch");
+            bool second_component_exact = true;
+            for (uint32_t x = 0; x < W; ++x)
+                second_component_exact &=
+                    rg_dst[x] == rg_level1_linear[static_cast<size_t>(x) * 2u + 1u];
+            CHECK(second_component_exact,
+                  "#3048: dmask:0x3 returns level one's SECOND component in the second VGPR");
+            CHECK(std::none_of(rg_dst.begin(), rg_dst.end(),
+                               [](uint32_t value) { return value == 0x66666666u; }),
+                  "#3048: every dmask:0x3 destination texel was actually written");
         }
     }
 

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -2316,6 +2316,108 @@ int main() {
               "IMAGE_LOAD_MIP 2D_ARRAY fetches distinct slice one instead of dropping the layer");
     }
 
+    // #3048: the DYNAMIC mip operand. Sonic Frontiers' three scene-target-width stage kernels issue
+    // IMAGE_LOAD_MIP against a 12-level 2048x2048 surface with the mip NOT provably zero, so the
+    // zero-specialization arms above can never admit them -- and emitting a Lod against the old
+    // hard-coded `mipLevels = 1` image would have fetched a level that does not exist. The compute
+    // backend now materializes the chain the T# declares, uploading each level from the guest's own
+    // tiled mip offsets, and the operand reaches OpImageFetch's Lod. The discriminator is that the
+    // dispatch returns LEVEL ONE's texels: a single-level image cannot produce them.
+    {
+        constexpr uint32_t CHAIN_W = 256, CHAIN_H = 256, CHAIN_BPE = 4, CHAIN_MAX_MIP = 8;
+        const uint32_t chain_tile = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        const TiledMipLevelLayout chain_level0 = tiled_mip_level_layout(
+            CHAIN_W, CHAIN_H, CHAIN_BPE, chain_tile, CHAIN_MAX_MIP, 0);
+        const TiledMipLevelLayout chain_level1 = tiled_mip_level_layout(
+            CHAIN_W, CHAIN_H, CHAIN_BPE, chain_tile, CHAIN_MAX_MIP, 1);
+        const size_t chain_bytes = tiled_mip_chain_bytes(
+            CHAIN_W, CHAIN_H, CHAIN_BPE, chain_tile, CHAIN_MAX_MIP);
+        CHECK(chain_level0.supported && !chain_level0.in_tail && chain_level1.supported &&
+                  !chain_level1.in_tail && chain_bytes != 0,
+              "the dynamic-mip fixture places levels zero and one outside the shared mip tail");
+
+        std::vector<uint8_t> chain_allocation(chain_bytes, 0x5a);
+        std::vector<uint32_t> chain_level0_linear(static_cast<size_t>(CHAIN_W) * CHAIN_H);
+        std::vector<uint32_t> chain_level1_linear(
+            static_cast<size_t>(CHAIN_W / 2u) * (CHAIN_H / 2u));
+        for (size_t i = 0; i < chain_level0_linear.size(); ++i)
+            chain_level0_linear[i] = static_cast<uint32_t>(i * 2654435761u + 0x11111111u);
+        for (size_t i = 0; i < chain_level1_linear.size(); ++i)
+            chain_level1_linear[i] = static_cast<uint32_t>(i * 40503u + 0xa5a50000u);
+        tile_surface(chain_allocation.data() + chain_level0.byte_offset,
+                     reinterpret_cast<const uint8_t*>(chain_level0_linear.data()),
+                     CHAIN_W, CHAIN_H, chain_tile, 0, CHAIN_BPE);
+        tile_surface(chain_allocation.data() + chain_level1.byte_offset,
+                     reinterpret_cast<const uint8_t*>(chain_level1_linear.data()),
+                     CHAIN_W / 2u, CHAIN_H / 2u, chain_tile, 0, CHAIN_BPE);
+
+        // word0 f0040108 = IMAGE_LOAD_MIP (opcode 1) dmask:x dim:2D with UNRM and GLC CLEAR -- the
+        // exact modifier shape Sonic Frontiers emits, which `rdna2_mimg_zero_mip_shape` rejects.
+        const uint32_t dynamic_mip_program[] = {
+            0x7e080300u,                     // v4 = x (save the shell input before v0 is reused)
+            0x7e020280u,                     // v1 = y = 0
+            0x7e040281u,                     // v2 = mip = inline constant 1 (never provably zero)
+            0x7e0a0280u,                     // v5 = destination y = 0
+            0xf0040108u, 0x00050000u,        // IMAGE_LOAD_MIP v0, [v0,v1,v2], s[20:27]
+            0xbf8c3f70u,                     // s_waitcnt
+            0xf0200108u, 0x00020004u,        // IMAGE_STORE v0, [v4,v5], s[8:15]
+            0xbf810000u,                     // s_endpgm
+        };
+        std::vector<uint32_t> chain_dst(W, 0x77777777u);
+        ShaderResourceTable chain_rt = irt;
+        for (ShaderResource& resource : chain_rt.resources) {
+            if (resource.binding == 4) {
+                resource.cls = ResourceClass::Texture;
+                resource.sgpr_base = 20;
+                resource.fetch_pc = 4;
+                resource.img_dim = 1;
+                resource.format = DataFormat::Uint32;
+                resource.num_components = 1;
+                resource.width = CHAIN_W;
+                resource.height = CHAIN_H;
+                resource.depth = 1;
+                resource.tile_mode = chain_tile;
+                resource.declared_mip_levels = CHAIN_MAX_MIP + 1u;
+                resource.mip_chain_element_width = CHAIN_W;
+                resource.mip_chain_element_height = CHAIN_H;
+                resource.mip_chain_bytes_per_block = CHAIN_BPE;
+                resource.mip_chain_max_level = CHAIN_MAX_MIP;
+                resource.mip_chain_base_level = 0;
+                resource.proven_zero_mip = false;   // the whole point: the operand is a real value
+                resource.gpu_addr = reinterpret_cast<uint64_t>(
+                    chain_allocation.data() + chain_level0.byte_offset);
+                resource.size = static_cast<uint32_t>(
+                    tiled_surface_bytes(CHAIN_W, CHAIN_H, chain_tile, 0, CHAIN_BPE));
+            } else if (resource.binding == 5) {
+                resource.img_dim = 1;   // exact destination IMAGE_STORE has DIM=2D
+                resource.format = DataFormat::Uint32;
+                resource.num_components = 1;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(chain_dst.data());
+                resource.size = static_cast<uint32_t>(chain_dst.size() * sizeof(uint32_t));
+            }
+        }
+        const std::vector<uint32_t> chain_spirv = recompile_valu(
+            dynamic_mip_program, std::size(dynamic_mip_program), 1, 0, &chain_rt);
+        CHECK(!chain_spirv.empty(),
+              "IMAGE_LOAD_MIP with a runtime mip operand recompiles once the declared chain is "
+              "materialized (#3048)");
+        if (!chain_spirv.empty()) {
+            ComputeItem item;
+            item.spirv = chain_spirv;
+            item.resources = std::make_shared<ShaderResourceTable>(chain_rt);
+            item.launch.threads_x = W; item.launch.local_x = 64; item.launch.groups_x = 1;
+            item.launch.local_y = item.launch.local_z = 1;
+            item.launch.groups_y = item.launch.groups_z = 1;
+            item.code_addr = 0x2005714000ull;
+            CHECK(prosper::frontend::execute_live_compute_items({item}),
+                  "live backend executes a dynamic-mip IMAGE_LOAD_MIP dispatch");
+            CHECK(std::equal(chain_dst.begin(), chain_dst.end(), chain_level1_linear.begin()),
+                  "IMAGE_LOAD_MIP at a runtime mip returns LEVEL ONE's own guest texels");
+            CHECK(!std::equal(chain_dst.begin(), chain_dst.end(), chain_level0_linear.begin()),
+                  "level one is distinguishable from level zero in this fixture");
+        }
+    }
+
     const uint32_t gta_store_mip_2d[] = {
         0x7e080300u,                         // v4 = x, while v0 remains stored data
         0x7e060280u,                         // v3 = y = 0

--- a/prosper/tests/gpu/recompiler/test_indirect_pointer_descriptor_range.cpp
+++ b/prosper/tests/gpu/recompiler/test_indirect_pointer_descriptor_range.cpp
@@ -432,7 +432,7 @@ void test_capture_roundtrip(const Shape& shape, const std::vector<uint32_t>& exa
     CHECK(capture_submit_items(
               {}, {compute}, {{SubmitOperationKind::Dispatch, 0u, 1u}},
               metadata, capture_reader, captured, error) &&
-              captured.format_version == 56u,
+              captured.format_version == 57u,
           "v53 capture stores a DescriptorRange dispatch without reading unused candidates");
     const GpuCapturedResource* captured_unused = captured_resource_at(
         captured, unused_large_pc);

--- a/prosper/tests/gpu/recompiler/test_indirect_pointer_static_footprint.cpp
+++ b/prosper/tests/gpu/recompiler/test_indirect_pointer_static_footprint.cpp
@@ -564,7 +564,7 @@ int main() {
               {}, {captured_compute},
               {{SubmitOperationKind::Dispatch, 0u, 1u}}, metadata,
               capture_reader, captured, capture_error) &&
-              captured.format_version == 56u && captured.computes.size() == 1u &&
+              captured.format_version == 57u && captured.computes.size() == 1u &&
               captured.computes[0].resources.resources[0].internal_bytes.size() ==
                   compiled_source->host_data_size,
           "capture stores the dispatch-owned relocation snapshot as current-version internal bytes");

--- a/prosper/tests/gpu/recompiler/test_rdna2_decode.cpp
+++ b/prosper/tests/gpu/recompiler/test_rdna2_decode.cpp
@@ -744,6 +744,49 @@ int main() {
               !rdna2_mimg_zero_mip_shape(
                   rdna2_decode_one(stray_load_mip_2d_nsa_dmask3_words, 3)),
           "Stray IMAGE_LOAD_MIP NSA shape rejects UNORM/GLC-set and dmask mutations");
+    // #3048: `rdna2_mimg_dynamic_mip_shape` is the GENERAL consecutive-address IMAGE_LOAD_MIP form,
+    // whose mip operand is a runtime value rather than something a proof may discard. It is
+    // deliberately free of the UNRM/GLC requirement -- Sonic Frontiers' stage kernels issue
+    // `f0040308` with both CLEAR and dmask 0x3, which is why the zero-mip shape above reports
+    // `shape=0` on them -- and it accepts any DMASK while still rejecting every modifier that moves
+    // the operand.
+    {
+        // dim:2D, dmask:0x3, UNRM/GLC clear, VADDR=v1: [x, y, mip] -> mip is v3.
+        const uint32_t frontiers_words[] = {0xf0040308u, 0x00000101u};
+        // The same op at dim:2D_ARRAY, VADDR=v1: [x, y, slice, mip] -> mip is v4. Consumed by no
+        // lowering yet; covered here so the header's advertised arm is exercised rather than dead.
+        const uint32_t dim5_words[] = {0xf0040328u, 0x00000101u};
+        uint32_t dynamic_vgpr = UINT32_MAX;
+        const Rdna2Inst frontiers = rdna2_decode_one(frontiers_words, 2);
+        CHECK(frontiers.opcode == 0x01u && frontiers.mimg_dim == 1u &&
+                  frontiers.mimg_dmask == 0x3u && !frontiers.mimg_unorm && !frontiers.mimg_glc &&
+                  !rdna2_mimg_zero_mip_shape(frontiers) &&
+                  rdna2_mimg_dynamic_mip_shape(frontiers, &dynamic_vgpr) && dynamic_vgpr == 3u,
+              "#3048: Sonic Frontiers' dmask:0x3 UNRM/GLC-clear IMAGE_LOAD_MIP 2D names v3 as its mip");
+        const Rdna2Inst dim5 = rdna2_decode_one(dim5_words, 2);
+        CHECK(dim5.opcode == 0x01u && dim5.mimg_dim == 5u &&
+                  rdna2_mimg_dynamic_mip_shape(dim5, &dynamic_vgpr) && dynamic_vgpr == 4u,
+              "#3048: the 2D_ARRAY form names the mip AFTER its preserved slice coordinate");
+        // Every rejection below is a modifier that moves the operand or changes its width, so the
+        // VGPR this function reports would not be the mip.
+        const uint32_t d16_words[] = {0xf0040308u, 0x80000101u};   // D16 packs the result
+        const uint32_t a16_words[] = {0xf0040308u, 0x40000101u};   // A16 packs the address
+        const uint32_t tfe_words[] = {0xf0050308u, 0x00000101u};   // TFE appends a status dword
+        const uint32_t lwe_words[] = {0xf0060308u, 0x00000101u};
+        const uint32_t plain_load_words[] = {0xf0000308u, 0x00000101u};  // opcode 0: IMAGE_LOAD
+        const uint32_t dim3d_words[] = {0xf0040310u, 0x00000101u};       // dim:3D
+        CHECK(!rdna2_mimg_dynamic_mip_shape(rdna2_decode_one(d16_words, 2)) &&
+                  !rdna2_mimg_dynamic_mip_shape(rdna2_decode_one(a16_words, 2)) &&
+                  !rdna2_mimg_dynamic_mip_shape(rdna2_decode_one(tfe_words, 2)) &&
+                  !rdna2_mimg_dynamic_mip_shape(rdna2_decode_one(lwe_words, 2)) &&
+                  !rdna2_mimg_dynamic_mip_shape(rdna2_decode_one(plain_load_words, 2)) &&
+                  !rdna2_mimg_dynamic_mip_shape(rdna2_decode_one(dim3d_words, 2)),
+              "#3048: the dynamic-mip shape rejects D16/A16/TFE/LWE, a plain IMAGE_LOAD, and dim:3D");
+        // An NSA packet spells its addresses in the extra dwords, so the consecutive-VGPR
+        // arithmetic this function does would name the wrong register.
+        CHECK(!rdna2_mimg_dynamic_mip_shape(rdna2_decode_one(stray_load_mip_2d_nsa_words, 3)),
+              "#3048: the dynamic-mip shape rejects the NSA address form");
+    }
     const uint32_t gta_pc10_vop2_word[] = {0x4a000804u};
     const uint32_t wide_vop3_words[] = {0xd5761e01u, 0x040a0100u};
     const uint32_t wide_mimg_words[] = {0xf0003f08u, 0x00050000u};

--- a/prosper/tests/gpu/resources/test_shader_resources.cpp
+++ b/prosper/tests/gpu/resources/test_shader_resources.cpp
@@ -1,8 +1,11 @@
 // test_shader_resources — fixes the resource-binding contract (shader_resources.hpp): format sizing
 // and the recompiler/pipeline lookups both halves rely on. Pure (no Vulkan), runs in CI.
+#include "gpu/resources/mip_chain_plan.hpp"
+#include "gpu/texture/tile.hpp"
 #include "gpu/resources/shader_resources.hpp"
 #include "gpu/execute/gpu_execute.hpp"
 #include "shared/live/live_compute.hpp"
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <initializer_list>
@@ -1046,6 +1049,123 @@ int main() {
     CHECK(!validate_runtime_descriptor_contract("test", spv, &missing, 0, SpirvShaderStage::Vertex),
           "strict runtime gate rejects a missing binding before backend submission");
     set_descriptor_mode("off");
+
+    // ---- #3048: the declared mip chain a compute image must materialize -------------------
+    // A T# declares how MANY levels exist; the allocation-wide placement says WHERE they are. The
+    // backend that creates the image and the recompiler that emits IMAGE_LOAD_MIP's explicit LOD
+    // both read shader_resource_compute_mip_chain_levels, so these arms fix that one contract.
+    {
+        // Level zero must not itself be packed in the shared mip tail, or `gpu_addr` and the plan
+        // would name different bytes. Assert that precondition rather than assuming the geometry.
+        constexpr uint32_t kWidth = 256, kHeight = 256, kBytesPerBlock = 4;
+        constexpr uint32_t kTile = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        constexpr uint32_t kMaxMip = 8;   // 256 -> 1 is nine levels
+        const TiledMipLevelLayout level0 = tiled_mip_level_layout(
+            kWidth, kHeight, kBytesPerBlock, kTile, kMaxMip, 0);
+        CHECK(level0.supported && !level0.in_tail,
+              "the mip-chain fixture's level zero is a placed, non-tail level");
+
+        ShaderResource chain{};
+        chain.cls = ResourceClass::Texture;
+        chain.format = DataFormat::Uint32;
+        chain.num_components = 1;
+        chain.img_dim = 1;
+        chain.width = kWidth;
+        chain.height = kHeight;
+        chain.depth = 1;
+        chain.tile_mode = kTile;
+        chain.declared_mip_levels = kMaxMip + 1;
+        chain.mip_chain_element_width = kWidth;
+        chain.mip_chain_element_height = kHeight;
+        chain.mip_chain_bytes_per_block = kBytesPerBlock;
+        chain.mip_chain_max_level = kMaxMip;
+        chain.mip_chain_base_level = 0;
+        chain.gpu_addr = 0x2026900000ull + level0.byte_offset;
+
+        const MipChainPlan plan = shader_resource_mip_chain_plan(chain);
+        CHECK(plan.valid && plan.level_count == kMaxMip + 1 &&
+              plan.levels.size() == kMaxMip + 1,
+              "a fully declared tiled 2D chain places every level it declares");
+        CHECK(shader_resource_compute_mip_chain_levels(chain) == kMaxMip + 1,
+              "the compute backend materializes the declared chain for a native sampled format");
+
+        bool extents_halve = plan.valid;
+        bool inside_allocation = plan.valid;
+        bool disjoint = plan.valid;
+        for (size_t level = 0; plan.valid && level < plan.levels.size(); ++level) {
+            const MipChainLevel& entry = plan.levels[level];
+            const uint32_t expect_w = kWidth >> level ? kWidth >> level : 1u;
+            const uint32_t expect_h = kHeight >> level ? kHeight >> level : 1u;
+            extents_halve &= entry.width == expect_w && entry.height == expect_h;
+            inside_allocation &= entry.byte_offset + entry.byte_size <= plan.allocation_bytes;
+            // Non-tail levels own disjoint byte ranges; tail levels deliberately share the
+            // allocation's first block and are addressed by element coordinate instead.
+            for (size_t other = 0; other < level; ++other) {
+                const MipChainLevel& earlier = plan.levels[other];
+                if (entry.in_tail || earlier.in_tail) continue;
+                disjoint &= entry.byte_offset + entry.byte_size <= earlier.byte_offset ||
+                            earlier.byte_offset + earlier.byte_size <= entry.byte_offset;
+            }
+        }
+        CHECK(extents_halve, "each planned level carries its own halved extent");
+        CHECK(inside_allocation, "every planned level lies inside the allocation it names");
+        CHECK(disjoint, "planned non-tail levels never overlap one another");
+        CHECK(plan.valid && !plan.levels[0].in_tail &&
+              plan.levels[0].byte_offset == level0.byte_offset,
+              "level zero of the plan is the level the resource's own gpu_addr names");
+        CHECK(plan.valid &&
+              std::any_of(plan.levels.begin(), plan.levels.end(),
+                          [](const MipChainLevel& entry) { return entry.in_tail; }),
+              "the fixture exercises the packed mip tail as well as the placed levels");
+
+        // Reject-by-default. Every one of these leaves the historical single-level image, because a
+        // guessed offset is worse than the operation staying unimplemented.
+        const auto levels_after = [&](void (*mutate)(ShaderResource&)) {
+            ShaderResource copy = chain;
+            mutate(copy);
+            return shader_resource_compute_mip_chain_levels(copy);
+        };
+        CHECK(levels_after([](ShaderResource& r) { r.tile_mode = 0; }) == 1,
+              "a LINEAR chain is declined: its per-level 256-byte pitch is not reproduced yet");
+        CHECK(levels_after([](ShaderResource& r) { r.in_mip_tail = true; }) == 1,
+              "a selected level packed in the tail is declined");
+        CHECK(levels_after([](ShaderResource& r) { r.depth = 3; }) == 1,
+              "a multi-layer view is declined: each slice owns its own chain");
+        CHECK(levels_after([](ShaderResource& r) { r.layer_stride_bytes = 4096; }) == 1,
+              "a strided array slice is declined");
+        CHECK(levels_after([](ShaderResource& r) { r.compression_enabled = true; }) == 1,
+              "a DCC-compressed base is not ordinary tiled texels at any level");
+        CHECK(levels_after([](ShaderResource& r) { r.mip_chain_base_level = 1; }) == 1,
+              "a shifted BASE_LEVEL view is declined rather than rebased on a guess");
+        CHECK(levels_after([](ShaderResource& r) { r.mip_chain_element_width = 0; }) == 1,
+              "an unmodelled placement (zero element extent) is declined");
+        CHECK(levels_after([](ShaderResource& r) { r.mip_chain_element_width = 128; }) == 1,
+              "an element extent that disagrees with the texel extent is declined");
+        CHECK(levels_after([](ShaderResource& r) { r.declared_mip_levels = 1; }) == 1,
+              "a single-level T# keeps the historical single-level image");
+        CHECK(levels_after([](ShaderResource& r) { r.format = DataFormat::Float16; }) == 1,
+              "a format whose sampled upload converts rather than copies is declined");
+        CHECK(levels_after([](ShaderResource& r) { r.mip_chain_bytes_per_block = 8; }) == 1,
+              "a bytes-per-block that disagrees with format x components is declined");
+        CHECK(levels_after([](ShaderResource& r) { r.cls = ResourceClass::StorageImage; }) == 1,
+              "a storage image keeps one level: its writeback contract is per selected level");
+        CHECK(levels_after([](ShaderResource& r) { r.sample_count = 4; }) == 1,
+              "a multisample resource has no mip chain to place");
+        uint8_t host_bytes[4]{};
+        ShaderResource host_backed = chain;
+        host_backed.host_data = host_bytes;
+        host_backed.host_data_size = sizeof host_bytes;
+        CHECK(shader_resource_compute_mip_chain_levels(host_backed) == 1,
+              "a host_data-backed resource exposes only its selected level and is declined");
+        // The chain is bounded by the extent as well as by the declaration: a T# may not name more
+        // levels than 256x256 can have.
+        ShaderResource over_declared = chain;
+        over_declared.declared_mip_levels = 12;
+        over_declared.mip_chain_max_level = 11;
+        CHECK(shader_resource_compute_mip_chain_levels(over_declared) <=
+                  full_mip_chain_levels(kWidth, kHeight),
+              "the materialized chain never exceeds the levels the extent can hold");
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/gpu/resources/test_shader_resources.cpp
+++ b/prosper/tests/gpu/resources/test_shader_resources.cpp
@@ -1162,9 +1162,12 @@ int main() {
         ShaderResource over_declared = chain;
         over_declared.declared_mip_levels = 12;
         over_declared.mip_chain_max_level = 11;
-        CHECK(shader_resource_compute_mip_chain_levels(over_declared) <=
-                  full_mip_chain_levels(kWidth, kHeight),
-              "the materialized chain never exceeds the levels the extent can hold");
+        // Equality, not `<=`: a DECLINE (1) also satisfies "does not exceed the full chain", so the
+        // inequality would have passed without the clamp ever running.
+        CHECK(shader_resource_compute_mip_chain_levels(over_declared) ==
+                  full_mip_chain_levels(kWidth, kHeight) &&
+              full_mip_chain_levels(kWidth, kHeight) == 9u,
+              "a T# declaring more levels than the extent can hold is CLAMPED to the full chain");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
Fixes #3048. Refs #2790, #2818.

## The gap

Compute-path images were created with `ici.mipLevels = 1` unconditionally. That single line made
`IMAGE_LOAD_MIP` unimplementable rather than merely unimplemented: the obvious recompiler fix —
lower it to `OpImageFetch` with a `Lod` operand — would fetch a level that does not exist. So the
recompiler could only admit the op when it could be *specialised away* to an ordinary level-zero
load, and declined every case where the guest's mip selector is a real runtime value.

Sonic Frontiers' three scene-target-width Cyber Space kernels are exactly that case: a **12-level
2048x2048 RG32F** surface (`type=13`/2D_ARRAY with `depth=1`, `tile_mode=27`, `BASE_LEVEL=0`,
`LAST_LEVEL=MAX_MIP=11`) read at a runtime LOD, with `proven_zero_mip=0`. No specialisation can
ever admit them.

The charter's rule applies directly: an unsupported GPU operation the guest exercises is a fatal
gap, not an acceptable skip.

## What changed

Both halves land together because neither works alone.

**1. One derivation, two consumers.** New `src/gpu/resources/mip_chain_plan.{hpp,cpp}` answers
"how many levels does this resource's compute image carry, and where does each level's guest data
live". `live_compute`'s image creation and the recompiler's MIMG lowering both call
`shader_resource_compute_mip_chain_levels`. If those two ever answered differently, a shader would
fetch a level nobody created — this is the shape the #2265 drift lesson asks for.

**2. The placement provenance the plan needs.** `image_base_level_view` shifts
`gpu_addr`/`width`/`height` onto the *selected* level, so nothing downstream could recover the
others: `tiled_mip_level_layout` needs the ALLOCATION's level-zero element extent and its effective
`MAX_MIP`, and neither survives that shift. `DecodedImageView` and `ShaderResource` now carry them
(`mip_chain_element_width/height`, `mip_chain_bytes_per_block`, `mip_chain_max_level`,
`mip_chain_base_level`), copied at all three `(descriptor, view) -> ShaderResource` build sites
through one shared helper.

**3. Real guest bytes, not a generated cascade.** Every declared level is detiled from the guest's
own `tiled_mip_level_layout` offset — packed-tail levels included, via `detile_surface_level` —
straight into the staging buffer, and copied with one `VkBufferImageCopy` per level. The graphics
path's linear-blit cascade (#1272) is deliberately **not** reused: `IMAGE_LOAD_MIP` asks for a
specific level's texels, and synthesizing them by downsampling level zero would render plausible
wrong content. `SONIC_FRONTIERS_STATUS.md` already argued this; the guest builds this pyramid itself
through twelve single-level descriptors, so the bytes are there to read.

**4. The recompiler emits the LOD.** New `rdna2_mimg_dynamic_mip_shape` identifies the general
`IMAGE_LOAD_MIP` address form — any DMASK, **UNRM and GLC free** (Sonic's packet has both clear,
which `rdna2_mimg_zero_mip_shape` rejects), no operand-shape modifier. The guest's own selector
reaches `OpImageFetch`'s `Lod`, clamped to the materialized level count the way hardware clamps to
`LAST_LEVEL`. Compute only: the graphics texture path still uploads one level.

## Reject-by-default, and where it fails visibly

The plan is invalid — leaving the historical single-level image and the historical decline — for a
linear chain, a selected level packed in the tail, a layered or volume view, DCC, block-compressed
or converting formats, a shifted `BASE_LEVEL`, and `host_data` backing (the allocation base sits
*below* `gpu_addr`, which host-backed resources cannot expose).

Three places deliberately fail visibly instead of degrading silently:

* A binding whose **shape** cannot carry the chain — imported/renderer-owned surfaces above all —
  is declined (`skip_image`), because building fewer levels than the compiled module may address is
  SPIR-V undefined behaviour. **The blast radius is wider than the first draft of this body said,
  and the failure was not as loud as it claimed.** The decline is *not* conditional on the module
  actually issuing `IMAGE_LOAD_MIP` — a sampling-only use behaves identically at one level or N, so
  declining it is pure loss, and the backend cannot see which ops a compiled module contains.
  Separately, `skip_image` warns once per `gpu_addr` for the whole process while the dispatch is
  dropped **every frame**, so the one line it prints reads as a one-off. Both are now written down
  at the site and in the status doc, and the decline reports as `[compute-mip-chain] declined …`
  on a geometric schedule (occurrences 1, 2, 4, 8, …) so a lane reading a black frame can see it
  recurring.
* A chain that reaches the end of the sampled conversion cascade with levels 1..N-1 **unwritten**
  declines. Two predicates decide "is this upload a straight per-texel copy" — the whitelist that
  chose the level count and the branch that does the copying — and a one-line widening of either
  would otherwise copy uninitialized staging into the image. This is a detector rather than a third
  copy of the predicate.
* The **persistent sampled cache is disabled for multi-level images**, because its revalidation
  covers only the selected level's guest bytes: an unchanged level zero would wrongly certify a
  stale level three. Costs upload time, never correctness.

Sampling behaviour for existing multi-level textures is unchanged: the sampler's `maxLod` stays 0
and `image_load`/`image_sample*` still resolve level zero, so a texture that merely *gains* levels
produces byte-identical results.

## Capture format

Serialized as a trailing tail at **v57**: the placement is what nothing else preserves once
`image_base_level_view` has shifted `gpu_addr`/`width`/`height` onto the selected level.

**What it does not do, corrected from the first draft of this body:** `gpu_replay` still declines
`IMAGE_LOAD_MIP`. A replayed resource is `host_data`-backed and its blob covers only the selected
level's footprint, and the chain derivation declines any `host_data` resource — so replay behaves
exactly as it did before v57. Making replay materialize the chain needs the capture to own the whole
**allocation's** bytes; filed as **#3202** with the three concrete steps. This tail is the
descriptor half, recorded now so the placement is not lost from capsules taken in the meantime.
Pre-v57 files read as "not modelled" and fail closed to one level.

## Verification

Build: fresh configure, `cmake -S prosper -B prosper/build-linux -G Ninja -DCMAKE_BUILD_TYPE=Debug`
inside the `ps5ys` distrobox.

```
cmake --build prosper/build-linux -j6                 -> exit 0, 0 errors
ctest --test-dir prosper/build-linux --no-tests=error -> exit 0
   100% tests passed out of 323
```

Rebased onto `origin/master` (`bee26b9e`) — the previous head had **zero CI runs** because it was
`CONFLICTING`, which is instrument trap 242 and looks exactly like Actions being broken. One content
conflict, in `live_compute.cpp` against #3160's alias census: both sides add an independent statement
at the same point, so both are kept (master's census block first, so its comment stays attached to
what it describes). The branch deletes 40 lines against master and every one of them is this PR's
own — checked line by line, per trap 41. The 323 count is master's 318 plus the five tests that
landed while this was open.

Registered coverage:

* `build_shader_resources` — four arms pinning `unmapped_format_image_view`'s fail-closed contract
  (the blocking finding below), including that it reports its mip chain as *not modelled*.
* `shader_resource_contract` — the plan's geometry (extents halve, every level inside the
  allocation, non-tail levels pairwise disjoint, level zero is the level `gpu_addr` names, the
  fixture really reaches the packed tail) plus **fifteen reject-by-default arms**.
* `rdna2_decode_walk` — the dynamic-mip address shape: Sonic's own `f0040308` (dmask `0x3`,
  UNRM/GLC clear, which `rdna2_mimg_zero_mip_shape` rejects) naming v3, the 2D_ARRAY form naming v4
  after its slice, and rejection of D16/A16/TFE/LWE/NSA/plain-load/dim:3D.
* `gpu_capture_roundtrip` — five **distinct** v57 fields round-tripped individually, a v56 downgrade
  reading as "not modelled", and a partially present placement rejected.
* `game_compute_exec` — **two** executed dispatches through the production compute backend against
  real tiled nine-level guest chains: `dmask:0x1` R32_UINT reading mip 1, and `dmask:0x3` on a
  two-channel 8 B/texel surface storing the **second** returned component — the mask Sonic actually
  issues, which the first arm could not observe. Both assert the guest's own level-one texels, plus
  that every destination texel was written.

**Mutation verification.** Two mutations, each with the build's exit code checked before the result
was believed:

| arm | build | ctest | result |
| --- | --- | --- | --- |
| baseline | 0 | 0 | — |
| `unmapped_format_image_view` reverted to the positional aggregate | 0 | 8 | **4 arms redden**, including both fail-closed guards and the "not modelled" one (the `supported` expression lands on `chain_element_width`) |
| restored | 0 | 0 | passes |
| baseline | 0 | 0 | 426 assertions in `game_compute_exec` |
| `ici.mipLevels = bi.mip_levels` reverted to `= 1` | 0 | 8 | **2 of 426 redden**, and they are the two that matter: `IMAGE_LOAD_MIP at a runtime mip returns LEVEL ONE's own guest texels` and `dmask:0x3 returns level one's SECOND component in the second VGPR` |
| restored | 0 | 0 | passes |

**On the anti-coincidence guard — corrected twice, and the second correction matters.** The first
version of this PR credited the "distinguishable from level zero" arm as the guard; it is not, since
it stays green under the mutant. The replacement explanation — "because an unwritten destination also
differs from level zero" — was **also** wrong, and measurement says so: under the mutant **both**
"every destination texel was actually written" arms stay green too. The dispatch does write every
texel, with something that is neither level one nor the sentinel.

So the two companion arms are **fixture-validity guards**, not discriminators: they rule out a
fixture that could pass vacuously (level one byte-identical to level zero; the dispatch never
running). The discriminator is the level-one equality itself, and behind it the fact that this
program only recompiles through the dynamic-LOD path. The comment now says exactly that and tells
the next reader not to draw mutant conclusions from either arm.

`PIPESTATUS[0]` was used throughout so no pipeline masked a failing stage. No snapshots were run and
no title was launched (another lane holds the GPU).

## Review response (#3197)

**The defect class is now eliminated, not just the instance.** `DecodedImageView() = default;` makes
the struct a non-aggregate under C++20 (P1008R1), so *any* positional braced initialization of it is
a compile error, while `V v;`, `V v{}` and `return {};` keep working. This matters because the arms
below pin the **function** that held the tree's one positional initializer — they cannot catch the
same shape at a **new** call site, which is how the original defect arrived. Verified in a standalone
TU on gcc 16 `-Wall -Wextra` before applying it (positional → `no matching function for call to
'V::V(<brace-enclosed initializer list>)'`; the other three forms compile), and a
`static_assert(!std::is_aggregate_v<DecodedImageView>)` stops the line being tidied away as
redundant.

**Blocking finding — fixed.** `gpu_executor.cpp` built the unmapped-format fallback view with a
**positional** `DecodedImageView` aggregate of eleven values, the only one in the tree. Inserting
five fields before `supported` re-bound the eleventh onto `chain_element_width`, so `supported` fell
back to its default `true` and the `BASE_ARRAY`/`BASE_LEVEL` guard went dead — silently, because
`bool -> uint32_t` is a promotion, not a narrowing. On the storage-image path that also writes slice
N's results into slice zero's guest bytes. Replaced with a named `unmapped_format_image_view` that
assigns every field by name, carries a comment saying why it may not go back, and is directly
testable. I handled the same hazard correctly for `ComputeImageCacheKey` and missed it here; the
tree now has no positional `DecodedImageView` left.

The other five, in the reviewer's numbering:

1. **v57 does not deliver replay** — confirmed against the source before rewriting anything
   (`bind_range` sets `r.host_data` for every replayed resource; `resource_footprint_impl` starts
   from `r.size`, the selected level). Claim corrected in the format comment, the status doc and
   this body; follow-up filed as **#3202** with the three concrete steps.
2. **v57 had no value coverage** — added, with distinct values so a transposition reddens, plus a
   v56 downgrade arm and a partial-placement rejection arm. Given the blocking finding was itself a
   field-ordering defect, this was the right thing to insist on.
3. **Two straight-copy predicates** — given a **drift detector** rather than a third copy. A
   detector that cannot fail silently seemed better here than exporting `live_compute`'s whole
   format classification; say so if you would still rather see them collapsed.
4. **Blast radius** — accepted and written down, at the site and in the status doc, plus the
   geometric-schedule report. See the bullet above.
5. **Smaller ones** — the clamp now separates the certain half (out-of-range `Lod` is SPIR-V UB, so
   *some* clamp is mandatory) from the inferred half (saturating to the last level, from doc 70648's
   BASE_LEVEL/LAST_LEVEL fields, which do not spell out MIMG's out-of-range behaviour), marked
   `CONFIDENCE: MED`; the 2D_ARRAY arm of `rdna2_mimg_dynamic_mip_shape` is now exercised by a
   decoder test instead of being advertised and dead; `dmask:0x3` has an executed arm; and the `<=`
   arm is now an equality that a decline cannot satisfy.

## Not claimed

**No routed arm has been run on Sonic Frontiers since this landed.** Nothing here says the Cyber
Space world renders. The status doc's own `## Ruled out` row — "fixing a recompiler decline that
unblocks these programs will change the frame" — has failed four times, and this is not evidence
against it. The next two measurements, in order: whether the three scene-width programs leave the
census skip list on a **default** build, and only then the composite's non-black percentage and
bounding box.

