### PR TITLE
gpu: key a resolve pass on the destination its copy acts with

### DIFF
--- a/prosper/docs/ASTERIX_BABYLON_STATUS.md
+++ b/prosper/docs/ASTERIX_BABYLON_STATUS.md
@@ -649,6 +649,17 @@ HLE registration. #1599, #1884.
   readback. It returned the same `792bed5a3f02a383` uniformly-black pixels and byte-identical BMP as
   operation 4 and the op6 destination. Both resolves therefore copy black to black in this capture;
   neither loses useful color. This is localization evidence only; rung remains 0.
+- **The existing MSAA evidence here already covers #3025 (consecutive resolves grouping into one
+  pass, all but the first destination dropped):** falsified — it cannot, in either direction. This
+  submit has the exact shape the defect needs: four `MODE=RESOLVE` operations at 5, 6, 9 and 10, in
+  two ADJACENT pairs, all four reading one source (`4→5`, `4→6`, `4→9`, `4→10`), so nothing separates
+  a pair into two passes but the destination term #3025 added. But every measurement above reads
+  `792bed5a3f02a383` — uniformly black — for op4's source and for both recorded destinations, so a
+  destination that was never written is byte-identical to one that was, and neither the op6 nor the
+  op10 selector could have distinguished them. Whether ops 5 and 9 name a *different* `color1_base`
+  from their partners is not recorded anywhere, so whether the defect fires on this title is
+  **untested, not ruled out** — re-derive the four raw `color1_base` values from a fresh capture
+  before treating this submit as unaffected. #3025.
 - **An omitted immediately preceding submit as operation 4's black temporal input:** a bounded two-frame
   whole-frame capture contains consecutive submits 180 and 181. Resolve-aware scanning identifies submit
   180 operation 4 as the last semantic writer of submit 181 operation 4's same run-local `0x2033b10000`

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -7757,12 +7757,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const VkFormat format0 = pass_formats[0];
                     const VkFormat format1 = base1
                         ? pass_formats[1] : VK_FORMAT_UNDEFINED;
-                    // A MODE=RESOLVE draw shares color0_base with the scene it resolves and reports
-                    // active_color1()==0 (it exports nothing), so without keying the group on cb_resolve
-                    // it could merge with the scene draws; the resolve-copy `continue` below would then
-                    // silently drop any ordinary draws grouped after it. Key on it so a resolve is always
-                    // its own pass.
-                    const bool resolve0 = items[pass_i].ps.cb_resolve;
                     // The DEPTH/STENCIL attachment is part of a pass's target identity, not just its
                     // colour attachments.
                     //
@@ -7795,8 +7789,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         if (ds_identity(draw) != ds0) return false;
                         return true;
                     };
+                    // A MODE=RESOLVE draw is answered by a COPY below, not by a render, so its
+                    // pass identity is the source/destination pair that copy acts with rather than
+                    // the attachment set `same_targets` compares. `mrt_same_resolve_pass` carries
+                    // that whole rule -- keeping a resolve out of a scene group, and keeping two
+                    // resolves with different destinations out of each other's (#3025) -- and its
+                    // header states why each half exists.
                     while (pass_i < items.size() && same_targets(items[pass_i]) &&
-                           items[pass_i].ps.cb_resolve == resolve0) {
+                           prosper::frontend::mrt_same_resolve_pass(pass_head, items[pass_i])) {
                         pass.push_back(&items[pass_i]); ++pass_i;
                     }
 
@@ -8000,10 +8000,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             if (PROSPER_ENV_ON("PROSPER_MSAA_LOG"))
                                 fprintf(stderr, "[msaa] resolve copy 0x%llx -> 0x%llx (%ux%u)\n",
                                         (unsigned long long)rsrc, (unsigned long long)rdst, rw, rh);
