### PR TITLE
render_runner: report the VkResult at all six color-target vkCreateImage sites

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2689,6 +2689,15 @@ if(TARGET prosper_core)
       target_link_libraries(test_multidraw_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME multidraw_render COMMAND test_multidraw_render)
 
+      # #3180: a failed color-target vkCreateImage must name its site and the real VkResult. Same
+      # block as the other render_runner.h tests -- it needs the `tests` and `frontends` include
+      # roots and a real Vulkan device.
+      add_executable(test_color_target_create_failure tests/gpu/test_color_target_create_failure.cpp)
+      target_include_directories(test_color_target_create_failure PRIVATE tests)
+      target_include_directories(test_color_target_create_failure PRIVATE frontends)
+      target_link_libraries(test_color_target_create_failure PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME color_target_create_failure COMMAND test_color_target_create_failure)
+
       # Indexed draws (#64): vkCmdDrawIndexed from a BackendDraw's index data — the [0,1,2,2,3,0] quad
       # must match the retired perimeter-fan rendering pixel-exact, and indices must really be applied.
       add_executable(test_indexed_render tests/gpu/state/test_indexed_render.cpp)

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2673,6 +2673,86 @@ inline bool consume_render_texture_create_failure_once() {
     return true;
 }
 
+// #3180: the COLOR-TARGET vkCreateImage sites, the milder siblings of #3045's two.
+//
+// Each of the six already guarded the HANDLE before touching it further (`if (!img) return out;`),
+// so unlike #3045 none of them fed a definitely-null image into a Vulkan call. What they did do is
+// discard the VkResult, which left two smaller problems:
+//
+//   * the guard rested on a driver CONVENTION, not on the spec. Every implementation leaves
+//     `pImage` at VK_NULL_HANDLE when vkCreateImage fails, but Vulkan does not require it, so a
+//     conforming driver that left the slot untouched would walk straight past `if (!img)`. Testing
+//     the result FIRST and the handle second removes that dependency at no cost.
+//   * a failure was silent. The pass returned an empty frame with nothing in the run log, so
+//     "the device refused a 4K attachment" and "the draw list was empty" produced the same
+//     evidence, and the real VkResult -- the one fact that separates them -- was thrown away.
+//
+// The control flow is deliberately unchanged: every site still returns from the pass exactly where
+// it did. This adds a report, and one rate-limited counter shared by all six so a device failing
+// every target cannot flood a run log.
+enum class RenderColorTargetCreateSite : uint32_t {
+    None = 0,
+    Slot0,              // primary slot-0 (the pass's own color target)
+    Slot0Fallback,      // slot-0 retry as a transient image after a persistent-cache budget miss
+    Slot1,              // primary slot-1 (MRT1's independent guest identity)
+    Slot1Fallback,      // slot-1's budget-miss retry
+    SlotExtra,          // primary MRT slots 2..7
+    SlotExtraFallback,  // an MRT slot's budget-miss retry
+};
+
+inline const char* render_color_target_site_name(RenderColorTargetCreateSite site) {
+    switch (site) {
+        case RenderColorTargetCreateSite::Slot0:             return "slot0";
+        case RenderColorTargetCreateSite::Slot0Fallback:     return "slot0-fallback";
+        case RenderColorTargetCreateSite::Slot1:             return "slot1";
+        case RenderColorTargetCreateSite::Slot1Fallback:     return "slot1-fallback";
+        case RenderColorTargetCreateSite::SlotExtra:         return "slot-extra";
+        case RenderColorTargetCreateSite::SlotExtraFallback: return "slot-extra-fallback";
+        default:                                             return "none";
+    }
+}
+
+// Deterministic one-shot injection, the site-selective twin of the sampled-texture hook above and
+// for the same reason: these requests are ordinary 2D color attachments at the caller's own extent,
+// so no real device can be made to refuse one on demand. Arming a site makes the NEXT create at
+// exactly that site report VK_ERROR_OUT_OF_DEVICE_MEMORY without calling the driver. The production
+// path never arms this state.
+inline RenderColorTargetCreateSite& render_color_target_create_failure_storage() {
+    static thread_local RenderColorTargetCreateSite armed = RenderColorTargetCreateSite::None;
+    return armed;
+}
+
+inline void inject_render_color_target_create_failure_once(RenderColorTargetCreateSite site) {
+    render_color_target_create_failure_storage() = site;
+}
+
+inline bool consume_render_color_target_create_failure(RenderColorTargetCreateSite site) {
+    RenderColorTargetCreateSite& armed = render_color_target_create_failure_storage();
+    if (armed != site || site == RenderColorTargetCreateSite::None) return false;
+    armed = RenderColorTargetCreateSite::None;
+    return true;
+}
+
+// Create a color target, reporting the driver's own verdict. Returns VK_SUCCESS with a non-null
+// `out_image`, or a failure code with `out_image` forced to VK_NULL_HANDLE so the caller's existing
+// handle guard stays correct whatever the driver left behind.
+inline VkResult create_color_target_image(VkDevice dev, const VkImageCreateInfo& ci,
+                                          RenderColorTargetCreateSite site, VkImage* out_image) {
+    const VkResult result = consume_render_color_target_create_failure(site)
+        ? VK_ERROR_OUT_OF_DEVICE_MEMORY
+        : vkCreateImage(dev, &ci, nullptr, out_image);
+    if (result == VK_SUCCESS && *out_image) return VK_SUCCESS;
+    *out_image = VK_NULL_HANDLE;
+    static std::atomic<uint32_t> color_target_create_failure_logs{0};
+    if (color_target_create_failure_logs.fetch_add(1, std::memory_order_relaxed) < 32)
+        std::fprintf(stderr,
+                     "[color-target-create-failed] site=%s vkCreateImage result=%d extent=%ux%u "
+                     "fmt=%d usage=0x%x -- dropping the pass\n",
+                     render_color_target_site_name(site), (int)result,
+                     ci.extent.width, ci.extent.height, (int)ci.format, (unsigned)ci.usage);
+    return result == VK_SUCCESS ? VK_ERROR_INITIALIZATION_FAILED : result;
+}
+
 // Create, populate, and unmap one transient storage buffer. Every partial failure tears down in
 // Vulkan lifetime order (buffer before any bound memory) and leaves both outputs null. Returning the
 // exact failed step lets the caller report the binding before substituting a safe zero-word buffer.
