### PR TITLE
refactor(compute): extract three decision clusters from execute_item into named, tested predicates (#3204)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2049,7 +2049,11 @@ if(TARGET prosper_core)
   # chain -- the shape that cost Dead Cells an HDR target (#773) and Syberia its 3D menu. Now an
   # exhaustive switch: the compiler pins exhaustiveness, this test pins the table.
   add_executable(test_live_target_format_match tests/gpu/test_live_target_format_match.cpp)
-  target_link_libraries(test_live_target_format_match PRIVATE prosper_core prosper_live_renderer)
+  # The header is inline-only and needs nothing but prosper_core's types, so DON'T link
+  # prosper_live_renderer: that target is defined later and only inside `if(Vulkan_FOUND)`,
+  # so on MinGW/macOS this test found neither the library nor its PUBLIC include path.
+  target_link_libraries(test_live_target_format_match PRIVATE prosper_core)
+  target_include_directories(test_live_target_format_match PRIVATE frontends)
   add_test(NAME live_target_format_match COMMAND test_live_target_format_match)
 
   # #3204: SPIR-V/guest storage-format agreement, extracted from execute_item. The permissive

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2038,6 +2038,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_mip_provenance_identity PRIVATE prosper_core)
   add_test(NAME mip_provenance_identity COMMAND test_mip_provenance_identity)
 
+  # #3204: the image-identity predicates extracted from execute_item. They decide whether two
+  # bindings alias ONE Vulkan image -- the aliasing GTA V's four quadrant writes depend on, and
+  # the thing #3205 broke while it was an unnamed local expression. Pure comparisons.
+  add_executable(test_image_identity tests/gpu/agc/test_image_identity.cpp)
+  target_link_libraries(test_image_identity PRIVATE prosper_core)
+  add_test(NAME image_identity COMMAND test_image_identity)
+
   # Descriptor-binding policy (#157): textures/storage images never land on the recompiler's hardwired
   # cbuf bindings 2/3; constant/vertex buffers assigned first. Pure, no game dump / Vulkan needed.
   add_executable(test_convention_bindings tests/gpu/test_convention_bindings.cpp)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2045,17 +2045,6 @@ if(TARGET prosper_core)
   target_link_libraries(test_image_identity PRIVATE prosper_core)
   add_test(NAME image_identity COMMAND test_image_identity)
 
-  # #3204: the renderer-target format table, extracted from execute_item where it was an `||`
-  # chain -- the shape that cost Dead Cells an HDR target (#773) and Syberia its 3D menu. Now an
-  # exhaustive switch: the compiler pins exhaustiveness, this test pins the table.
-  add_executable(test_live_target_format_match tests/gpu/test_live_target_format_match.cpp)
-  # The header is inline-only and needs nothing but prosper_core's types, so DON'T link
-  # prosper_live_renderer: that target is defined later and only inside `if(Vulkan_FOUND)`,
-  # so on MinGW/macOS this test found neither the library nor its PUBLIC include path.
-  target_link_libraries(test_live_target_format_match PRIVATE prosper_core)
-  target_include_directories(test_live_target_format_match PRIVATE frontends)
-  add_test(NAME live_target_format_match COMMAND test_live_target_format_match)
-
   # #3204: SPIR-V/guest storage-format agreement, extracted from execute_item. The permissive
   # direction binds the guest image with the wrong element type, so every arm has a rejection
   # partner -- including atomics, which are never a native storage image however well formats match.
@@ -2194,6 +2183,16 @@ if(TARGET prosper_core)
       if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(prosper_live_renderer PRIVATE -Werror=switch)
       endif()
+
+      # #3204: the renderer-target format table, extracted from execute_item where it was an
+      # `||` chain -- the shape that cost Dead Cells an HDR target (#773) and Syberia its 3D
+      # menu. Now an exhaustive switch: the compiler pins exhaustiveness, this test pins the
+      # table. Registered HERE, inside if(Vulkan_FOUND), because live_target_format.hpp includes
+      # <vulkan/vulkan.h> -- registering it outside built on Linux and broke MinGW and macOS.
+      add_executable(test_live_target_format_match tests/gpu/test_live_target_format_match.cpp)
+      target_link_libraries(test_live_target_format_match PRIVATE prosper_core Vulkan::Vulkan)
+      target_include_directories(test_live_target_format_match PRIVATE frontends src)
+      add_test(NAME live_target_format_match COMMAND test_live_target_format_match)
       target_link_libraries(boot_trace PRIVATE prosper_live_renderer)
 
       # Keep the production compute backend covered on native Windows too. This catches host- and
@@ -2521,6 +2520,17 @@ if(TARGET prosper_core)
       target_include_directories(test_draw_program_skip_render PRIVATE src tests tools/boot_trace)
       target_link_libraries(test_draw_program_skip_render PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
       add_test(NAME draw_program_skip_render COMMAND test_draw_program_skip_render)
+
+      # #3204: the renderer-target format table, extracted from execute_item where it was an
+      # `||` chain -- the shape that cost Dead Cells an HDR target (#773) and Syberia its 3D menu.
+      # Now an exhaustive switch: the compiler pins exhaustiveness, this test pins the table.
+      # Registered in BOTH the UNIX and WIN32 branches, like the compute-backend tests above:
+      # live_target_format.hpp includes <vulkan/vulkan.h>, so it needs an if(Vulkan_FOUND) scope,
+      # and this file has one per platform.
+      add_executable(test_live_target_format_match tests/gpu/test_live_target_format_match.cpp)
+      target_link_libraries(test_live_target_format_match PRIVATE prosper_core Vulkan::Vulkan)
+      target_include_directories(test_live_target_format_match PRIVATE frontends src)
+      add_test(NAME live_target_format_match COMMAND test_live_target_format_match)
       # Armed from the ENVIRONMENT rather than by a setenv inside the test. The persistent-target
       # opt-out is read through PROSPER_ENV_VALUE, which caches, so arming it from inside the process
       # is exactly the vacuous-arm defect cached_env_arming_logic exists to catch; and the selector

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2052,6 +2052,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_live_target_format_match PRIVATE prosper_core prosper_live_renderer)
   add_test(NAME live_target_format_match COMMAND test_live_target_format_match)
 