-                        } else if (PROSPER_ENV_VALUE("PROSPER_MSAA_LOG")) {
-                            fprintf(stderr, "[msaa] resolve SKIP src=0x%llx dst=0x%llx (%s)\n",
-                                    (unsigned long long)rsrc, (unsigned long long)rdst,
-                                    !rsrc || !rdst ? "missing base" : "source has no rendered surface");
+                        } else {
+                            // A resolve that performs no copy is DROPPED RENDERED CONTENT: the
+                            // destination keeps whatever it held before, and every later census
+                            // reads it as "written by nothing". Report it unconditionally, bounded
+                            // like the copy-failure warning above, so the one remaining way a
+                            // resolve can produce nothing is fail-visible rather than silent.
+                            // PROSPER_MSAA_LOG still reports every occurrence.
+                            static std::atomic<int> skipped{0};
+                            if (PROSPER_ENV_VALUE("PROSPER_MSAA_LOG") ||
+                                skipped.fetch_add(1) < 8)
+                                fprintf(stderr, "[msaa] resolve SKIP src=0x%llx dst=0x%llx (%s)\n",
+                                        (unsigned long long)rsrc, (unsigned long long)rdst,
+                                        !rsrc || !rdst ? "missing base"
+                                                       : "source has no rendered surface");
                         }
                         if (timing_enabled) ++pending_timing.resolve_n;
                         continue;   // resolve is a copy, not an ordinary-draw render

--- a/prosper/frontends/shared/rtt/mrt_binding.hpp
+++ b/prosper/frontends/shared/rtt/mrt_binding.hpp
@@ -144,6 +144,43 @@ bool mrt_same_color_pass(const prosper::gpu::DrawItem& first,
     return true;
 }
 
+// Can two consecutive draws share one pass given their FIXED-FUNCTION RESOLVE identity?
+//
+// A CB_COLOR_CONTROL.MODE=RESOLVE draw is not an ordinary draw: live_renderer answers it with a
+// straight copy of the already-rendered `color0_base` surface into `color1_base` and then ends the
+// group, because a resolve is a copy and not a render. Two consequences follow, and the predicate
+// has to carry both.
+//
+// 1. A resolve must never group with an ordinary draw. It shares `color0_base` with the scene it
+//    resolves and reports `mrt_active_color(draw, 1) == 0` -- a fixed-function resolve exports
+//    nothing, so its `color1_write_mask` is 0 and slot 1 contributes no attachment -- so on colour
+//    identity alone it would merge with those scene draws, and the copy's `continue` would then
+//    silently drop every ordinary draw grouped after it.
+//
+// 2. Two resolves must not group unless they resolve into the SAME destination. `cb_resolve` alone
+//    is a boolean and cannot separate one resolve from another, while slot 1 -- the slot the
+//    destination lives in -- is inactive for every resolve and so contributes no discriminating
+//    term to `mrt_same_color_pass`. Consecutive resolves sharing a source and naming DIFFERENT
+//    `color1_base` destinations therefore satisfied every grouping term, became one pass, and had
+//    one copy performed from the group's first draw; every other destination was discarded with no
+//    copy, no render and no diagnostic (#3025). The destination the copy acts with is the raw
+//    `color1_base`, so that is the field the group must be keyed on -- the same principle #3023
+//    established for slot 0: THE IDENTITY A PASS GROUPS ON MUST BE THE IDENTITY IT ACTS WITH.
+//
+// With the destination in the key, every member of a resolve group names one source and one
+// destination, so the single copy the group performs is exactly right for all of them and no member
+// needs its own.
+//
+// Deliberately keyed on the RAW named field rather than on `mrt_active_color(draw, 1, ...)`, for
+// the same reason the copy reads it raw: a fixed-function resolve's slot 1 is never active, so the
+// active-binding rule reports 0 for every resolve and would key the group on a constant.
+inline bool mrt_same_resolve_pass(const prosper::gpu::DrawItem& first,
+                                  const prosper::gpu::DrawItem& candidate) {
+    if (first.ps.cb_resolve != candidate.ps.cb_resolve) return false;
+    if (!first.ps.cb_resolve) return true;
+    return first.color1_base == candidate.color1_base;
+}
+
 // Does this draw bind the sampled VIEW as any ACTIVE colour target? Address alone is insufficient:
 // packed mip tails may give two levels the same guest base even though they are separate Vulkan
 // images. Known, conflicting extents therefore prove that the sampled view is not the attachment.

