### PR TITLE
present: give the mostly-unchanged verdict a form windowed callers can satisfy

### DIFF
--- a/prosper/frontends/prosper-app/fps_hud.hpp
+++ b/prosper/frontends/prosper-app/fps_hud.hpp
@@ -39,11 +39,15 @@ inline bool fps_window_due(double window_start_seconds, double now_seconds, doub
 
 // The HUD's lines, newest measurement first.
 //
-// `distinct_total` is the run's cumulative distinct-frame count, shown so the rate has a population
-// beside it: "0.4 fps" from three frames is not the same claim as "0.4 fps" from four hundred.
+// `rate` is the ROLLING window; `run` is the cumulative snapshot its later end was read from. Both,
+// because the two answer different questions and the HUD reports both. From `run` come the
+// population beside the rate ("0.4 fps" from three frames is not the same claim as "0.4 fps" from
+// four hundred) and -- the part that cannot come from the window at all -- whether a picture that
+// has stopped changing belongs to a title that HAS produced frames or to one that never did
+// (gpu/present/present_frame_rate.hpp; #3027).
 inline std::vector<std::string> fps_hud_lines(const prosper::gpu::FrameRate& rate,
                                               uint32_t width, uint32_t height,
-                                              uint64_t distinct_total) {
+                                              const prosper::gpu::PresentRateSnapshot& run) {
     char headline[96], detail[160];
     if (!rate.measured) {
         std::snprintf(headline, sizeof headline, "-- fps");
@@ -53,7 +57,7 @@ inline std::vector<std::string> fps_hud_lines(const prosper::gpu::FrameRate& rat
     std::snprintf(headline, sizeof headline, "%.1f fps", rate.distinct_fps);
     std::snprintf(detail, sizeof detail, "%.1f presented   %ux%u   %llu frames",
                   rate.presented_fps, width, height,
-                  static_cast<unsigned long long>(distinct_total));
+                  static_cast<unsigned long long>(run.distinct));
     std::vector<std::string> lines{headline, detail};
     // Stated in words, not left to be inferred from two numbers. The whole failure mode is a reader
     // taking the healthy-looking number, so this has to be prose rather than arithmetic.
@@ -62,8 +66,15 @@ inline std::vector<std::string> fps_hud_lines(const prosper::gpu::FrameRate& rat
     // frame are indistinguishable from this metric by construction, and an earlier wording asserted
     // the second -- which fired on a rung-6 title's own title screen. The HUD reports what it can
     // see.
-    if (prosper::gpu::frame_rate_is_mostly_unchanged(rate))
-        lines.emplace_back("picture not changing");
+    //
+    // What it CAN see, once the run snapshot is in hand, is the one thing that separates those two
+    // for a reader: whether this title has produced frames at all. The window cannot say -- inside
+    // one second a menu and a freeze are identical -- so the verdict is classified against the run
+    // and printed with the run's own rate, active share and distinct count beside it. That figure is
+    // required by present_frame_rate.hpp and used to be unprintable here (#3027).
+    const std::string note =
+        prosper::gpu::format_unchanged_picture(prosper::gpu::unchanged_picture(rate, run));
+    if (!note.empty()) lines.emplace_back(note);
     return lines;
 }
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -2027,6 +2027,11 @@ int main(int argc, char** argv) {
     // collapsed must show the collapse. `fpsWindow` is re-based every kFpsWindowSeconds.
     constexpr double kFpsWindowSeconds = 1.0;
     prosper::gpu::PresentRateSnapshot fpsWindow = prosper::gpu::present_rate_snapshot();
+    // The cumulative reading the window was closed against. Kept because "the picture is not
+    // changing" cannot be reported honestly from a window alone: separating a static menu from a
+    // title that has produced nothing is a question about the RUN (#3027). Held here rather than
+    // re-snapshotted at each print site so the HUD and the stderr lines cannot disagree.
+    prosper::gpu::PresentRateSnapshot fpsRun = fpsWindow;
     prosper::gpu::FrameRate fpsRate;
     std::vector<std::string> fpsLines;
     // The extent last presented through the GPU path, for the HUD's resolution field (#3010).
@@ -2729,13 +2734,14 @@ int main(int argc, char** argv) {
                                                   kFpsWindowSeconds)) {
                 fpsRate = prosper::gpu::frame_rate_between(fpsWindow, now);
                 fpsWindow = now;
+                fpsRun = now;
                 // present_frame_width/height are fed by the CPU publish path and read 0 under GPU
                 // present, so the HUD showed "0x0" there. Prefer the extent actually presented.
                 fpsLines = prosper::frontend::fps_hud_lines(
                     fpsRate,
                     gpuPresentedW ? gpuPresentedW : gpu::present_frame_width(),
                     gpuPresentedH ? gpuPresentedH : gpu::present_frame_height(),
-                    now.distinct);
+                    now);
             }
         }
         // Only a HUD that has something to say is passed down; an empty list leaves both present
@@ -2788,26 +2794,30 @@ int main(int argc, char** argv) {
                     if (shown - mark >= 60) {
                         auto now = std::chrono::steady_clock::now();
                         double s = std::chrono::duration<double>(now - t0).count();
-                        // present_frame_rate.hpp says any caller of frame_rate_is_mostly_unchanged
-                        // must report active_fraction beside it, to separate "a static menu that HAS
-                        // produced frames" from "a title producing nothing". frame_rate_between
-                        // cannot supply it (:290 leaves it unfilled by construction), so the
-                        // PRESENTED rate printed on this same line carries that job: a non-zero
-                        // presented rate is exactly the evidence that frames are still arriving.
-                        // Recorded as #3027 rather than left as a silent divergence.
                         // The PRESENTED rate, and -- when --fps armed the content sample (#3010) --
-
                         // the DISTINCT rate beside it. Both, because they answer different questions:
                         // a title whose picture is frozen still presents at 60, and this line alone
                         // read healthy right through the Windows splash stall in #3011.
-                        char distinct[64] = "";
-                        if (showFps && fpsRate.measured)
-                            snprintf(distinct, sizeof distinct, ", %.1f distinct%s",
-                                     fpsRate.distinct_fps,
-                                     prosper::gpu::frame_rate_is_mostly_unchanged(fpsRate)
-                                         ? " PICTURE NOT CHANGING" : "");
+                        //
+                        // The "picture not changing" verdict is classified against `fpsRun` -- the
+                        // cumulative snapshot -- and not against the one-second window.
+                        // present_frame_rate.hpp requires the run's active share beside that verdict,
+                        // and a differenced window cannot supply it; this line used to lean on its own
+                        // presented rate to carry that job, which was an accident of the formatting
+                        // rather than anything the contract could check (#3027).
+                        std::string distinct;
+                        if (showFps && fpsRate.measured) {
+                            char measured[48];
+                            snprintf(measured, sizeof measured, ", %.1f distinct",
+                                     fpsRate.distinct_fps);
+                            distinct = measured;
+                            const std::string note = prosper::gpu::format_unchanged_picture(
+                                prosper::gpu::unchanged_picture(fpsRate, fpsRun));
+                            if (!note.empty()) distinct += " -- " + note;
+                        }
                         fprintf(stderr, "[app] %.1f fps (%llu frames, gpu-present%s)\n",
-                                (shown - mark) / (s > 0 ? s : 1), (unsigned long long)shown, distinct);
+                                (shown - mark) / (s > 0 ? s : 1), (unsigned long long)shown,
+                                distinct.c_str());
 
                         t0 = now; mark = shown;
                     }
@@ -2900,16 +2910,21 @@ int main(int argc, char** argv) {
                         } else {
                             // Same two rates as the GPU branch (#3010), so a run can be compared
                             // across present paths. Here the distinct rate comes from the CPU
-                            // publish hash rather than from a sampled grid.
-                            char distinct[64] = "";
-                            if (showFps && fpsRate.measured)
-                                snprintf(distinct, sizeof distinct, ", %.1f distinct%s",
-                                         fpsRate.distinct_fps,
-                                         prosper::gpu::frame_rate_is_mostly_unchanged(fpsRate)
-                                             ? " PICTURE NOT CHANGING" : "");
+                            // publish hash rather than from a sampled grid. Same run-classified
+                            // verdict too, for the reason given in that branch (#3027).
+                            std::string distinct;
+                            if (showFps && fpsRate.measured) {
+                                char measured[48];
+                                snprintf(measured, sizeof measured, ", %.1f distinct",
+                                         fpsRate.distinct_fps);
+                                distinct = measured;
+                                const std::string note = prosper::gpu::format_unchanged_picture(
+                                    prosper::gpu::unchanged_picture(fpsRate, fpsRun));
+                                if (!note.empty()) distinct += " -- " + note;
+                            }
                             fprintf(stderr, "[app] %.1f fps (%llu frames%s)\n",
                                     (shown - mark) / (s > 0 ? s : 1),
-                                    (unsigned long long)shown, distinct);
+                                    (unsigned long long)shown, distinct.c_str());
                         }
 
                         t0 = now; mark = shown;