+  # #3204: SPIR-V/guest storage-format agreement, extracted from execute_item. The permissive
+  # direction binds the guest image with the wrong element type, so every arm has a rejection
+  # partner -- including atomics, which are never a native storage image however well formats match.
+  add_executable(test_spirv_storage_match tests/gpu/agc/test_spirv_storage_match.cpp)
+  target_link_libraries(test_spirv_storage_match PRIVATE prosper_core)
+  add_test(NAME spirv_storage_match COMMAND test_spirv_storage_match)
+
   # Descriptor-binding policy (#157): textures/storage images never land on the recompiler's hardwired
   # cbuf bindings 2/3; constant/vertex buffers assigned first. Pure, no game dump / Vulkan needed.
   add_executable(test_convention_bindings tests/gpu/test_convention_bindings.cpp)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2045,6 +2045,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_image_identity PRIVATE prosper_core)
   add_test(NAME image_identity COMMAND test_image_identity)
 
+  # #3204: the renderer-target format table, extracted from execute_item where it was an `||`
+  # chain -- the shape that cost Dead Cells an HDR target (#773) and Syberia its 3D menu. Now an
+  # exhaustive switch: the compiler pins exhaustiveness, this test pins the table.
+  add_executable(test_live_target_format_match tests/gpu/test_live_target_format_match.cpp)
+  target_link_libraries(test_live_target_format_match PRIVATE prosper_core prosper_live_renderer)
+  add_test(NAME live_target_format_match COMMAND test_live_target_format_match)
+
   # Descriptor-binding policy (#157): textures/storage images never land on the recompiler's hardwired
   # cbuf bindings 2/3; constant/vertex buffers assigned first. Pure, no game dump / Vulkan needed.
   add_executable(test_convention_bindings tests/gpu/test_convention_bindings.cpp)

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -20,7 +20,8 @@
 #include "gpu/resources/shader_resources.hpp"
 #include "gpu/recompiler/spirv_builder.hpp"
 #include "gpu/resources/mip_chain_plan.hpp"
-#include "gpu/resources/image_identity.hpp"  // #3204: named image-identity predicates
+#include "gpu/resources/image_identity.hpp"
+#include "gpu/resources/spirv_storage_match.hpp"  // #3204: SPIR-V/guest storage agreement  // #3204: named image-identity predicates
 #include "gpu/texture/tile.hpp"
 #include "gpu/capture/writer_provenance.hpp"
 #include "host/memory/guest_write_watch.hpp"
@@ -5988,19 +5989,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 r->num_components ? r->num_components : 1;
             const VkFormat native_storage_format =
                 native_storage_vk_format(r->format, descriptor_components);