--- a/prosper/frontends/shared/tests/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_binding.cpp
@@ -51,6 +51,7 @@ int main() {
     using prosper::frontend::mrt_draw_binds_target;
     using prosper::frontend::mrt_draw_binds_target_view;
     using prosper::frontend::mrt_same_color_pass;
+    using prosper::frontend::mrt_same_resolve_pass;
 
     constexpr uint64_t kMrt0 = 0x2050000000ull;
     constexpr uint64_t kMrt2 = 0x2083e00000ull;
@@ -271,6 +272,55 @@ int main() {
         array_other.color_targets[0].base = 0x600000ull;
         CHECK(!mrt_same_color_pass(array_only, array_other, format_defined, format_at));
         CHECK(mrt_same_color_pass(array_only, array_only, format_defined, format_at));
+    }
+
+    // #3025 -- the resolve DESTINATION is part of a resolve pass's identity.
+    //
+    // These arms establish the mechanism, not the outcome. The load-bearing assertion for this fix
+    // is in test_gpu_capture_render ("a second resolve into a different destination receives the
+    // resolved pixels"), which reads the destination surface's CONTENTS; a predicate that returns
+    // false proves only that two draws are not grouped, not that both destinations were written.
+    // What these arms add is the part that experiment cannot isolate: that the discriminating term
+    // is the destination and nothing else.
+    {
+        // The exact shape live_renderer sees. A fixed-function resolve exports nothing, so its
+        // color1_write_mask is 0 -- which is precisely why slot 1 could not discriminate.
+        auto resolve = make_draw();
+        resolve.ps.cb_resolve = true;
+        resolve.color0_base = 0x700000ull;             // the MSAA scene being resolved
+        resolve.color0_width = 32u; resolve.color0_height = 32u;
+        resolve.color1_base = 0x710000ull;             // the single-sample destination
+        resolve.color1_width = 32u; resolve.color1_height = 32u;
+        resolve.ps.color_write_mask = 0xfu;
+        resolve.ps.color1_write_mask = 0u;
+
+        auto second = resolve;
+        second.color1_base = 0x720000ull;              // a DIFFERENT destination
+
+        // The premise, asserted rather than assumed: slot 1 is inactive on a resolve, so the
+        // colour-identity predicate cannot tell these two apart. If this ever fails the fix below
+        // is keying on a term that was already discriminating, and these arms would pass for the
+        // wrong reason.
+        CHECK(mrt_active_color(resolve, 1, format_defined) == 0u);
+        CHECK(mrt_active_color_count(resolve, format_defined) == 1u);
+        CHECK(mrt_same_color_pass(resolve, second, format_defined, format_at));
+
+        CHECK(!mrt_same_resolve_pass(resolve, second));
+        CHECK(mrt_same_resolve_pass(resolve, resolve));
+
+        // A resolve never joins an ordinary draw's group: the copy ends the group, so an ordinary
+        // draw grouped after one would be dropped.
+        auto scene = resolve;
+        scene.ps.cb_resolve = false;
+        CHECK(!mrt_same_resolve_pass(resolve, scene));
+        CHECK(!mrt_same_resolve_pass(scene, resolve));
+
+        // Two ordinary draws are unaffected by the destination term, including when their stale
+        // named color1_base differs. This is what keeps the change scoped to resolves: keying every
+        // pass on a raw named field would split ordinary groups on stale register state.
+        auto scene_other_c1 = scene;
+        scene_other_c1.color1_base = 0x730000ull;
+        CHECK(mrt_same_resolve_pass(scene, scene_other_c1));
     }
 
     if (failures == 0) std::printf("mrt_binding: OK\n");

--- a/prosper/tests/misc/test_gpu_capture_render.cpp
+++ b/prosper/tests/misc/test_gpu_capture_render.cpp
@@ -1129,6 +1129,76 @@ int main() {
               "later pass samples the GREEN pixels retained from color attachment 1");
     }
 