@@ -4903,8 +4983,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                       (persistent_color ? VK_IMAGE_USAGE_SAMPLED_BIT : 0u) |
                       ((seed_rgba || persistent_color) ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
-        vkCreateImage(dev, &imgci, nullptr, &img);
-        if (!img) {
+        // #3180: the result is the primary test, the handle the secondary one.
+        if (create_color_target_image(dev, imgci, RenderColorTargetCreateSite::Slot0,
+                                      &img) != VK_SUCCESS) {
             if (cached_color) persistent_color_target_cache().erase(color_key);
             return out;
         }
@@ -4935,8 +5016,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 persistent_color = false;
                 imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                               (seed_rgba ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
-                vkCreateImage(dev, &imgci, nullptr, &img);
-                if (!img) return out;
+                if (create_color_target_image(dev, imgci,
+                                              RenderColorTargetCreateSite::Slot0Fallback,
+                                              &img) != VK_SUCCESS)
+                    return out;
                 vkGetImageMemoryRequirements(dev, img, &ir);
                 iai.allocationSize = ir.size; iai.memoryTypeIndex = pick(ir.memoryTypeBits, 0);
             }
@@ -5015,8 +5098,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                           (persistent_color1 ? VK_IMAGE_USAGE_SAMPLED_BIT : 0u) |
                           ((effective_seed1 || persistent_color1)
                                ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
-        vkCreateImage(dev, &color1_ci, nullptr, &img1);
-        if (!img1) {
+        if (create_color_target_image(dev, color1_ci, RenderColorTargetCreateSite::Slot1,
+                                      &img1) != VK_SUCCESS) {
             if (cached_color1) persistent_color_target_cache().erase(color_key1);
             return out;
         }
@@ -5049,8 +5132,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 color1_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
                                   VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                                   (effective_seed1 ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
-                vkCreateImage(dev, &color1_ci, nullptr, &img1);
-                if (!img1) return out;
+                if (create_color_target_image(dev, color1_ci,
+                                              RenderColorTargetCreateSite::Slot1Fallback,
+                                              &img1) != VK_SUCCESS)
+                    return out;
                 vkGetImageMemoryRequirements(dev, img1, &color1_requirements);
                 color1_allocation.allocationSize = color1_requirements.size;
                 color1_allocation.memoryTypeIndex = pick(color1_requirements.memoryTypeBits, 0);
@@ -5119,8 +5204,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                    (cached_extra[slot] ? (VK_IMAGE_USAGE_SAMPLED_BIT |
                                           VK_IMAGE_USAGE_TRANSFER_DST_BIT) : 0u) |
                    (slot_seeded ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
-        vkCreateImage(dev, &ci, nullptr, &extra_images[slot]);
-        if (!extra_images[slot]) {
+        if (create_color_target_image(dev, ci, RenderColorTargetCreateSite::SlotExtra,
+                                      &extra_images[slot]) != VK_SUCCESS) {
             if (cached_extra[slot]) {
                 persistent_color_target_cache().erase(extra_keys[slot]);
                 cached_extra[slot] = nullptr;
@@ -5155,8 +5240,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 cached_extra[slot] = nullptr;
                 ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                            (slot_seeded ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
-                vkCreateImage(dev, &ci, nullptr, &extra_images[slot]);
-                if (!extra_images[slot]) return out;
+                if (create_color_target_image(dev, ci,
+                                              RenderColorTargetCreateSite::SlotExtraFallback,
+                                              &extra_images[slot]) != VK_SUCCESS)
+                    return out;
                 vkGetImageMemoryRequirements(dev, extra_images[slot], &requirements);
                 allocation.allocationSize = requirements.size;
                 allocation.memoryTypeIndex = pick(requirements.memoryTypeBits, 0);

--- a/prosper/tests/gpu/test_color_target_create_failure.cpp
+++ b/prosper/tests/gpu/test_color_target_create_failure.cpp
@@ -1,0 +1,204 @@
+// test_color_target_create_failure -- #3180: a failed color-target vkCreateImage must say so.
+//
+// `render_draw_pass_rgba` creates its color attachments at six sites: a primary and a
+// budget-miss-fallback create for slot 0, for slot 1, and for MRT slots 2..7. Every one of them
+// already guarded the resulting HANDLE before using it, so unlike #3045's two sites none fed a
+// null image into a Vulkan call. They still discarded the `VkResult`, which left the pass dropping
+// silently: an empty frame and nothing in the run log, so a device refusing a 4K attachment and an
+// empty draw list produced identical evidence.
+//
+// Each arm here arms ONE site, renders a configuration that reaches it, and requires the run log to
+// name that site and the real VkResult. Without the fix nothing is printed and every log assertion
+// fails; the "pass is dropped" assertions alone would pass on unfixed code, which is exactly why
+// they are not the contract this test exists for.
+//
+// The failure is injected rather than provoked, for the reason #3045 recorded: these are ordinary
+// 2D color attachments at the test's own 64x64 extent, so no real device can be made to refuse one
+// on demand.
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/state/render_state.hpp"
+#include "fixtures/render_runner.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+using prosper::test::RenderColorTargetCreateSite;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static void set_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
+
+static bool has(const std::string& haystack, const char* needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+// Run `body` with stderr redirected to a scratch file and return everything it printed. stderr is
+// not restored; every assertion in this test reports on stdout.
+template <typename Body>
+static std::string capture_stderr(const char* scratch, Body&& body) {
+    std::fflush(stderr);
+    if (!std::freopen(scratch, "w+", stderr)) {
+        printf("  [FAIL] cannot redirect stderr\n"); fails++; return {};
+    }
+    body();
+    std::fflush(stderr);
+    std::string text;
+    if (FILE* f = std::fopen(scratch, "rb")) {
+        char buf[4096];
+        size_t n;
+        while ((n = std::fread(buf, 1, sizeof buf, f)) > 0) text.append(buf, n);
+        std::fclose(f);
+    }
+    std::remove(scratch);
+    return text;
+}
+
+int main() {
+    printf("== test_color_target_create_failure (#3180) ==\n");
+
+    // Must precede every render: persistent_color_target_limit() memoizes the environment on its
+    // first call. A zero budget makes every persistent target miss and take its FALLBACK create,
+    // which is the only way the three fallback sites are reachable at all.
+    set_env("PROSPER_BACKEND_TARGET_CACHE_MB", "0");
+
+    const uint32_t W = 64, H = 64;
+    #include "../tools/boot_trace/refvs.inc"
+    const std::vector<uint32_t> vs(kRefVs, kRefVs + sizeof(kRefVs) / 4);
+    // Solid red, exported to MRT0. Inline consts: 0xF2 = 1.0f, 0x80 = 0.0f.
+    static const uint32_t kRedPs[] = {0x7E0002F2u, 0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+                                      0xF800180Fu, 0x03020100u, 0xBF810000u};
+    const std::vector<uint32_t> fs = recompile_fragment(kRedPs, sizeof(kRedPs) / 4, nullptr);
+    CHECK(!vs.empty() && !fs.empty(), "fullscreen VS + solid-red PS available");
+    if (vs.empty() || fs.empty()) { printf("FAILED (%d)\n", fails); return 1; }
+
+    ResolvedPipelineState opaque{};
+    opaque.topology = 3 /*VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST*/;
+    opaque.color_write_mask = 0xF;
+    const float black[4] = {0, 0, 0, 1};
+
+    // One render, configured to reach `site`'s creation. `persistent` arms the budget-miss path.
+    struct Arm {
+        RenderColorTargetCreateSite site;
+        const char* name;          // as it must appear in the log
+        uint32_t color_count;      // 1 -> slot 0 only, 2 -> +slot 1, 3 -> +MRT slot 2
+        bool persistent;           // set the identities that route through the budget check
+        uint64_t id_base;          // distinct per arm so the target cache cannot answer from before
+    };
+    const Arm arms[] = {
+        {RenderColorTargetCreateSite::Slot0,             "slot0",               1, false, 0},
+        {RenderColorTargetCreateSite::Slot0Fallback,     "slot0-fallback",      1, true,  0x1100},
+        {RenderColorTargetCreateSite::Slot1,             "slot1",               2, false, 0},
+        {RenderColorTargetCreateSite::Slot1Fallback,     "slot1-fallback",      2, true,  0x2200},
+        {RenderColorTargetCreateSite::SlotExtra,         "slot-extra",          3, false, 0},
+        {RenderColorTargetCreateSite::SlotExtraFallback, "slot-extra-fallback", 3, true,  0x3300},
+    };
+
+    auto run = [&](const Arm& arm, bool inject, std::vector<uint8_t>* pixels) -> std::string {
+        char scratch[128];
+        std::snprintf(scratch, sizeof scratch, "test_color_target_create_failure_%s_%d.log",
+                      arm.name, inject ? 1 : 0);
+        return capture_stderr(scratch, [&] {
+            prosper::test::BackendDraw d;
+            d.vs = vs; d.fs = fs; d.ps = &opaque; d.vcount = 3;
+            prosper::test::BackendColorTarget target{};
+            if (arm.persistent) {
+                target.persistent_id = arm.id_base + 1;
+                target.persistent_id1 = arm.id_base + 2;
+                target.persistent_id_slots[2] = arm.id_base + 3;
+            }
+            prosper::test::BackendMrtOutputs outputs;
+            outputs.color_count = arm.color_count;
+            if (inject) prosper::test::inject_render_color_target_create_failure_once(arm.site);
+            *pixels = prosper::test::render_draws_rgba(
+                {d}, W, H, nullptr, black, false, arm.persistent ? &target : nullptr,
+                nullptr, black, nullptr, nullptr, true, &outputs);
+        });
+    };
+
+    for (const Arm& arm : arms) {
+        printf("  -- site %s --\n", arm.name);
+
+        // Control FIRST: the same configuration with nothing armed must render and stay silent.
+        // Without it, an arm that reached the site by accident (or never reached it, and printed
+        // from some other site) would be indistinguishable from one that worked.
+        std::vector<uint8_t> control_px;
+        const std::string control_log = run(arm, false, &control_px);
+        char msg[192];
+        std::snprintf(msg, sizeof msg,
+                      "%s: an uninjected run renders a frame", arm.name);
+        CHECK(control_px.size() == static_cast<size_t>(W) * H * 4, msg);
+        std::snprintf(msg, sizeof msg,
+                      "%s: an uninjected run logs no create failure", arm.name);
+        CHECK(!has(control_log, "[color-target-create-failed]"), msg);
+
+        std::vector<uint8_t> failed_px;
+        const std::string failure_log = run(arm, true, &failed_px);
+
+        // THE CONTRACT. Unfixed code prints nothing at all, so all three of these go red.
+        std::string expect_site = std::string("[color-target-create-failed] site=") + arm.name + " ";
+        std::snprintf(msg, sizeof msg, "%s: the failure names ITS OWN site", arm.name);
+        CHECK(has(failure_log, expect_site.c_str()), msg);
+        std::snprintf(msg, sizeof msg,
+                      "%s: the failure reports the real VkResult, not just 'a null handle'",
+                      arm.name);
+        // VK_ERROR_OUT_OF_DEVICE_MEMORY == -2, what the injector simulates.
+        CHECK(has(failure_log, "vkCreateImage result=-2"), msg);
+        std::snprintf(msg, sizeof msg, "%s: the failure reports the requested extent", arm.name);
+        CHECK(has(failure_log, "extent=64x64"), msg);
+
+        // The pre-existing control flow is unchanged: the pass is still dropped, not continued
+        // with a null image. (True on unfixed code too -- stated so a future change that made the
+        // report by CONTINUING past the failure would be caught.)
+        std::snprintf(msg, sizeof msg, "%s: the pass is still dropped, not continued", arm.name);
+        CHECK(failed_px.empty(), msg);
+    }
+
+    // Site selectivity and one-shot semantics: arming slot1 must not fire at slot0, and the arm
+    // must be spent by the render that consumed it. Without selectivity every arm above would pass
+    // on whichever site happened to run first.
+    {
+        std::vector<uint8_t> px;
+        const std::string log = run(arms[0] /* slot0 config, color_count 1 */, false, &px);
+        (void)log;
+        prosper::test::inject_render_color_target_create_failure_once(
+            RenderColorTargetCreateSite::Slot1);
+        std::vector<uint8_t> unaffected;
+        const std::string slot0_log = capture_stderr(
+            "test_color_target_create_failure_selectivity.log", [&] {
+                prosper::test::BackendDraw d;
+                d.vs = vs; d.fs = fs; d.ps = &opaque; d.vcount = 3;
+                prosper::test::BackendMrtOutputs outputs;   // color_count 1 -> slot 1 never created
+                unaffected = prosper::test::render_draws_rgba(
+                    {d}, W, H, nullptr, black, false, nullptr, nullptr, black, nullptr, nullptr,
+                    true, &outputs);
+            });
+        CHECK(unaffected.size() == static_cast<size_t>(W) * H * 4,
+              "a slot-1 arm does not fire at the slot-0 site");
+        CHECK(!has(slot0_log, "[color-target-create-failed]"),
+              "...and prints nothing while it stays armed");
+        // Still armed: disarm it so it cannot leak into anything later.
+        CHECK(prosper::test::consume_render_color_target_create_failure(
+                  RenderColorTargetCreateSite::Slot1),
+              "the unfired arm is still pending and consumes exactly once");
+        CHECK(!prosper::test::consume_render_color_target_create_failure(
+                  RenderColorTargetCreateSite::Slot1),
+              "...and is spent after one consume");
+        CHECK(!prosper::test::consume_render_color_target_create_failure(
+                  RenderColorTargetCreateSite::None),
+              "the None site never fires");
+    }
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #3180

## Failure scenario

`render_draw_pass_rgba` creates its color attachments at six sites — a primary and a
budget-miss-fallback create for slot 0, for slot 1, and for the MRT slots 2..7 — and every one of
them discarded the `VkResult`:

```cpp
vkCreateImage(dev, &imgci, nullptr, &img);
if (!img) {
    if (cached_color) persistent_color_target_cache().erase(color_key);
    return out;
}
```

Unlike the two sites #3045 fixed, each of these already guarded the resulting **handle** before
touching it further, so none fed a definitely-null image into a Vulkan call. Two smaller problems
remained:

1. **The guard rested on a driver convention, not the spec.** Every implementation leaves `pImage`
   at `VK_NULL_HANDLE` when `vkCreateImage` fails, but Vulkan does not require it — a conforming
   driver that left the slot untouched would walk straight past `if (!img)`. (The handles here are
   all provably null going in, so today this is a latent dependency rather than a live bug.)
2. **A failure was silent.** The pass returned an empty frame with nothing in the run log, so "the
   device refused this attachment" and "the draw list was empty" produced identical evidence, and
   the real `VkResult` — the single fact that separates them — was thrown away.

## Behavioural contract

A color-target creation failure at any of the six sites drops the pass exactly where it already did,
and now also reports one rate-limited `stderr` line naming the site, the real `VkResult`, and the
requested extent/format/usage. Success is entirely unchanged.

## Approach

Route all six through one helper:

```cpp
inline VkResult create_color_target_image(VkDevice dev, const VkImageCreateInfo& ci,
                                          RenderColorTargetCreateSite site, VkImage* out_image);
```

It tests the **result first and the handle second**, forces the handle to `VK_NULL_HANDLE` on
failure so the callers' existing guards stay correct whatever the driver left behind, and emits a
rate-limited report following the `[texture-upload-failed]` / `[ds-create-failed]` convention #3045
established:

```
[color-target-create-failed] site=slot1-fallback vkCreateImage result=-2 extent=64x64 fmt=37 usage=0x16 -- dropping the pass
```

The rate limit is a **single counter shared by all six sites**, so a device failing every target
cannot flood a run log.

## Deliberately unaffected

- **Control flow.** Every site still returns from the pass at exactly the same point, and each
  failure path's `persistent_color_target_cache().erase(...)` is untouched. The diff replaces a
  create-plus-handle-check with a create-plus-result-check; it does not move, add, or remove a
  `return`.
- The depth/stencil site (`[ds-create-failed]`) and the sampled-texture upload site
  (`[texture-upload-failed]`), both already fixed by #3045.
- `vkCreateImageView` / `vkCreateSampler` / `vkCreateRenderPass` / `vkCreateFramebuffer` — see the
  finding below.
- The persistent-target budget, eviction, and caching logic.

## A bigger finding, filed separately: #3210

Auditing the neighbouring sites for the same shape turned up a **worse** class, which this PR
deliberately does not touch:

```cpp
5406:    VkRenderPass rp; vkCreateRenderPass(dev, &rpci, nullptr, &rp);
5414:    VkFramebuffer fb; vkCreateFramebuffer(dev, &fbci, nullptr, &fb);
```

Both handles are **uninitialized**, both results are discarded, and both are used with **no guard at
all** — `rp` reaches every pipeline's `renderPass`, `rpbi.renderPass`, and `vkDestroyRenderPass`;
`fb` reaches `vkCmdBeginRenderPass`. On failure Vulkan does not write the output parameter, so this
is reading an indeterminate automatic variable, not the null-handle reliance described above.
Separately, five `vkCreateImageView`/`vkCreateSampler` results (5259, 7296/7297, 7307/7309) are
unchecked and a possibly-null view goes into a `VkDescriptorImageInfo` and then
`vkUpdateDescriptorSets` — the exact #3045 shape, one API along, and two of them cache the null
into `persistent_image->second.bindings` so one failure is re-served to later draws.

These need **new failure paths** rather than a report added to control flow that already exists, and
they span four Vulkan entry points, so folding them in here would make this PR neither mechanical
nor reviewable. Filed as **#3210** with exact line numbers.

## Risks

The helper is the only new logic and it is nine lines. The residual risk is that a site's guard
changed meaning; the diff shows each replacement is `create → check handle` becoming
`create → check result (handle forced null on failure)`, with the surrounding block byte-identical.
The injector is off unless a test arms it and is `thread_local`, one-shot, and site-selective, so it
cannot leak into the production path or between tests.

## Build and test

```
cmake -S prosper -B prosper/build-linux      CFG_RC=0
cmake --build prosper/build-linux -j6        BUILD_RC=0
```

New test registered **by name** (not inferred from a total), in the same `if(Vulkan_FOUND)` block as
the other `render_runner.h` tests:

```
ctest -N | grep color_target_create_failure
  Test #311: color_target_create_failure
```

```
./test_color_target_create_failure
  ... 42 arms ...
PASSED
TEST_RC=0
```

```
ctest --no-tests=error
100% tests passed out of 330
CTEST_RC=0
```

All six sites are driven by a **real render**, each preceded by an uninjected control run of the
identical configuration that must render a full 64x64x4 frame and log nothing — without that
control, an arm that reached the site by accident, or that printed from some *other* site, would be
indistinguishable from one that worked.

Reaching the three fallback sites needs `PROSPER_BACKEND_TARGET_CACHE_MB=0`, set before the first
render because `persistent_color_target_limit()` memoizes its environment; a zero budget makes every
persistent target miss and take its fallback create.

## Mutation arms — the test fails without the fix

Both mutations **compiled and ran** (`BUILD_RC=0`), so the reddening is assertions failing, not the
build:

**Mutation A — the pre-fix behaviour.** The `fprintf` removed, i.e. fail silently:

```
MUT_A_BUILD_RC=0
18 [FAIL] lines  (3 log assertions x 6 sites)
MUT_A_TEST_RC=1
```

**Mutation B — a constant site name** (`"slot0"` instead of `render_color_target_site_name(site)`).
This is the arm that matters most, because it is the one a test could pass for the wrong reason:

```
MUT_B_BUILD_RC=0
  [FAIL] slot0-fallback: the failure names ITS OWN site
  [FAIL] slot1: the failure names ITS OWN site
  [FAIL] slot1-fallback: the failure names ITS OWN site
  [FAIL] slot-extra: the failure names ITS OWN site
  [FAIL] slot-extra-fallback: the failure names ITS OWN site
MUT_B_TEST_RC=1
```

Exactly the five non-slot0 sites go red and slot0 stays green — which is what proves each site is
independently wired rather than one site reporting for all six.

The fixture was restored from a pristine copy after each arm.

## Ruled out

No entry: this issue's premise was confirmed rather than falsified — the six sites do rely on the
null-handle convention and do fail silently. The audit's negative result (that the *neighbouring*
sites are worse, not equivalent) is recorded in #3210, which is where the next reader will look.

## Not run

No emulator, snapshot or GPU capture: the GPU is claimed by another lane.

## A note on this box's render tests under load

An earlier run of this suite reported 5 failures under `-j4` and 2 serially
(`recompiled_shaders_render`, `multidraw_render`) while another lane held the GPU at 100%. **They
are not from this change**, and the control is on the record rather than asserted: the identical
`multidraw_render` failure reproduced 3 of 3 on a *different* worktree whose `render_runner.h` is
untouched `origin/master`. Once the other lane's load eased, both trees ran 330/330 green with no
rebuild in between. Quote the green run; the red one measured the box, not the diff.