-            const bool spirv_native_float_storage = bi.storage &&
-                image_descriptors[i].image_numeric_class == SpirvImageNumericClass::Float;
-            const bool spirv_native_uint_storage = bi.storage &&
-                image_descriptors[i].image_numeric_class == SpirvImageNumericClass::Uint &&
-                !image_descriptors[i].atomic_access &&
-                ((r->format == DataFormat::Uint32 && descriptor_components == 1 &&
-                  image_descriptors[i].storage_image_format == kSpirvImageFormatR32ui) ||
-                 (r->format == DataFormat::Uint8 && descriptor_components == 1 &&
-                  image_descriptors[i].storage_image_format == kSpirvImageFormatR8ui) ||
-                 (r->format == DataFormat::Uint8 && descriptor_components == 4 &&
-                  image_descriptors[i].storage_image_format == kSpirvImageFormatRgba8ui) ||
-                 (r->format == DataFormat::Uint16 && descriptor_components == 1 &&
-                  image_descriptors[i].storage_image_format == kSpirvImageFormatR16ui));
+            // #3204: the SPIR-V/guest storage-format agreement lives in spirv_storage_match.hpp,
+            // where the enumerated pairs are named and tested. The format operand VALUES stay here,
+            // passed in, so the header never becomes a second source of truth for them.
+            const prosper::gpu::SpirvStorageDeclaration storage_decl{
+                image_descriptors[i].image_numeric_class == SpirvImageNumericClass::Uint,
+                image_descriptors[i].image_numeric_class == SpirvImageNumericClass::Float,
+                image_descriptors[i].atomic_access,
+                image_descriptors[i].storage_image_format};
+            const bool spirv_native_float_storage =
+                bi.storage && prosper::gpu::spirv_native_float_storage(storage_decl);
+            const bool spirv_native_uint_storage =
+                bi.storage && prosper::gpu::spirv_native_uint_storage(
+                    storage_decl, r->format, descriptor_components,
+                    kSpirvImageFormatR32ui, kSpirvImageFormatR16ui,
+                    kSpirvImageFormatR8ui, kSpirvImageFormatRgba8ui);
             const bool spirv_native_storage =
                 spirv_native_float_storage || spirv_native_uint_storage;
             bi.packed_r11_storage = bi.storage && !spirv_native_storage &&

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6506,29 +6506,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                 }
                 if (renderer_owned && bi.storage) {
-                    const uint32_t nc = r->num_components ? r->num_components : 1;
-                    const bool compatible =
-                        (live_target.format == LiveTargetPixelFormat::Rgba8Unorm &&
-                         r->format == DataFormat::Unorm8 && nc == 4) ||
-                        (live_target.format == LiveTargetPixelFormat::Rgba16Float &&
-                         r->format == DataFormat::Float16 && nc == 4) ||
-                        (live_target.format == LiveTargetPixelFormat::Rg16Float &&
-                         r->format == DataFormat::Float16 && nc == 2) ||
-                        (live_target.format == LiveTargetPixelFormat::R16Float &&
-                         r->format == DataFormat::Float16 && nc == 1) ||
-                        (live_target.format == LiveTargetPixelFormat::R11G11B10Float &&
-                         r->format == DataFormat::Float10_11_11 && nc == 3) ||
-                        (live_target.format == LiveTargetPixelFormat::R8Unorm &&
-                         r->format == DataFormat::Unorm8 && nc == 1) ||
-                        (live_target.format == LiveTargetPixelFormat::Rg8Unorm &&
-                         r->format == DataFormat::Unorm8 && nc == 2) ||
-                        (live_target.format == LiveTargetPixelFormat::R32Uint &&
-                         (r->format == DataFormat::Uint32 ||
-                          r->format == DataFormat::Float32) && nc == 1) ||
-                        (live_target.format == LiveTargetPixelFormat::R32Float &&
-                         r->format == DataFormat::Float32 && nc == 1) ||
-                        (live_target.format == LiveTargetPixelFormat::Rgba32Float &&
-                         r->format == DataFormat::Float32 && nc == 4);
+                    const uint32_t nc = r->num_components ? r->num_components : 1;  // used by the trace below
+                    // #3204: the format-compatibility table now lives in live_target_format.hpp as an
+                    // exhaustive switch, so adding a LiveTargetPixelFormat is a build error there instead
+                    // of silently reporting every binding of that format incompatible.
+                    const bool compatible = prosper::frontend::live_target_format_matches_declaration(
+                        live_target.format, r->format, r->num_components);
                     if (!compatible) {
                         // The same allocation can carry another target view before this compute
                         // operation (Astro Bot uses R8G8 and RGBA16F views at one base). A snapshot

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -20,6 +20,7 @@
 #include "gpu/resources/shader_resources.hpp"
 #include "gpu/recompiler/spirv_builder.hpp"
 #include "gpu/resources/mip_chain_plan.hpp"
+#include "gpu/resources/image_identity.hpp"  // #3204: named image-identity predicates
 #include "gpu/texture/tile.hpp"
 #include "gpu/capture/writer_provenance.hpp"
 #include "host/memory/guest_write_watch.hpp"
@@ -6572,64 +6573,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     (!bi.depth_bits_source ||
                      (prior.depth_bits_image == bi.depth_bits_image &&
                       prior.depth_bits_format == bi.depth_bits_format));
-                const bool same_dcc_identity = p &&
-                    p->max_uncompressed_block_size == r->max_uncompressed_block_size &&
-                    p->max_compressed_block_size == r->max_compressed_block_size &&
-                    p->meta_pipe_aligned == r->meta_pipe_aligned &&
-                    p->write_compress_enabled == r->write_compress_enabled &&
-                    p->compression_enabled == r->compression_enabled &&
-                    p->alpha_is_on_msb == r->alpha_is_on_msb &&
-                    p->color_transform == r->color_transform &&
-                    p->metadata_addr == r->metadata_addr &&
-                    p->dcc_metadata_size == r->dcc_metadata_size &&
-                    p->dcc_metadata_host_data == r->dcc_metadata_host_data &&
-                    p->dcc_metadata_host_data_size == r->dcc_metadata_host_data_size;
-                // Captures materialize each descriptor's bytes into an independently-owned blob,
-                // so pointer equality is not an architectural backing identity. Two exact image
-                // descriptors for the same non-null guest range must still alias one Vulkan image:
-                // GTA V's 4K output shader writes the four 8x8 quadrants of each 16x16 block through
-                // four bindings at the same address. Treating the reconstructed blobs as four
-                // images loses three stores and leaves the red/green checker in Performance mode.
-                const bool same_host_backing = p &&
-                    (p->host_data == r->host_data ||
-                     (p->gpu_addr != 0 && p->gpu_addr == r->gpu_addr &&
-                      p->host_data_size == r->host_data_size));
-                const bool same_view = p && same_backing_representation &&
-                    prior.storage == bi.storage &&
-                    p->gpu_addr == r->gpu_addr && p->size == r->size &&
-                    p->width == r->width && p->height == r->height && p->depth == r->depth &&
-                    prior.texel_depth == bi.texel_depth && prior.array_layers == bi.array_layers &&
-                    p->format == r->format && p->num_components == r->num_components &&
-                    p->tile_mode == r->tile_mode && p->img_dim == r->img_dim &&
-                    p->layer_stride_bytes == r->layer_stride_bytes &&
-                    p->layer_mip_offset_bytes == r->layer_mip_offset_bytes &&
-                    p->in_mip_tail == r->in_mip_tail &&
-                    p->mip_tail_x == r->mip_tail_x && p->mip_tail_y == r->mip_tail_y &&
-                    // The chain length is derived from these six fields (#3048); two descriptors
-                    // that disagree on any of them materialize different images.
-                    p->declared_mip_levels == r->declared_mip_levels &&
-                    // #3205: the derived chain provenance is part of image identity only when a
-                    // chain exists. It is populated on one construction path and left unset on
-                    // another, so comparing it unconditionally split identical single-level
-                    // descriptors into separate images -- which breaks the aliasing the comment
-                    // above requires and renders GTA V's checkerboard.
-                    prosper::gpu::shader_resource_mip_chain_provenance_matches(*p, *r) &&
-                    p->srgb == r->srgb && same_host_backing &&
-                    p->host_data_size == r->host_data_size && same_dcc_identity;
+                // #3204: image identity now lives in gpu/resources/image_identity.hpp, where each
+                // predicate is named and unit-tested. These were unnamed local expressions, which is
+                // why #3205 could add a field that describes nothing for a single-level image and
+                // break the aliasing GTA V's quadrant writes depend on, with no test able to see it.
+                const prosper::gpu::ComputeImageViewShape prior_shape{
+                    prior.storage, prior.texel_depth, prior.array_layers};
+                const prosper::gpu::ComputeImageViewShape this_shape{
+                    bi.storage, bi.texel_depth, bi.array_layers};
+                const bool same_view = p && prosper::gpu::shader_resource_same_view(
+                    *p, *r, prior_shape, this_shape, same_backing_representation);
                 bool same_sampler = true;
-                if (!bi.storage && same_view) {
-                    same_sampler = p->mag_filter == r->mag_filter &&
-                        p->min_filter == r->min_filter && p->mip_filter == r->mip_filter &&
-                        p->addr_uvw[0] == r->addr_uvw[0] && p->addr_uvw[1] == r->addr_uvw[1] &&
-                        p->addr_uvw[2] == r->addr_uvw[2] &&
-                        p->border_color_type == r->border_color_type &&
-                        p->min_lod == r->min_lod && p->max_lod == r->max_lod &&
-                        p->lod_bias == r->lod_bias && p->max_aniso_ratio == r->max_aniso_ratio &&
-                        p->depth_compare_func == r->depth_compare_func &&
-                        p->depth_compare == r->depth_compare && p->unnormalized == r->unnormalized &&
-                        p->swizzle[0] == r->swizzle[0] && p->swizzle[1] == r->swizzle[1] &&
-                        p->swizzle[2] == r->swizzle[2] && p->swizzle[3] == r->swizzle[3];
-                }
+                if (!bi.storage && same_view)
+                    same_sampler = prosper::gpu::shader_resource_same_sampler(*p, *r);
                 if (!same_view || !same_sampler) continue;
                 bi.alias_of = prior.alias_of == SIZE_MAX ? j : prior.alias_of;
                 const BoundImage& owner = images[bi.alias_of];

--- a/prosper/frontends/shared/live/live_target_format.hpp
+++ b/prosper/frontends/shared/live/live_target_format.hpp
@@ -190,4 +190,35 @@ constexpr bool renderer_mip_target_requires_submit_retention(VkFormat format) {
     return format == VK_FORMAT_B10G11R11_UFLOAT_PACK32;
 }
 
+
+// #3204: does a renderer-owned target's storage format match what this compute binding declares?
+//
+// Extracted from `execute_item`, where it was a 22-line `||` chain -- the exact shape this file
+// exists to eliminate. An `||` chain over an enum answers "no" for a member nobody taught it about,
+// so adding a LiveTargetPixelFormat would silently make every binding of that format incompatible
+// and fall back to a snapshot path, with no build error and no test failure. As a `switch` with no
+// `default:`, adding a member is a compile error here, which is this header's whole contract.
+//
+// Behaviour is otherwise identical to the chain it replaces, including R32Uint accepting a Float32
+// declaration (a guest that stores float bits through a uint view).
+inline bool live_target_format_matches_declaration(prosper::gpu::LiveTargetPixelFormat target,
+                                                   prosper::gpu::DataFormat declared,
+                                                   uint32_t num_components) {
+    using LTF = prosper::gpu::LiveTargetPixelFormat;
+    using DF = prosper::gpu::DataFormat;
+    const uint32_t nc = num_components ? num_components : 1u;
+    switch (target) {
+        case LTF::Rgba8Unorm:     return declared == DF::Unorm8 && nc == 4;
+        case LTF::Rgba16Float:    return declared == DF::Float16 && nc == 4;
+        case LTF::Rg16Float:      return declared == DF::Float16 && nc == 2;
+        case LTF::R16Float:       return declared == DF::Float16 && nc == 1;
+        case LTF::R11G11B10Float: return declared == DF::Float10_11_11 && nc == 3;
+        case LTF::R8Unorm:        return declared == DF::Unorm8 && nc == 1;
+        case LTF::Rg8Unorm:       return declared == DF::Unorm8 && nc == 2;
+        case LTF::R32Uint:        return (declared == DF::Uint32 || declared == DF::Float32) && nc == 1;
+        case LTF::R32Float:       return declared == DF::Float32 && nc == 1;
+        case LTF::Rgba32Float:    return declared == DF::Float32 && nc == 4;
+    }
+    return false;  // fail closed; unreachable while the switch stays exhaustive
+}
 } // namespace prosper::frontend

--- a/prosper/src/gpu/resources/image_identity.hpp
+++ b/prosper/src/gpu/resources/image_identity.hpp
@@ -1,0 +1,100 @@
+#pragma once
+// Image IDENTITY: do two bindings describe the same image, such that they must alias one Vulkan
+// image rather than becoming two? (#3204 extraction of the predicates that decided #3205.)
+//
+// This is not a cache optimisation. Callers DEPEND on the aliasing: GTA V's 4K output shader writes
+// the four 8x8 quadrants of each 16x16 block through four bindings at a single guest address, so a
+// binding that fails to alias drops three of four stores and renders a checkerboard over the frame.
+// #3205 is exactly that failure -- a field added to the comparison that described nothing for
+// single-level images and was populated on only one of two construction paths.
+//
+// Extracted from a ~5,000-line function where these were unnamed local expressions, so that the
+// contract can be stated, tested, and pointed at in review. Every function here is a pure
+// comparison of two descriptors: no allocation, no lookup, no side effects, `inline` so the hot
+// per-binding loop pays the same cost it did as an inline expression.
+//
+// The BoundImage-derived half of identity (representation, storage flag, texel depth, array layers)
+// stays with the caller and arrives through `ComputeImageViewShape`, because BoundImage is a
+// frontend-local type and dragging it into the resource layer would invert the dependency.
+#include "gpu/resources/shader_resources.hpp"
+#include "gpu/agc/agc_shader_layout.hpp"
+
+namespace prosper::gpu {
+
+// The non-descriptor half of image identity, supplied by the caller.
+struct ComputeImageViewShape {
+    bool storage = false;        // a storage image and a sampled image are never the same image
+    uint32_t texel_depth = 0;    // realized depth, which may differ from the descriptor's
+    uint32_t array_layers = 0;   // realized layer count
+};
+
+// DCC/metadata identity. Two descriptors that compress differently are different images even when
+// every extent matches, because the compressed footprint is part of the allocation.
+inline bool shader_resource_same_dcc_identity(const ShaderResource& a, const ShaderResource& b) {
+    return a.max_uncompressed_block_size == b.max_uncompressed_block_size &&
+           a.max_compressed_block_size == b.max_compressed_block_size &&
+           a.meta_pipe_aligned == b.meta_pipe_aligned &&
+           a.write_compress_enabled == b.write_compress_enabled &&
+           a.compression_enabled == b.compression_enabled &&
+           a.alpha_is_on_msb == b.alpha_is_on_msb &&
+           a.color_transform == b.color_transform &&
+           a.metadata_addr == b.metadata_addr &&
+           a.dcc_metadata_size == b.dcc_metadata_size &&
+           a.dcc_metadata_host_data == b.dcc_metadata_host_data &&
+           a.dcc_metadata_host_data_size == b.dcc_metadata_host_data_size;
+}
+
+// Same guest bytes behind both descriptors.
+//
+// Pointer equality is NOT sufficient as the only test: a capture materializes each descriptor's
+// bytes into an independently-owned blob, so two descriptors for one guest range get two pointers.
+// The address+size arm is what keeps those aliasing -- it is the arm GTA V's quadrant writes need.
+inline bool shader_resource_same_host_backing(const ShaderResource& a, const ShaderResource& b) {
+    return a.host_data == b.host_data ||
+           (a.gpu_addr != 0 && a.gpu_addr == b.gpu_addr && a.host_data_size == b.host_data_size);
+}
+
+// Full view identity. `same_backing_representation` is the caller's BoundImage-derived half, passed
+// in rather than recomputed here.
+inline bool shader_resource_same_view(const ShaderResource& a, const ShaderResource& b,
+                                      const ComputeImageViewShape& sa,
+                                      const ComputeImageViewShape& sb,
+                                      bool same_backing_representation) {
+    return same_backing_representation &&
+           sa.storage == sb.storage &&
+           a.gpu_addr == b.gpu_addr && a.size == b.size &&
+           a.width == b.width && a.height == b.height && a.depth == b.depth &&
+           sa.texel_depth == sb.texel_depth && sa.array_layers == sb.array_layers &&
+           a.format == b.format && a.num_components == b.num_components &&
+           a.tile_mode == b.tile_mode && a.img_dim == b.img_dim &&
+           a.layer_stride_bytes == b.layer_stride_bytes &&
+           a.layer_mip_offset_bytes == b.layer_mip_offset_bytes &&
+           a.in_mip_tail == b.in_mip_tail &&
+           a.mip_tail_x == b.mip_tail_x && a.mip_tail_y == b.mip_tail_y &&
+           a.declared_mip_levels == b.declared_mip_levels &&
+           // #3205: the derived chain provenance describes nothing for a single-level image, and is
+           // populated on only one of two construction paths. See the predicate's own comment.
+           shader_resource_mip_chain_provenance_matches(a, b) &&
+           a.srgb == b.srgb &&
+           shader_resource_same_host_backing(a, b) &&
+           a.host_data_size == b.host_data_size &&
+           shader_resource_same_dcc_identity(a, b);
+}
+
+// Sampler identity. Only meaningful for sampled bindings: a storage image has no sampler, so the
+// caller skips this entirely rather than comparing fields that mean nothing.
+inline bool shader_resource_same_sampler(const ShaderResource& a, const ShaderResource& b) {
+    return a.mag_filter == b.mag_filter && a.min_filter == b.min_filter &&
+           a.mip_filter == b.mip_filter &&
+           a.addr_uvw[0] == b.addr_uvw[0] && a.addr_uvw[1] == b.addr_uvw[1] &&
+           a.addr_uvw[2] == b.addr_uvw[2] &&
+           a.border_color_type == b.border_color_type &&
+           a.min_lod == b.min_lod && a.max_lod == b.max_lod &&
+           a.lod_bias == b.lod_bias && a.max_aniso_ratio == b.max_aniso_ratio &&
+           a.depth_compare_func == b.depth_compare_func &&
+           a.depth_compare == b.depth_compare && a.unnormalized == b.unnormalized &&
+           a.swizzle[0] == b.swizzle[0] && a.swizzle[1] == b.swizzle[1] &&
+           a.swizzle[2] == b.swizzle[2] && a.swizzle[3] == b.swizzle[3];
+}
+
+}  // namespace prosper::gpu

--- a/prosper/src/gpu/resources/spirv_storage_match.hpp
+++ b/prosper/src/gpu/resources/spirv_storage_match.hpp
@@ -1,0 +1,58 @@
+#pragma once
+// #3204: does a compute binding's guest format match the SPIR-V storage-image format the recompiled
+// module declares?
+//
+// Extracted from `execute_item`, where it was an unnamed `||` chain. The question it answers is
+// narrow and load-bearing: when the module's declared storage format and the guest's declared data
+// format agree NATIVELY, the backend can bind the guest image directly; when they do not, the
+// binding falls to a repacking path. Getting it wrong in the permissive direction binds an image
+// the shader will read with the wrong element type.
+//
+// The pairs are enumerated rather than derived because there is no general rule -- SPIR-V storage
+// formats and Gen5 data formats are two independent vocabularies, and only these combinations have
+// been confirmed to round-trip. A pair that is absent is not "unsupported"; it is "not yet
+// established", and the difference matters when adding one.
+#include "gpu/resources/shader_resources.hpp"
+
+namespace prosper::gpu {
+
+// The module-side half of the question, lifted out of the reflected descriptor so this stays a pure
+// comparison of two vocabularies rather than a reach into frontend types.
+struct SpirvStorageDeclaration {
+    bool numeric_class_is_uint = false;   // the module declares a uint image
+    bool numeric_class_is_float = false;  // ...or a float image
+    bool atomic_access = false;           // atomics force the linear SSBO path, never a native bind
+    uint32_t storage_image_format = 0;    // the SPIR-V Image Format operand
+};
+
+// The SPIR-V Image Format operand values are passed IN by the caller rather than restated here.
+// Duplicating them would create a second source of truth for constants this header has no way
+// to verify, and a wrong one would silently reclassify a binding as native.
+// A float storage image binds natively on the module's word alone: the float paths agree on element
+// width by construction, so there is no format pair to enumerate.
+inline bool spirv_native_float_storage(const SpirvStorageDeclaration& decl) {
+    return decl.numeric_class_is_float;
+}
+
+// A uint storage image must additionally match the guest's format AND component count, because the
+// uint vocabulary distinguishes widths the float one does not.
+inline bool spirv_native_uint_storage(const SpirvStorageDeclaration& decl,
+                                      DataFormat guest_format, uint32_t components,
+                                      uint32_t fmt_r32ui, uint32_t fmt_r16ui,
+                                      uint32_t fmt_r8ui, uint32_t fmt_rgba8ui) {
+    if (!decl.numeric_class_is_uint) return false;
+    // Atomics are served by a linear SSBO view, never a native storage image, so a native match
+    // here would bind the wrong thing however well the formats agree.
+    if (decl.atomic_access) return false;
+    if (guest_format == DataFormat::Uint32 && components == 1)
+        return decl.storage_image_format == fmt_r32ui;
+    if (guest_format == DataFormat::Uint8 && components == 1)
+        return decl.storage_image_format == fmt_r8ui;
+    if (guest_format == DataFormat::Uint8 && components == 4)
+        return decl.storage_image_format == fmt_rgba8ui;
+    if (guest_format == DataFormat::Uint16 && components == 1)
+        return decl.storage_image_format == fmt_r16ui;
+    return false;
+}
+
+}  // namespace prosper::gpu

--- a/prosper/tests/gpu/agc/test_image_identity.cpp
+++ b/prosper/tests/gpu/agc/test_image_identity.cpp
@@ -1,0 +1,124 @@
+// #3204: the image-identity predicates, extracted from execute_item so they can be tested at all.
+//
+// These decide whether two bindings alias ONE Vulkan image. Callers depend on that aliasing: GTA V's
+// 4K output shader writes the four 8x8 quadrants of each 16x16 block through four bindings at one
+// guest address, so a binding that stops aliasing drops three of four stores and renders a
+// checkerboard. #3205 was exactly that, introduced by a field added to an unnamed local expression
+// no test could reach.
+//
+// Each arm below states a rule the aliasing depends on, and each has a counter-arm: a predicate that
+// returned a constant would fail the pair.
+#include "gpu/resources/image_identity.hpp"
+#include <cstdio>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); ++fails; } \
+                         else printf("  [ok]   %s\n", m); } while (0)
+
+static ShaderResource base_descriptor() {
+    ShaderResource r{};
+    r.gpu_addr = 0x2046ce0000ull;
+    r.size = 2560 * 1440 * 4;
+    r.width = 2560; r.height = 1440; r.depth = 1;
+    r.num_components = 4;
+    r.declared_mip_levels = 1;
+    r.host_data_size = 2560 * 1440 * 4;
+    return r;
+}
+
+int main() {
+    printf("== image identity (#3204) ==\n");
+    const ComputeImageViewShape shape{false, 1, 1};
+
+    // --- host backing -------------------------------------------------------------------------
+    {
+        ShaderResource a = base_descriptor(), b = base_descriptor();
+        // THE ARM GTA V DEPENDS ON. A capture materializes each descriptor's bytes into its own
+        // blob, so two bindings for one guest range have DIFFERENT host_data pointers. They must
+        // still be the same backing, via address + size.
+        static uint8_t blob_a[4], blob_b[4];
+        a.host_data = blob_a; b.host_data = blob_b;
+        CHECK(shader_resource_same_host_backing(a, b),
+              "different host_data pointers at one gpu_addr are still the same backing");
+
+        // Counter-arm: a genuinely different address is NOT the same backing, so the rule above is
+        // not just "always true".
+        b.gpu_addr = a.gpu_addr + 0x1000;
+        CHECK(!shader_resource_same_host_backing(a, b),
+              "...but a different gpu_addr is not");
+
+        // And a null gpu_addr cannot vouch for identity -- only the pointer can.
+        ShaderResource c = base_descriptor(), d = base_descriptor();
+        c.gpu_addr = d.gpu_addr = 0; c.host_data = blob_a; d.host_data = blob_b;
+        CHECK(!shader_resource_same_host_backing(c, d),
+              "a zero gpu_addr does not make two distinct pointers the same backing");
+    }
+
+    // --- view identity ------------------------------------------------------------------------
+    {
+        ShaderResource a = base_descriptor(), b = base_descriptor();
+        CHECK(shader_resource_same_view(a, b, shape, shape, true),
+              "two identical descriptors are the same view");
+        CHECK(!shader_resource_same_view(a, b, shape, shape, false),
+              "...unless the caller's backing representation differs");
+
+        const ComputeImageViewShape storage_shape{true, 1, 1};
+        CHECK(!shader_resource_same_view(a, b, shape, storage_shape, true),
+              "a storage binding and a sampled binding are never the same view");
+
+        const ComputeImageViewShape deeper{false, 2, 1};
+        CHECK(!shader_resource_same_view(a, b, shape, deeper, true),
+              "a different realized texel depth is a different view");
+        const ComputeImageViewShape layered{false, 1, 6};
+        CHECK(!shader_resource_same_view(a, b, shape, layered, true),
+              "a different realized layer count is a different view");
+
+        b.width += 1;
+        CHECK(!shader_resource_same_view(a, b, shape, shape, true),
+              "a different extent is a different view");
+    }
+
+    // --- #3205 regression, at the level that actually decides aliasing --------------------------
+    {
+        ShaderResource a = base_descriptor(), b = base_descriptor();
+        // One construction path fills provenance in, the other leaves it unset. Both single-level:
+        // the provenance describes nothing, and must not split the image.
+        b.mip_chain_element_width = 2560;
+        b.mip_chain_element_height = 1440;
+        b.mip_chain_bytes_per_block = 4;
+        CHECK(shader_resource_same_view(a, b, shape, shape, true),
+              "#3205: single-level descriptors alias when provenance is set on one side only");
+
+        // Counter-arm: with a chain declared, that same difference DOES mean different images.
+        a.declared_mip_levels = b.declared_mip_levels = 4;
+        CHECK(!shader_resource_same_view(a, b, shape, shape, true),
+              "...but with a chain declared, differing provenance is a different view");
+    }
+
+    // --- dcc identity -------------------------------------------------------------------------
+    {
+        ShaderResource a = base_descriptor(), b = base_descriptor();
+        CHECK(shader_resource_same_dcc_identity(a, b), "identical dcc state matches");
+        b.compression_enabled = !b.compression_enabled;
+        CHECK(!shader_resource_same_dcc_identity(a, b),
+              "a different compression state is a different image");
+        CHECK(!shader_resource_same_view(a, b, shape, shape, true),
+              "...and that difference reaches the view predicate");
+    }
+
+    // --- sampler identity ----------------------------------------------------------------------
+    {
+        ShaderResource a = base_descriptor(), b = base_descriptor();
+        CHECK(shader_resource_same_sampler(a, b), "identical sampler state matches");
+        b.max_aniso_ratio += 1;
+        CHECK(!shader_resource_same_sampler(a, b), "a different anisotropy is a different sampler");
+        ShaderResource c = base_descriptor(), d = base_descriptor();
+        d.swizzle[2] = d.swizzle[2] + 1;
+        CHECK(!shader_resource_same_sampler(c, d), "a different swizzle is a different sampler");
+    }
+
+    printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/gpu/agc/test_spirv_storage_match.cpp
+++ b/prosper/tests/gpu/agc/test_spirv_storage_match.cpp
@@ -1,0 +1,68 @@
+// #3204: does a compute binding's guest format match the SPIR-V storage-image format the module
+// declares? Extracted from execute_item, where it was an unnamed `||` chain.
+//
+// The permissive direction is the dangerous one: a false "native" binds the guest image directly and
+// the shader reads it with the wrong element type. Every arm below therefore has a rejection partner.
+#include "gpu/resources/spirv_storage_match.hpp"
+#include <cstdio>
+
+using prosper::gpu::DataFormat;
+using prosper::gpu::SpirvStorageDeclaration;
+using prosper::gpu::spirv_native_float_storage;
+using prosper::gpu::spirv_native_uint_storage;
+
+// Stand-ins for the SPIR-V Image Format operands. The real values live at the call site and are
+// passed in; this test only needs them to be DISTINCT, which is the property the predicate relies on.
+static constexpr uint32_t R32UI = 101, R16UI = 102, R8UI = 103, RGBA8UI = 104;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); ++fails; } \
+                         else printf("  [ok]   %s\n", m); } while (0)
+
+static SpirvStorageDeclaration uint_decl(uint32_t fmt, bool atomic = false) {
+    SpirvStorageDeclaration d{}; d.numeric_class_is_uint = true; d.atomic_access = atomic;
+    d.storage_image_format = fmt; return d;
+}
+
+int main() {
+    printf("== spirv storage match (#3204) ==\n");
+
+    // Float: the module's word is sufficient, no format pair to check.
+    SpirvStorageDeclaration f{}; f.numeric_class_is_float = true;
+    CHECK(spirv_native_float_storage(f), "a float storage image is native on the module's word");
+    SpirvStorageDeclaration u{}; u.numeric_class_is_uint = true;
+    CHECK(!spirv_native_float_storage(u), "a uint declaration is not a float storage image");
+
+    // The four established uint pairs.
+    CHECK(spirv_native_uint_storage(uint_decl(R32UI), DataFormat::Uint32, 1, R32UI, R16UI, R8UI, RGBA8UI),
+          "Uint32 x1 <-> R32ui");
+    CHECK(spirv_native_uint_storage(uint_decl(R8UI), DataFormat::Uint8, 1, R32UI, R16UI, R8UI, RGBA8UI),
+          "Uint8 x1 <-> R8ui");
+    CHECK(spirv_native_uint_storage(uint_decl(RGBA8UI), DataFormat::Uint8, 4, R32UI, R16UI, R8UI, RGBA8UI),
+          "Uint8 x4 <-> Rgba8ui");
+    CHECK(spirv_native_uint_storage(uint_decl(R16UI), DataFormat::Uint16, 1, R32UI, R16UI, R8UI, RGBA8UI),
+          "Uint16 x1 <-> R16ui");
+
+    // The module's declared format must match the guest's -- a right-width guess is not enough.
+    CHECK(!spirv_native_uint_storage(uint_decl(R16UI), DataFormat::Uint32, 1, R32UI, R16UI, R8UI, RGBA8UI),
+          "Uint32 x1 is NOT native against an R16ui declaration");
+    CHECK(!spirv_native_uint_storage(uint_decl(R8UI), DataFormat::Uint8, 4, R32UI, R16UI, R8UI, RGBA8UI),
+          "component count is part of the pair: Uint8 x4 is not R8ui");
+
+    // Atomics are served by a linear SSBO view, so a native bind would hand back the wrong object
+    // however well the formats agree. This arm is why the check is not just a format comparison.
+    CHECK(!spirv_native_uint_storage(uint_decl(R32UI, /*atomic=*/true), DataFormat::Uint32, 1,
+                                     R32UI, R16UI, R8UI, RGBA8UI),
+          "atomic access is never a native storage image, even on a matching pair");
+
+    // A float guest format has no uint pair -- absent means "not established", not "equivalent".
+    CHECK(!spirv_native_uint_storage(uint_decl(R32UI), DataFormat::Float32, 1, R32UI, R16UI, R8UI, RGBA8UI),
+          "Float32 has no uint pair");
+    // ...and a non-uint module never takes this path at all.
+    SpirvStorageDeclaration neither{}; neither.storage_image_format = R32UI;
+    CHECK(!spirv_native_uint_storage(neither, DataFormat::Uint32, 1, R32UI, R16UI, R8UI, RGBA8UI),
+          "a module declaring neither class is not a native uint storage image");
+
+    printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/gpu/test_live_target_format_match.cpp
+++ b/prosper/tests/gpu/test_live_target_format_match.cpp
@@ -1,0 +1,58 @@
+// #3204: the renderer-target format compatibility table, extracted from execute_item.
+//
+// It was a 22-line `||` chain over LiveTargetPixelFormat -- the exact shape live_target_format.hpp
+// exists to eliminate. That file's own header records what the shape costs: Dead Cells lost an HDR
+// lighting target (#773) and Syberia lost its whole 3D menu scene, both because a partial mapping
+// silently reported one format as another. An `||` chain answers "not compatible" for any enum
+// member nobody taught it about, with no build error and no failing test.
+//
+// As an exhaustive switch with no `default:`, adding a member is a compile error. This test pins the
+// TABLE; the compiler pins the exhaustiveness.
+#include "shared/live/live_target_format.hpp"
+#include <cstdio>
+
+using prosper::gpu::LiveTargetPixelFormat;
+using prosper::gpu::DataFormat;
+using prosper::frontend::live_target_format_matches_declaration;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); ++fails; } \
+                         else printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    printf("== live target format match (#3204) ==\n");
+
+    // Every member's positive case: the declaration the target actually accepts.
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::Rgba8Unorm, DataFormat::Unorm8, 4), "Rgba8Unorm <- Unorm8 x4");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::Rgba16Float, DataFormat::Float16, 4), "Rgba16Float <- Float16 x4");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::Rg16Float, DataFormat::Float16, 2), "Rg16Float <- Float16 x2");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::R16Float, DataFormat::Float16, 1), "R16Float <- Float16 x1");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::R11G11B10Float, DataFormat::Float10_11_11, 3), "R11G11B10Float <- Float10_11_11 x3");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::R8Unorm, DataFormat::Unorm8, 1), "R8Unorm <- Unorm8 x1");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::Rg8Unorm, DataFormat::Unorm8, 2), "Rg8Unorm <- Unorm8 x2");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::R32Float, DataFormat::Float32, 1), "R32Float <- Float32 x1");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::Rgba32Float, DataFormat::Float32, 4), "Rgba32Float <- Float32 x4");
+
+    // R32Uint is the one target accepting TWO declarations: a guest may store float bits through a
+    // uint view. Preserved from the chain this replaced -- dropping it would silently push those
+    // bindings onto the guest-backing path.
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::R32Uint, DataFormat::Uint32, 1), "R32Uint <- Uint32 x1");
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::R32Uint, DataFormat::Float32, 1), "R32Uint <- Float32 x1 (float bits through a uint view)");
+
+    // Component count is part of the match, not decoration: the same DataFormat at the wrong width
+    // is a different surface.
+    CHECK(!live_target_format_matches_declaration(LiveTargetPixelFormat::Rgba8Unorm, DataFormat::Unorm8, 1), "Rgba8Unorm rejects Unorm8 x1");
+    CHECK(!live_target_format_matches_declaration(LiveTargetPixelFormat::R8Unorm, DataFormat::Unorm8, 4), "R8Unorm rejects Unorm8 x4");
+    CHECK(!live_target_format_matches_declaration(LiveTargetPixelFormat::Rg16Float, DataFormat::Float16, 4), "Rg16Float rejects Float16 x4");
+
+    // Cross-format rejection, so the predicate is not "any float matches any float target".
+    CHECK(!live_target_format_matches_declaration(LiveTargetPixelFormat::Rgba16Float, DataFormat::Float32, 4), "Rgba16Float rejects Float32 x4");
+    CHECK(!live_target_format_matches_declaration(LiveTargetPixelFormat::Rgba32Float, DataFormat::Float16, 4), "Rgba32Float rejects Float16 x4");
+    CHECK(!live_target_format_matches_declaration(LiveTargetPixelFormat::R32Float, DataFormat::Uint32, 1), "R32Float rejects Uint32 x1 (only R32Uint takes both)");
+
+    // Zero components is normalised to one, matching the `nc` the call site computed.
+    CHECK(live_target_format_matches_declaration(LiveTargetPixelFormat::R8Unorm, DataFormat::Unorm8, 0), "zero components reads as one");
+
+    printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Refs #3204. First pass at breaking up `execute_item` — three self-contained clusters extracted into
named, unit-tested predicates.