+    // #3025 -- consecutive MSAA resolves into DIFFERENT destinations.
+    //
+    // A CB_COLOR_CONTROL.MODE=RESOLVE draw is answered by a copy of the already-rendered
+    // `color0_base` surface into `color1_base`, and the copy is performed ONCE for the pass, from
+    // the group's first draw. Slot 1 is inactive on every resolve (a fixed-function resolve exports
+    // nothing, so `color1_write_mask` is 0), so before this fix the colour-identity predicate could
+    // not separate two resolves and `cb_resolve` -- a boolean -- did not either: two adjacent
+    // resolves sharing a source and naming different destinations became one pass, one copy was
+    // performed, and the second destination was discarded with no copy, no render and no diagnostic.
+    //
+    // LOAD-BEARING ASSERTION: "a second resolve into a different destination receives the resolved
+    // pixels". It reads the second DESTINATION SURFACE'S CONTENTS and requires them to equal the
+    // source's, byte for byte. Weaker forms were deliberately not used -- a pass count cannot see
+    // which destination was written, and the mere existence of a target entry does not show it
+    // received the scene. The first-destination arm beside it is the control: it passes both before
+    // and after the fix, so a run where BOTH fail is a broken fixture rather than this defect.
+    //
+    // No title is known to emit this shape (Blue Prince, the title the resolve path was built for,
+    // separates its resolves with ordinary draws so they never group), so this construction is the
+    // whole evidence for the fix -- built by hand here rather than drawn from a capture.
+    {
+        constexpr uint64_t RESOLVE_SRC = 0x1a00000ull;
+        constexpr uint64_t RESOLVE_DST1 = 0x1a10000ull;
+        constexpr uint64_t RESOLVE_DST2 = 0x1a20000ull;
+        constexpr uint32_t RW = 32, RH = 32;
+
+        DrawItem resolve_source = replay.items[0];   // the MSAA scene the guest resolves
+        resolve_source.color0_base = RESOLVE_SRC;
+        resolve_source.color0_width = RW;
+        resolve_source.color0_height = RH;
+
+        DrawItem resolve_first = resolve_source;
+        resolve_first.ps.cb_resolve = true;
+        resolve_first.color1_base = RESOLVE_DST1;
+        resolve_first.color1_width = RW;
+        resolve_first.color1_height = RH;
+        resolve_first.ps.color1_write_mask = 0;       // a fixed-function resolve exports nothing
+
+        DrawItem resolve_second = resolve_first;
+        resolve_second.color1_base = RESOLVE_DST2;    // ... into a DIFFERENT destination
+
+        render_submit_items({resolve_source, resolve_first, resolve_second}, W, H);
+
+        LiveTargetSnapshot resolve_src_snapshot, resolve_dst1, resolve_dst2;
+        const bool src_read = read_live_render_target(RESOLVE_SRC, resolve_src_snapshot) &&
+            resolve_src_snapshot.pixels &&
+            resolve_src_snapshot.width == RW && resolve_src_snapshot.height == RH;
+        // Anti-triviality: the equality below must not be satisfiable by two blank surfaces. If the
+        // source rendered nothing there is no content for a resolve to move and the arms after this
+        // one would pass for a reason that has nothing to do with grouping.
+        bool src_has_content = false;
+        if (src_read)
+            for (size_t i = 0; i + 3 < resolve_src_snapshot.pixels->size(); i += 4)
+                if ((*resolve_src_snapshot.pixels)[i] > 0x40) { src_has_content = true; break; }
+        CHECK(src_read && src_has_content,
+              "the resolve source renders non-blank content for the resolves to move");
+
+        const bool dst1_read = read_live_render_target(RESOLVE_DST1, resolve_dst1) &&
+            resolve_dst1.pixels && resolve_dst1.width == RW && resolve_dst1.height == RH;
+        CHECK(src_read && dst1_read &&
+                  *resolve_dst1.pixels == *resolve_src_snapshot.pixels,
+              "the first resolve destination receives the resolved pixels");
+
+        const bool dst2_read = read_live_render_target(RESOLVE_DST2, resolve_dst2) &&
+            resolve_dst2.pixels && resolve_dst2.width == RW && resolve_dst2.height == RH;
+        CHECK(src_read && dst2_read &&
+                  *resolve_dst2.pixels == *resolve_src_snapshot.pixels,
+              "a second resolve into a different destination receives the resolved pixels");
+    }
+
     render_submit_items({producer}, W, H);
     const uint64_t producer_center = producer.color0_base +
         (static_cast<uint64_t>(producer.color0_width) + producer.color0_width / 2u) * 4u;


### PR DESCRIPTION
## What this is

The same defect class as #3015 (fixed by #3023), on the path #3023 deliberately left in place: a
pass grouped on an identity that is not the identity it acts with. Here the identity is a
**fixed-function MSAA resolve's destination**.

## Failure scenario

`CB_COLOR_CONTROL.MODE=RESOLVE` is answered by a straight copy of the already-rendered `color0_base`
surface into the raw named `color1_base`. The copy is performed **once for the pass**, from
`pass.front()`, after which the group ends (`continue;   // resolve is a copy, not an ordinary-draw
render`).

