### PR TITLE
gpu: check the slot-0/1 colour-target alias mirror where the pass target is chosen

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -507,9 +507,33 @@ decode, shader recompiler, Vulkan backend — all unit-testable in isolation) pr
 
 ## Ruled out
 
-Cross-title falsifications for the **present / publish path** (what reaches the screen once passes
-have rendered). One line each: the dead hypothesis, the evidence, the link. Extend this rather than
+Cross-title falsifications for the **present / publish path** — what reaches the screen once passes
+have rendered, together with the pass identity that decides which surface receives those pixels in
+the first place. One line each: the dead hypothesis, the evidence, the link. Extend this rather than
 re-deriving — and read it before forming a hypothesis about a frozen, black, or missing frame.
+
+- **The three slot-0 colour-target readers cannot be merged into one accessor as a refactor — the
+  merge is a semantic decision, and it decides what the renderer renders to.** `mrt_color_binding`
+  (array-first, the active-binding rule behind the attachment count and feedback detection),
+  `mrt_pass_color_binding` (named-first, pass identity) and `live_renderer`'s `pass_bases[0]` (the
+  raw named field) agree on every draw any producer emits, so unifying them *looks* free. On a draw
+  whose named and array representations disagree they answer three different ways, and the sharpest
+  case is not the obvious one: with the array naming a surface and the named triple naming none,
+  grouping compares that address while `pass_bases[0]` is **0**, so the winner decides whether the
+  pass renders to the array's surface or to nothing at all. Hand-built instances for all three
+  divergence shapes are in `frontends/shared/tests/test_mrt_binding.cpp`; no producer can emit one,
+  so there is no evidence to pick a winner with. #3026 landed the consumer-side check instead and
+  filed the decision separately. #3026.
+- **"A named/array divergence is inexpressible" is true of captures and live draws and NOT of the
+  tree as a whole — the render fixtures emit them today.** #3023 established that captures cannot
+  carry a divergence (the wire format holds slots 2 and up only, and
+  `restore_legacy_color_target_aliases` re-derives 0/1 from the named triple on load) and that
+  `realize_draw_item` mirrors at its single success exit. That is correct and is why the #3023 fix
+  is a no-op on real content. It does not generalise: a fixture that takes a captured item and
+  updates only the named fields leaves the array holding the capture's original base, and one run of
+  `gpu_capture_render_replay` reports **eight** such draws (`array=0x200000 0x0` against a live named
+  triple). So the enforceable invariant is "the array mirrors the named triple **or is absent**", not
+  equality — a strict-equality guard fires on every legacy and synthetic draw. #3026.
 
 - **A frozen frame with a live guest is not necessarily a guest or a draw problem — check the publish
   gate first.** Sonic Frontiers (PPSA03831) looked dead from t≈140 s with `frame_seq` frozen at 2,081,

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -7573,6 +7573,46 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 auto active_color_count = [](const prosper::gpu::DrawItem& draw) {
                     return prosper::frontend::mrt_active_color_count(draw, mrt_format_defined);
                 };
+                // #3026 -- the slot-0/1 alias mirror, checked HERE, at the consumer.
+                //
+                // `DrawItem::color_targets[0]`/`[1]` mirror the named `color0_*`/`color1_*` triples
+                // or are absent; every producer honours that and nothing enforced it. The moment
+                // one does not, the readers below answer differently: this loop's pass target is
+                // the RAW named field (`base`, and `native_w`/`native_h` for the framebuffer
+                // extent), grouping is named-first (`mrt_pass_color_binding`), and the
+                // active-binding rule behind the attachment count and feedback detection is
+                // array-first (`mrt_color_binding`). #3023 is what one such disagreement cost: two
+                // draws rendering to different addresses grouped into one pass, and the second
+                // draw's surface was discarded with no pass, no published pixels and no diagnostic.
+                //
+                // It is checked here and not beside the assignments that establish it because an
+                // assertion at `realize_draw_item`'s success exit would sit two lines below its own
+                // mirror and could never fail. This is the place a divergence would have had to
+                // survive to matter.
+                //
+                // Report-only, deliberately. Which representation should win is undecided, and
+                // deciding it here would change the surface the renderer renders to.
+                for (const auto& alias_draw : items) {
+                    prosper::frontend::mrt_check_color_alias_mirror(
+                        alias_draw,
+                        [](uint32_t slot,
+                           const prosper::gpu::DrawItem::ColorTargetBinding& carried,
+                           const prosper::gpu::DrawItem::ColorTargetBinding& named,
+                           uint64_t ordinal) {
+                            static const bool alias_log =
+                                PROSPER_ENV_VALUE("PROSPER_MRT_ALIAS_LOG") != nullptr;
+                            if (ordinal > 8 && !alias_log) return;
+                            fprintf(stderr,
+                                    "[mrt-alias] c%u array=0x%llx %ux%u vs named=0x%llx %ux%u -- "
+                                    "the pass renders to the NAMED surface; grouping, feedback and "
+                                    "the attachment count may read the other one (#3026) x%llu%s\n",
+                                    slot, (unsigned long long)carried.base, carried.width,
+                                    carried.height, (unsigned long long)named.base, named.width,
+                                    named.height, (unsigned long long)ordinal,
+                                    ordinal == 8 && !alias_log
+                                        ? "  (further reports need PROSPER_MRT_ALIAS_LOG=1)" : "");
+                        });
+                }
                 size_t pass_i = 0;
                 prosper::test::BackendSubmissionBatch backend_submission;
                 if (timing_enabled)