--- a/prosper/frontends/prosper-app/test_fps_hud.cpp
+++ b/prosper/frontends/prosper-app/test_fps_hud.cpp
@@ -8,6 +8,7 @@
 
 using namespace prosper::frontend;
 using prosper::gpu::FrameRate;
+using prosper::gpu::FrameRateCounter;
 using prosper::gpu::PresentRateSnapshot;
 using prosper::gpu::frame_rate_between;
 
@@ -26,6 +27,38 @@ FrameRate window(uint64_t published, uint64_t distinct, double seconds) {
     return frame_rate_between(a, b);
 }
 
+PresentRateSnapshot snapshot_of(const FrameRateCounter& counter, double now_seconds) {
+    PresentRateSnapshot s;
+    s.published = counter.published();
+    s.distinct = counter.distinct();
+    s.first_publication_seconds = counter.first_publication_seconds();
+    s.last_publication_seconds = counter.last_publication_seconds();
+    s.typical_interval_seconds = counter.typical_interval_seconds();
+    s.active_seconds = counter.active_seconds();
+    s.interval_samples = counter.interval_samples();
+    s.now_seconds = now_seconds;
+    return s;
+}
+
+// The cumulative counters the HUD is handed alongside the window. Built with the REAL accumulator
+// rather than by filling a struct in: a hand-written "produced nothing" snapshot is just the
+// interval fields left at zero, which would prove nothing about the code that reads them.
+PresentRateSnapshot run_that_produced(uint64_t distinct_frames) {
+    FrameRateCounter counter;
+    double t = 0;
+    for (uint64_t i = 0; i < distinct_frames; i++) { counter.observe(i + 1, t); t += 1.0 / 60.0; }
+    return snapshot_of(counter, t);
+}
+
+// One picture, republished from the first frame to the last: no interval was ever measured, so the
+// run has no typical rate and no active seconds. The R-Type Delta (#2783) shape.
+PresentRateSnapshot run_that_produced_nothing(uint64_t published) {
+    FrameRateCounter counter;
+    double t = 0;
+    for (uint64_t i = 0; i < published; i++) { counter.observe(7, t); t += 1.0 / 60.0; }
+    return snapshot_of(counter, t);
+}
+
 bool contains(const std::vector<std::string>& lines, const std::string& needle) {
     for (const std::string& line : lines)
         if (line.find(needle) != std::string::npos) return true;
@@ -39,7 +72,8 @@ int main() {
     // both at 60 the headline check could not tell "the headline is the distinct rate" from "the
     // headline is the presented rate", and the claim would rest entirely on the frozen arm below.
     {
-        const std::vector<std::string> lines = fps_hud_lines(window(60, 55, 1.0), 1920, 1080, 3600);
+        const std::vector<std::string> lines =
+            fps_hud_lines(window(60, 55, 1.0), 1920, 1080, run_that_produced(3600));
         CHECK(lines.size() == 2, "a healthy title gets two lines");
         CHECK(lines[0] == "55.0 fps", "the headline is the DISTINCT rate, not the presented one");
         CHECK(contains(lines, "60.0 presented"), "the presented rate is shown and labelled");
@@ -50,7 +84,8 @@ int main() {
 
     // THE ARM. Identical publication rate; the content never changes. The headline must NOT read 60.
     {
-        const std::vector<std::string> lines = fps_hud_lines(window(60, 0, 1.0), 3840, 2160, 1);
+        const std::vector<std::string> lines =
+            fps_hud_lines(window(60, 0, 1.0), 3840, 2160, run_that_produced_nothing(1260));
         CHECK(lines[0] == "0.0 fps",
               "a frozen title's HEADLINE is 0.0 fps, not the 60 it is publishing");
         CHECK(contains(lines, "60.0 presented"),
@@ -62,11 +97,40 @@ int main() {
               "from a re-served retained frame here, and naming the second manufactures a defect");
     }
 
+    // #3027, THE ARM. The same window twice -- 60 publications, not one of them new -- with only the
+    // RUN behind it changed. present_frame_rate.hpp requires the run's active share beside this
+    // verdict precisely because these two are the same picture and completely different news, and
+    // until now the HUD could not supply it: `frame_rate_between` does not fill active_fraction, so
+    // the requirement was unmeetable and the line said the same thing in both cases.
+    {
+        const FrameRate frozen = window(60, 0, 1.0);
+        const std::vector<std::string> menu =
+            fps_hud_lines(frozen, 1920, 1080, run_that_produced(1200));
+        const std::vector<std::string> dead =
+            fps_hud_lines(frozen, 1920, 1080, run_that_produced_nothing(1260));
+
+        CHECK(menu[0] == "0.0 fps" && dead[0] == menu[0],
+              "the headline is identical -- the WINDOW genuinely cannot tell these apart");
+        CHECK(menu.size() == 3 && dead.size() == 3, "both get the picture-not-changing line");
+        CHECK(menu[2] != dead[2], "...and that line SEPARATES them, which is the whole fix");
+        CHECK(menu[2].find("nothing produced") == std::string::npos &&
+                  dead[2].find("nothing produced") != std::string::npos,
+              "only the title that never produced a second frame is reported as such");
+        CHECK(menu[2].find("% active") != std::string::npos &&
+                  menu[2].find("1200 distinct") != std::string::npos,
+              "the static case carries the run's rate, active share and population -- the figure "
+              "the contract asks for, now actually printed");
+        CHECK(dead[2].find("-- fps") != std::string::npos &&
+                  dead[2].find("0.0 fps") == std::string::npos,
+              "the dead case reports an ABSENT rate, never a zero one");
+    }
+
     // A title genuinely running slowly is NOT a frozen one, and must not be labelled as one. This is
     // the arm that stops the warning being keyed on an absolute rate: prosper has titles that
     // legitimately run at ~1 fps, and calling those frozen would make the warning noise.
     {
-        const std::vector<std::string> lines = fps_hud_lines(window(1, 1, 1.0), 3840, 2160, 42);
+        const std::vector<std::string> lines =
+            fps_hud_lines(window(1, 1, 1.0), 3840, 2160, run_that_produced(42));
         CHECK(lines[0] == "1.0 fps", "a genuinely 1 fps title reports 1.0 fps");
         CHECK(!contains(lines, "not changing"),
               "a slow-but-live title is not warned about -- every publication carried content");
@@ -75,7 +139,8 @@ int main() {
     // Before anything is published there is no rate. "-- fps" is a different claim from "0.0 fps",
     // and a HUD that showed 0.0 during boot would look like a hang.
     {
-        const std::vector<std::string> lines = fps_hud_lines(FrameRate{}, 0, 0, 0);
+        const std::vector<std::string> lines =
+            fps_hud_lines(FrameRate{}, 0, 0, PresentRateSnapshot{});
         CHECK(lines[0] == "-- fps", "nothing published yet shows no rate rather than zero");
         CHECK(contains(lines, "no frames published yet"), "...and says why");
     }

--- a/prosper/src/gpu/present/AGENTS.md
+++ b/prosper/src/gpu/present/AGENTS.md
@@ -1,7 +1,39 @@
-# `present` — scanout
+# `present` — scanout, and how fast it is going
 
-`videoout_present` — taking a finished frame to the display path.
+Two modules, and they answer different questions.
 
-The last stage, and therefore the one where an upstream failure is *observed* rather than caused. A
-black or stale frame here is almost never a bug here. Check that something was drawn, and that the
-target being presented is the target that was drawn to, before looking for a defect in this folder.
+`videoout_present` — taking a finished frame to the display path. The last stage, and therefore the
+one where an upstream failure is *observed* rather than caused. A black or stale frame here is almost
+never a bug here. Check that something was drawn, and that the target being presented is the target
+that was drawn to, before looking for a defect in this folder.
+
+`present_frame_rate` — the framerate the project quotes. It sits here rather than in `diagnostics/`
+because it is fed by the publish path itself: every accepted publication is signed and counted, for
+every title, whether or not anybody asked for a number. Its header is long on purpose and is the
+thing to read first — the short version is that a *present* count reads full speed for a completely
+frozen title, so this module counts publications and content-distinct publications separately, and
+every consumer reports both.
+
+Two vocabularies live here and mixing them is the recurring mistake. A **run** rate comes from
+`frame_rate_since_first_publication` and carries the headline (`typical_fps`) and its qualifier
+(`active_fraction`). A **window** rate comes from `frame_rate_between` and carries neither: the
+interval histogram behind them is cumulative for the process and cannot be differenced. Anything
+reading `active_fraction` must check `active_fraction_measured` first, because `0` otherwise means
+both "this title produced nothing" and "nobody filled this in".
+
+## Ruled out
+
+- **Filling a window's `active_fraction` by differencing the two snapshots' `active_seconds`**
+  (option 1 on #3027) — falsified on the counter itself. `active_seconds` is a whole-run
+  recomputation against the *current* median interval, not an accumulator, so the cutoff moves as
+  the run goes on: 201 publications at 1 fps followed by 1000 at 60 fps take it from 200.000 s to
+  16.650 s, making the difference **negative** (-183.4 s across a 16.7 s window). It is also wrong
+  where it stays positive, and that is the dangerous half — a window holding 6000 unbroken frames at
+  60 fps differences to **1.0% active**, and one holding 100 frames at a healthy 1 fps to **0.02%**,
+  both of which read as the "produced nothing" shape the metric exists to flag. Pinned by
+  `a_windowed_active_share_cannot_be_differenced` in `tests/gpu/present/`.
+- **Any windowed statistic separating "a static menu" from "a title that produced nothing"** — not a
+  measurement problem, an information one (#3027). Within one second the two are identical by
+  construction, because in both cases nothing changed during that second. The answer is a property
+  of the run, so `unchanged_picture` takes the cumulative snapshot alongside the window; do not go
+  looking for a cleverer window statistic.

--- a/prosper/src/gpu/present/present_frame_rate.cpp
+++ b/prosper/src/gpu/present/present_frame_rate.cpp
@@ -162,8 +162,12 @@ FrameRate frame_rate_since_first_publication(const PresentRateSnapshot& s) {
         r.typical_measured = true;
         r.typical_fps = 1.0 / s.typical_interval_seconds;
     }
-    if (r.window_seconds > 0)
+    if (r.window_seconds > 0) {
         r.active_fraction = std::min(1.0, s.active_seconds / r.window_seconds);
+        // Measured, not defaulted -- this is the one constructor that can say so. A 0 here is the
+        // verdict "the run produced nothing"; a 0 from frame_rate_between is an unfilled field.
+        r.active_fraction_measured = true;
+    }
     return r;
 }
 
@@ -211,7 +215,13 @@ std::string format_frame_rate(const FrameRate& rate) {
 std::string format_frame_rate_short(const FrameRate& rate, uint32_t width, uint32_t height) {
     char text[160];
     if (!rate.measured || (!rate.typical_measured && rate.distinct <= 1)) {
-        std::snprintf(text, sizeof text, "-- fps  0%% active  %ux%u", width, height);
+        // "0% active" asserts that the run produced nothing, so it may only be printed when the
+        // fraction was actually measured. A differenced window never measures it (#3027), and one
+        // still second is not evidence about the run.
+        if (rate.active_fraction_measured)
+            std::snprintf(text, sizeof text, "-- fps  0%% active  %ux%u", width, height);
+        else
+            std::snprintf(text, sizeof text, "-- fps  %ux%u", width, height);
         return text;
     }
     if (!rate.typical_measured) {
@@ -228,6 +238,43 @@ std::string format_frame_rate_short(const FrameRate& rate, uint32_t width, uint3
 bool frame_rate_is_mostly_unchanged(const FrameRate& rate, uint64_t min_published,
                                    double max_distinct_fraction) {
     return rate.published >= min_published && rate.distinct_fraction < max_distinct_fraction;
+}
+
+UnchangedPicture unchanged_picture(const FrameRate& window, const PresentRateSnapshot& run,
+                                   uint64_t min_published, double max_distinct_fraction) {
+    UnchangedPicture out;
+    // The run figures are read whatever the verdict, so a caller that keeps the struct around has
+    // them for a later line too, and so the `changing` case is not a different shape of value.
+    const FrameRate run_rate = frame_rate_since_first_publication(run);
+    out.run_typical_measured = run_rate.typical_measured;
+    out.run_typical_fps = run_rate.typical_fps;
+    out.run_active_fraction = run_rate.active_fraction;
+    out.run_distinct = run_rate.distinct;
+    if (!frame_rate_is_mostly_unchanged(window, min_published, max_distinct_fraction)) return out;
+    // The window says the picture stopped; only the run can say whether it ever started. An absent
+    // typical rate over the WHOLE run is the R-Type Delta (#2783) shape; a measured one means the
+    // title produced frames and is now sitting on a picture, which is correct behaviour.
+    out.change = run_rate.typical_measured ? PictureChange::static_picture
+                                           : PictureChange::nothing_produced;
+    return out;
+}
+
+std::string format_unchanged_picture(const UnchangedPicture& picture) {
+    if (picture.change == PictureChange::changing) return {};
+    char text[192];
+    if (picture.change == PictureChange::nothing_produced)
+        // "--", never "0.0": there is no rate, and the module's whole argument is that reporting one
+        // would be a measurement where none exists.
+        std::snprintf(text, sizeof text,
+                      "picture not changing; run so far -- fps, 0%% active, %llu distinct "
+                      "(nothing produced yet)",
+                      static_cast<unsigned long long>(picture.run_distinct));
+    else
+        std::snprintf(text, sizeof text,
+                      "picture not changing; run so far %.1f fps, %.0f%% active, %llu distinct",
+                      picture.run_typical_fps, picture.run_active_fraction * 100.0,
+                      static_cast<unsigned long long>(picture.run_distinct));
+    return text;
 }
 
 void note_present_publication(const uint8_t* pixels, size_t bytes, uint32_t width, uint32_t height) {

--- a/prosper/src/gpu/present/present_frame_rate.hpp
+++ b/prosper/src/gpu/present/present_frame_rate.hpp
@@ -280,6 +280,14 @@ struct FrameRate {
     // Share of the window spent producing frames at roughly the typical rate, in [0, 1]. Always
     // shown beside typical_fps: on its own the headline could describe two frames half a second
     // apart in an otherwise dead run, and this is the field that says so.
+    //
+    // `active_fraction_measured` says whether the number below is a MEASUREMENT or an unset default,
+    // and it exists because 0 otherwise means two incompatible things. On a run rate 0% is the
+    // load-bearing verdict "this title produced nothing"; on a differenced window it means only that
+    // the field was never filled, because frame_rate_between cannot fill it (see there). Anything
+    // that prints the fraction -- or that reports frame_rate_is_mostly_unchanged, whose contract is
+    // to print it -- has to test this first. #3027.
+    bool active_fraction_measured = false;
     double active_fraction = 0;
 };
 
@@ -291,10 +299,29 @@ FrameRate frame_rate_since_first_publication(const PresentRateSnapshot& snapshot
 // Window = [earlier, later]. Returns an unmeasured result if the counters moved backwards, which
 // can only mean a reset happened between the two readings.
 //
-// `typical_fps` and `active_fraction` are NOT filled in here, and `typical_measured` stays false: a
-// histogram accumulated since process start cannot be differenced. Callers that want a live rate
-// over a short window (prosper-app's HUD) should use `distinct_fps`, which over a one-second window
-// is not meaningfully an average of anything.
+// `typical_fps` and `active_fraction` are NOT filled in here; `typical_measured` and
+// `active_fraction_measured` both stay false. Callers that want a live rate over a short window
+// (prosper-app's HUD) should use `distinct_fps`, which over a one-second window is not meaningfully
+// an average of anything.
+//
+// TWO INDEPENDENT REASONS, AND THE SECOND IS THE ONE THAT SETTLES IT (#3027).
+//
+// 1. `active_seconds` is a whole-run RECOMPUTATION, not an accumulator, so it cannot be differenced.
+//    Each snapshot re-derives it against the CURRENT median interval, and that cutoff moves as the
+//    run goes on -- so the quantity subtracted at the near end is not the quantity added at the far
+//    one. Measured on the counter itself (the arm in tests/gpu/present pins all three):
+//      * 201 publications at 1 fps then 1000 at 60 fps takes active_seconds from 200.000 s to
+//        16.650 s, so the difference is NEGATIVE: -183.4 s across a 16.7 s window, "-1100% active";
+//      * a window holding 6000 consecutive frames at a perfect 60 fps differences to 1.0% active;
+//      * a window holding 100 frames at a healthy-and-slow 1 fps differences to 0.02%.
+//    The last two are the dangerous ones: they are positive, plausible, and read as exactly the
+//    "produced nothing" shape this metric exists to flag.
+// 2. Even a perfectly differenceable active share would answer the wrong question. The distinction
+//    active_fraction protects -- "a static menu that HAS produced frames" against "a title that has
+//    produced nothing" -- is a property of the RUN, not of the window. Inside one second the two are
+//    indistinguishable by construction, because in both cases nothing changed during that second. No
+//    statistic computed from the window alone can separate them; the answer lives in the cumulative
+//    snapshot. That is what `unchanged_picture` below takes, and why it takes it.
 FrameRate frame_rate_between(const PresentRateSnapshot& earlier, const PresentRateSnapshot& later);
 
 // Two lines. The first is the headline and its qualifier and nothing else; the second is every
@@ -310,6 +337,11 @@ std::string format_frame_rate(const FrameRate& rate);
 // A compact form for burning into an image or drawing in a HUD:
 // "18.5 fps  62% active  3840x2160". Falls back to the run average when the typical rate is not
 // available (a short window, or frame_rate_between), and to "--" when nothing was produced.
+//
+// The "0% active" that accompanies "--" is a MEASUREMENT -- it is the sentence "this run produced
+// nothing" -- so it is emitted only when `active_fraction_measured` says the fraction was computed.
+// A differenced window gets "-- fps  WxH" with no active claim, because one second of stillness is
+// not evidence about the run (#3027).
 std::string format_frame_rate_short(const FrameRate& rate, uint32_t width, uint32_t height);
 
 // True when publications kept arriving but almost none of them carried new content.
@@ -331,7 +363,16 @@ std::string format_frame_rate_short(const FrameRate& rate, uint32_t width, uint3
 //
 // `active_fraction` is what separates (a) from (b): a static menu still produced frames before it
 // arrived, so its active share is non-zero; a title that produced nothing has an absent typical rate
-// and 0% active. Any caller that reports this predicate must report that alongside it.
+// and 0% active. Any caller that reports this predicate must report that alongside it -- WHICH IS
+// POSSIBLE EXACTLY WHEN `rate.active_fraction_measured` IS TRUE, i.e. when the rate came from
+// `frame_rate_since_first_publication`. Those are tools/screenshot's summary line and its manifest;
+// they print the fraction on the spot, and this predicate is theirs.
+//
+// A WINDOWED CALLER MUST NOT REPORT THIS PREDICATE BARE -- use `unchanged_picture` below. Until
+// #3027 the requirement above was stated unconditionally, which made it unsatisfiable for every
+// caller of `frame_rate_between`: it demanded a field that constructor cannot fill, for the two
+// reasons spelled out there. So the requirement stands, and the windowed form of it takes the
+// cumulative snapshot as an ARGUMENT rather than leaving it as an instruction nobody could follow.
 //
 // The thresholds are named parameters so nobody has to guess what "almost none" meant, and the
 // predicate keys on the FRACTION rather than an absolute rate because titles here legitimately run
@@ -339,6 +380,50 @@ std::string format_frame_rate_short(const FrameRate& rate, uint32_t width, uint3
 bool frame_rate_is_mostly_unchanged(const FrameRate& rate,
                                     uint64_t min_published = 30,
                                     double max_distinct_fraction = 0.5);
+
+// The windowed form of that predicate, and the reason this file has two.
+//
+// A rolling window can see that the picture stopped changing. It cannot see whether the title ever
+// produced anything, because within one second a static menu and a re-served retained frame are the
+// same bytes. So the classification takes BOTH: the window that fired the predicate, and the
+// cumulative snapshot that says what the run has managed so far. The second argument is not a
+// convenience -- it IS the disambiguating figure the contract above demands, made impossible to
+// omit.
+enum class PictureChange : uint8_t {
+    changing,          // the window carried new content -- there is nothing to report
+    static_picture,    // unchanged across this window, and the run HAS produced frames: case (b)
+    nothing_produced,  // unchanged, and the run has produced nothing at all: the case (a) shape
+};
+
+// The verdict and the run-wide evidence for it in one value, so a caller cannot hold the first
+// without the second. The `run_*` fields come from frame_rate_since_first_publication(run) and are
+// filled whatever the verdict is.
+struct UnchangedPicture {
+    PictureChange change = PictureChange::changing;
+    bool run_typical_measured = false;   // false => fewer than two distinct frames in the WHOLE run
+    double run_typical_fps = 0;
+    double run_active_fraction = 0;
+    uint64_t run_distinct = 0;
+};
+
+// `window` is what frame_rate_between returned; `run` is the cumulative snapshot the window's later
+// end was read from. The two thresholds are frame_rate_is_mostly_unchanged's, unchanged.
+//
+// `nothing_produced` keys on the RUN having no typical rate -- which is literally the "absent
+// typical rate and 0% active" the paragraph above names -- rather than on a threshold somebody
+// tuned. The borderline case (two distinct frames a long way apart) is left LEGIBLE rather than
+// arbitrated: the formatter prints the rate, the share and the distinct COUNT, so a reader can see
+// the population a verdict rests on instead of inheriting a hidden cutoff.
+UnchangedPicture unchanged_picture(const FrameRate& window, const PresentRateSnapshot& run,
+                                   uint64_t min_published = 30,
+                                   double max_distinct_fraction = 0.5);
+
+// The line a caller prints for that verdict; empty for `changing`. It always carries the run
+// figures, which is the entire point -- the words on their own are what was ambiguous:
+//
+//   picture not changing; run so far 59.4 fps, 96% active, 1204 distinct
+//   picture not changing; run so far -- fps, 0% active, 1 distinct (nothing produced yet)
+std::string format_unchanged_picture(const UnchangedPicture& picture);
 
 // ---- process-wide counters, fed by the present layer ---------------------------------------
 //

--- a/prosper/tests/gpu/present/test_present_frame_rate.cpp
+++ b/prosper/tests/gpu/present/test_present_frame_rate.cpp
@@ -388,6 +388,180 @@ void dense_signature_pins_the_gpu_path() {
     present_reset();
 }
 
+
+// #3027. `frame_rate_between` deliberately leaves active_fraction unfilled, and the header now says
+// why. This arm is the "why", asserted rather than asserted-about: the FIRST option on the issue was
+// to difference the two snapshots' `active_seconds`, which looks derivable and is not.
+//
+// `active_seconds` is a whole-run RECOMPUTATION against the CURRENT median interval, not an
+// accumulator, so the cutoff that decided which intervals counted moves as the run goes on. Three
+// constructed runs, all with the naive difference computed exactly as the rejected option would
+// have. The negative one is the proof that the quantity is ill-formed; the two positive ones are the
+// dangerous ones, because they are plausible and they read as the "produced nothing" shape.
+void a_windowed_active_share_cannot_be_differenced() {
+    // (i) NON-MONOTONIC. 1 fps for 200 s, then 60 fps: the median drops to 16.7 ms, the 1 s
+    // intervals stop qualifying, and the whole-run figure FALLS.
+    {
+        FrameRateCounter c;
+        double t = 0;
+        uint8_t v = 0;
+        for (int i = 0; i < 201; i++) { c.observe(signature_of(frame(v++)), t); t += 1.0; }
+        const PresentRateSnapshot a = snapshot_of(c, t);
+        for (int i = 0; i < 1000; i++) { c.observe(signature_of(frame(v++)), t); t += 1.0 / 60.0; }
+        const PresentRateSnapshot b = snapshot_of(c, t);
+        CHECK(b.active_seconds < a.active_seconds,
+              "active_seconds can DECREASE between two readings -- it is not an accumulator");
+        const double naive = (b.active_seconds - a.active_seconds) / (b.now_seconds - a.now_seconds);
+        CHECK(naive < 0,
+              "...so differencing it yields a NEGATIVE active fraction, which is not a share of "
+              "anything -- this is why option 1 on #3027 was rejected");
+    }
+    // (ii) A PERFECT 60 fps WINDOW READ AS DEAD. 1 fps for 100 s, then 100 s of unbroken 60 fps.
+    // Every frame in the window is new and on time; the naive difference still says ~0% active.
+    {
+        FrameRateCounter c;
+        double t = 0;
+        uint8_t v = 0;
+        for (int i = 0; i < 100; i++) { c.observe(signature_of(frame(v++)), t); t += 1.0; }
+        const PresentRateSnapshot a = snapshot_of(c, t);
+        for (int i = 0; i < 6000; i++) { c.observe(signature_of(frame(v++)), t); t += 1.0 / 60.0; }
+        const PresentRateSnapshot b = snapshot_of(c, t);
+        const FrameRate window = frame_rate_between(a, b);
+        CHECK(window.distinct == 6000 && window.distinct_fps > 55 && window.distinct_fps < 65,
+              "the window really did hold 6000 new frames at ~60 fps");
+        const double naive = (b.active_seconds - a.active_seconds) / window.window_seconds;
+        CHECK(naive < 0.05,
+              "...and the naive difference calls it under 5% active -- the R-Type Delta shape, "
+              "manufactured out of a healthy window");
+    }
+    // (iii) A HEALTHY-AND-SLOW WINDOW READ AS DEAD. The "we have work to do" bucket is the one this
+    // project has most titles in, so getting it wrong is not a corner case.
+    {
+        FrameRateCounter c;
+        double t = 0;
+        uint8_t v = 0;
+        for (int i = 0; i < 6000; i++) { c.observe(signature_of(frame(v++)), t); t += 1.0 / 60.0; }
+        const PresentRateSnapshot a = snapshot_of(c, t);
+        for (int i = 0; i < 100; i++) { c.observe(signature_of(frame(v++)), t); t += 1.0; }
+        const PresentRateSnapshot b = snapshot_of(c, t);
+        const FrameRate window = frame_rate_between(a, b);
+        CHECK(window.distinct == 100 && window.distinct_fps > 0.9 && window.distinct_fps < 1.1,
+              "the window really did hold 100 new frames at ~1 fps");
+        const double naive = (b.active_seconds - a.active_seconds) / window.window_seconds;
+        CHECK(naive < 0.05, "...and the naive difference calls that under 5% active too");
+    }
+
+    // The field that lets a consumer tell a measurement from a default. Without it, `0` means both
+    // "this run produced nothing" and "nobody filled this in", which is the ambiguity #3027 is.
+    PresentRateSnapshot x, y;
+    x.now_seconds = 0;
+    y.published = 60; y.distinct = 60; y.now_seconds = 1.0;
+    CHECK(!frame_rate_between(x, y).active_fraction_measured,
+          "a differenced window says its active fraction is NOT measured");
+    FrameRateCounter run;
+    for (int i = 0; i < 120; i++) run.observe(signature_of(frame(static_cast<uint8_t>(i))), i / 60.0);
+    CHECK(frame_rate_since_first_publication(snapshot_of(run, 2.0)).active_fraction_measured,
+          "...and a whole-run rate says it IS");
+    // The compact form must not claim "0% active" -- a verdict about the run -- from a window.
+    const FrameRate one_frame_window = [] {
+        PresentRateSnapshot a, b;
+        a.now_seconds = 0;
+        b.published = 60; b.distinct = 1; b.now_seconds = 1.0;
+        return frame_rate_between(a, b);
+    }();
+    CHECK(format_frame_rate_short(one_frame_window, 1920, 1080) == "-- fps  1920x1080",
+          "the compact form drops the '0% active' claim when the fraction was never measured");
+}
+
+// #3027, THE ARM. Two runs whose LAST SECOND is identical -- same publications, same zero distinct
+// frames, same duration -- and which differ only in what the title did before it. One is a static
+// menu reached after twenty seconds of 60 fps gameplay; the other never produced a second frame at
+// all, which is the R-Type Delta (#2783) failure. A reader has to be able to tell them apart, and
+// the bare predicate provably cannot: it is shown here returning true for both.
+void the_unchanged_picture_verdict_separates_static_from_dead() {
+    // (a) A STATIC MENU. 1200 real frames at 60 fps, then one second of the last picture republished.
+    FrameRateCounter menu;
+    double t = 0;
+    uint8_t v = 0;
+    for (int i = 0; i < 1200; i++) { menu.observe(signature_of(frame(v++)), t); t += 1.0 / 60.0; }
+    const PresentRateSnapshot menu_before = snapshot_of(menu, t);
+    const uint64_t held = signature_of(frame(static_cast<uint8_t>(v - 1)));   // the picture on screen
+    for (int i = 0; i < 60; i++) { menu.observe(held, t); t += 1.0 / 60.0; }
+    const PresentRateSnapshot menu_after = snapshot_of(menu, t);
+
+    // (b) A TITLE THAT PRODUCED NOTHING. Identical publication count and identical timing; the
+    // content never changed after the first frame.
+    FrameRateCounter dead;
+    double t2 = 0;
+    const uint64_t only = signature_of(frame(200));
+    for (int i = 0; i < 1200; i++) { dead.observe(only, t2); t2 += 1.0 / 60.0; }
+    const PresentRateSnapshot dead_before = snapshot_of(dead, t2);
+    for (int i = 0; i < 60; i++) { dead.observe(only, t2); t2 += 1.0 / 60.0; }
+    const PresentRateSnapshot dead_after = snapshot_of(dead, t2);
+
+    const FrameRate menu_window = frame_rate_between(menu_before, menu_after);
+    const FrameRate dead_window = frame_rate_between(dead_before, dead_after);
+
+    // The premise: the two WINDOWS are the same measurement, so anything that separates the cases
+    // has to come from outside the window. If this ever stops holding, the arm below is passing for
+    // a reason that has nothing to do with the fix.
+    CHECK(menu_window.published == 60 && dead_window.published == 60,
+          "both windows published 60 frames");
+    CHECK(menu_window.distinct == 0 && dead_window.distinct == 0,
+          "...and neither carried a single new frame");
+    CHECK(frame_rate_is_mostly_unchanged(menu_window) && frame_rate_is_mostly_unchanged(dead_window),
+          "the BARE predicate fires identically on both -- it cannot tell a menu from a dead title");
+
+    const UnchangedPicture menu_verdict = unchanged_picture(menu_window, menu_after);
+    const UnchangedPicture dead_verdict = unchanged_picture(dead_window, dead_after);
+
+    // THE DISCRIMINATION. Not "the field is populated" -- the two verdicts must DIFFER.
+    CHECK(menu_verdict.change != dead_verdict.change,
+          "the windowed verdict separates the two cases the bare predicate cannot");
+    CHECK(menu_verdict.change == PictureChange::static_picture,
+          "a title that produced 1200 frames and then stopped is a STATIC PICTURE");
+    CHECK(dead_verdict.change == PictureChange::nothing_produced,
+          "a title that never produced a second frame is NOTHING PRODUCED -- the #2783 shape");
+
+    // ...and the evidence travels with the verdict, which is the contract the header states.
+    CHECK(menu_verdict.run_typical_measured && menu_verdict.run_typical_fps > 55 &&
+              menu_verdict.run_typical_fps < 65,
+          "the static case carries the run's real 60 fps");
+    CHECK(menu_verdict.run_active_fraction > 0.9 && menu_verdict.run_distinct == 1200,
+          "...its active share and the population behind it");
+    CHECK(!dead_verdict.run_typical_measured && dead_verdict.run_typical_fps == 0 &&
+              dead_verdict.run_active_fraction == 0 && dead_verdict.run_distinct == 1,
+          "the dead case has no rate, 0% active, and one distinct frame");
+
+    const std::string menu_text = format_unchanged_picture(menu_verdict);
+    const std::string dead_text = format_unchanged_picture(dead_verdict);
+    CHECK(menu_text != dead_text, "and the two print differently -- a reader can act on the line");
+    CHECK(menu_text.find("picture not changing") == 0 && dead_text.find("picture not changing") == 0,
+          "both still lead with the observation, which is all the metric can see");
+    CHECK(menu_text.find("nothing produced") == std::string::npos &&
+              dead_text.find("nothing produced") != std::string::npos,
+          "only the dead one says nothing was produced");
+    CHECK(dead_text.find("-- fps") != std::string::npos && dead_text.find("0.0 fps") == std::string::npos,
+          "the absent rate is '--', never '0.0' -- reporting a number here would be a measurement "
+          "where none exists");
+    CHECK(menu_text.find(" fps,") != std::string::npos && menu_text.find("% active") != std::string::npos &&
+              menu_text.find("1200 distinct") != std::string::npos,
+          "the static one carries rate, active share and population on the line");
+
+    // A window that is producing gets no line at all: the verdict is not a permanent warning.
+    FrameRateCounter live;
+    double t3 = 0;
+    uint8_t w = 0;
+    for (int i = 0; i < 60; i++) { live.observe(signature_of(frame(w++)), t3); t3 += 1.0 / 60.0; }
+    const PresentRateSnapshot live_before = snapshot_of(live, t3);
+    for (int i = 0; i < 60; i++) { live.observe(signature_of(frame(w++)), t3); t3 += 1.0 / 60.0; }
+    const PresentRateSnapshot live_after = snapshot_of(live, t3);
+    const UnchangedPicture live_verdict =
+        unchanged_picture(frame_rate_between(live_before, live_after), live_after);
+    CHECK(live_verdict.change == PictureChange::changing, "a live window is not warned about");
+    CHECK(format_unchanged_picture(live_verdict).empty(), "...and prints nothing");
+}
+
 } // namespace
 
 int main() {
@@ -398,6 +572,8 @@ int main() {
     std::printf("== a title that pauses (the arm) ==\n"); a_title_that_pauses_reports_its_producing_rate();
     std::printf("== estimator accuracy ==\n");           interval_estimator_is_accurate();
     std::printf("== window arithmetic ==\n");            window_math();
+    std::printf("== windowed active share (#3027) ==\n"); a_windowed_active_share_cannot_be_differenced();
+    std::printf("== static vs dead (the arm, #3027) ==\n"); the_unchanged_picture_verdict_separates_static_from_dead();
     std::printf("== present-layer wiring ==\n");         present_layer_wiring();
     std::printf("== dense signature (GPU path) ==\n"); dense_signature_pins_the_gpu_path();
     std::printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);


### PR DESCRIPTION
Fixes #3027.

## The unsatisfiable contract

`present_frame_rate.hpp` required, of `frame_rate_is_mostly_unchanged`:

> `active_fraction` is what separates (a) from (b) … **Any caller that reports this predicate must
> report that alongside it.**

The distinction is real and is the one people get wrong: "the picture is not changing" reads as a
hang, when a static menu — publishing the same correct image — is the benign case. Case (a) is the
R-Type Delta shape (#2783); case (b) is a rung-6 title on its own title screen.

But `frame_rate_between`, the constructor every rolling/live caller must use, does not fill
`active_fraction` and says so in its own comment. So the requirement was **unsatisfiable for both
windowed callers** — the `--fps` HUD line and the app's stderr rate lines from #3010. Neither caller
was at fault; the contract asked for something the type could not provide. In practice the stderr
line disambiguated by printing the presented rate on the same line, which is an accident of that call
site's formatting rather than anything the contract asked for or could check.

## The option chosen, and what the others would have cost

**Option 1 — have `frame_rate_between` fill `active_fraction` from the two snapshots'
`active_seconds` — is falsified, not merely imprecise.** Measured on the counter itself and now
pinned by a test arm:

| constructed run | window | naive differenced active share | truth |
| --- | --- | --- | --- |
| 201 pubs at 1 fps, then 1000 at 60 fps | 16.7 s | **-1100%** (`active_seconds` 200.000 → 16.650) | ill-formed |
| 100 pubs at 1 fps, then 6000 at 60 fps | 100 s | **1.0% active** | 6000 new frames at a perfect 60 fps |
| 6000 pubs at 60 fps, then 100 at 1 fps | 100 s | **0.02% active** | 100 new frames at a healthy 1 fps |

`active_seconds` is a whole-run **recomputation** against the *current* median interval, not an
accumulator: the cutoff that decides which intervals count moves as the run goes on, so the quantity
subtracted at the near end is not the quantity added at the far one. The negative case proves the
subtraction is ill-formed; the two positive cases are the dangerous ones, because they are plausible
and both read as exactly the "produced nothing" shape the metric exists to flag.

**Option 2 — narrow the contract to whole-run callers and name what a windowed caller must print
instead — would have cost the distinction itself.** There is nothing a windowed caller could print
in its place, because *no statistic computed from the window can separate the two cases*: within one
second a static menu and a frozen renderer are byte-identical, since in both cases nothing changed
during that second. The question "has this title ever produced frames?" is a property of the **run**.
That is also why option 1 was doomed independently of the arithmetic.

**Option 3 — an overload that cannot be called without the disambiguating figure — is what landed**,
because the figure has to come from the cumulative snapshot and making it a *parameter* is the only
way to stop a caller omitting it.

## Behavioural contract afterwards

- `UnchangedPicture unchanged_picture(const FrameRate& window, const PresentRateSnapshot& run, …)`
  returns a three-way `PictureChange` — `changing` / `static_picture` / `nothing_produced` — together
  with the run's typical rate, active share and distinct count. The verdict and its evidence are one
  value, so a caller cannot hold the first without the second.
- `nothing_produced` keys on the run having **no typical rate**, which is literally the "absent
  typical rate and 0% active" the header names, rather than on a threshold somebody tuned. The
  borderline case (two distinct frames far apart) is left legible rather than arbitrated: the line
  carries the rate, the share *and* the population.
- `std::string format_unchanged_picture(const UnchangedPicture&)` is the one line callers print, and
  it always carries the run figures:
  ```
  picture not changing; run so far 59.4 fps, 96% active, 1204 distinct
  picture not changing; run so far -- fps, 0% active, 1 distinct (nothing produced yet)
  ```
  Empty for `changing`. The absent rate is `--`, never `0.0`.
- `FrameRate::active_fraction_measured` makes "is this fraction a measurement or an unset default" a
  fact in the value. Without it `0` means both "this run produced nothing" (load-bearing) and "nobody
  filled this in" — which is the ambiguity this issue is.
- `frame_rate_is_mostly_unchanged` is unchanged in behaviour and stays the **whole-run** callers'
  (`tools/screenshot`'s summary line and its manifest); both already print `active_fraction` on the
  spot, so they satisfy the contract as written. The header now says so, and says windowed callers
  must use `unchanged_picture`.
- `format_frame_rate_short` no longer prints `0% active` — a claim about the run — for a rate whose
  fraction was never measured. A window gets `-- fps  1920x1080`.
- The `--fps` HUD and both app stderr lines now report which of the two cases they are looking at,
  and classify against the same snapshot so they cannot disagree with each other.

## Deliberately unaffected

- `tools/screenshot`, its manifest JSON (`mostly_unchanged`, `active_fraction`) and its summary
  paragraph: unchanged output, unchanged semantics.
- `format_frame_rate`'s wording, which `gen_progress_tracker.py`'s `FPS_RECORD_RE` accepts. It is a
  run-summary formatter and is documented as one; no windowed caller passes it a window.
- The thresholds (`min_published = 30`, `max_distinct_fraction = 0.5`), the interval histogram, the
  signature functions, and every rate this module computes. No number changes.
- No new tunable was introduced.

## Risks

- The HUD's third line is longer than the bare `picture not changing` it replaces (~70 chars). It is
  a diagnostic line in an overlay that already prints `60.0 presented   1920x1080   3600 frames`.
- `format_frame_rate_short` on a run rate snapshotted at the exact instant of the first publication
  now prints `-- fps  WxH` instead of `-- fps  0% active  WxH`. Nothing was measured in that case, so
  the shorter form is the honest one; the existing overlay assertion (a 10 s run window) is
  unaffected.
- `unchanged_picture` runs `frame_rate_since_first_publication` per call — pure arithmetic on a
  snapshot, no lock. Called once per HUD window (1 Hz) and once per 60 presented frames.

## Verification

Build and test in the `ps5ys` container, from a clean configure of this branch:

```
cmake -S prosper -B prosper/build-linux                 # exit 0
cmake --build prosper/build-linux -j6                   # exit 0
ctest --no-tests=error                                  # exit 0 — 332/332 passed
```

`prosper-app` is off by default, so it was built explicitly to compile the changed call sites:

```
cmake -S prosper -B prosper/build-app -DPROSPER_APP=ON  # exit 0
cmake --build prosper/build-app --target prosper-app -j6  # exit 0
```

Targeted, by name (`ctest -N`): `#110 prosper_app_fps_hud`, `#237 present_frame_rate` — both Passed.

Docs gate over every tracked `.md`: exit 0. `git diff --check`: clean.

### The arm

`the_unchanged_picture_verdict_separates_static_from_dead` builds two runs whose **last second is the
same measurement** — 60 publications, zero distinct frames, one second — differing only in history:
a static menu reached after 1200 real frames at 60 fps, and a title that never produced a second
frame. It first asserts the premise, that `frame_rate_is_mostly_unchanged` **fires identically on
both**, so nothing about the window can be doing the work; then asserts the two verdicts *differ*,
and that only one of them says nothing was produced. Both runs come from the real `FrameRateCounter`,
so the "produced nothing" snapshot is the accumulator's own answer rather than interval fields left
at zero. The HUD test repeats the same pair through `fps_hud_lines`.

`a_windowed_active_share_cannot_be_differenced` pins the three measurements in the table above, plus
`active_fraction_measured` on both constructors and the `format_frame_rate_short` claim.

### Mutation arms

Both mutations **compiled and ran** (build exit 0), so the red is the assertion failing and not the
patch failing to apply.

| mutation | build | ctest | failing checks |
| --- | --- | --- | --- |
| `unchanged_picture` always returns `static_picture` when unchanged — i.e. the field is populated but cannot discriminate | exit 0 | exit 8 | 4 in `present_frame_rate` (incl. *"the windowed verdict separates the two cases the bare predicate cannot"*), 2 in `prosper_app_fps_hud` |
| `frame_rate_between` implements option 1 — differences `active_seconds` and sets `active_fraction_measured` | exit 0 | exit 8 | 2 in `present_frame_rate`: *"a differenced window says its active fraction is NOT measured"*, *"the compact form drops the '0% active' claim…"* |

The first mutation is the one that matters: it is the "populated field with better cosmetics" failure
mode, and the test rejects it.

## Ruled out

Recorded in `prosper/src/gpu/present/AGENTS.md` (which also gains a map of the folder's second
module, since it described only `videoout_present`):

- Filling a window's `active_fraction` by differencing `active_seconds` — falsified with the three
  measurements above.
- Any windowed statistic separating a static menu from a title that produced nothing — an information
  problem, not a measurement one.