Pass grouping did not carry that destination:

* Slot 1 is inactive on **every** resolve. A fixed-function resolve exports nothing, so
  `color1_write_mask` is 0, so `mrt_active_color_count` returns **1** — which means
  `mrt_same_color_pass` does not merely compare a constant at slot 1, it **never reaches slot 1 at
  all**. (Worth stating precisely: the issue describes the effect correctly, the mechanism is the
  loop bound rather than a zero comparison.)
* The only resolve term in the key was `items[pass_i].ps.cb_resolve == resolve0` — a boolean. It
  correctly keeps a resolve out of a scene group, and cannot separate one resolve from another.

So two adjacent `cb_resolve` draws sharing a source and naming **different** `color1_base`
destinations satisfied every grouping term, became one pass, had one copy performed, and every other
destination was discarded — **no copy, no render, no diagnostic**. The dropped destination keeps
whatever it held, which downstream reads as a stale or never-written surface.

## Behavioural contract

A resolve pass is keyed on the pair its copy acts with, `(color0_base, color1_base)`. Two resolves
share a pass only if they name the same source *and* the same destination, in which case the two
copies are identical and one is enough. A resolve never shares a pass with an ordinary draw.

## The change

`mrt_same_resolve_pass` in `frontends/shared/rtt/mrt_binding.hpp`, beside `mrt_same_color_pass`,
carrying the whole resolve half of pass identity; `live_renderer.cpp`'s grouping loop keys on it.

```cpp
inline bool mrt_same_resolve_pass(const DrawItem& first, const DrawItem& candidate) {
    if (first.ps.cb_resolve != candidate.ps.cb_resolve) return false;
    if (!first.ps.cb_resolve) return true;
    return first.color1_base == candidate.color1_base;
}
```

Deliberately the **raw named field**, for the same reason the copy reads it raw: the active-binding
rule reports 0 for every resolve, so keying on `mrt_active_color(draw, 1, …)` would key on a
constant. That is mutation arm B below.

### Alternatives considered