## Why this, and why now

`live_compute.cpp` is ~11,000 lines and `execute_item` is ~5,200 of them. That size is not an
aesthetic problem: it is why **#3205 shipped**. The predicate deciding whether two image descriptors
alias one Vulkan image was an unnamed local expression, so it had no name a reviewer could question,
no seam a test could reach, and no way to be exercised except by booting a title and looking at the
screen. The review of #3197 was thorough — adversarial mutation testing, a separate silent
positional-init defect caught, a compile-time guard added — and none of it could see the defect.

Each extraction below converts one invisible decision into one that can be named, tested and
reviewed. None changes behaviour.

## The three

**1. Image identity** (`gpu/resources/image_identity.hpp`) — the predicates that decided #3205.
`same_dcc_identity`, `same_host_backing`, `same_view`, `same_sampler`, plus `ComputeImageViewShape`
for the caller's `BoundImage`-derived half. Call site: 58 lines of boolean soup → 13 lines of named
calls.

**Proven field-identical, not assumed**: the set of fields compared before and after is the same —
20 each, empty diff in both directions.

The test states each rule with a **counter-arm**, so a predicate returning a constant fails the pair.
The important one had no test before: after a capture materializes each descriptor's bytes into its
own blob, two bindings for one guest address hold *different* `host_data` pointers and must still
resolve to the same backing via address+size. That is the rule whose violation renders GTA V's
checkerboard.

