### PR TITLE
Derive the advertised display mode from the host instead of hardcoding 1080p59.94 (#3017)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2072,6 +2072,17 @@ if(TARGET prosper_core)
   target_link_libraries(test_videoout PRIVATE prosper_core)
   add_test(NAME videoout_queries COMMAND test_videoout)
 
+  # #3017: the display prosper advertises must be DERIVED from the host's real mode rather than
+  # hardcoded 1080p59.94. Its own executable, not an arm of test_videoout, because the advertised
+  # mode resolves ONCE per process on first use -- so the derived case needs a process whose
+  # environment is set before any VideoOut call, and test_videoout above is exactly the
+  # complementary process where those variables are unset and the untouched `legacy` default is
+  # asserted. CROSS-PLATFORM for the same reason test_videoout is: it drives the HLE registry and
+  # a pure header, with no OS display access.
+  add_executable(test_display_mode tests/hle/graphics/test_display_mode.cpp)
+  target_link_libraries(test_display_mode PRIVATE prosper_core)
+  add_test(NAME display_mode_derivation COMMAND test_display_mode)
+
   # precise_sleep's deadline post-condition (#3074): every sleep_until_steady_ns() backend must
   # never return before now_ns() >= deadline_ns. Win32SleepFallback did not re-check after its one
   # OS sleep call, unlike the sibling high-resolution-timer path. CROSS-PLATFORM like test_videoout

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -229,6 +229,15 @@ sceVideoOutGetOutputStatus, `w0hLuNarQxY` sceVideoOutConfigureOutput. Plus fixed
 (was all-zero → now 1920×1080@59.94Hz) and added GetVblankStatus (advancing counter) +
 GetDeviceCapabilityInfo (SDR). All output-struct writes are size-exact.
 
+> **The 1080p@59.94 in this entry is no longer the whole answer (#3017).** It remains the *default*,
+> so this record still describes what a default run advertises — but that pair was hardcoded, and a
+> title that reads the advertised mode and paces to it was therefore told 59.94 Hz on any host and
+> 1080p on a 4K one. Since #3017 the mode is **derived** from the host's real display under
+> `PROSPER_DISPLAY_MODE` (`legacy` | `host` | `host-high-refresh`), and the vblank period that paces
+> the guest comes from the *same* resolved mode rather than from a third constant kept in step by
+> hand. `src/hle/graphics/display_mode.hpp` holds the policy and the evidence grading behind each
+> refresh enumerant; deriving is opt-in because titles act on this value.
+
 **Verified the game requests exactly what we advertise:** `SetBufferAttribute2` arrives with
 `width=0x780 (1920)`, `height=0x438 (1080)`, `pixel_format=0x8000000000000000` (PS5 A8R8G8B8 sRGB);
 `RegisterBuffers2` registers **3** framebuffers (triple-buffered). Recorded them in a display-buffer

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -216,6 +216,30 @@ tuning one; leave it unset for normal use.
 - `--record-axis flip|pad-read` — timestamp recorded intervals by display flips (the backward-compatible
   default) or by successful guest input-state reads. Pad-read routes remain stable when presentation
   pauses while the title continues polling input.
+- `--display-mode legacy|host|host-high-refresh` — which display prosper tells the **guest** it is
+  attached to. See below. Default `legacy`.
+
+## `--display-mode`: what the guest is told it is plugged into
+
+This is not a window or swapchain setting — it is the display prosper *advertises* through
+`libSceVideoOut`, which some titles read to pick their render resolution and to pace themselves. It
+also sets the vblank period the guest is woken on, because those two must agree: a title paced at a
+rate it does not believe it is in behaves as badly as one told a rate it cannot act on.
+
+- `legacy` (**default**) — always 1920×1080 @ 59.94 Hz, exactly what prosper advertised before #3017.
+  Deriving is opt-in because titles *act* on this: anything that advances state per flip rather than
+  per elapsed second runs fast at a higher rate.
+- `host` — derive resolution and refresh from the real display. The resolution becomes the largest
+  **PS5 output mode** the host can show (720p / 1080p / 4K — never the host's own desktop resolution,
+  which may be one no PS5 ever reports). Refresh is capped at 59.94: the 119.88 enumerant's integer
+  value rests on no primary evidence, so deriving alone never reaches it.
+- `host-high-refresh` — additionally allow the 119.88 Hz enumerant on a host that can present it.
+  **Experimental**, for exactly the reason above; verify the title before trusting a run made with it.
+
+The app publishes the host's mode as `PROSPER_HOST_DISPLAY_MODE=<w>x<h>@<hz>` before the guest boots;
+`PROSPER_DISPLAY_MODE` is the same policy switch for harnesses that do not go through this frontend.
+An unknown or unparseable host mode falls back to 1920×1080 @ 59.94, and the chosen mode is printed
+once at startup (`[vo] display: …`).
 
 ## `--fps`: two numbers, and the first one is the honest one
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -32,6 +32,7 @@
 #include "keyboard_pad_map.hpp"         // which key is which pad control (#2234)
 #include "hle/input/ime_input.hpp"           // #1093: forward host keyboard keys to the guest IME path
 #include "present_mode.hpp"             // explicit swapchain latency/vsync policy, pure regression seam
+#include "hle/graphics/display_mode.hpp" // #3017: validate --display-mode against the one policy parser
 #include "present_policy.hpp"           // bounded-acquire present classification (#1182), pure seam
 #include "window_controls.hpp"           // debounced app-window shortcuts, pure regression seam
 #include "game_path.hpp"                 // dropped/picked path -> app0 root + open action, pure seam
@@ -1429,6 +1430,25 @@ int main(int argc, char** argv) {
                 return 2;
             }
         }
+        else if (a == "--display-mode" && i + 1 < argc) {
+            // Which display prosper tells the guest it is attached to (#3017). `legacy` (the
+            // default, so this flag is never needed to keep today's behaviour) always advertises
+            // 1920x1080 @ 59.94. `host` derives resolution and refresh from the real display.
+            // `host-high-refresh` additionally allows the 119.88 Hz enumerant, whose VALUE prosper
+            // cannot yet defend from primary evidence and which no title here has been checked
+            // against for flip-rate-dependent logic -- see display_mode.hpp.
+            const std::string requested = argv[++i];
+            prosper::hle::graphics::DisplayModePolicy parsed{};
+            if (!prosper::hle::graphics::parse_display_mode_policy(requested, parsed)) {
+                fprintf(stderr, "prosper-app: --display-mode must be legacy, host, or "
+                                "host-high-refresh (got \"%s\")\n", requested.c_str());
+                return 2;
+            }
+            if (!set_environment("PROSPER_DISPLAY_MODE", requested.c_str())) {
+                fprintf(stderr, "prosper-app: failed to set PROSPER_DISPLAY_MODE\n");
+                return 2;
+            }
+        }
         else if (a[0] != '-' && dump.empty()) dump = a;                          // positional dump path
     }
     pick.has_dump = !dump.empty();
