### PR TITLE
snapshot: record when a baseline was verified and by whom (verified_at / verified_by)

### DIFF
--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -218,10 +218,11 @@ booting anything:
 
 ```
   guard                      last verified          configuration
-  gris-gameplay              NEVER VERIFIED         dump=PPSA09804-app0 min_colors=1200 ...
-  terminator-boot            2026-08-03 human  30d  dump=PPSA25872-app0 min_colors=300 ...
+  some-gameplay              NEVER VERIFIED         dump=PPSAxxxxx-app0 min_colors=12000 min_frames=20 min_changes=20 references=16
+  other-gameplay             2026-08-31 human    1d dump=PPSAxxxxx-app0 min_colors=12000 min_frames=20 min_changes=20 references=16
+  third-gameplay             2026-07-23 agent   40d dump=PPSAxxxxx-app0 min_colors=12000 min_frames=20 min_changes=20 references=16
 
-  17 guards: 15 never verified, 1 agent-verified, 1 human-verified
+  3 guards: 1 never verified, 1 agent-verified, 1 human-verified
 ```
 
 `list` also takes guard names, so `snapshot.py list gris-gameplay` answers "when was this last

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -21,7 +21,8 @@ python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 
 A red guard is only evidence about your change if the guard itself is sound. Two are not, and a lane
 that treats either as a regression will spend a session chasing its own tools. **Selection is
-positional** — `snapshot.py check <name> [<name>...]`; there is no `--only` flag.
+positional** — `snapshot.py check <name> [<name>...]`; there is no `--only` flag, and an
+unrecognised option is now refused with exit 2 rather than read as a guard name.
 
 - **`gris-gameplay` — do not run it, and do not act on it.** Project-owner decision, 2026-09-02: its
   baseline has not been updated and *GRIS* is to be verified by hand instead. It fails on master
@@ -172,15 +173,65 @@ wrong scene.
 3. For content mode, choose a conservative `min_colors`, require at least two
    qualifying frames, and add `min_pixel_changes` for moving routes.
 4. Run `snapshot.py update NAME --reviewed` only after every image is accepted.
-   Content mode records reviewed luminance references for SSIM plus a
-   conservative non-black coverage floor; exact mode records the identical
-   pixel hash. Never use exact hashes for threaded gameplay merely because one
-   run happened to be stable.
+   Add `--verified-by=human` **only if a person looked at the images**; see
+   *Who verified it, and when* below. Content mode records reviewed luminance
+   references for SSIM plus a conservative non-black coverage floor; exact mode
+   records the identical pixel hash. Never use exact hashes for threaded
+   gameplay merely because one run happened to be stable.
 5. Replace the generic `review` string that `update` wrote with the factual note
    describing what was actually inspected.
 6. Run `snapshot.py check NAME` after approval.
 
 See `README.md` for every manifest field and the current title matrix.
+
+### Who verified it, and when
+
+Two structured fields record the *provenance* of a baseline, as data rather than as the English
+inside `review`:
+
+| field | shape | written by |
+| --- | --- | --- |
+| `verified_at` | ISO 8601 UTC instant, `2026-09-02T12:34:56Z` | `update NAME --reviewed` |
+| `verified_by` | `agent` or `human` | `update NAME --reviewed` |
+
+**`agent` is the default; `human` must be asserted.** The tool cannot observe who ran it, so it has
+to be told: `snapshot.py update NAME --reviewed --verified-by=human`. Nothing infers `human` from a
+TTY, from `$USER`, from an interactive terminal, or from the absence of an environment variable —
+every one of those is a proxy for "somebody was probably there", and a proxy is exactly what would
+make the field a lie. The asymmetry is deliberate and is the whole point: a `human` that never
+happened is far worse than an `agent` that understates a real review, because the only reason to
+record the actor at all is so a human-reviewed baseline can be trusted further than a
+machine-approved one. **So if you are an agent, do not pass the flag — not even when a person asked
+you to run the command.** They asked for the run; they did not look at the images.
+
+**Only `update --reviewed` stamps.** `check` never does, and must never be made to: checking a
+baseline is not verifying it, and a routine regression run that refreshed the date would launder a
+baseline nobody re-read into one that looks freshly reviewed. `verify` does not stamp either — it
+writes no manifest at all, and it runs *before* the images have been inspected, so a stamp there
+would record a review that has not happened yet.
+
+**Absence means "never recorded", and that is the useful signal.** The entries that predate the
+fields carry neither, and nothing backfills them — a date recovered from `review` prose or from git
+history would read as a recorded fact while being an inference, which is worse than no date at all.
+`snapshot.py list` prints the column, so a never-verified or long-stale baseline is visible without
+booting anything:
+
+```
+  guard                      last verified          configuration
+  gris-gameplay              NEVER VERIFIED         dump=PPSA09804-app0 min_colors=1200 ...
+  terminator-boot            2026-08-03 human  30d  dump=PPSA25872-app0 min_colors=300 ...
+
+  17 guards: 15 never verified, 1 agent-verified, 1 human-verified
+```
+
+`list` also takes guard names, so `snapshot.py list gris-gameplay` answers "when was this last
+looked at" for one entry.
+
+Two mechanical notes. Both fields are excluded from `entry_fingerprint`, like `review`, because
+`update` writes them — hashing them would make a second `update NAME --reviewed` refuse its own
+candidate with *"snapshot configuration changed after verify"*. And `update` now requires at least
+one guard name: an unnamed `update --reviewed` would sweep the whole manifest and stamp every entry
+with a verification nobody performed.
 
 ### Three ordering traps that silently produce a bad baseline
 

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -8,7 +8,8 @@ likeness to reviewed references, stable dimensions, non-black coverage, and opti
 
 Game dumps and captured images are local and gitignored, so this cannot run in
 CI. Only reviewed 16x9 luminance signatures, diagnostic hashes, coarse content
-thresholds, routes, and review notes live in `snapshots.json`.
+thresholds, routes, review notes, and verification provenance live in
+`snapshots.json`.
 
 ## Run
 
@@ -92,6 +93,17 @@ entry can define:
 - `dims`: expected scaled framebuffer dimensions.
 - `review`: factual record of the evidence that a person inspected when the
   guard was introduced or materially changed.
+- `verified_at`: ISO 8601 UTC instant of the last approval,
+  `2026-09-02T12:34:56Z`. Written only by `update --reviewed`. Sortable and
+  comparable, which the date inside `review` prose is not.
+- `verified_by`: `agent` or `human`. Defaults to `agent`; `human` requires
+  `update NAME --reviewed --verified-by=human` and is never inferred from a TTY,
+  `$USER`, or the environment. Recording a human review that did not happen is
+  the failure this default exists to prevent.
+
+Both are absent on baselines adopted before the fields existed, and nothing
+backfills them: absence means "never recorded", which is the signal a stale
+guard needs. `snapshot.py list` prints them with an age in days.
 
 The checker measures every complete frame in the evidence window. It does not
 compare exact pixels. It computes the established Structural Similarity Index