**2. Renderer-target format table** (`live_target_format.hpp`) — this one **hardens** rather than
moves. It was a 22-line `||` chain over `LiveTargetPixelFormat`, which is precisely the shape that
file exists to eliminate; its header records the cost — Dead Cells lost an HDR lighting target
(#773), Syberia lost its entire 3D menu scene. An `||` chain answers "not compatible" for any enum
member nobody taught it about: no build error, no failing test, a symptom months later in one game.

Now a `switch` with no `default:`, so under `-Werror=switch` adding a member is a **build failure**
here. The test pins the table; the compiler pins exhaustiveness. Neither alone suffices.

**3. SPIR-V/guest storage agreement** (`gpu/resources/spirv_storage_match.hpp`) — four enumerated
format pairs. The permissive direction binds the guest image with the wrong element type, so every
arm has a rejection partner — including the one that makes it more than a format comparison: atomic
access is served by a linear SSBO view and is **never** a native storage image, however well the
formats agree.

The SPIR-V format operand *values* stay at the call site and are passed in. An earlier draft
restated them as constants in the header; they were written from memory, unverified, and a wrong one
would have silently reclassified a binding as natively bindable. A header that cannot verify a
constant must not own it.

## No performance cost

All **seven** extracted functions are `inline` and header-only, and **no new translation unit**
enters the build — the only `.cpp` changed is `live_compute.cpp` itself, for the call sites. The
compiler sees the same expression trees it saw when these were written longhand. That matters
because two of the three sit in the per-binding loop.

## Verification

`ctest --no-tests=error`: **329/329**, exit 0 (326 before + 3 new test binaries). Fresh configure,
distrobox build, 0 errors.

`execute_item` goes from 5,236 to 5,176 lines. The line count is the least interesting number here —
what changed is that three decision clusters are now reachable by tests, one of which cost a
rendering regression last night.

## Deliberately not in this PR

The remaining ~140 named decisions in `execute_item`, and every stateful cluster (the storage-cache
gate, the seed/writeback decision, the decline paths). Those need their own extractions and their
own tests; #3204 tracks the work.