@@ -1482,6 +1502,34 @@ int main(int argc, char** argv) {
             printf("%s\t%s\t%s\n", g.title_id.c_str(), g.title_name.c_str(), g.app0_root.c_str());
         fprintf(stderr, "prosper-app: %zu title(s) in %s\n", games.size(), gamesDir.c_str());
         return games.empty() ? 1 : 0;
+    }
+
+    // #3017: publish the host's REAL display mode before anything boots, so the VideoOut layer can
+    // derive what it advertises to the guest instead of hardcoding 1920x1080 @ 59.94 Hz. Publishing
+    // is unconditional and inert on its own -- PROSPER_DISPLAY_MODE (default `legacy`) decides
+    // whether the derivation actually uses it, so a title that works today is untouched until
+    // somebody opts in.
+    //
+    // Position is load-bearing: start_guest() below spawns the guest thread, and the VideoOut layer
+    // resolves its mode ONCE on first use. Publishing after the boot would make which mode the guest
+    // sees depend on whether it asked before we wrote the variable -- a race, and one that would
+    // usually resolve the wrong way. SDL_InitSubSystem rather than the authoritative SDL_Init
+    // further down: video is not up yet here, and a failure must cost only the derivation (the
+    // documented fallback is exactly the hardcoded mode prosper always used), never the boot.
+    if (SDL_InitSubSystem(SDL_INIT_VIDEO)) {
+        const SDL_DisplayMode* host_mode = SDL_GetDesktopDisplayMode(SDL_GetPrimaryDisplay());
+        if (host_mode && host_mode->w > 0 && host_mode->h > 0 && host_mode->refresh_rate > 0.0f) {
+            char published[64];
+            snprintf(published, sizeof published, "%dx%d@%.4f",
+                     host_mode->w, host_mode->h, (double)host_mode->refresh_rate);
+            if (set_environment("PROSPER_HOST_DISPLAY_MODE", published))
+                fprintf(stderr, "[app] host display: %s\n", published);
+            else
+                fprintf(stderr, "[app] failed to publish PROSPER_HOST_DISPLAY_MODE\n");
+        } else {
+            fprintf(stderr, "[app] host display mode unavailable (%s); VideoOut keeps its "
+                            "1920x1080 @ 59.94 default.\n", SDL_GetError());
+        }
     }
 
     // Boot the game (unless test-pattern): the shared start_guest() path registers the live renderer