@@ -126,16 +138,20 @@ inspected image evidence:
 4. For a content guard, confirm the threshold has a conservative margin below
    the observed valid range. Never lower a threshold just to make a failure pass.
 5. After inspecting every image, run
-   `python3 tools/snapshot/snapshot.py update NAME --reviewed`. Content mode
+   `python3 tools/snapshot/snapshot.py update NAME --reviewed`, adding
+   `--verified-by=human` only when a person did the inspecting. Content mode
    records the reviewed structural references and a conservative non-black
-   floor; exact mode records the verified pixel hash. `update` refuses stale,
-   incomplete, or unverified candidates.
+   floor; exact mode records the verified pixel hash; both record `verified_at`
+   and `verified_by`. `update` refuses stale, incomplete, or unverified
+   candidates, and refuses to run without a guard name.
 6. Run `check NAME` once more. Commit only the manifest and route, never the
    local review/failure images or game data.
 
 Repeat this review when the route, evidence window, expected scene, dimensions,
 hash, or threshold changes materially. Ordinary `check` runs need no manual
-inspection unless they fail.
+inspection unless they fail — and `check` deliberately does not touch
+`verified_at`, because a check that refreshed the date would make a baseline
+nobody re-read look freshly reviewed.
 
 ## Current Matrix
 

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -14,8 +14,13 @@ diagnostic hashes live in the repo (snapshots.json), never game imagery.
 Usage:
   snapshot.py check  [name ...]   # compare captures to baselines; exit 1 on any diff/error
   snapshot.py verify [name ...]   # capture twice and retain multiple local review images
-  snapshot.py update NAME --reviewed  # approve an inspected exact-hash candidate
-  snapshot.py list
+  snapshot.py update NAME --reviewed [--verified-by=human]  # approve an inspected candidate
+  snapshot.py list [name ...]     # inventory, including when each baseline was last verified
+
+`update --reviewed` is the only command that writes snapshots.json, and the only one that stamps
+`verified_at`/`verified_by`. `check` never stamps: checking a baseline is not verifying it, and a
+routine check that refreshed the date would silently launder a baseline nobody re-reviewed.
+`verified_by` defaults to `agent`; `human` must be asserted with `--verified-by=human`.
 
 Env overrides:
   PROSPER_GAME_ROOT   dir holding the <dump> subdirs   (default: the main checkout root)
