### PR TITLE
snapshot: record the two guards that are not currently a regression signal

### DIFF
--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -17,6 +17,30 @@ python3 tools/snapshot/snapshot.py check dead-cells-splash
 python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 ```
 
+## Guards that are NOT currently a regression signal
+
+A red guard is only evidence about your change if the guard itself is sound. Two are not, and a lane
+that treats either as a regression will spend a session chasing its own tools. **Selection is
+positional** — `snapshot.py check <name> [<name>...]`; there is no `--only` flag.
+
+- **`gris-gameplay` — do not run it, and do not act on it.** Project-owner decision, 2026-09-02: its
+  baseline has not been updated and *GRIS* is to be verified by hand instead. It fails on master
+  independently of any branch (#3148), and it has now been seen failing at two *different* points in
+  the route — stuck on the publisher splash with `structural matches 0 of 60`, and separately with
+  the character visible and SSIM 0.12-0.14 against every baseline. Neither is a rendering
+  regression. Exclude it from any subset you run, and if you run the full matrix, do not report its
+  failure as a finding.
+- **`terminator-boot` clears its own threshold by exactly zero frames** (#3208): 14 consecutive
+  content matches against a required 15 in one sweep, and exactly 15 in the next, on builds whose
+  difference cannot affect that title's boot timing. Its menu arrives ~42 s into a hard 62 s window,
+  so one second of extra boot latency flips the verdict. A failure reading
+  `consecutive content matches 14 < 15` is indistinguishable from a real regression that dropped one
+  menu frame, and it is almost always the former.
+
+Neither entry means the guarded title is broken, and neither should be "fixed" by lowering a
+threshold — that trades a false alarm for a guard that asserts less. Both need a re-profiled window
+against the current boot, which is its own reviewed baseline change.
+
 ## Contract
 
 - Local only. Game dumps and captured imagery must never be committed.


### PR DESCRIPTION
## What this is

Docs only. Records, where a lane will actually look, that two snapshot guards are not currently a
regression signal — and why acting on either wastes a session.

## Why

Both came up today while reviewing merged work:

- **`gris-gameplay`** — project-owner decision: its baseline has not been updated and *GRIS* is to be
  verified **by hand** instead. It already fails on master independently of any branch (#3148), and
  it has now been observed failing at two *different* points in the route: stuck on the publisher
  splash with `structural matches 0 of 60` (as #3148's body records), and separately with the
  character visible and SSIM 0.12–0.14 against every baseline (seen while checking #3217). Neither
  is a rendering regression, and a lane that reads the second as one is chasing the guard.
- **`terminator-boot`** — clears its own threshold by exactly zero frames (#3208): 14 consecutive
  content matches against a required 15 in one sweep, exactly 15 in the next, on builds whose
  difference cannot affect that title's boot timing.

The note also states that guard selection is **positional** (`snapshot.py check <name>`); there is no
`--only` flag. That is not hypothetical pedantry — I published a `--only` invocation in #3208
yesterday and have since corrected it. `snapshot.py`'s CLI is a four-verb `sys.argv` check, not
argparse, so a wrong flag is consumed as a guard name rather than rejected.

## Deliberately not done

Neither guard is "fixed" here by lowering a threshold. That would trade a false alarm for a guard
that asserts less. Both need a re-profiled window against the current boot, which is its own
reviewed baseline change under `## New Or Changed Baselines`.

## Verification

Docs-only: `git diff --name-only origin/master...HEAD | grep -v '\.md$'` is empty. `diff --check`
clean. `check_numbered_table.py` over every tracked `.md` exits 0, and `check_merge_result.py`
reports a clean merge whose result passes against `origin/master`.

Refs #3148, #3208