| option | why not | what it would have cost |
| --- | --- | --- |
| **Key the group on the destination** (taken) | — | One field compare per candidate draw. Splits only groups that were already wrong. |
| Perform one copy **per item** in the group instead of one per group | Redundant once the key is complete: with the destination keyed, every member names the same `(source, destination)`, so the extra copies are byte-identical repeats of the first. It also leaves the group's *identity* still wrong, so any future reader of `pass.front()` inherits the same bug. | ~200 lines of flush/readback/copy logic moved inside a loop, and N identical GPU copies where one is correct. |
| Stop grouping resolves with each other entirely (one resolve = one pass) | Correct, and simpler to state, but strictly worse behaviour: a run of genuinely identical adjacent resolves would perform N identical copies, each with its own pipeline flush — and the resolve flush is the single most expensive early exit in this loop (Blue Prince, #2266). | Same correctness, unnecessary flushes. |

### Fail-visible, not silent

The one remaining way a resolve can produce nothing is the `resolve SKIP` branch — no source base, no
destination base, or a source with no rendered surface. It used to print **only** under
`PROSPER_MSAA_LOG`, i.e. dropped rendered content with no default-run trace. It now reports
unconditionally, bounded at 8 like the neighbouring copy-failure warning; `PROSPER_MSAA_LOG` still
reports every occurrence.

## Verification — and how the positive instance was built

**This defect is latent: no title capture demonstrates it, so the regression test IS the evidence.**
It was therefore constructed by hand, outside anything that produced the null, rather than derived
from a generator or a capture — the trap this project records as a same-source positive control
testing the discriminator rather than the domain.

The construction (`tests/misc/test_gpu_capture_render.cpp`, run through the real live renderer):

1. an ordinary draw renders content into `0x1a00000` at 32x32;
2. a `cb_resolve` draw with `color0_base = 0x1a00000`, `color1_base = 0x1a10000`,
   `color1_write_mask = 0` (as a fixed-function resolve really is);
3. an identical one whose only difference is `color1_base = 0x1a20000`;
4. all three in **one** `render_submit_items` call, so they are adjacent items in one span.

**The load-bearing assertion is on the destination CONTENTS**, not on a pass count and not on a
target merely existing: `read_live_render_target(0x1a20000)` must return a 32x32 surface whose pixels
are **byte-identical to the source's**. Two supporting arms make it hard to pass for another reason —
an anti-triviality arm requiring the source to be non-blank (two blank surfaces would compare equal),
and a first-destination control arm that passes both before and after the fix, so a run where *both*
destination arms fail is a broken fixture rather than this defect.

`frontends/shared/tests/test_mrt_binding.cpp` adds pure-predicate arms for the mechanism, including
the premise asserted rather than assumed — `mrt_active_color(resolve, 1) == 0`,
`mrt_active_color_count(resolve) == 1`, and `mrt_same_color_pass(resolve, second) == true`, i.e. that
the colour predicate genuinely cannot tell the two apart. Without that arm the new arms could pass
because the term was already discriminating.

### Commands and results (Linux, distrobox `ps5ys`)

```
cmake -S prosper -B prosper/build-linux                        # rc=0
cmake --build prosper/build-linux -j6                          # rc=0
ctest --no-tests=error                                         # rc=0, 100% tests passed out of 332
```

`ctest -N` confirms both affected cases by name: `#128 mrt_binding`, `#289 gpu_capture_render_replay`.
No new ctest executable is registered (the arms extend existing tests), so the count is unchanged
from master's 332 by construction rather than by accident.

### Mutation arms — both wrong fixes are rejected, and both compiled

| mutant | build | `mrt_binding` | `gpu_capture_render_replay` |
| --- | --- | --- | --- |
| **A** — `return true;` (exact pre-fix behaviour: `cb_resolve` is the only term) | rc=**0** | rc=1, `:308 !mrt_same_resolve_pass(resolve, second)` | rc=1, **1** FAIL: *a second resolve into a different destination receives the resolved pixels* |
| **B** — key on `color_targets[1].base` (the ARRAY representation, 0 here) instead of the raw named field | rc=**0** | rc=1, same arm | rc=1, same single FAIL |

Both mutant builds exited 0, so the arms ran against the mutated code rather than a stale binary.
Under mutant A — which *is* the unfixed renderer — the control arms stay green and only the
load-bearing arm reddens, which is the discriminating result: the first destination is written, the
second is dropped.

## Affected / deliberately unaffected

* **Affected:** grouping of two or more adjacent `cb_resolve` draws that name different
  `color1_base` destinations; and the default-run visibility of a skipped resolve.
* **Unaffected:** ordinary draws — the destination term is inside `if (first.ps.cb_resolve)`, so a
  stale named `color1_base` can never split a scene group (asserted). Slot 0's identity, slots 1 and
  above, feedback detection, the DS identity term, the copy itself, its flush/readback ordering, and
  every `PROSPER_*` lever. A resolve group whose members share a destination still groups and still
  performs exactly one copy.
* **Blue Prince (PPSA25009)**, the title the resolve path was built for, separates its resolves with
  ordinary draws, so they never grouped with each other and its behaviour is unchanged.

## Risks

Low. The predicate can only *refuse* groupings that previously succeeded, so the failure mode of a
mistake here is an extra pass, not a dropped one. The extra pass costs one `submit_and_wait` flush on
the resolve path. The one behaviour a reader might not expect is the new unconditional `resolve SKIP`
line; it is bounded at 8 per process.

## A lead this turned up — stated as a hypothesis, not a measurement

The issue records this as latent because no title is known to emit the shape. **Asterix & Obelix:
Babylon Mission (PPSA30490) may.** `docs/ASTERIX_BABYLON_STATUS.md` records one 14-operation submit
containing **four** `MODE=RESOLVE` operations at 5, 6, 9 and 10 — in two **adjacent** pairs — all four
reading one source (`4→5`, `4→6`, `4→9`, `4→10`). That is exactly the precondition. Whether the
members of a pair name *different* `color1_base` values is not recorded anywhere, so this is
untested, and I could not test it (no emulator access this session).

What is certain is that the existing Asterix evidence **cannot** settle it in either direction: every
measurement in that document reads `792bed5a3f02a383` — uniformly black — for the source and for both
recorded destinations, so a destination that was never written is byte-identical to one that was.
Recorded as a `## Ruled out` bullet in `docs/ASTERIX_BABYLON_STATUS.md` so nobody reads that
investigation as having cleared this title.

Fixes #3025