@@ -33,6 +38,7 @@ collapse without rejecting subtle pixel improvements.
 """
 import sys, os, json, time, hashlib, math, struct, subprocess, tempfile, shutil, signal, ctypes, errno
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PROSPER_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
@@ -236,6 +242,149 @@ def save_manifest(m):
     with open(MANIFEST, "w") as f:
         json.dump(m, f, indent=2)
         f.write("\n")
+
+
+# --- Baseline verification provenance ------------------------------------------------------------
+#
+# `verified_at` / `verified_by` record WHEN a baseline was last established from inspected images
+# and WHO asserted that inspection. They are provenance about the baseline, not part of its
+# contract, and three properties make them worth trusting:
+#
+#   * Their ABSENCE is meaningful. A guard with no `verified_at` has never had one recorded, which
+#     is the useful signal in its own right and exactly the state `gris-gameplay` was in when its
+#     stale baseline started failing on master (#3148). Nothing backfills them: a date guessed out
+#     of `review` prose or git history would read as a recorded fact while being an inference.
+#   * Only `update --reviewed` writes them. `check` must never stamp — see stamp_verification.
+#   * `agent` is the default and `human` cannot be reached by accident. See stamp_verification.
+VERIFIED_BY_AGENT = "agent"
+VERIFIED_BY_HUMAN = "human"
+VERIFIED_BY_VALUES = (VERIFIED_BY_AGENT, VERIFIED_BY_HUMAN)
+
+
+def utc_timestamp(now=None):
+    """The single spelling of an instant this manifest stores: ISO 8601, UTC, second resolution.
+
+    Deliberately not a bare date like the one `review` prose carries: a manifest field exists to be
+    sorted and compared, and an unqualified local date cannot be either without knowing the zone.
+    """
+    now = now or datetime.now(timezone.utc)
+    return now.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_verified_at(stamp):
+    """Return an aware datetime, or None when the field is absent or unreadable.
+
+    Unreadable is reported rather than raised, and never quietly repaired. A hand-edited manifest
+    must not make `list` unusable, and a value nobody can parse must not be rendered as though it
+    were a date somebody could.
+    """
+    if not isinstance(stamp, str) or not stamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def verification_age_days(stamp, now=None):
+    """Whole days between `stamp` and now, or None when the stamp is absent/unreadable."""
+    parsed = parse_verified_at(stamp)
+    if parsed is None:
+        return None
+    return ((now or datetime.now(timezone.utc)).astimezone(timezone.utc) - parsed).days
+
+
+def stamp_verification(entry, verified_by=VERIFIED_BY_AGENT, now=None):
+    """Record who established this baseline and when.
+
+    The default is `agent`, and reaching `human` by accident is deliberately impossible. The tool
+    cannot observe who ran it, so `human` has to be ASSERTED (`update ... --verified-by=human`).
+    The asymmetry is the point: a falsely recorded human review is far worse than a falsely
+    recorded agent one, because the entire value of the field is that a human-reviewed baseline
+    may be trusted further than a machine-approved one. Nothing here consults a TTY, `$USER`, an
+    environment variable, or whether stdin is interactive — every one of those is a proxy for
+    "somebody was probably there", and a proxy is what would make the field a lie.
+    """
+    if verified_by not in VERIFIED_BY_VALUES:
+        raise ValueError(f"verified_by must be one of {VERIFIED_BY_VALUES}, not {verified_by!r}")
+    entry["verified_at"] = utc_timestamp(now)
+    entry["verified_by"] = verified_by
+    return entry
+
+
+def format_verification(entry, now=None):
+    """One compact column for `list`. Absence must not be able to read as a date."""
+    stamp = entry.get("verified_at")
+    if not stamp:
+        return "NEVER VERIFIED"
+    who = entry.get("verified_by")
+    who_text = who if who in VERIFIED_BY_VALUES else f"?{who}"
+    parsed = parse_verified_at(stamp)
+    if parsed is None:
+        return f"UNPARSEABLE {who_text}"
+    return (f"{parsed.astimezone(timezone.utc).strftime('%Y-%m-%d')} {who_text:<5} "
+            f"{verification_age_days(stamp, now):>4}d")
+
+
+# --- Command-line options -------------------------------------------------------------------------
+#
+# The CLI is a four-verb `sys.argv` test rather than argparse, so guard names are POSITIONAL and
+# anything else on the command line is read as one. `--reviewed` used to be special-cased inside
+# cmd_update and every other dash token fell through to `select`, which reported it as an unknown
+# SNAPSHOT NAME -- or, for `list`, ignored it silently, because cmd_list never looked at its
+# arguments at all. That is the wrong failure for a flag that decides whether a baseline is
+# recorded as human-verified, so options are parsed once, here, and an unrecognised or malformed
+# one is refused before any command runs.
+#
+# Maps command -> {option: takes_a_value}.
+COMMAND_OPTIONS = {
+    "check": {},
+    "update": {"--reviewed": False, "--verified-by": True},
+    "verify": {},
+    "list": {},
+}
+
+
+def _option_error(command, message):
+    print(f"[{command}] {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+def split_options(command, tokens):
+    """Split `tokens` into (options, guard names), refusing anything unrecognised.
+
+    A guard name never begins with `-`, so a leading dash is an unambiguous option marker. Both
+    malformed shapes fail loudly rather than being absorbed: a value on a boolean option, and a
+    missing value on one that needs it.
+    """
+    spec = COMMAND_OPTIONS.get(command, {})
+    options, names = {}, []
+    for token in tokens:
+        if not token.startswith("-"):
+            names.append(token)
+            continue
+        key, separator, value = token.partition("=")
+        if key not in spec:
+            accepted = ", ".join(sorted(spec)) if spec else "no options"
+            _option_error(command, f"unknown option {token}; {command} accepts {accepted}")
+        if spec[key] and not separator:
+            _option_error(command, f"{key} needs a value: {key}=<value>")
+        if not spec[key] and separator:
+            _option_error(command, f"{key} takes no value")
+        options[key] = value if spec[key] else True
+    return options, names
+
+
+def resolve_verified_by(options):
+    """`agent` unless a human explicitly asserts otherwise. See stamp_verification."""
+    value = options.get("--verified-by")
+    if value is None:
+        return VERIFIED_BY_AGENT
+    if value not in VERIFIED_BY_VALUES:
+        _option_error("update",
+                      f"--verified-by={value} is not one of {', '.join(VERIFIED_BY_VALUES)}")
+    return value
 
 
 def pixel_hash(bmp_path):
@@ -677,9 +826,14 @@ def reset_review_evidence(name):
 
 
 def entry_fingerprint(entry):
+    # Everything `verify` captured against, and nothing an approval itself writes. `verified_at`
+    # and `verified_by` join `review` here for the same reason `review` is here: `update` writes
+    # them, so including them would make a SECOND `update NAME --reviewed` refuse its own candidate
+    # with "snapshot configuration changed after verify" and demand a fresh two-capture run.
     stable = {k: v for k, v in entry.items()
               if k not in ("hash", "dims", "review", "structural_references",
-                           "perceptual_references", "min_nonblack_ratio")}
+                           "perceptual_references", "min_nonblack_ratio",
+                           "verified_at", "verified_by")}
     raw = json.dumps(stable, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(raw).hexdigest()
 
@@ -700,7 +854,7 @@ def save_exact_candidate(entry, first, second, pixel_digest, dims):
     return first_out, second_out
 
 
-def approve_exact_candidate(entry):
+def approve_exact_candidate(entry, verified_by=VERIFIED_BY_AGENT):
     path = os.path.join(REVIEW_DIR, entry["name"], "candidate.json")
     if not os.path.isfile(path):
         raise RuntimeError(f"no reviewed candidate at {path}; run verify first")
@@ -714,6 +868,9 @@ def approve_exact_candidate(entry):
     entry["dims"] = candidate["dims"]
     entry["review"] = (f"Pixel evidence approved with snapshot.py update --reviewed on "
                        f"{time.strftime('%Y-%m-%d')}")
+    # Stamped inside the approval rather than by its caller, so no path can establish a baseline
+    # without recording who established it and when.
+    stamp_verification(entry, verified_by)
 
 
 def save_content_candidate(entry, summaries):
@@ -759,7 +916,7 @@ def save_content_candidate(entry, summaries):
         f.write("\n")
 
 
-def approve_content_candidate(entry):
+def approve_content_candidate(entry, verified_by=VERIFIED_BY_AGENT):
     path = os.path.join(REVIEW_DIR, entry["name"], "candidate.json")
     if not os.path.isfile(path):
         raise RuntimeError(f"no reviewed candidate at {path}; run verify first")
@@ -782,6 +939,7 @@ def approve_content_candidate(entry):
     entry["review"] = (
         f"Approved {candidate['evidence_count']} composited images from two independent runs on "
         f"{time.strftime('%Y-%m-%d')}; intended scene, layers, and progression visually confirmed.")
+    stamp_verification(entry, verified_by)
 
 
 def capture(entry, run_log=None):
@@ -993,8 +1151,14 @@ def select(m, names):
     return snaps
 
 
-def cmd_list(m, names):
-    for s in m["snapshots"]:
+def cmd_list(m, names, options=None):
+    # `list` is where a stale or never-verified baseline is supposed to become obvious WITHOUT
+    # booting anything, so the verification column sits second — beside the name, not at the end of
+    # a 110-column line where nobody scans. "NEVER VERIFIED" cannot be mistaken for a date.
+    selected = select(m, names)
+    print(f"  {'guard':<26} {'last verified':<22} configuration")
+    tally = {"never": 0, VERIFIED_BY_AGENT: 0, VERIFIED_BY_HUMAN: 0, "other": 0}
+    for s in selected:
         if "min_colors" in s:
             mode = (f"min_colors={s['min_colors']} "
                     f"min_frames={s.get('min_qualifying_frames', 2)} "
@@ -1003,13 +1167,33 @@ def cmd_list(m, names):
         else:
             mode = (f"frame={s.get('frame', 'MISSING')} "
                     f"hash={'set' if s.get('hash') else 'MISSING'}")
-        print(f"  {s['name']:<28} dump={s['dump']} {mode}")
+        if not s.get("verified_at"):
+            tally["never"] += 1
+        elif s.get("verified_by") in VERIFIED_BY_VALUES:
+            tally[s["verified_by"]] += 1
+        else:
+            tally["other"] += 1
+        print(f"  {s['name']:<26} {format_verification(s):<22} dump={s['dump']} {mode}")
+    summary = (f"{len(selected)} guard{'' if len(selected) == 1 else 's'}: "
+               f"{tally['never']} never verified, "
+               f"{tally[VERIFIED_BY_AGENT]} agent-verified, {tally[VERIFIED_BY_HUMAN]} human-verified")
+    if tally["other"]:
+        summary += f", {tally['other']} with an unrecognised verified_by"
+    print(f"\n  {summary}")
 
 
-def cmd_update(m, names):
+def cmd_update(m, names, options=None):
     # Exact hashes require two identical verify captures plus explicit review of the saved images.
-    reviewed = "--reviewed" in names
-    names = [n for n in names if n != "--reviewed"]
+    options = options or {}
+    reviewed = "--reviewed" in options
+    verified_by = resolve_verified_by(options)
+    # An unnamed `update --reviewed` would sweep every guard in the manifest and stamp each one
+    # with a verification nobody performed — the precise failure the `verified_by` asymmetry exists
+    # to prevent, reached by a typo rather than by a lie. Approval is per-guard by construction
+    # (each reads its own review/NAME/candidate.json), so requiring the name costs nothing.
+    if not names:
+        _option_error("update", "name at least one guard; `update --reviewed` with no name would "
+                                "approve and stamp every entry in the manifest")
     rc = 0
     for s in select(m, names):
         try:
@@ -1019,18 +1203,19 @@ def cmd_update(m, names):
                           f"both runs, then rerun update {s['name']} --reviewed", file=sys.stderr)
                     rc = 1
                     continue
-                approve_content_candidate(s)
+                approve_content_candidate(s, verified_by)
                 print(f"[update] {s['name']}: approved "
-                      f"{len(s['structural_references'])} structural references")
+                      f"{len(s['structural_references'])} structural references "
+                      f"verified_by={s['verified_by']} at {s['verified_at']}")
                 continue
             if not reviewed:
                 print(f"[update] {s['name']}: REFUSED — run verify, inspect both review images, "
                       f"then rerun update {s['name']} --reviewed", file=sys.stderr)
                 rc = 1
                 continue
-            approve_exact_candidate(s)
+            approve_exact_candidate(s, verified_by)
             print(f"[update] {s['name']}: approved {s['dims'][0]}x{s['dims'][1]} "
-                  f"hash={s['hash'][:16]}…")
+                  f"hash={s['hash'][:16]}… verified_by={s['verified_by']}")
         except Exception as e:
             print(f"[update] {s['name']}: ERROR {e}", file=sys.stderr)
             rc = 1
@@ -1038,7 +1223,7 @@ def cmd_update(m, names):
     return rc
 
 
-def cmd_verify(m, names):
+def cmd_verify(m, names, options=None):
     rc = 0
     for s in select(m, names):
         temps = []
@@ -1118,7 +1303,7 @@ def cmd_verify(m, names):
     return rc
 
 
-def cmd_check(m, names):
+def cmd_check(m, names, options=None):
     os.makedirs(FAIL_DIR, exist_ok=True)
     rc = 0
     for s in select(m, names):
@@ -1198,17 +1383,18 @@ def cmd_check(m, names):
 
 
 def main():
-    if len(sys.argv) < 2 or sys.argv[1] not in ("check", "update", "verify", "list"):
+    if len(sys.argv) < 2 or sys.argv[1] not in COMMAND_OPTIONS:
         print(__doc__)
         sys.exit(2)
-    cmd, names = sys.argv[1], sys.argv[2:]
+    cmd = sys.argv[1]
+    options, names = split_options(cmd, sys.argv[2:])
     m = load_manifest()
     runner = {"check": cmd_check, "update": cmd_update, "verify": cmd_verify, "list": cmd_list}[cmd]
     if cmd in ("check", "verify"):
         with snapshot_run_lock(cmd, names):
-            rc = runner(m, names)
+            rc = runner(m, names, options)
     else:
-        rc = runner(m, names)
+        rc = runner(m, names, options)
     sys.exit(rc or 0)
 
 

--- a/prosper/tools/snapshot/test_snapshot.py
+++ b/prosper/tools/snapshot/test_snapshot.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
+import contextlib
+import difflib
 import importlib.util
+import io
 import json
 import os
 import signal
@@ -8,6 +11,7 @@ import sys
 import tempfile
 import time
 import unittest
+from datetime import datetime, timedelta, timezone
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -541,6 +545,337 @@ while True:
                     SNAPSHOT.approve_content_candidate(entry)
             finally:
                 SNAPSHOT.REVIEW_DIR = old_review
+
+
+class BaselineVerificationMetadataTests(unittest.TestCase):
+    """`verified_at` / `verified_by`: when a baseline was last established, and by whom.
+
+    Each arm asserts a BEHAVIOUR that would change if the feature were reverted or inverted, not
+    that a key exists. The default-is-agent arm and the check-never-stamps arm are the two that
+    matter: between them they are the reason a `verified_by: human` in the manifest may be believed.
+    """
+
+    def setUp(self):
+        self._saved_review_dir = SNAPSHOT.REVIEW_DIR
+        self._saved_manifest = SNAPSHOT.MANIFEST
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.addCleanup(self._restore)
+        SNAPSHOT.REVIEW_DIR = os.path.join(self.tmp.name, "review")
+        SNAPSHOT.MANIFEST = os.path.join(self.tmp.name, "snapshots.json")
+
+    def _restore(self):
+        SNAPSHOT.REVIEW_DIR = self._saved_review_dir
+        SNAPSHOT.MANIFEST = self._saved_manifest
+
+    ISO_UTC = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+
+    def _content_entry(self, name="gameplay"):
+        return {"name": name, "dump": "PPSAXXXXX-app0", "min_colors": 10,
+                "min_structural_similarity": 0.85}
+
+    def _stage_content_candidate(self, entry):
+        """Build the review evidence `approve_content_candidate` insists on, with no capture."""
+        summaries = []
+        for run in (1, 2):
+            run_records = []
+            for index in range(2):
+                path = os.path.join(SNAPSHOT.REVIEW_DIR, entry["name"], f"run{run}_{index:02d}.png")
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "wb") as image:
+                    image.write(b"reviewed image")
+                run_records.append({
+                    "path": path, "elapsed": run * 10 + index, "colors": 20, "dims": (4, 3),
+                    "average_hash": run * 10 + index, "difference_hash": run * 20 + index,
+                    "luma16x9": (run * 10 + index,) * (16 * 9), "nonblack_ratio": 0.8,
+                })
+            summaries.append({"records": run_records, "qualifying": run_records,
+                              "richest": run_records[0], "dims": (4, 3)})
+        SNAPSHOT.save_content_candidate(entry, summaries)
+
+    def _stage_exact_candidate(self, entry):
+        first = os.path.join(self.tmp.name, "first.bmp")
+        second = os.path.join(self.tmp.name, "second.bmp")
+        for path in (first, second):
+            with open(path, "wb") as image:
+                image.write(b"exact frame")
+        SNAPSHOT.save_exact_candidate(entry, first, second, "d" * 64, (4, 3))
+
+    # --- the default, and the assertion that overrides it -----------------------------------------
+
+    def test_content_approval_defaults_to_agent_verification(self):
+        entry = self._content_entry()
+        self._stage_content_candidate(entry)
+        SNAPSHOT.approve_content_candidate(entry)
+        self.assertEqual("agent", entry["verified_by"])
+        self.assertRegex(entry["verified_at"], self.ISO_UTC)
+
+    def test_exact_approval_defaults_to_agent_verification(self):
+        entry = {"name": "exact", "dump": "PPSAXXXXX-app0", "frame": 7}
+        self._stage_exact_candidate(entry)
+        SNAPSHOT.approve_exact_candidate(entry)
+        self.assertEqual("agent", entry["verified_by"])
+        self.assertRegex(entry["verified_at"], self.ISO_UTC)
+
+    def test_human_verification_requires_the_explicit_assertion(self):
+        # The whole point of the field is that `human` is worth more than `agent`, so it must be
+        # unreachable except by saying so. Nothing about the environment may produce it.
+        for variables in ({}, {"USER": "mattias"}, {"CI": ""}, {"TERM": "xterm-256color"},
+                          {"PROSPER_SNAPSHOT_VERIFIED_BY": "human"}):
+            with self.subTest(env=variables):
+                saved = {key: os.environ.get(key) for key in variables}
+                os.environ.update(variables)
+                try:
+                    entry = self._content_entry()
+                    self._stage_content_candidate(entry)
+                    SNAPSHOT.approve_content_candidate(entry)
+                    self.assertEqual("agent", entry["verified_by"])
+                finally:
+                    for key, value in saved.items():
+                        if value is None:
+                            os.environ.pop(key, None)
+                        else:
+                            os.environ[key] = value
+
+        entry = self._content_entry()
+        self._stage_content_candidate(entry)
+        SNAPSHOT.approve_content_candidate(entry, SNAPSHOT.VERIFIED_BY_HUMAN)
+        self.assertEqual("human", entry["verified_by"])
+
+    def test_resolve_verified_by_is_agent_unless_the_option_says_human(self):
+        self.assertEqual("agent", SNAPSHOT.resolve_verified_by({}))
+        self.assertEqual("agent", SNAPSHOT.resolve_verified_by({"--reviewed": True}))
+        self.assertEqual("agent", SNAPSHOT.resolve_verified_by({"--verified-by": "agent"}))
+        self.assertEqual("human", SNAPSHOT.resolve_verified_by({"--verified-by": "human"}))
+        with self.assertRaises(SystemExit) as refused, contextlib.redirect_stderr(io.StringIO()):
+            SNAPSHOT.resolve_verified_by({"--verified-by": "Human"})
+        self.assertEqual(2, refused.exception.code)
+
+    def test_stamp_verification_refuses_an_unrecognised_actor(self):
+        for actor in ("HUMAN", "person", "", None, True):
+            with self.subTest(actor=actor), self.assertRaises(ValueError):
+                SNAPSHOT.stamp_verification({"name": "x"}, actor)
+
+    # --- checking is not verifying ----------------------------------------------------------------
+
+    def test_check_never_stamps_a_verification(self):
+        # Conflating check with verify is the failure this feature exists to prevent: a routine
+        # regression run must not be able to refresh a date nobody re-reviewed. Two arms, both
+        # reachable without a GPU: the early no-baseline refusal, and the full loop with a baseline
+        # whose capture then fails.
+        def refuse_to_save(_manifest):
+            raise AssertionError("check wrote the manifest")
+
+        saved_save, saved_fail_dir = SNAPSHOT.save_manifest, SNAPSHOT.FAIL_DIR
+        saved_boot_trace = os.environ.get("PROSPER_BOOT_TRACE")
+        SNAPSHOT.save_manifest = refuse_to_save
+        SNAPSHOT.FAIL_DIR = os.path.join(self.tmp.name, "failures")
+        os.environ["PROSPER_BOOT_TRACE"] = os.path.join(self.tmp.name, "no-such-boot-trace")
+        try:
+            no_baseline = {"name": "unbaselined", "dump": "PPSAXXXXX-app0", "frame": 3}
+            with_baseline = {"name": "baselined", "dump": "PPSAXXXXX-app0", "frame": 3,
+                             "hash": "a" * 64, "review": "inspected by hand"}
+            manifest = {"snapshots": [no_baseline, with_baseline]}
+            with contextlib.redirect_stdout(io.StringIO()), \
+                    contextlib.redirect_stderr(io.StringIO()):
+                rc = SNAPSHOT.cmd_check(manifest, [], {})
+            self.assertEqual(1, rc, "both arms must reach a failure, not a pass")
+            for entry in (no_baseline, with_baseline):
+                self.assertNotIn("verified_at", entry)
+                self.assertNotIn("verified_by", entry)
+        finally:
+            SNAPSHOT.save_manifest, SNAPSHOT.FAIL_DIR = saved_save, saved_fail_dir
+            if saved_boot_trace is None:
+                os.environ.pop("PROSPER_BOOT_TRACE", None)
+            else:
+                os.environ["PROSPER_BOOT_TRACE"] = saved_boot_trace
+
+    def test_update_writes_the_stamp_that_check_withholds(self):
+        # The positive half of the arm above: the same manifest, the same helpers, and the field
+        # DOES appear — so "check leaves it absent" is a fact about check, not about the fixture.
+        entry = self._content_entry()
+        self._stage_content_candidate(entry)
+        manifest = {"snapshots": [entry]}
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = SNAPSHOT.cmd_update(manifest, ["gameplay"],
+                                     {"--reviewed": True, "--verified-by": "human"})
+        self.assertEqual(0, rc)
+        self.assertEqual("human", entry["verified_by"])
+        self.assertRegex(entry["verified_at"], self.ISO_UTC)
+        with open(SNAPSHOT.MANIFEST, encoding="utf-8") as written:
+            self.assertEqual(manifest, json.load(written))
+
+    def test_unnamed_update_is_refused_rather_than_stamping_every_guard(self):
+        entries = [self._content_entry("one"), self._content_entry("two")]
+        with self.assertRaises(SystemExit) as refused, contextlib.redirect_stderr(io.StringIO()):
+            SNAPSHOT.cmd_update({"snapshots": entries}, [], {"--reviewed": True})
+        self.assertEqual(2, refused.exception.code)
+        for entry in entries:
+            self.assertNotIn("verified_at", entry)
+
+    # --- no invented history ----------------------------------------------------------------------
+
+    def test_repository_manifest_round_trips_byte_for_byte(self):
+        # A rewrite that reflowed or reordered the other entries would bury every future baseline
+        # change in noise, so the read/write pair must be the identity on an untouched manifest.
+        real_manifest = os.path.join(HERE, "snapshots.json")
+        with open(real_manifest, "rb") as source:
+            original = source.read()
+        SNAPSHOT.MANIFEST = real_manifest
+        manifest = SNAPSHOT.load_manifest()
+        SNAPSHOT.MANIFEST = os.path.join(self.tmp.name, "roundtrip.json")
+        SNAPSHOT.save_manifest(manifest)
+        with open(SNAPSHOT.MANIFEST, "rb") as written:
+            self.assertEqual(original, written.read())
+
+    def test_stamping_one_guard_leaves_every_other_entry_untouched(self):
+        real_manifest = os.path.join(HERE, "snapshots.json")
+        SNAPSHOT.MANIFEST = real_manifest
+        manifest = SNAPSHOT.load_manifest()
+        before = [dict(entry) for entry in manifest["snapshots"]]
+        target = manifest["snapshots"][0]["name"]
+        SNAPSHOT.stamp_verification(manifest["snapshots"][0], SNAPSHOT.VERIFIED_BY_HUMAN)
+
+        SNAPSHOT.MANIFEST = os.path.join(self.tmp.name, "stamped.json")
+        SNAPSHOT.save_manifest(manifest)
+        reloaded = SNAPSHOT.load_manifest()["snapshots"]
+        self.assertEqual(len(before), len(reloaded))
+        for original, current in zip(before, reloaded):
+            if current["name"] == target:
+                self.assertEqual("human", current["verified_by"])
+                self.assertEqual(set(original) | {"verified_at", "verified_by"}, set(current))
+                continue
+            self.assertEqual(original, current)
+            self.assertNotIn("verified_at", current)
+
+        # And the on-disk diff really is a two-line append, not a reflow of the whole file. The
+        # only line that can legitimately DISAPPEAR is the stamped entry's former last key, which
+        # comes back verbatim with the JSON comma the append requires.
+        with open(real_manifest, encoding="utf-8") as source:
+            old_lines = source.read().splitlines()
+        with open(SNAPSHOT.MANIFEST, encoding="utf-8") as written:
+            new_lines = written.read().splitlines()
+        delta = [line for line in difflib.unified_diff(old_lines, new_lines, n=0)
+                 if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))]
+        removed = [line[1:] for line in delta if line.startswith("-")]
+        added = [line[1:] for line in delta if line.startswith("+")]
+        self.assertEqual(1, len(removed), delta)
+        self.assertEqual([removed[0] + ","], added[:1], delta)
+        self.assertRegex(added[1], r'^ +"verified_at": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z",$')
+        self.assertRegex(added[2], r'^ +"verified_by": "human"$')
+        self.assertEqual(3, len(added), delta)
+
+    def test_no_shipped_entry_carries_a_verification_stamp(self):
+        # The 17 entries in the repository predate the fields. Absence is the honest record of
+        # "never recorded"; a date inferred from `review` prose or git history would read as fact.
+        SNAPSHOT.MANIFEST = os.path.join(HERE, "snapshots.json")
+        stamped = [entry["name"] for entry in SNAPSHOT.load_manifest()["snapshots"]
+                   if "verified_at" in entry or "verified_by" in entry]
+        self.assertEqual([], stamped, "existing baselines must not be backfilled")
+
+    def test_fingerprint_ignores_verification_metadata(self):
+        # Provenance is not contract. If it were hashed, `update NAME --reviewed` run twice would
+        # refuse the second time with "snapshot configuration changed after verify".
+        base = {"name": "x", "frame": 7}
+        stamped = SNAPSHOT.stamp_verification(dict(base), SNAPSHOT.VERIFIED_BY_HUMAN)
+        self.assertEqual(SNAPSHOT.entry_fingerprint(base), SNAPSHOT.entry_fingerprint(stamped))
+        self.assertNotEqual(SNAPSHOT.entry_fingerprint(base),
+                            SNAPSHOT.entry_fingerprint(dict(base, frame=8)))
+
+    def test_a_second_approval_is_not_refused_as_a_configuration_change(self):
+        entry = self._content_entry()
+        self._stage_content_candidate(entry)
+        SNAPSHOT.approve_content_candidate(entry)
+        first_stamp = entry["verified_at"]
+        SNAPSHOT.approve_content_candidate(entry, SNAPSHOT.VERIFIED_BY_HUMAN)
+        self.assertEqual("human", entry["verified_by"])
+        self.assertGreaterEqual(entry["verified_at"], first_stamp)
+
+    # --- visibility ---------------------------------------------------------------------------------
+
+    def test_list_distinguishes_never_verified_from_a_recent_human_verification(self):
+        now = datetime(2026, 9, 2, 12, 0, 0, tzinfo=timezone.utc)
+        never = {"name": "never-verified", "dump": "PPSA00001-app0", "min_colors": 10}
+        fresh = SNAPSHOT.stamp_verification(
+            {"name": "fresh-human", "dump": "PPSA00002-app0", "min_colors": 10},
+            SNAPSHOT.VERIFIED_BY_HUMAN, now)
+        stale = SNAPSHOT.stamp_verification(
+            {"name": "stale-agent", "dump": "PPSA00003-app0", "min_colors": 10},
+            SNAPSHOT.VERIFIED_BY_AGENT, now - timedelta(days=48, hours=3))
+
+        rendered = {entry["name"]: SNAPSHOT.format_verification(entry, now)
+                    for entry in (never, fresh, stale)}
+        self.assertEqual("NEVER VERIFIED", rendered["never-verified"])
+        self.assertNotIn("NEVER", rendered["fresh-human"])
+        self.assertIn("2026-09-02", rendered["fresh-human"])
+        self.assertIn("human", rendered["fresh-human"])
+        self.assertIn("0d", rendered["fresh-human"])
+        self.assertIn("agent", rendered["stale-agent"])
+        self.assertIn("48d", rendered["stale-agent"])
+        self.assertEqual(3, len(set(rendered.values())), rendered)
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            SNAPSHOT.cmd_list({"snapshots": [never, fresh, stale]}, [], {})
+        printed = out.getvalue()
+        self.assertIn("NEVER VERIFIED", printed)
+        self.assertIn("3 guards: 1 never verified, 1 agent-verified, 1 human-verified", printed)
+        never_line = next(l for l in printed.splitlines() if l.startswith("  never-verified"))
+        human_line = next(l for l in printed.splitlines() if l.startswith("  fresh-human"))
+        self.assertNotEqual(never_line[28:50], human_line[28:50])
+
+    def test_an_unreadable_stamp_is_reported_rather_than_shown_as_a_date(self):
+        for broken in ("yesterday", "2026-13-45T00:00:00Z", "", 20260902, None):
+            with self.subTest(stamp=broken):
+                self.assertIsNone(SNAPSHOT.verification_age_days(broken))
+        rendered = SNAPSHOT.format_verification({"verified_at": "yesterday", "verified_by": "human"})
+        self.assertIn("UNPARSEABLE", rendered)
+
+    def test_verification_age_is_measured_in_whole_days_from_the_stamp(self):
+        now = datetime(2026, 9, 2, 12, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(0, SNAPSHOT.verification_age_days("2026-09-02T00:00:00Z", now))
+        self.assertEqual(32, SNAPSHOT.verification_age_days("2026-08-01T00:00:00Z", now))
+        # A non-UTC offset must be normalised, not compared as wall-clock text.
+        self.assertEqual(0, SNAPSHOT.verification_age_days("2026-09-02T14:00:00+02:00", now))
+
+    def test_utc_timestamp_is_sortable_iso_8601_in_utc(self):
+        stamp = SNAPSHOT.utc_timestamp(datetime(2026, 9, 2, 14, 30, 5,
+                                                tzinfo=timezone(timedelta(hours=2))))
+        self.assertEqual("2026-09-02T12:30:05Z", stamp)
+        self.assertRegex(SNAPSHOT.utc_timestamp(), self.ISO_UTC)
+        self.assertLess("2026-08-31T23:59:59Z", stamp)          # plain string sort is chronological
+
+    # --- the option parser this feature added -------------------------------------------------------
+
+    def test_an_unrecognised_option_is_refused_not_read_as_a_guard_name(self):
+        # Guard names are positional, so before this a mistyped flag became a name -- and for
+        # `list`, which ignored its arguments entirely, it vanished without a word.
+        for command, tokens in (("update", ["--reviewd"]),
+                                ("update", ["--verified-by=human", "--force"]),
+                                ("check", ["--reviewed"]),
+                                ("verify", ["--verified-by=human"]),
+                                ("list", ["--verified-by=human"])):
+            with self.subTest(command=command, tokens=tokens):
+                with self.assertRaises(SystemExit) as refused, \
+                        contextlib.redirect_stderr(io.StringIO()) as err:
+                    SNAPSHOT.split_options(command, tokens)
+                self.assertEqual(2, refused.exception.code)
+                self.assertIn("unknown option", err.getvalue())
+
+    def test_malformed_option_values_are_refused_in_both_directions(self):
+        for tokens, expected in ((["--verified-by"], "needs a value"),
+                                 (["--reviewed=yes"], "takes no value")):
+            with self.subTest(tokens=tokens):
+                with self.assertRaises(SystemExit), contextlib.redirect_stderr(io.StringIO()) as err:
+                    SNAPSHOT.split_options("update", tokens)
+                self.assertIn(expected, err.getvalue())
+
+    def test_guard_names_and_options_are_separated_in_any_order(self):
+        options, names = SNAPSHOT.split_options(
+            "update", ["gris-gameplay", "--reviewed", "worms-armageddon-gameplay",
+                       "--verified-by=human"])
+        self.assertEqual({"--reviewed": True, "--verified-by": "human"}, options)
+        self.assertEqual(["gris-gameplay", "worms-armageddon-gameplay"], names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3222

## The gap

`snapshots.json` records *what* a baseline asserts, but nothing about its provenance. The only
trace was the free-text `review` note. Every one of the 17 entries happens to carry a date inside
that prose, and not one of them is machine-readable — so nothing could sort by it, warn on it, or
surface it in a listing.

Two live cases are that gap, both recorded in `tools/snapshot/AGENTS.md`
§ *Guards that are NOT currently a regression signal* (#3221):

- **`gris-gameplay` (#3148)** — a stale baseline nobody noticed until it failed on master, at two
  *different* points in the route on different runs, now excluded pending manual verification.
- **`terminator-boot` (#3208)** — clears its threshold by exactly zero frames while its `review`
  note still describes the margin it had at adoption. Prose ages silently; a timestamp does not.

## The fields

| field | shape | example |
| --- | --- | --- |
| `verified_at` | ISO 8601 instant, UTC, second resolution | `"2026-09-02T09:31:04Z"` |
| `verified_by` | `"agent"` or `"human"` | `"human"` |

`verified_at` is deliberately an *instant*, not the bare date `review` prose carries: a manifest
field exists to be sorted and compared, and this spelling sorts correctly as a plain string.

## Why the default is `agent`

**The tool cannot observe who ran it, so it has to be told, and only in one direction.**
`verified_by` defaults to `agent`; `human` requires
`snapshot.py update NAME --reviewed --verified-by=human`.

Nothing infers `human` from a TTY, from `$USER`, from an interactive terminal, or from the absence
of an environment variable. Every one of those is a proxy for *"somebody was probably there"*, and
a proxy is exactly what would make the field a lie. The asymmetry is the most important decision in
the change: a `human` that never happened is far worse than an `agent` that understates a real
review, because the **only** reason to record the actor is so a human-reviewed baseline can be
trusted further than a machine-approved one. A field that is wrong in the trusted direction
destroys the value of every correct instance of it.

`AGENTS.md` states the operational consequence for agents: do not pass the flag, *not even when a
person asked you to run the command*. They asked for the run; they did not look at the images.

## Where the stamp is written, and why not elsewhere

**`update --reviewed`, inside `approve_exact_candidate` / `approve_content_candidate`.** It is
stamped inside the approval rather than by its caller, so no code path can establish a baseline
without recording who established it.

- **Not `check`.** Checking a baseline is not verifying it. A routine regression run that refreshed
  the date would launder a baseline nobody re-read into one that looks freshly reviewed — which
  would make the field worse than useless, because it would be most wrong on exactly the guards
  that get run most often. That distinction is the whole value of the feature.
- **Not `verify`.** Two independent reasons. `verify` writes no manifest at all — it produces
  `review/NAME/candidate.json` — and it runs *before* the images are inspected, so a stamp there
  would record a review that has not happened yet.
- **`update --reviewed` is the moment the assertion is actually made**: the operator has inspected
  every retained image from both runs and is saying so. It is also the manifest's only writer.

## Existing entries

The 17 shipped baselines get **neither field**, and nothing backfills them. Absence means "never
recorded", which is the useful signal in its own right and precisely `gris-gameplay`'s state. A
date recovered from `review` prose or from git history would read as a recorded fact while being an
inference — worse than no date, because it invites trust.

`snapshots.json` is **unchanged in this PR** (`git diff --stat` below), and a test pins that.

## Visibility

`snapshot.py list` now prints the column beside the name — not at the end of a 110-column line
where nobody scans — with an age in days and a tally footer. `list` also accepts guard names now,
so `list gris-gameplay` answers "when was this last looked at" for one entry.

```
  guard                      last verified          configuration
  some-gameplay              NEVER VERIFIED         dump=PPSAxxxxx-app0 min_colors=12000 min_frames=20 min_changes=20 references=16
  other-gameplay             2026-08-31 human    1d dump=PPSAxxxxx-app0 min_colors=12000 min_frames=20 min_changes=20 references=16
  third-gameplay             2026-07-23 agent   40d dump=PPSAxxxxx-app0 min_colors=12000 min_frames=20 min_changes=20 references=16

  3 guards: 1 never verified, 1 agent-verified, 1 human-verified
```

`NEVER VERIFIED` cannot be mistaken for a date; an unreadable stamp renders as `UNPARSEABLE` rather
than being silently repaired or shown as a date somebody could parse.

## Two supporting changes

- **`entry_fingerprint` excludes both fields**, for the same reason it already excludes `review`:
  `update` writes them, so hashing them would make a *second* `update NAME --reviewed` refuse its
  own candidate with "snapshot configuration changed after verify" and demand a fresh two-capture
  run. Mutation arm 4 below shows this is load-bearing for an existing test, not just a new one.
- **Options are parsed once in `main`.** The CLI is a four-verb `sys.argv` test, not argparse, so
  guard names are positional: `--reviewed` was filtered out inside `cmd_update` and every other
  dash token fell through to `select`, which reported it as an unknown *snapshot name* — or, for
  `list`, was ignored in silence, because `cmd_list` never looked at its arguments at all. That is
  the wrong failure mode for a flag that decides whether a baseline is recorded as human-verified.
  Now an unrecognised option, a value on a boolean option, and a missing value on one that needs a
  value all exit 2 with a message naming what the command accepts.

  `update` additionally requires at least one guard name. An unnamed `update --reviewed` would
  sweep the whole manifest and stamp every entry with a verification nobody performed — the exact
  failure the `verified_by` asymmetry exists to prevent, reached by a typo rather than by a lie.
  Approval is per-guard by construction (each reads its own `review/NAME/candidate.json`), and both
  `README.md` and `AGENTS.md` have always documented the command with a name, so this costs nothing.

## Verification

Python- and docs-only diff; no C++ changed, so no full build is required to exercise it. The
registered ctest case that covers this file is `snapshot_guard_logic`, run by name:

```bash
cmake -S prosper -B prosper/build-linux -DPROSPER_APP=ON        # 334 tests registered
ctest --no-tests=error -R '^snapshot_guard_logic$' --output-on-failure
#   1/1 Test #18: snapshot_guard_logic ....   Passed    0.66 sec
#   100% tests passed out of 1                            rc=0

python3 prosper/tools/snapshot/test_snapshot.py
#   Ran 38 tests ... OK          (18 on master; 20 added)

python3 prosper/tools/snapshot/test_snaps.py    # sibling suite, unaffected: == PASS ==
git diff --check                                # clean
```

`snapshots.json` is untouched:

```
 prosper/tools/snapshot/AGENTS.md        |  61 +++++-
 prosper/tools/snapshot/README.md        |  26 ++-
 prosper/tools/snapshot/snapshot.py      | 228 ++++++++++++++++++++--
 prosper/tools/snapshot/test_snapshot.py | 335 ++++++++++++++++++++++++++++++++
```

### What the new tests assert

Behaviour, not field presence. The load-bearing ones:

- `test_content_approval_defaults_to_agent_verification`, `test_exact_approval_defaults_to_agent_verification`
- `test_human_verification_requires_the_explicit_assertion` — approves under `USER`, `CI`, `TERM`
  and a plausible-looking `PROSPER_SNAPSHOT_VERIFIED_BY=human` and still gets `agent`; only the
  explicit argument yields `human`
- `test_check_never_stamps_a_verification` — `cmd_check` over two entries (one with no baseline,
  one whose capture fails) with `save_manifest` replaced by a raising stub; needs no GPU
- `test_update_writes_the_stamp_that_check_withholds` — the positive control for the arm above, so
  "check leaves it absent" is a fact about `check` and not about the fixture
- `test_no_shipped_entry_carries_a_verification_stamp` — reads the real `snapshots.json`
- `test_repository_manifest_round_trips_byte_for_byte` — load/save is the identity on the real file
- `test_stamping_one_guard_leaves_every_other_entry_untouched` — stamps one entry and asserts the
  on-disk diff is exactly one line re-punctuated plus the two new keys, and that no other entry
  changed
- `test_a_second_approval_is_not_refused_as_a_configuration_change`
- `test_list_distinguishes_never_verified_from_a_recent_human_verification`
- `test_an_unrecognised_option_is_refused_not_read_as_a_guard_name`,
  `test_malformed_option_values_are_refused_in_both_directions`

### Mutation arms

Each was applied to the working tree, the suite run, and the tree restored.

| # | mutation | result |
| --- | --- | --- |
| 1 | `verified_by` default flipped to `human` (in `stamp_verification`, both approvals, `resolve_verified_by`) | **FAILED (failures=8)** — both `..._defaults_to_agent_verification` arms, all five `test_human_verification_requires_the_explicit_assertion` subtests, `test_resolve_verified_by_is_agent_unless_the_option_says_human` |
| 2 | `cmd_check` stamps each selected entry | **FAILED (failures=1)** — `test_check_never_stamps_a_verification` |
| 3 | backfill all 17 entries from their `review` prose dates | **FAILED (failures=2)** — `test_no_shipped_entry_carries_a_verification_stamp`, `test_stamping_one_guard_leaves_every_other_entry_untouched` |
| 4 | verification metadata put back into `entry_fingerprint` | **FAILED (failures=2, errors=1)** — `test_fingerprint_ignores_verification_metadata`, `test_a_second_approval_is_not_refused_as_a_configuration_change`, **and the pre-existing `test_content_candidate_requires_complete_review_evidence`** |

Unmutated: `Ran 38 tests ... OK`.

## Not done here

No `snapshot.py check`/`verify` run against a real title — that needs the GPU and a many-minute
boot, and the change is deliberately designed to be verifiable without one. Nothing in the capture
path changed.

`tools/snapshot/snaps.py` (the human-authored snapshot store) is a separate system with its own
metadata and is untouched; whether it wants the same provenance fields is a separate question.