--- a/prosper/frontends/shared/rtt/mrt_binding.hpp
+++ b/prosper/frontends/shared/rtt/mrt_binding.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include <cstdint>
 
 #include "gpu/execute/gpu_execute.hpp"
@@ -13,13 +14,20 @@
 // classified stale named state as a live binding, which denies the authoritative direct-GPU path and
 // — when no CPU snapshot exists — degrades to guest bytes rather than to a slower correct source.
 //
-// One asymmetry this header does NOT itself resolve: for SLOT 0 the two read different
-// representations. Grouping takes slot 0's identity from the named fields (see
-// `mrt_same_color_pass`), because that is where live_renderer takes the address it renders to,
-// while feedback stays array-first through `mrt_active_color`. They agree because every producer
-// mirrors `color_targets[0]` from the named triple, not because anything here enforces it — so a
-// producer that ever filled the two independently would break the agreement without this header
-// changing.
+// One asymmetry this header does NOT resolve: for SLOTS 0 AND 1 its readers consult different
+// representations. Pass identity is named-first (`mrt_pass_color_binding`), because that is where
+// live_renderer takes the address it renders to; the active-binding rule that feeds grouping's
+// attachment count and feedback detection is array-first (`mrt_color_binding`). They agree because
+// every producer keeps `color_targets[0]`/`[1]` a mirror of the named triple — or leaves it absent —
+// not because either rule enforces it.
+//
+// `mrt_color_alias_mirrored` is that convention written down, and `mrt_check_color_alias_mirror` is
+// how a consumer checks it AT THE POINT OF USE. Deliberately not at the producers: an assertion
+// beside `realize_draw_item`'s mirror would sit two lines below the assignment it verifies and
+// could never fail, which is worse than no check because it reads as coverage (#3026). Which
+// representation should win when they disagree is UNDECIDED — no producer emits a divergence, so
+// there is no evidence to decide it, and deciding would change the surface the renderer renders to.
+// The check therefore reports and changes nothing.
 //
 // The rule: a slot is active when it has a base, a non-zero write mask, and a format the backend
 // accepts. That last term is TOTAL in the current backend -- `backend_color_format` maps every
@@ -33,19 +41,104 @@
 // different and wrong rule: a genuinely masked-off slot then inherits a stale named mask.
 //
 // That "ONLY" scopes to the active-binding rule and does not extend to slot 0's PASS IDENTITY,