--- a/prosper/src/hle/graphics/AGENTS.md
+++ b/prosper/src/hle/graphics/AGENTS.md
@@ -1,0 +1,46 @@
+# `src/hle/graphics` — the guest-facing graphics libraries
+
+This folder is prosper's reimplementation of the Sony **libraries a title calls** to get pictures on
+screen: `libSceVideoOut` (the display, its buffers, flips and vblanks) and the `libSceAgc` driver
+surface (command-buffer submission, GPU completion events, register defaults). It is the HLE side of
+the boundary — NIDs in, ABI structs out.
+
+**Its boundary against `src/gpu/` is the important one.** Everything here answers the guest; nothing
+here draws. When `SubmitFlip` arrives, this folder does the bookkeeping the guest can observe (flip
+count, current buffer, flip arg, buffer labels, the completion event) and then hands the buffer index
+to `gpu::present_flip`. Translating command streams, recompiling shaders and talking to Vulkan all
+live under `src/gpu/`. If you are reaching for a Vulkan type in this folder, the code probably wants
+to be somewhere else.
+
+What lives here:
+
+- **`hle_graphics.cpp`** — `libSceVideoOut`. The display prosper advertises, the registered
+  framebuffer set, flip submission and completion (from both the API call and the in-stream GPU
+  `SetFlip` packet), and the vblank timebase.
+- **`hle_agc.cpp`** — the AGC driver entry points a title submits work through, plus the
+  `PROSPER_PROGRESS` heartbeat.
+- **`agc_reg_defaults.cpp`** — the register state the guest inherits before it sets anything.
+- **`display_mode.hpp`** — pure, dependency-free: host display capabilities in, the mode prosper
+  advertises out.
+- **`render_cadence.hpp`** — the sampling/skip policy for headless capture runs.
+
+## Two things this folder gets wrong in ways that are hard to see
+
+**An answer here is something the guest ACTS on, so a wrong one does not look like a crash.** The
+title behaves correctly given what it was told, which means the symptom shows up as the game's own
+UI or pacing being wrong — a resolution it would not otherwise pick, a frame rate it caps itself to.
+`display_mode.hpp` exists because two constants were hardcoded here for a year and read as normal
+(#3017). When adding a query, ask what the guest does with the answer before deciding it is cosmetic.
+
+**Anything describing the display must be DERIVED, and must have exactly one origin.** The
+advertised mode is the worked example: what the title *reads*
+(`sceVideoOutGetResolutionStatus`) and what actually *paces* it (the vblank grid, which the kernel's
+kevent pump in `hle/kernel/hle_kernel_time.cpp` also schedules on) were once independent literals
+that agreed only because somebody maintained them by hand. They now come from one resolved
+`AdvertisedDisplayMode`, and they should stay that way: if you find yourself writing a second
+constant for a quantity that already exists here, that is the bug reappearing.
+
+The refresh rate is an **enum**, not a number, so advertising a rate means asserting the integer Sony
+assigned it. `display_mode.hpp` grades each row by evidence and the selection policy carries a floor,
+so a value prosper cannot defend is unreachable by default rather than merely discouraged. Keep that
+property when adding rows.

--- a/prosper/src/hle/graphics/display_mode.hpp
+++ b/prosper/src/hle/graphics/display_mode.hpp
@@ -1,0 +1,259 @@
+#pragma once
+// The one place prosper decides WHICH DISPLAY it tells the guest it is attached to.
+//
+// Before #3017 this decision was two unrelated hardcoded constants in hle_graphics.cpp: a
+// 1920x1080 / refresh-enumerant-3 pair written into SceVideoOutResolutionStatus, and a separate
+// 16683350 ns vblank period driving both sceVideoOutGetVblankStatus's count and
+// sceVideoOutWaitVblank's wake boundary (and, since #3024, the kernel's vblank kevent pump). They
+// agreed only because somebody kept two literals in step by hand. A title that reads the advertised
+// mode and paces to it therefore sat at 59.94 Hz on any host, and a 4K host was told it was 1080p.
+//
+// The rule this header exists to enforce is the charter's: DERIVE the answer, never hardcode it.
+// So one `select_display_mode()` resolves ONE AdvertisedDisplayMode, and both the status struct and
+// the pacing grid read their fields off that single object. They can no longer disagree, because
+// there is no longer a second place for them to disagree in.
+//
+// Pure and dependency-free on purpose: no SDL, no Vulkan, no guest memory. The host's real mode
+// arrives as plain data (the frontend queries SDL and publishes it), which is what lets the whole
+// derivation be unit-tested against SYNTHESIZED host capabilities -- including the arm that proves
+// a different host produces a different advertised mode, rather than one constant swapped for
+// another.
+
+#include <cstdint>
+#include <string_view>
+
+namespace prosper::hle::graphics {
+
+// How much evidence stands behind a refresh enumerant's VALUE -- not behind the rate existing.
+// SceVideoOutRefreshRate is an ENUM, so advertising a rate means asserting the integer Sony
+// assigned it. Getting that integer wrong is worse than not offering the rate at all: the title
+// reads a number it may act on as a different rate entirely. Per the charter's evidence hierarchy,
+// each row records what it rests on and the selection policy carries a floor, so an unevidenced
+// enumerant can never be reached by accident.
+enum class ModeEvidence {
+    low,      // a hypothesis; reachable only when explicitly asked for
+    medium,   // agreement among independently written secondary implementations
+    high,     // prosper's own live-title evidence
+};
+
+struct RefreshMode {
+    uint64_t enumerant;    // SceVideoOutRefreshRate value written at ResolutionStatus + 0x10
+    uint64_t period_ns;    // the vblank period THIS rate implies -- the pacing grid's period
+    double   hz;
+    ModeEvidence evidence;
+};
+
+// The refresh rates prosper is willing to advertise, ascending by rate.
+//
+// Deliberately minimal: one row per rate a real host display can actually be. Every row is a
+// liability (a wrong enumerant is a wrong answer the guest acts on), so rates no desktop monitor
+// runs at are omitted even where the enumerant is guessable.
+//
+//   59.94  CONFIDENCE: HIGH   -- enumerant 3 is what prosper has advertised since the VideoOut
+//                                bring-up and what every booting title has read; its period is the
+//                                16683350 ns grid hle_graphics.cpp and the #3024 kevent pump share.
+//   50.00  CONFIDENCE: MED    -- enumerant 2. Secondary-implementation agreement only; no title
+//                                observed reading it here. Reachable under `host` because a 50 Hz
+//                                host is a real configuration and telling it 59.94 is the lie this
+//                                issue is about.
+//  119.88  CONFIDENCE: LOW    -- enumerant 6. This is the rate #3017 actually wants and the one
+//                                prosper can least defend: no primary evidence pins the integer,
+//                                and no 120 Hz-capable title has been checked here for
+//                                flip-rate-dependent logic (the charter records The Plucky Squire
+//                                advancing in-game time PER FLIP, which at double the rate runs at
+//                                double speed). Reachable ONLY via the explicit
+//                                host-high-refresh policy, never by deriving from the host alone.
+inline constexpr RefreshMode kRefreshModes[] = {
+    {  2, 20000000,  50.00, ModeEvidence::medium },
+    {  3, 16683350,  59.94, ModeEvidence::high   },
+    {  6,  8341675, 119.88, ModeEvidence::low    },
+};
+
+// The documented fallback, and today's behaviour exactly: 1080p at 59.94 Hz. Used whenever the
+// host mode is unknown, unparseable, or matches no enumerant we are willing to advertise.
+inline constexpr uint32_t kFallbackWidth  = 1920;
+inline constexpr uint32_t kFallbackHeight = 1080;
+inline constexpr uint64_t kFallbackRefreshEnum = 3;
+inline constexpr uint64_t kFallbackPeriodNs    = 16683350;
+
+// The output resolutions a PS5 actually scans out. The host's desktop resolution is NOT passed
+// through: a title told it is attached to a 1366x768 panel is being told something no PS5 ever
+// reports. We pick the largest REAL PS5 output mode the host can display instead, which keeps the
+// answer derived from the host while staying inside the set of modes titles are built for.
+struct Resolution { uint32_t width, height; };
+inline constexpr Resolution kOutputResolutions[] = {
+    { 1280,  720 },
+    { 1920, 1080 },
+    { 3840, 2160 },
+};
+
+// What the host reports about its display. All-zero / non-positive means "unknown", which is the
+// normal case for headless runs, boot_trace, and the unit tests -- and must land on the fallback.
+struct HostDisplayMode {
+    uint32_t width = 0;
+    uint32_t height = 0;
+    double   refresh_hz = 0.0;
+
+    constexpr bool known() const {
+        return width > 0 && height > 0 && refresh_hz > 0.0;
+    }
+};
+
+// The resolved answer. Every VideoOut surface that describes the display reads its fields off one
+// of these, so the status struct and the vblank grid share a single origin by construction.
+struct AdvertisedDisplayMode {
+    uint32_t width = kFallbackWidth;
+    uint32_t height = kFallbackHeight;
+    uint64_t refresh_enum = kFallbackRefreshEnum;
+    uint64_t vblank_period_ns = kFallbackPeriodNs;
+    // True only when the host's real mode was consulted AND used. False means this is the
+    // documented 59.94/1080p fallback, whatever the reason -- which is what the boot log prints.
+    bool derived = false;
+};
+
+// PROSPER_DISPLAY_MODE. Default is `legacy`: byte-identical to prosper's pre-#3017 behaviour, so a
+// title that works today cannot be changed by this code existing. Deriving is opt-in because the
+// advertised mode is something titles ACT on -- resolution selection and frame pacing both hang
+// off it -- so it needs per-title verification rather than a global flip.
+enum class DisplayModePolicy {
+    legacy,             // always 1920x1080 @ 59.94 (enum 3). The default.
+    host,               // derive from the host, among enumerants of MEDIUM evidence or better.
+    host_high_refresh,  // additionally allow LOW-evidence high-rate enumerants (119.88).
+};
+
+constexpr const char* display_mode_policy_name(DisplayModePolicy policy) {
+    switch (policy) {
+    case DisplayModePolicy::legacy: return "legacy";
+    case DisplayModePolicy::host: return "host";
+    case DisplayModePolicy::host_high_refresh: return "host-high-refresh";
+    }
+    return "legacy";
+}
+
+// A malformed value selects nothing and returns false, so the caller keeps the conservative
+// default rather than silently picking a policy nobody asked for (the same rule the capture
+// triggers follow: a typo costs you the feature, never a wrong measurement).
+constexpr bool parse_display_mode_policy(std::string_view text, DisplayModePolicy& policy) {
+    if (text == "legacy") policy = DisplayModePolicy::legacy;
+    else if (text == "host") policy = DisplayModePolicy::host;
+    else if (text == "host-high-refresh") policy = DisplayModePolicy::host_high_refresh;
+    else return false;
+    return true;
+}
+
+namespace detail {
+
+// Minimal, locale-independent "<uint>" and "<double>" scanners. std::stoul/strtod would pull in
+// locale and errno behaviour this header has no reason to inherit, and constexpr parsing keeps the
+// whole seam usable in static_asserts.
+constexpr bool scan_uint(std::string_view& text, uint32_t& out) {
+    if (text.empty()) return false;
+    uint64_t value = 0;
+    size_t digits = 0;
+    while (digits < text.size() && text[digits] >= '0' && text[digits] <= '9') {
+        value = value * 10 + (uint64_t)(text[digits] - '0');
+        if (value > 0xFFFFFFFFull) return false;
+        ++digits;
+    }
+    if (digits == 0) return false;
+    text.remove_prefix(digits);
+    out = (uint32_t)value;
+    return true;
+}
+
+constexpr bool scan_double(std::string_view& text, double& out) {
+    uint32_t whole = 0;
+    if (!scan_uint(text, whole)) return false;
+    double value = (double)whole;
+    if (!text.empty() && text.front() == '.') {
+        text.remove_prefix(1);
+        double scale = 0.1;
+        size_t digits = 0;
+        while (digits < text.size() && text[digits] >= '0' && text[digits] <= '9') {
+            value += (double)(text[digits] - '0') * scale;
+            scale *= 0.1;
+            ++digits;
+        }
+        if (digits == 0) return false;   // "60." is malformed, not 60
+        text.remove_prefix(digits);
+    }
+    out = value;
+    return true;
+}
+
+}  // namespace detail
+
+// Parse the frontend's published host mode: "<width>x<height>@<hz>", e.g. "3840x2160@119.88".
+// Anything else fails and leaves `mode` untouched, which lands the caller on the fallback.
+constexpr bool parse_host_display_mode(std::string_view text, HostDisplayMode& mode) {
+    HostDisplayMode parsed;
+    if (!detail::scan_uint(text, parsed.width)) return false;
+    if (text.empty() || text.front() != 'x') return false;
+    text.remove_prefix(1);
+    if (!detail::scan_uint(text, parsed.height)) return false;
+    if (text.empty() || text.front() != '@') return false;
+    text.remove_prefix(1);
+    if (!detail::scan_double(text, parsed.refresh_hz)) return false;
+    if (!text.empty()) return false;              // trailing junk is malformed, not ignorable
+    if (!parsed.known()) return false;
+    mode = parsed;
+    return true;
+}
+
+// The largest PS5 output resolution the host can actually display. A host smaller than 720p still
+// gets 720p: that is the floor a PS5 scans out, and shrinking below it would advertise a mode no
+// title expects.
+constexpr Resolution select_output_resolution(const HostDisplayMode& host) {
+    Resolution best = kOutputResolutions[0];
+    for (const Resolution& candidate : kOutputResolutions)
+        if (candidate.width <= host.width && candidate.height <= host.height)
+            best = candidate;
+    return best;
+}
+
+// The fastest enumerant the host can actually present, at or below its reported rate, subject to
+// the policy's evidence floor.
+//
+// The 0.5% tolerance is what maps a host reporting a nominal "60.000" onto the 59.94 enumerant --
+// the rate a PS5 calls 60. It is deliberately far too tight to let 119.88 through on a 60 Hz host
+// (119.88 > 60.3), because advertising a rate the host cannot present would be a lie the pacing
+// grid then has to honour: the guest would be woken at 119.88 Hz on a panel that cannot show it.
+constexpr const RefreshMode* select_refresh_mode(const HostDisplayMode& host,
+                                                 ModeEvidence min_evidence) {
+    const RefreshMode* best = nullptr;
+    for (const RefreshMode& candidate : kRefreshModes) {
+        if (candidate.evidence < min_evidence) continue;
+        if (candidate.hz > host.refresh_hz * 1.005) continue;
+        if (!best || candidate.hz > best->hz) best = &candidate;
+    }
+    return best;
+}
+
+// Resolve the one mode prosper advertises. Both halves the issue names -- what the title READS
+// (SceVideoOutResolutionStatus) and what actually PACES it (the vblank grid's period) -- come out
+// of this single call, which is the structural half of the fix.
+constexpr AdvertisedDisplayMode select_display_mode(DisplayModePolicy policy,
+                                                    const HostDisplayMode& host) {
+    AdvertisedDisplayMode mode;   // the documented 1080p @ 59.94 fallback
+    if (policy == DisplayModePolicy::legacy) return mode;
+    if (!host.known()) return mode;
+
+    const ModeEvidence floor = policy == DisplayModePolicy::host_high_refresh
+                                   ? ModeEvidence::low
+                                   : ModeEvidence::medium;
+    const RefreshMode* refresh = select_refresh_mode(host, floor);
+    // A host slower than every enumerant we will advertise (a 30 Hz panel) keeps the fallback
+    // refresh. Its resolution is still derived: the two halves fail independently, and there is no
+    // reason to lie about both because we could not answer one.
+    const Resolution resolution = select_output_resolution(host);
+    mode.width = resolution.width;
+    mode.height = resolution.height;
+    if (refresh) {
+        mode.refresh_enum = refresh->enumerant;
+        mode.vblank_period_ns = refresh->period_ns;
+    }
+    mode.derived = true;
+    return mode;
+}
+
+}  // namespace prosper::hle::graphics

--- a/prosper/src/hle/graphics/hle_graphics.cpp
+++ b/prosper/src/hle/graphics/hle_graphics.cpp
@@ -19,6 +19,7 @@
 #include "gpu/texture/tile.hpp"             // de-swizzle a TILE-mode scanout into a linear image
 #include "host/memory/guest_memory_map.hpp" // guest_readable_mapping_containing (real over-read proof)
 #include "host/platform/precise_sleep.hpp"   // #1765: a vblank wait whose resolution is not the Win32 tick
+#include "hle/graphics/display_mode.hpp"      // #3017: the one derived answer for "which display is this?"
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
@@ -139,9 +140,59 @@ namespace {
         g_last_submit_tsc = completion_tsc;
     }
 
-    // The one display we advertise. 1920x1080 @ 59.94Hz (refresh-rate enum 3), 16:9, ~50".
-    constexpr uint32_t kDispW = 1920, kDispH = 1080;
-    constexpr uint64_t kRefresh5994 = 3;   // SCE_VIDEO_OUT_REFRESH_RATE_59_94HZ
+    // The one display we advertise, and the ONE place it is decided (#3017).
+    //
+    // This used to be two hardcoded constants here plus a third (the 16683350 ns vblank period)
+    // 600 lines further down, kept in step by hand. A title that reads the advertised mode and
+    // paces to it was therefore told 59.94 Hz on every host, and a 4K host was told 1080p. Now the
+    // answer is DERIVED from the host's real mode -- published by the frontend as
+    // PROSPER_HOST_DISPLAY_MODE="<w>x<h>@<hz>" -- under the PROSPER_DISPLAY_MODE policy, and both
+    // the status struct and the pacing grid read their fields off this single object. See
+    // display_mode.hpp for the policy, the resolution set, and the evidence grading behind each
+    // refresh enumerant.
+    //
+    // Default is `legacy`: 1920x1080 @ 59.94 (enum 3), byte-identical to the pre-#3017 behaviour.
+    // Deriving is opt-in because titles ACT on the advertised mode -- both their render resolution
+    // and their frame pacing hang off it -- so it wants per-title verification, not a global flip.
+    //
+    // Resolved ONCE, on first use, and never re-read. The vblank grid's epoch is itself first-use
+    // anchored, so a period that changed mid-run would step the guest's vblank count sideways; and
+    // a status struct that disagreed with the grid it is paced by is exactly the defect this
+    // replaces. One immutable answer removes both possibilities by construction.
+    const prosper::hle::graphics::AdvertisedDisplayMode& advertised_display_mode() {
+        using namespace prosper::hle::graphics;
+        static const AdvertisedDisplayMode mode = [] {
+            DisplayModePolicy policy = DisplayModePolicy::legacy;
+            if (const char* requested = getenv("PROSPER_DISPLAY_MODE")) {
+                // A malformed policy keeps the conservative default rather than picking one
+                // nobody asked for, and says so: silently ignoring it would leave a user who
+                // typo'd the opt-in believing they had measured it.
+                if (!parse_display_mode_policy(requested, policy))
+                    fprintf(stderr, "[vo] PROSPER_DISPLAY_MODE=\"%s\" is not one of "
+                                    "legacy|host|host-high-refresh -- keeping legacy.\n", requested);
+            }
+            HostDisplayMode host;
+            if (const char* published = getenv("PROSPER_HOST_DISPLAY_MODE")) {
+                if (!parse_host_display_mode(published, host))
+                    fprintf(stderr, "[vo] PROSPER_HOST_DISPLAY_MODE=\"%s\" is not "
+                                    "\"<w>x<h>@<hz>\" -- falling back to 1920x1080 @ 59.94.\n",
+                            published);
+            }
+            const AdvertisedDisplayMode resolved = select_display_mode(policy, host);
+            // Always logged, not gated behind PROSPER_GFXLOG: which display the guest believes it
+            // is attached to changes what several titles render and how fast they run, so it
+            // belongs in the record of every run rather than in an opt-in diagnostic.
+            fprintf(stderr, "[vo] display: %ux%u @ refresh-enum %llu (%llu ns vblank) "
+                            "policy=%s source=%s\n",
+                    resolved.width, resolved.height,
+                    (unsigned long long)resolved.refresh_enum,
+                    (unsigned long long)resolved.vblank_period_ns,
+                    display_mode_policy_name(policy),
+                    resolved.derived ? "host" : "fallback");
+            return resolved;
+        }();
+        return mode;
+    }
 
     void vo_argtrace(const char* fn, uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
         if (getenv("PROSPER_GFXLOG"))
@@ -768,22 +819,27 @@ HLE(g_vo_flipstatus)  { // (handle, SceVideoOutFlipStatus* status): report our s
     *(int32_t*) (s + 0x38) = buf;          // currentBuffer
     return 0;
 }
-// SceVideoOutResolutionStatus (0x30 bytes): report a real 1080p60 panel instead of the previous
-// all-zero display, and initialize flags/reserved0/reserved1 rather than leaking caller garbage.
+// SceVideoOutResolutionStatus (0x30 bytes): report a real panel instead of the previous all-zero
+// display, and initialize flags/reserved0/reserved1 rather than leaking caller garbage.
+//
+// This is half of what #3017 is about -- what the title READS. The other half is what actually
+// paces it (the vblank grid below). Both now come from advertised_display_mode(), so a title that
+// reads this struct and paces to it is paced at the rate this struct reports.
 HLE(g_vo_resstatus)   {
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
     VideoOutHandleGuard handle(a0);
     if (!handle.valid()) return kVoErrorInvalidHandle;
+    const auto& display = advertised_display_mode();
     uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x30);
-    *(uint32_t*)(s + 0x00) = kDispW;   *(uint32_t*)(s + 0x04) = kDispH;   // full w/h
-    *(uint32_t*)(s + 0x08) = kDispW;   *(uint32_t*)(s + 0x0c) = kDispH;   // pane w/h
-    *(uint64_t*)(s + 0x10) = kRefresh5994;
+    *(uint32_t*)(s + 0x00) = display.width;   *(uint32_t*)(s + 0x04) = display.height;  // full w/h
+    *(uint32_t*)(s + 0x08) = display.width;   *(uint32_t*)(s + 0x0c) = display.height;  // pane w/h
+    *(uint64_t*)(s + 0x10) = display.refresh_enum;
     *(float*)   (s + 0x18) = 50.0f;                                      // screen size (inch)
     return 0;
 }
 
-// The monotonic ~59.94 Hz timebase shared by sceVideoOutGetVblankStatus's `count` and
+// The monotonic vblank timebase shared by sceVideoOutGetVblankStatus's `count` and
 // sceVideoOutWaitVblank's wake-up boundary. They MUST share it in PHASE, not merely in period: a
 // game that waits for a vblank and then reads the count has to observe the tick it just waited for,
 // which is a statement about where the boundaries fall, not about how far apart they are. Anchored
@@ -813,7 +869,12 @@ HLE(g_vo_resstatus)   {
 // tracks when the title started caring about vblanks rather than when it first asked -- but
 // it is a change, and a comment claiming callers cannot move the grid would have hidden it.
 namespace {
-constexpr uint64_t kVblankNs = 16683350;             // 59.94 Hz period
+// The vblank period, derived from the SAME resolved mode the status struct reports (#3017). It was
+// a hardcoded 16683350 ns beside a separately hardcoded refresh enumerant, so changing one without
+// the other would pace a title at a rate it does not believe it is in -- the exact failure this
+// issue names. Reading both off one object makes that unrepresentable rather than merely avoided.
+// Still constant for the process: advertised_display_mode() resolves once.
+uint64_t vblank_period_ns() { return advertised_display_mode().vblank_period_ns; }
 // Deterministic clock used only by test_videoout's phase-integration check. Zero leaves the
 // production steady clock and sleep path untouched. Keeping the seam here, underneath both public
 // HLE calls, lets the test prove their shared grid without making host scheduler latency part of
@@ -845,7 +906,7 @@ void vblank_sleep_until_ns(uint64_t deadline_ns) {
 // comment ("aligning them is a real follow-up; asserting they are aligned is wrong"). Sharing
 // the origin and the period here is what closes it (#3024).
 extern "C" uint64_t prosper_vo_vblank_grid_origin_ns() { return vblank_epoch_ns(); }
-extern "C" uint64_t prosper_vo_vblank_period_ns() { return kVblankNs; }
+extern "C" uint64_t prosper_vo_vblank_period_ns() { return vblank_period_ns(); }
 
 extern "C" void prosper_vo_set_vblank_now_for_test(uint64_t now_ns) {
     g_vblank_test_now_ns.store(now_ns, std::memory_order_relaxed);
@@ -870,7 +931,7 @@ HLE(g_vo_vblankstatus) {
     // the first query made Astro Bot compute a frame-rate sample as
     // `(frames * refresh) / (count - previous_count)` with both counts zero and trap on
     // IDIV. Keep the time-based behavior, but number the first process-relative vblank 1.
-    *(uint64_t*)(s + 0x00) = 1 + (ns - t0) / kVblankNs;  // count: one tick per vblank period
+    *(uint64_t*)(s + 0x00) = 1 + (ns - t0) / vblank_period_ns();  // count: one tick per vblank period
     *(uint64_t*)(s + 0x08) = (ns - t0) / 1000;           // processTime (µs)
     *(uint64_t*)(s + 0x10) = ns;                         // tsc (monotonic ns; matches ReadTsc's unit)
     return 0;
@@ -885,7 +946,7 @@ HLE(g_vo_vblankstatus) {
 // decode, present, frame timing) runs unbounded. Found on PPSA26414 (R-Type Delta: HD Boosted,
 // #1746), whose display thread is exactly that loop.
 //
-// The wait boundary comes from vblank_epoch_ns()/kVblankNs — the SAME timebase
+// The wait boundary comes from vblank_epoch_ns()/vblank_period_ns() — the SAME timebase
 // sceVideoOutGetVblankStatus reports — so a thread that waits for a vblank and then reads the
 // status observes the tick it waited for, not a disagreeing second clock. The handle is validated
 // under g_vo_handle_mx and the guard is released BEFORE sleeping: holding it across a ~16 ms sleep
@@ -912,7 +973,8 @@ HLE(g_vo_wait_vblank) {
     const uint64_t now = vblank_now_ns();
     // Next strictly-future boundary: a caller that is already exactly on one still waits a full
     // period, which is what "wait for the NEXT vblank" means.
-    const uint64_t next = t0 + ((now - t0) / kVblankNs + 1) * kVblankNs;
+    const uint64_t period = vblank_period_ns();
+    const uint64_t next = t0 + ((now - t0) / period + 1) * period;
     // F5: the deadline crosses into host::sleep_until_steady_ns as a plain nanosecond count, and the
     // duration_cast back to a steady_clock::time_point happens there — see precise_sleep.cpp, which
     // also records why this is not a bare std::this_thread::sleep_until on Windows (#1765).

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -990,9 +990,11 @@ namespace { bool evlog() { static int v = getenv("PROSPER_EVLOG") ? 1 : 0; retur
 // --- Real event-queue backend (kqueue/kevent model). Registered flip/vblank sources post events into
 // their equeue; WaitEqueue blocks until an event is ready (or timeout) and returns it. A single ~60 Hz
 // pump thread drives vblank + flip-completion events so Unity's render/timing threads pace frames. ---
-// The shared 59.94 Hz vblank grid, defined in hle/graphics/hle_graphics.cpp. Declared here
-// rather than in a header because that file deliberately keeps the grid internal, and these
-// two accessors are the whole of what it publishes (#3024).
+// The shared vblank grid, defined in hle/graphics/hle_graphics.cpp. Declared here rather than
+// in a header because that file deliberately keeps the grid internal, and these two accessors
+// are the whole of what it publishes (#3024). The PERIOD is not a constant: since #3017 it comes
+// from the display mode prosper advertises to the guest, so this pump paces at whatever rate the
+// title was told it is running at -- which is the point, and why it is read rather than assumed.
 extern "C" uint64_t prosper_vo_vblank_grid_origin_ns();
 extern "C" uint64_t prosper_vo_vblank_period_ns();
 

--- a/prosper/tests/hle/graphics/test_display_mode.cpp
+++ b/prosper/tests/hle/graphics/test_display_mode.cpp
@@ -1,0 +1,245 @@
+// test_display_mode -- #3017: prosper must DERIVE the display it advertises to the guest from the
+// host's real mode, not hardcode 1920x1080 @ 59.94 Hz.
+//
+// Two halves, and the second is the one that matters:
+//
+//   Part A is the pure derivation (display_mode.hpp) against SYNTHESIZED host capabilities. The
+//   load-bearing arms are the ones where two DIFFERENT hosts must produce two DIFFERENT advertised
+//   modes. A test that only checked "1080p host -> 1080p59.94" would pass just as happily against
+//   the hardcoded constants this replaces, so it would prove nothing about deriving.
+//
+//   Part B drives the real HLE surface and asserts the two places the issue names -- what the title
+//   READS (sceVideoOutGetResolutionStatus) and what actually PACES it (the vblank period the
+//   kevent pump schedules on) -- BOTH follow the one synthesized host. Before #3017 those were
+//   independent constants that agreed only by hand, so this is the arm that pins them together.
+//
+// Part B must run in its own process: the advertised mode resolves ONCE on first use (deliberately
+// -- a period that moved mid-run would step the guest's vblank count sideways), so the environment
+// has to be set before any VideoOut call. test_videoout.cpp covers the complementary case, the
+// untouched `legacy` default, in a process where these variables are unset.
+
+#include "hle/graphics/display_mode.hpp"
+#include "hle/dispatch/dispatch.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+using namespace prosper;
+using namespace prosper::hle::graphics;
+
+// The accessor hle_kernel_time.cpp's vblank kevent pump schedules on (#3024). Reading it here is
+// what proves the PACING half moved, not merely the status struct the title reads.
+extern "C" uint64_t prosper_vo_vblank_period_ns();
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static void set_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+int main() {
+    printf("== test_display_mode ==\n");
+
+    // ---- Part A: the pure derivation -------------------------------------------------------
+    printf("-- parsing --\n");
+    {
+        HostDisplayMode host;
+        CHECK(parse_host_display_mode("1920x1080@59.94", host) &&
+              host.width == 1920 && host.height == 1080 &&
+              host.refresh_hz > 59.93 && host.refresh_hz < 59.95,
+              "a well-formed host mode parses to its three fields");
+
+        HostDisplayMode integral;
+        CHECK(parse_host_display_mode("3840x2160@120", integral) &&
+              integral.width == 3840 && integral.height == 2160 &&
+              integral.refresh_hz > 119.99 && integral.refresh_hz < 120.01,
+              "an integral refresh rate parses without a fractional part");
+
+        // A malformed value must leave the caller on the documented fallback rather than half-
+        // applying: the same rule the capture triggers follow -- a typo costs the feature, never a
+        // wrong answer.
+        HostDisplayMode untouched;
+        const char* malformed[] = { "", "1920x1080", "1920@59.94", "1920x1080@", "x1080@59.94",
+                                    "1920x1080@59.94junk", "1920x1080@60.", "0x1080@60",
+                                    "1920x0@60", "1920x1080@0" };
+        bool all_rejected = true;
+        for (const char* text : malformed)
+            all_rejected &= !parse_host_display_mode(text, untouched);
+        CHECK(all_rejected, "every malformed host mode is rejected");
+        CHECK(untouched.width == 0 && untouched.height == 0 && untouched.refresh_hz == 0.0,
+              "a rejected parse does not partially overwrite the caller's mode");
+
+        DisplayModePolicy policy = DisplayModePolicy::host;
+        CHECK(!parse_display_mode_policy("hosty", policy) && policy == DisplayModePolicy::host,
+              "an unknown policy name is rejected and leaves the caller's choice alone");
+        CHECK(parse_display_mode_policy("legacy", policy) && policy == DisplayModePolicy::legacy,
+              "\"legacy\" parses");
+        CHECK(parse_display_mode_policy("host", policy) && policy == DisplayModePolicy::host,
+              "\"host\" parses");
+        CHECK(parse_display_mode_policy("host-high-refresh", policy) &&
+              policy == DisplayModePolicy::host_high_refresh,
+              "\"host-high-refresh\" parses");
+    }
+
+    printf("-- the default is exactly what prosper advertised before #3017 --\n");
+    {
+        // The conservative default, and the whole reason deriving is opt-in: a title that works
+        // today cannot be changed by this code existing.
+        const HostDisplayMode big{ 3840, 2160, 119.88 };
+        const AdvertisedDisplayMode legacy = select_display_mode(DisplayModePolicy::legacy, big);
+        CHECK(legacy.width == 1920 && legacy.height == 1080,
+              "legacy advertises 1920x1080 even on a 4K host");
+        CHECK(legacy.refresh_enum == 3 && legacy.vblank_period_ns == 16683350,
+              "legacy advertises refresh enum 3 with the 59.94 Hz period");
+        CHECK(!legacy.derived, "legacy reports itself as not derived");
+
+        // An unknown host is the headless / boot_trace / unit-test case and MUST land on the same
+        // fallback, not on a zeroed or partially-filled mode.
+        const AdvertisedDisplayMode unknown = select_display_mode(DisplayModePolicy::host, {});
+        CHECK(unknown.width == 1920 && unknown.height == 1080 && unknown.refresh_enum == 3 &&
+              unknown.vblank_period_ns == 16683350 && !unknown.derived,
+              "an unknown host falls back to 1920x1080 @ 59.94 and says it did not derive");
+    }
+
+    printf("-- DERIVATION: a different host must produce a different advertised mode --\n");
+    {
+        // This block is the point of the whole test. Each arm pairs a synthesized host with an
+        // answer the pre-#3017 constants could not have produced.
+        const AdvertisedDisplayMode uhd = select_display_mode(
+            DisplayModePolicy::host, { 3840, 2160, 60.0 });
+        CHECK(uhd.width == 3840 && uhd.height == 2160,
+              "a 4K host is advertised 3840x2160, not the hardcoded 1080p");
+        CHECK(uhd.derived, "a 4K host reports a derived mode");
+
+        const AdvertisedDisplayMode hd = select_display_mode(
+            DisplayModePolicy::host, { 1920, 1080, 60.0 });
+        CHECK(hd.width == 1920 && hd.height == 1080,
+              "a 1080p host is advertised 1920x1080");
+        CHECK(uhd.width != hd.width && uhd.height != hd.height,
+              "two hosts of different SIZE yield two different advertised resolutions");
+
+        const AdvertisedDisplayMode small = select_display_mode(
+            DisplayModePolicy::host, { 1366, 768, 60.0 });
+        CHECK(small.width == 1280 && small.height == 720,
+              "a host too small for 1080p drops to the 720p output mode, not to the host's own "
+              "non-PS5 resolution");
+
+        // A nominal "60.000" host maps onto the 59.94 enumerant -- the rate a PS5 calls 60 -- and
+        // must NOT reach 119.88 even though the tolerance exists.
+        CHECK(hd.refresh_enum == 3 && hd.vblank_period_ns == 16683350,
+              "a 60.000 Hz host maps to the 59.94 enumerant");
+
+        // A 50 Hz host is a real configuration, and telling it 59.94 is precisely the lie #3017 is
+        // about. This arm cannot pass against a hardcoded refresh constant.
+        const AdvertisedDisplayMode pal = select_display_mode(
+            DisplayModePolicy::host, { 1920, 1080, 50.0 });
+        CHECK(pal.refresh_enum == 2 && pal.vblank_period_ns == 20000000,
+              "a 50 Hz host is advertised the 50 Hz enumerant and a 20 ms period");
+        CHECK(pal.refresh_enum != hd.refresh_enum &&
+              pal.vblank_period_ns != hd.vblank_period_ns,
+              "two hosts of different REFRESH yield two different enumerants AND two different "
+              "vblank periods");
+    }
+
+    printf("-- the evidence floor gates the enumerant prosper cannot yet defend --\n");
+    {
+        const HostDisplayMode fast{ 3840, 2160, 120.0 };
+        // `host` must not reach 119.88: its enumerant value rests on no primary evidence, and no
+        // title here has been checked for flip-rate-dependent logic (the charter records a title
+        // whose in-game time advances PER FLIP, which at double the rate runs at double speed).
+        const AdvertisedDisplayMode conservative = select_display_mode(DisplayModePolicy::host, fast);
+        CHECK(conservative.refresh_enum == 3 && conservative.vblank_period_ns == 16683350,
+              "`host` on a 120 Hz display still advertises 59.94 -- the LOW-evidence enumerant is "
+              "not reachable by deriving alone");
+        CHECK(conservative.width == 3840 && conservative.height == 2160,
+              "...while the resolution half, which needs no enumerant, still derives");
+
+        const AdvertisedDisplayMode opted_in =
+            select_display_mode(DisplayModePolicy::host_high_refresh, fast);
+        CHECK(opted_in.refresh_enum == 6 && opted_in.vblank_period_ns == 8341675,
+              "`host-high-refresh` reaches the 119.88 enumerant and its period");
+        CHECK(opted_in.vblank_period_ns * 2 == 16683350,
+              "the 119.88 period is exactly half the 59.94 period (the two enumerants are "
+              "consistent with each other)");
+
+        // Never advertise a rate the host cannot present: the pacing grid would then honour it and
+        // wake the guest faster than the panel can show.
+        const AdvertisedDisplayMode slow_panel =
+            select_display_mode(DisplayModePolicy::host_high_refresh, { 1920, 1080, 60.0 });
+        CHECK(slow_panel.refresh_enum == 3,
+              "even under host-high-refresh, a 60 Hz host is never told 119.88");
+
+        // A host slower than every enumerant we will advertise keeps the fallback refresh, but its
+        // resolution still derives: the two halves fail independently.
+        const AdvertisedDisplayMode very_slow = select_display_mode(
+            DisplayModePolicy::host, { 3840, 2160, 30.0 });
+        CHECK(very_slow.refresh_enum == 3 && very_slow.vblank_period_ns == 16683350,
+              "a 30 Hz host keeps the fallback refresh (no enumerant is at or below it)");
+        CHECK(very_slow.width == 3840 && very_slow.height == 2160,
+              "...and still gets its derived resolution");
+    }
+
+    printf("-- every advertised enumerant carries a self-consistent period --\n");
+    {
+        bool consistent = true;
+        for (const RefreshMode& mode : kRefreshModes) {
+            const double implied_hz = 1e9 / (double)mode.period_ns;
+            consistent &= implied_hz > mode.hz * 0.999 && implied_hz < mode.hz * 1.001;
+        }
+        CHECK(consistent,
+              "each refresh row's period_ns is the reciprocal of its own hz -- so the status "
+              "struct and the pacing grid cannot describe different rates");
+    }
+
+    // ---- Part B: the live HLE surface, end to end ------------------------------------------
+    printf("-- INTEGRATION: both enforcement points follow one synthesized host --\n");
+    {
+        // Set BEFORE the first VideoOut call: the mode resolves once, on first use.
+        set_env("PROSPER_DISPLAY_MODE", "host-high-refresh");
+        set_env("PROSPER_HOST_DISPLAY_MODE", "3840x2160@119.88");
+
+        register_builtin_hle();
+        auto open = Hle::lookup(nid_hash("sceVideoOutOpen"));
+        auto res  = Hle::lookup(nid_hash("sceVideoOutGetResolutionStatus"));
+        CHECK(open && res, "the VideoOut entry points are registered");
+        if (open && res) {
+            const uint64_t handle = open(0, 0, 0, 0, 0, 0);
+            uint8_t rs[0x30];
+            memset(rs, 0xEE, sizeof rs);
+            CHECK(res(handle, (uint64_t)(uintptr_t)rs, 0, 0, 0, 0) == 0,
+                  "GetResolutionStatus succeeds on a live handle");
+
+            // (1) what the title READS.
+            CHECK(*(uint32_t*)(rs + 0x00) == 3840 && *(uint32_t*)(rs + 0x04) == 2160,
+                  "the advertised resolution is the host's 3840x2160, NOT the hardcoded 1920x1080");
+            CHECK(*(uint32_t*)(rs + 0x08) == 3840 && *(uint32_t*)(rs + 0x0c) == 2160,
+                  "the pane resolution follows the same derived answer");
+            CHECK(*(uint64_t*)(rs + 0x10) == 6,
+                  "the advertised refresh enumerant is the host's 119.88, NOT the hardcoded 3");
+
+            // (2) what actually PACES it -- the accessor hle_kernel_time.cpp's vblank pump reads.
+            CHECK(prosper_vo_vblank_period_ns() == 8341675,
+                  "the vblank grid's period is the 119.88 Hz period, NOT the hardcoded 16683350");
+
+            // The invariant the issue asks for in so many words: changing only one of the two would
+            // give the title a number it cannot act on, or pace it in a mode it does not believe it
+            // is in. Assert they came from the same row rather than merely both being right.
+            const uint64_t advertised_enum = *(uint64_t*)(rs + 0x10);
+            const RefreshMode* row = nullptr;
+            for (const RefreshMode& candidate : kRefreshModes)
+                if (candidate.enumerant == advertised_enum) row = &candidate;
+            CHECK(row && row->period_ns == prosper_vo_vblank_period_ns(),
+                  "the reported enumerant and the pacing period are the SAME table row");
+        }
+    }
+
+    printf("%s: %d failure(s)\n", fails ? "FAILED" : "PASSED", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #3017.

## The defect

prosper advertised exactly one display to every guest, hardcoded — two constants in
`hle_graphics.cpp` and a third 600 lines below them:

```cpp
constexpr uint32_t kDispW = 1920, kDispH = 1080;
constexpr uint64_t kRefresh5994 = 3;          // SceVideoOutRefreshRate enumerant
constexpr uint64_t kVblankNs    = 16683350;   // the vblank pacing grid
```

The three agreed only because somebody kept them in step by hand. As the issue puts it, this is
enforced in two places and a change needs both: **what the title reads**
(`sceVideoOutGetResolutionStatus`, `hle_graphics.cpp:779-781` on master) and **what actually paces
it** (the vblank timebase at `hle_graphics.cpp:816`, which `hle_kernel_time.cpp`'s kevent pump has
also scheduled on since #3024). Changing one without the other either gives a title a number it
cannot act on, or paces it in a mode it does not believe it is in.

This is the failure mode the charter warns about: it fails in the direction that looks safe. Nothing
crashes, the title behaves *correctly* given what it was told, and so nobody files it — while a 4K
host is told 1080p and every host is told 59.94 Hz.

## The fix

A new pure header, `src/hle/graphics/display_mode.hpp`, resolves **one** `AdvertisedDisplayMode`
from the host's real mode. Both enforcement points now read their fields off that single object, so
they cannot disagree — there is no longer a second place for them to disagree in. The mode resolves
**once** per process (the vblank epoch is first-use anchored; a period that moved mid-run would step
the guest's vblank count sideways).

The frontend publishes the host's real mode as `PROSPER_HOST_DISPLAY_MODE=<w>x<h>@<hz>` **before the
guest boots** — position is load-bearing, since the guest thread starts at `main.cpp`'s
`start_guest()` and the mode resolves lazily on first use.

### Deliberately opt-in

`PROSPER_DISPLAY_MODE` (and `--display-mode`) defaults to **`legacy`**, byte-identical to previous
behaviour. Titles *act* on this value — anything advancing state per flip rather than per elapsed
second runs fast at a higher rate, which this project has already measured (*The Plucky Squire*).
The issue asks for exactly this gating, and it is why the default moves nothing.

| policy | resolution | refresh |
| --- | --- | --- |
| `legacy` (default) | 1920×1080 | 59.94 (enum 3) |
| `host` | largest PS5 output mode the host can show | derived, capped at 59.94 |
| `host-high-refresh` | same | additionally allows 119.88 (enum 6) |

### Two properties that keep this a derivation rather than a different constant

- **The refresh field is an enum**, so advertising a rate asserts the integer Sony assigned it, and a
  wrong integer is worse than not offering the rate. Each table row carries an evidence grade —
  59.94 `HIGH` (prosper's own live titles; its period is the existing grid), 50 `MED`
  (secondary-implementation agreement), 119.88 `LOW` — and the policy carries a floor, so an
  enumerant prosper cannot defend is **unreachable by default rather than merely discouraged**. No
  primary evidence pins 119.88's value, and no 120 Hz-capable title has been checked here for
  flip-rate-dependent logic; that is precisely why it needs the extra opt-in.
- **The host's desktop resolution is never passed through.** A title told it is attached to a
  1366×768 panel is told something no PS5 ever reports, so the largest real PS5 output mode the host
  can display is chosen instead (720p / 1080p / 4K, floored at 720p). Likewise a rate above what the
  host can present is never advertised — the pacing grid would then honour it and wake the guest
  faster than the panel can show.

## Verification

Linux, distrobox, **fresh** Debug configure (`-G Ninja`).

- Build: exit **0**, zero errors.
- `ctest --no-tests=error`: **319/319 passed, exit 0** (318 registered on master + the new case).
- `videoout_queries` — the existing guard asserting the 1920×1080 / enum-3 default — **still
  passes**, in a process where the new variables are unset. That is the untouched-default arm.

### Mutation verification

The important arm is the one proving the answer is **derived**, not one constant swapped for
another. Two independent mutations, each built and run:

| arm | build rc | test rc | result |
| --- | --- | --- | --- |
| baseline | 0 | **0** | 37/37 arms pass |
| **A** — `select_display_mode()` hardcoded back to the fallback | 0 | **1** | **14 arms fail**, including every "a different host must produce a different advertised mode" arm |
| **B** — only `vblank_period_ns()` hardcoded to 16683350, status struct left derived | 0 | **1** | **exactly 2 arms fail** — the two pinning the enforcement points together |
| restored | 0 | **0** | passes again |

Arm B is the sharpest: a fix that changed what the title *reads* without changing what *paces* it
would pass a weaker test, and fails this one on precisely those two assertions.

## Risk — this can affect titles that currently work

Honestly stated:

- **On the default path, nothing changes.** `legacy` produces the same three values from the same
  code path, and the existing `videoout_queries` guard confirms it. The publication of
  `PROSPER_HOST_DISPLAY_MODE` is inert on its own.
- **The real risk is behavioural and lives behind the opt-in.** Under `host`, a 4K host now reports
  3840×2160, and a title that picks render resolution from this may allocate larger targets or
  select different assets. Under `host-high-refresh` the flip rate doubles, which is unsafe for any
  per-flip logic. Neither is reachable without asking.
- **`vblank_period_ns()` is a function call now, not a constant**, on the vblank status/wait path and
  the kevent pump. It reads an immutable resolved value, so there is no synchronization change, but
  it is no longer constant-folded.
- **Not done, deliberately:** no live title run — another lane holds the GPU. So the derived paths
  are proven by unit + HLE-level tests, not by a booted title. Since the default is unchanged, no
  title's current behaviour depends on this; but the first person to use `host-high-refresh` on a
  real title is doing the per-title verification the issue asks for, and #3017 should stay open in
  spirit for that even though this closes the hardcoding half.
- `g_flip_rate` (`sceVideoOutSetFlipRate`) is deliberately untouched — it is the guest's flip
  divisor, not the display mode, and folding it in here would conflate two different questions.

## Also in this diff

- `src/hle/graphics/AGENTS.md` — the folder had none.
- `docs/GRAPHICS.md` — its 2026-07-04 entry asserted the hardcoded 1080p@59.94 as the whole answer; a
  note records that it is now the default rather than the only mode, so the stale figure does not
  keep carrying the doc's authority.
- `frontends/prosper-app/README.md` — documents `--display-mode`.