-// which is named-first for the reason given at `mrt_same_color_pass`.
+// which is named-first for the reason given at `mrt_pass_color_binding`.
 namespace prosper::frontend {
+
+// The named `color0_*` / `color1_*` triple a slot aliases. `DrawItem` predates the complete array
+// and only ever grew compatibility fields for the first two attachments, so slots 2 and up have no
+// named alias and answer with an empty binding; every caller in this header guards that.
+inline prosper::gpu::DrawItem::ColorTargetBinding mrt_named_color_alias(
+    const prosper::gpu::DrawItem& draw, uint32_t slot) {
+    if (slot == 0)
+        return prosper::gpu::DrawItem::ColorTargetBinding{
+            draw.color0_base, draw.color0_width, draw.color0_height};
+    if (slot == 1)
+        return prosper::gpu::DrawItem::ColorTargetBinding{
+            draw.color1_base, draw.color1_width, draw.color1_height};
+    return prosper::gpu::DrawItem::ColorTargetBinding{};
+}
 
 inline prosper::gpu::DrawItem::ColorTargetBinding mrt_color_binding(
     const prosper::gpu::DrawItem& draw, uint32_t slot) {
     auto binding = draw.color_targets[slot];
-    if (!binding.base && !binding.width && !binding.height && slot == 0)
-        binding = prosper::gpu::DrawItem::ColorTargetBinding{
-            draw.color0_base, draw.color0_width, draw.color0_height};
-    else if (!binding.base && !binding.width && !binding.height && slot == 1)
-        binding = prosper::gpu::DrawItem::ColorTargetBinding{
-            draw.color1_base, draw.color1_width, draw.color1_height};
+    if (!binding.base && !binding.width && !binding.height && slot < 2u)
+        binding = mrt_named_color_alias(draw, slot);
     return binding;
+}
+
+// THE surface a colour pass renders to, for one slot -- pass IDENTITY, as distinct from the
+// active-binding rule above.
+//
+// Slot 0 is taken from the NAMED triple whenever it names a surface, because that is the surface
+// the pass actually renders to: live_renderer takes `pass_bases[0]` from `color0_base` and the
+// framebuffer extent from `color0_width`/`color0_height`, while every slot above 0 goes through the
+// array. Reading slot 0's identity from the array instead makes GROUPING and TARGET SELECTION
+// consult different representations of one attachment -- and two draws that render to DIFFERENT
+// addresses then share a pass, so the second draw's target is silently discarded and its pixels are
+// never published (#3023).
+//
+// On captured and live draws the two representations are identical, so this costs nothing there.
+// For captures a divergence is not merely absent but INEXPRESSIBLE: the wire format carries slots 2
+// and up only, and `restore_legacy_color_target_aliases` re-derives slots 0/1 from the named triple
+// on every load. For live draws the same mirror sits at the single success exit of
+// `realize_draw_item`. The two differ only for a caller that builds a DrawItem directly and updates
+// the named aliases alone: exactly the shape that mirror exists to repair, and the shape the render
+// fixtures construct. Falling back to `mrt_color_binding` when `color0_base` is 0 keeps the previous
+// answer for a draw that names no slot-0 surface at all.
+inline prosper::gpu::DrawItem::ColorTargetBinding mrt_pass_color_binding(
+    const prosper::gpu::DrawItem& draw, uint32_t slot) {
+    if (slot == 0 && draw.color0_base) return mrt_named_color_alias(draw, 0);
+    return mrt_color_binding(draw, slot);
+}
+
+// Does an aliased slot's ARRAY entry still mirror its named triple?
+//
+// THE CONVENTION, written down. For slots 0 and 1 `DrawItem::color_targets[slot]` must either equal
+// the named `colorN_*` triple or be ABSENT (all three fields zero, the legacy shape the fallback in
+// `mrt_color_binding` exists for). Every producer honours it -- `realize_draw_item`'s success exit
+// and its failure record, the three DrawItem<->capture conversions, and
+// `restore_legacy_color_target_aliases` on every capture load -- and until #3026 nothing checked it.
+//
+// Given the convention, all four slot-0 readers return the same triple: this header's
+// `mrt_color_binding` and `mrt_pass_color_binding`, live_renderer's `pass_bases[0]`, and
+// live_renderer's framebuffer extent. Break it and they answer three different ways, which is the
+// class #3023 was one instance of. Slots 2 and up have no named alias, so nothing there can diverge.
+inline bool mrt_color_alias_mirrored(const prosper::gpu::DrawItem& draw, uint32_t slot) {
+    if (slot > 1u) return true;
+    const auto& carried = draw.color_targets[slot];
+    if (!carried.base && !carried.width && !carried.height) return true;   // absent, not divergent
+    const auto named = mrt_named_color_alias(draw, slot);
+    return carried.base == named.base && carried.width == named.width &&
+           carried.height == named.height;
+}
+
+// How many aliased slots this process has observed diverging. Exposed so a test can assert the
+// CONSUMER saw a hand-built divergence, not merely that the predicate above can compute one -- the
+// distinction this header already records under `mrt_direct_serves`, where tests that exercised the
+// helper instead of the decision stayed green while production was reverted.
+inline std::atomic<uint64_t>& mrt_color_alias_divergence_counter() {
+    static std::atomic<uint64_t> count{0};
+    return count;
+}
+
+inline uint64_t mrt_color_alias_divergences() {
+    return mrt_color_alias_divergence_counter().load(std::memory_order_relaxed);
+}
+
+// Check both aliased slots of one draw where a consumer is about to act on them. `report` receives
+// the slot, the carried array entry, the named alias, and this divergence's process-wide ordinal;
+// the caller owns it, so this header stays free of I/O and of any rate-limit policy. Returns how
+// many slots diverged -- 0 for every draw any production producer emits.
+template <typename Report>
+uint32_t mrt_check_color_alias_mirror(const prosper::gpu::DrawItem& draw, Report report) {
+    uint32_t diverged = 0;
+    for (uint32_t slot = 0; slot < 2u; ++slot) {
+        if (mrt_color_alias_mirrored(draw, slot)) continue;
+        ++diverged;
+        report(slot, draw.color_targets[slot], mrt_named_color_alias(draw, slot),
+               mrt_color_alias_divergence_counter().fetch_add(1, std::memory_order_relaxed) + 1u);
+    }
+    return diverged;
 }
 
 // Raw guest format for a slot, with the same named-field fallback. Left as the raw value so callers
@@ -102,35 +195,14 @@ template <typename FormatDefined, typename FormatAt>
 bool mrt_same_color_pass(const prosper::gpu::DrawItem& first,
                          const prosper::gpu::DrawItem& candidate,
                          FormatDefined format_defined, FormatAt format_at) {
-    // Slot 0 is compared on the NAMED triple whenever it names a surface, because that is the
-    // surface the pass actually renders to: live_renderer takes `pass_bases[0]` from `color0_base`,
-    // while every slot above 0 goes through the array. Reading slot 0's identity from the array
-    // instead makes GROUPING and TARGET SELECTION consult different representations of one
-    // attachment -- and two draws that render to DIFFERENT addresses then share a pass, so the
-    // second draw's target is silently discarded and its pixels are never published.
-    //
-    // On captured and live draws the two representations are identical, so this is a no-op there.
-    // For captures a divergence is not merely absent but INEXPRESSIBLE: the wire format carries
-    // slots 2 and up only, and `restore_legacy_color_target_aliases` re-derives slots 0/1 from the
-    // named triple on every load. For live draws the same mirror sits at the single success exit of
-    // `realize_draw_item`. Neither is asserted anywhere, which is the one soft spot -- they are
-    // conventions held by every producer rather than a checked invariant.
-    //
-    // The two differ only for a caller that builds a DrawItem directly and populates the named
-    // aliases alone: exactly the shape `realize_draw_item`'s mirror exists to repair, and the shape
-    // the render fixtures construct. Falling back to `mrt_color_binding` when `color0_base` is 0
-    // keeps the previous answer for a draw that names no slot-0 surface at all.
-    auto pass_binding = [](const prosper::gpu::DrawItem& draw, uint32_t slot) {
-        if (slot == 0 && draw.color0_base)
-            return prosper::gpu::DrawItem::ColorTargetBinding{
-                draw.color0_base, draw.color0_width, draw.color0_height};
-        return mrt_color_binding(draw, slot);
-    };
+    // Slot 0's identity is the surface the pass RENDERS to, which is `mrt_pass_color_binding` --
+    // named-first -- and not the active-binding rule. That distinction is the whole of #3023; the
+    // reasoning, and why it costs nothing on captured or live draws, is on that function.
     const uint32_t count = mrt_active_color_count(first, format_defined);
     if (mrt_active_color_count(candidate, format_defined) != count) return false;
     for (uint32_t slot = 0; slot < count; ++slot) {
-        const auto a = pass_binding(first, slot);
-        const auto b = pass_binding(candidate, slot);
+        const auto a = mrt_pass_color_binding(first, slot);
+        const auto b = mrt_pass_color_binding(candidate, slot);
         const uint64_t a_base = slot == 0 ? a.base
             : mrt_active_color(first, slot, format_defined);
         const uint64_t b_base = slot == 0 ? b.base

--- a/prosper/frontends/shared/tests/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_binding.cpp
@@ -274,6 +274,154 @@ int main() {
         CHECK(mrt_same_color_pass(array_only, array_only, format_defined, format_at));
     }
 
+    // #3026 -- the named/array mirror for slots 0 and 1, and a guard that CAN fail.
+    //
+    // THE CONVENTION: for the two aliased slots, `DrawItem::color_targets[slot]` either equals the
+    // named `colorN_*` triple or is ABSENT (all three fields zero, the legacy shape the fallback in
+    // `mrt_color_binding` exists for). Every production producer honours it -- `realize_draw_item`'s
+    // success exit and its failure record, the three DrawItem<->capture conversions, and
+    // `restore_legacy_color_target_aliases`, which runs on every capture load because the wire
+    // format carries slots 2 and up only. Nothing checked it, and #3023 is what happens when a
+    // consumer starts depending on which of the two it reads.
+    //
+    // The obvious guard is void, and these arms deliberately do not build it: an assertion inside
+    // `realize_draw_item` would sit two lines below the mirror it verifies, so it would pass forever
+    // and catch nothing. The predicate is checked at the CONSUMER instead -- live_renderer's pass
+    // loop, where the pass target is chosen -- and every divergent instance below is built BY HAND,
+    // because no producer can emit one.
+    {
+        using prosper::frontend::mrt_check_color_alias_mirror;
+        using prosper::frontend::mrt_color_alias_divergences;
+        using prosper::frontend::mrt_color_alias_mirrored;
+        using prosper::frontend::mrt_color_binding;
+        using prosper::frontend::mrt_named_color_alias;
+        using prosper::frontend::mrt_pass_color_binding;
+        using Binding = prosper::gpu::DrawItem::ColorTargetBinding;
+
+        auto same = [](Binding a, Binding b) {
+            return a.base == b.base && a.width == b.width && a.height == b.height;
+        };
+        // THE DEMONSTRATION behind "nothing changes for any reachable draw". Under the convention
+        // every slot-0/1 reader in the renderer returns one triple: grouping's pass identity
+        // (`mrt_pass_color_binding`), the active-binding rule behind the attachment count and
+        // feedback detection (`mrt_color_binding`), and live_renderer's own `pass_bases[0]` plus its
+        // framebuffer extent -- which are the raw named fields, so `mrt_named_color_alias` stands
+        // for them here. Break the convention and they stop agreeing; that is the whole hazard.
+        auto readers_agree = [&](const prosper::gpu::DrawItem& draw, uint32_t slot) {
+            return same(mrt_pass_color_binding(draw, slot), mrt_color_binding(draw, slot)) &&
+                   same(mrt_pass_color_binding(draw, slot), mrt_named_color_alias(draw, slot));
+        };
+
+        // Shape 1: the exact mirror. What `realize_draw_item` and every capture conversion emit.
+        auto mirrored = make_draw();
+        mirrored.color0_base = 0x300000ull;
+        mirrored.color0_width = 32u; mirrored.color0_height = 2u;
+        mirrored.color_targets[0] = {0x300000ull, 32u, 2u};
+        mirrored.color1_base = 0x310000ull;
+        mirrored.color1_width = 32u; mirrored.color1_height = 2u;
+        mirrored.color_targets[1] = {0x310000ull, 32u, 2u};
+        CHECK(mrt_color_alias_mirrored(mirrored, 0) && mrt_color_alias_mirrored(mirrored, 1));
+        CHECK(readers_agree(mirrored, 0) && readers_agree(mirrored, 1));
+
+        // Shape 2: the array ABSENT and the named triple authoritative -- captures through v33, and
+        // the direct/synthetic callers the render fixtures are. The fallback repairs it, so the
+        // readers still agree and this must NOT be reported as a divergence.
+        auto legacy = make_draw();
+        legacy.color0_base = 0x300000ull;
+        legacy.color0_width = 32u; legacy.color0_height = 2u;
+        CHECK(mrt_color_alias_mirrored(legacy, 0) && mrt_color_alias_mirrored(legacy, 1));
+        CHECK(readers_agree(legacy, 0) && readers_agree(legacy, 1));
+
+        // Shape 3: a draw that names no slot-0 surface at all. Both representations empty.
+        auto unbound = make_draw();
+        CHECK(mrt_color_alias_mirrored(unbound, 0) && mrt_color_alias_mirrored(unbound, 1));
+        CHECK(readers_agree(unbound, 0) && readers_agree(unbound, 1));
+
+        // Slots 2 and up have no named alias, so nothing there can diverge -- the array is the only
+        // representation and is authoritative by itself.
+        auto wide = make_draw();
+        wide.color_targets[2].base = kMrt2;
+        CHECK(mrt_color_alias_mirrored(wide, 2));
+
+        // DIVERGENCE A -- a stale array entry beside a live named triple. This is the shape the
+        // render fixtures reach by taking a captured item and updating only the named fields, and
+        // the shape #3023's grouping fix was written against.
+        auto stale_mirror = mirrored;
+        stale_mirror.color_targets[0].base = 0x200000ull;   // an earlier target, never cleared
+        stale_mirror.color_targets[0].width = 0u;
+        stale_mirror.color_targets[0].height = 0u;
+        CHECK(!mrt_color_alias_mirrored(stale_mirror, 0));
+        CHECK(!readers_agree(stale_mirror, 0));
+        // Named-first grouping and the renderer agree; the active-binding rule does not, so a
+        // feedback test on this draw answers about a surface the pass never renders to.
+        CHECK(mrt_pass_color_binding(stale_mirror, 0).base == 0x300000ull);
+        CHECK(mrt_color_binding(stale_mirror, 0).base == 0x200000ull);
+
+        // DIVERGENCE B -- the sharpest one, and the reason the unifying accessor is a semantic
+        // decision rather than a refactor: here GROUPING and TARGET SELECTION disagree. The array
+        // names a surface, the named triple names none, so grouping compares 0x500000 while
+        // live_renderer's `pass_bases[0]` -- the raw named field -- is 0.
+        auto array_only = make_draw();
+        array_only.color_targets[0].base = 0x500000ull;
+        CHECK(!mrt_color_alias_mirrored(array_only, 0));
+        CHECK(!readers_agree(array_only, 0));
+        CHECK(mrt_pass_color_binding(array_only, 0).base == 0x500000ull);
+        CHECK(mrt_named_color_alias(array_only, 0).base == 0u);
+
+        // DIVERGENCE C -- same address, different EXTENT. A base-only comparison would miss it, and
+        // the extent is half of an attachment's identity: it is what stops two packed mip levels
+        // sharing one Vulkan attachment.
+        auto extent_only = mirrored;
+        extent_only.color_targets[0].width = 16u;
+        extent_only.color_targets[0].height = 16u;
+        CHECK(!mrt_color_alias_mirrored(extent_only, 0));
+        CHECK(mrt_color_alias_mirrored(extent_only, 1));   // slot 1 is untouched and still mirrors
+
+        // DIVERGENCE D -- slot 1 diverges on its own. The resolve path takes its destination from
+        // the raw named `color1_base` (#3025), so this slot carries the same hazard as slot 0.
+        auto slot1_diverges = mirrored;
+        slot1_diverges.color_targets[1].base = 0x999000ull;
+        CHECK(!mrt_color_alias_mirrored(slot1_diverges, 1));
+        CHECK(mrt_color_alias_mirrored(slot1_diverges, 0));
+
+        // The consumer's entry point: it names the diverging slot and both representations, and it
+        // counts. `test_gpu_capture_render` asserts the live renderer actually calls this, which is
+        // the part a predicate test cannot establish.
+        uint32_t reported_slot = 99u;
+        Binding reported_carried{}, reported_named{};
+        uint64_t reported_ordinal = 0u;
+        const uint64_t before = mrt_color_alias_divergences();
+        const uint32_t diverged = mrt_check_color_alias_mirror(
+            stale_mirror, [&](uint32_t slot, const Binding& carried, const Binding& named,
+                              uint64_t ordinal) {
+                reported_slot = slot; reported_carried = carried; reported_named = named;
+                reported_ordinal = ordinal;
+            });
+        CHECK(diverged == 1u && reported_slot == 0u && reported_ordinal == before + 1u);
+        CHECK(reported_carried.base == 0x200000ull && reported_named.base == 0x300000ull &&
+              reported_named.width == 32u && reported_named.height == 2u);
+        CHECK(mrt_color_alias_divergences() == before + 1u);
+
+        // ... and the three producer shapes report nothing, so the guard is not a constant.
+        uint32_t spurious = 0;
+        auto count_spurious = [&](uint32_t, const Binding&, const Binding&, uint64_t) {
+            ++spurious;
+        };
+        CHECK(mrt_check_color_alias_mirror(mirrored, count_spurious) == 0u);
+        CHECK(mrt_check_color_alias_mirror(legacy, count_spurious) == 0u);
+        CHECK(mrt_check_color_alias_mirror(unbound, count_spurious) == 0u);
+        CHECK(spurious == 0u && mrt_color_alias_divergences() == before + 1u);
+
+        // Both slots of one draw are reported, once each.
+        auto both_diverge = stale_mirror;
+        both_diverge.color_targets[1].base = 0x999000ull;
+        uint32_t both_reports = 0;
+        CHECK(mrt_check_color_alias_mirror(
+                  both_diverge, [&](uint32_t, const Binding&, const Binding&, uint64_t) {
+                      ++both_reports; }) == 2u);
+        CHECK(both_reports == 2u && mrt_color_alias_divergences() == before + 3u);
+    }
+
     // #3025 -- the resolve DESTINATION is part of a resolve pass's identity.
     //
     // These arms establish the mechanism, not the outcome. The load-bearing assertion for this fix

--- a/prosper/tests/misc/test_gpu_capture_render.cpp
+++ b/prosper/tests/misc/test_gpu_capture_render.cpp
@@ -7,6 +7,7 @@
 #include "hle/dispatch/dispatch.hpp"
 #include "shared/live/live_compute.hpp"
 #include "shared/live/live_renderer.hpp"
+#include "shared/rtt/mrt_binding.hpp"
 #include "fixtures/render_runner.h"
 
 #include <algorithm>
@@ -1197,6 +1198,69 @@ int main() {
         CHECK(src_read && dst2_read &&
                   *resolve_dst2.pixels == *resolve_src_snapshot.pixels,
               "a second resolve into a different destination receives the resolved pixels");
+    }
+
+    // #3026 -- the named/array colour-target mirror for slots 0/1, checked at the CONSUMER.
+    //
+    // `DrawItem::color_targets[0]`/`[1]` mirror the named `color0_*`/`color1_*` triples, or are
+    // absent. Every producer honours it and nothing enforced it. The moment one does not, the
+    // renderer's readers answer differently: the pass renders to the RAW named field, grouping is
+    // named-first, and the active-binding rule behind the attachment count and feedback detection is
+    // array-first -- which is the class #3023 was one instance of.
+    //
+    // These arms establish the two things a predicate test cannot: that the live renderer actually
+    // performs the check where it chooses the pass target, and that the check is DETECT-ONLY -- it
+    // does not move the surface the pass renders to. The divergent draw is built by hand, because no
+    // producer can emit one.
+    {
+        constexpr uint64_t ALIAS_MIRRORED = 0x1b00000ull;   // named == array: every producer's shape
+        constexpr uint64_t ALIAS_NAMED    = 0x1b20000ull;   // the surface the divergent pass renders to
+        constexpr uint64_t ALIAS_ARRAY    = 0x1b10000ull;   // a second representation, naming another
+        constexpr uint32_t AW = 32, AH = 32;
+
+        DrawItem alias_mirrored = replay.items[0];
+        alias_mirrored.color0_base = ALIAS_MIRRORED;
+        alias_mirrored.color0_width = AW; alias_mirrored.color0_height = AH;
+        alias_mirrored.color_targets[0] = {ALIAS_MIRRORED, AW, AH};
+
+        const uint64_t alias_before_mirrored = prosper::frontend::mrt_color_alias_divergences();
+        render_submit_items({alias_mirrored}, W, H);
+        CHECK(prosper::frontend::mrt_color_alias_divergences() == alias_before_mirrored,
+              "a mirrored slot-0 alias -- the shape every producer emits -- reports no divergence");
+
+        LiveTargetSnapshot alias_mirrored_snapshot;
+        const bool alias_mirrored_read =
+            read_live_render_target(ALIAS_MIRRORED, alias_mirrored_snapshot) &&
+            alias_mirrored_snapshot.pixels && alias_mirrored_snapshot.width == AW &&
+            alias_mirrored_snapshot.height == AH;
+        // Anti-triviality: the pixel equality below must not be satisfiable by two blank surfaces.
+        bool alias_mirrored_content = false;
+        if (alias_mirrored_read)
+            for (size_t i = 0; i + 3 < alias_mirrored_snapshot.pixels->size(); i += 4)
+                if ((*alias_mirrored_snapshot.pixels)[i] > 0x40) {
+                    alias_mirrored_content = true; break;
+                }
+        CHECK(alias_mirrored_read && alias_mirrored_content,
+              "the mirrored control renders non-blank content into its named surface");
+
+        DrawItem alias_divergent = alias_mirrored;
+        alias_divergent.color0_base = ALIAS_NAMED;          // the named triple names one surface ...
+        alias_divergent.color_targets[0].base = ALIAS_ARRAY;   // ... and the array another
+
+        const uint64_t alias_before_divergent = prosper::frontend::mrt_color_alias_divergences();
+        render_submit_items({alias_divergent}, W, H);
+        CHECK(prosper::frontend::mrt_color_alias_divergences() > alias_before_divergent,
+              "the live renderer reports the divergence where it chooses the pass target");
+
+        LiveTargetSnapshot alias_named_snapshot, alias_array_snapshot;
+        const bool alias_named_read = read_live_render_target(ALIAS_NAMED, alias_named_snapshot) &&
+            alias_named_snapshot.pixels && alias_named_snapshot.width == AW &&
+            alias_named_snapshot.height == AH;
+        CHECK(alias_mirrored_read && alias_named_read &&
+                  *alias_named_snapshot.pixels == *alias_mirrored_snapshot.pixels,
+              "the guard is detect-only: the pass still renders to the NAMED surface, unchanged");
+        CHECK(!read_live_render_target(ALIAS_ARRAY, alias_array_snapshot),
+              "the divergent array entry receives nothing, exactly as before the guard");
     }
 
     render_submit_items({producer}, W, H);


### PR DESCRIPTION
## What this is

A guard around an unenforced convention, plus the analysis that says why the obvious version of it
would have been worthless and why the tempting alternative is a semantic decision rather than a
refactor. **No behaviour changes.**

## The convention

For colour slots 0 and 1, `DrawItem::color_targets[slot]` must either **equal** the named
`colorN_base` / `colorN_width` / `colorN_height` triple or be **absent** (all three fields zero — the
legacy shape `mrt_color_binding`'s fallback exists for). Every producer honours it:

* `realize_draw_item`'s single success exit and its `OperationRealizationFailure` record;
* the three `DrawItem`↔capture conversions in `gpu_capture.cpp`;
* `restore_legacy_color_target_aliases`, which runs on every capture load — necessarily, because the
  wire format carries slots 2 and up only;
* direct/synthetic callers (the render fixtures, tools) leave the array absent.

Nothing checked it. #3023 is what happens when a consumer starts depending on which of the two it
reads: pass grouping read slot 0 from the array while the pass rendered to the named field, and two
draws targeting different addresses merged into one pass.

## Why the obvious guard is void

An `#ifndef NDEBUG` assertion inside `realize_draw_item` would sit two lines below the mirror it
verifies, so it would pass forever and catch nothing — a check that cannot fail, which is worse than
no check because it reads as coverage. This project's standing rule is that a discriminator which
cannot show its lever moved is void, and that is the purest form of it. It is not what this PR adds.

## The option taken, and what the others would have cost

#3026 named two: **one accessor** (route every slot-0/1 read through a single function, removing the
class) or **a consumer-side check** (assert agreement where the pass target is chosen). This lands
the **consumer-side check**, because the accessor turned out to be a decision about what the renderer
renders to and there is no evidence with which to make it.

Four places read a slot-0 target, three different ways:

| reader | rule |
| --- | --- |
| `mrt_color_binding` — active binding: attachment count, feedback detection | ARRAY-first, named only when the array entry is absent |
| `mrt_pass_color_binding` — pass identity, i.e. grouping | NAMED-first when `color0_base` names a surface |
| `live_renderer`'s `pass_bases[0]` — the surface the pass renders to | the RAW named field |
| `live_renderer`'s framebuffer extent (`native_w`/`native_h`) | the RAW named extent |

Under the convention all four return one triple, for every input — that is the behaviour-preservation
argument, and it is a **test** in this PR (`readers_agree` over the three producer shapes) rather than
a paragraph in this body. Break the convention and they answer three different ways.

Two mutants of the one line that chooses the pass target measure what unifying would cost. Both
compiled — build rc=**0** — so the arms ran against mutated code:

| mutant | `mrt_binding` | `gpu_capture_render_replay` |
| --- | --- | --- |
| **E** — take the base from `mrt_color_binding` (unify on ARRAY-first) | Passed | **Failed, 19 arms**, incl. both this PR adds |
| **F** — take the base from `mrt_pass_color_binding` (unify on NAMED-first) | Passed | Passed |

Array-first is loudly wrong: the render fixtures carry a stale array entry beside a live named
triple, so 19 arms redden. Named-first is **indistinguishable from master across the whole suite** —
which is the problem, not the reassurance it looks like. The two differ on exactly one shape:
`color_targets[0].base` non-zero with `color0_base == 0`, where grouping compares that address while
`pass_bases[0]` is 0. Nothing produces that shape, no fixture builds it, and no capture can carry it,
so adopting F would be an **unverifiable change to what the renderer renders to** — which is exactly
the thing not to do quietly. Filed as **#3219** with the full site list and what each choice implies.

The third option, a producer-side assertion, is the void one above.

## The change

`frontends/shared/rtt/mrt_binding.hpp`:

* `mrt_color_alias_mirrored(draw, slot)` — the convention written down. Absent counts as mirrored;
  slots 2 and up have no named alias, so nothing there can diverge.
* `mrt_check_color_alias_mirror(draw, report)` — the consumer's entry point. Reports the slot and both
  representations through a caller-owned callback, and counts, so this header stays free of I/O and of
  rate-limit policy. `mrt_color_alias_divergences()` exposes the count.
* Two verbatim lifts, no semantic change: `mrt_named_color_alias` (the named triple, previously
  inlined twice in `mrt_color_binding`) and `mrt_pass_color_binding` (grouping's slot-0 rule,
  previously a lambda inside `mrt_same_color_pass`). Lifting the second is what lets a test name the
  three readers and assert they agree.

`frontends/shared/live/live_renderer.cpp`: one pass over `items` in the `pertarget` branch,
immediately above the pass loop — where `base`, `pass_bases[0]` and the framebuffer extent are
chosen. Report-only, bounded at 8 per process, with `PROSPER_MRT_ALIAS_LOG=1` for every occurrence
(the `resolve SKIP` pattern from #3216).

## A measurement worth recording: the fixtures diverge today

#3023 established that a divergence is *inexpressible* in a capture and impossible after
`realize_draw_item`. That is correct and is why its fix is a no-op on real content. It does **not**
generalise to the tree: a fixture that takes a captured item and updates only the named fields leaves
the array holding the capture's original base, and one run of `gpu_capture_render_replay` now reports
**eight** such draws (`array=0x200000 0x0` against a live named triple). The guard is therefore not
dead code on day one, and this is why the invariant is "mirrors **or is absent**" — a strict-equality
check would fire on every legacy and synthetic draw. Recorded in `docs/GRAPHICS.md` § Ruled out
along with the accessor falsification.

## Verification

```
cmake -S prosper -B prosper/build-linux                 # rc=0
cmake --build prosper/build-linux -j6                   # rc=0
ctest --no-tests=error                                  # rc=0, 100% tests passed out of 332
```

Linux, distrobox `ps5ys`. 332 is master's count: the arms extend existing tests, so no new ctest
executable is registered, and the count is unchanged by construction rather than by accident. Both
affected cases confirmed by name — `ctest -N` → `#128 mrt_binding`, `#289 gpu_capture_render_replay`.

### The tests, and what each can catch

`frontends/shared/tests/test_mrt_binding.cpp` — the predicate, against **hand-built** divergent
instances, since no producer can emit one:

* the three producer shapes (exact mirror / absent array / nothing bound) report no divergence, and
  all three readers return one triple on each;
* **A** a stale array entry beside a live named triple — the fixture shape, and #3023's subject;
* **B** the array naming a surface where the named triple names none — the one where *grouping and
  target selection* disagree;
* **C** same address, different extent — a base-only comparison would miss it;
* **D** slot 1 alone, which is the slot the resolve path takes its destination from (#3025);
* the callback reports the right slot and both representations, both slots of one draw are reported
  once each, and the three producer shapes report nothing.

`tests/misc/test_gpu_capture_render.cpp` — through the **live renderer**, because a predicate test
cannot establish that production calls it. A mirrored control renders non-blank content and reports
nothing; a divergent draw is reported; and the load-bearing pair asserts the guard is **detect-only** —
the pass still renders to the named surface with pixels byte-identical to the control's, and the
array's address receives nothing.

### Mutation arms — every one compiled and ran

| mutant | build | `mrt_binding` | `gpu_capture_render_replay` |
| --- | --- | --- | --- |
| **A** — `mrt_color_alias_mirrored` returns `true` (the guard cannot fail) | rc=**0** | rc=1, **10** arms | rc=1, *"the live renderer reports the divergence where it chooses the pass target"* |
| **B** — returns `false` for slots 0/1 (the guard is a constant the other way) | rc=**0** | rc=1, **8** arms | rc=1, *"a mirrored slot-0 alias … reports no divergence"* |
| **C** — the consumer never calls it (guard present, wiring deleted) | rc=**0** | **Passed** | rc=1, *"the live renderer reports the divergence where it chooses the pass target"* |
| **E** — the renderer takes slot 0 from the array | rc=**0** | Passed | rc=1, **19** arms incl. both new ones |
| **F** — the renderer takes slot 0 from `mrt_pass_color_binding` | rc=**0** | Passed | Passed |

**C is the discriminating one.** The predicate test stays green while the renderer arm reddens, which
is what separates "the helper works" from "the decision uses it" — the failure this header already
records under `mrt_direct_serves`, where tests that exercised the helper stayed green while production
was reverted. **E** shows the suite would catch the renderer change the accessor option risks;
**F** shows it would *not* catch the other candidate, which is why that one is #3219 and not this PR.

## Affected / deliberately unaffected

* **Affected:** a new bounded `[mrt-alias]` line on stderr when a draw's slot-0/1 array entry neither
  mirrors its named triple nor is absent. `gpu_capture_render_replay` prints eight of them, which are
  true statements about its fixtures.
* **Unaffected — everything else, by construction.** No pass groups differently, no pass renders to a
  different surface or extent, no attachment count changes, feedback detection is untouched, the
  resolve path is untouched, and no `PROSPER_*` lever changes meaning. The two lifted functions are
  verbatim moves. The only new state is a process-wide counter that nothing reads outside a test.

## Risks

Low. The check is a comparison of three integer pairs per draw, twice, with no branch into rendering.
The one thing a reader might not expect is the new default-visible `[mrt-alias]` line; it is bounded
at 8 per process and says what it means. If the invariant is ever violated at scale by a future
producer, the cost is eight lines and a counter, not a behaviour change — which is the deliberate
half: this PR detects the class and #3219 owns the decision that would remove it.

Refs #3026, #3023, #3025, #3216
