### PR TITLE
host: gate and drain guest GPU submissions before the frontends' _Exit (#3225)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -600,6 +600,16 @@ if(TARGET prosper_core)
   target_link_libraries(test_lifecycle PRIVATE prosper_core)
   add_test(NAME lifecycle_stop_signal COMMAND test_lifecycle)
 
+  # GPU submit gate (#3225): the counted region + bounded drain prosper-app runs before std::_Exit,
+  # so a detached guest thread cannot be killed inside an amdgpu submission (which parks the task in
+  # __drm_exec_lock_obj and takes the host compositor down with it). Pure — no Vulkan, no dump — so
+  # the admission/refusal/drain-timeout contract is asserted on every host, including CI without a
+  # GPU. Its own timing assertions are one-sided (a lower bound on a timeout, an upper bound far
+  # from the deadline), so it does not go red under host load.
+  add_executable(test_gpu_submit_gate tests/host/platform/test_gpu_submit_gate.cpp)
+  target_link_libraries(test_gpu_submit_gate PRIVATE prosper_core)
+  add_test(NAME gpu_submit_gate COMMAND test_gpu_submit_gate)
+
   # Screenshot evidence classification/JSON is pure and must remain testable without Vulkan or a dump.
   add_executable(test_capture_manifest tests/test_capture_manifest.cpp
                                        tools/screenshot/capture_manifest.cpp
@@ -2811,6 +2821,18 @@ if(TARGET prosper_core)
       target_include_directories(test_gpustate_render PRIVATE frontends)
       target_link_libraries(test_gpustate_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME gpustate_render COMMAND test_gpustate_render)
+
+      # #3225: the backend's queue wrappers really consult the shutdown gate. The pure gate test
+      # (gpu_submit_gate) asserts the gate's logic; this asserts the wiring, which needs
+      # render_runner.h. Its positive arm uses a real queue when one exists and is skipped with a
+      # printed note when it does not — the refusal arm needs no device at all.
+      add_executable(test_submit_gate_wiring tests/gpu/test_submit_gate_wiring.cpp)
+      # Includes a shared fixture, which resolves from the `tests` root.
+      target_include_directories(test_submit_gate_wiring PRIVATE tests)
+      # Reaches `shared/...` through render_runner.h, which resolves from `frontends`.
+      target_include_directories(test_submit_gate_wiring PRIVATE frontends)
+      target_link_libraries(test_submit_gate_wiring PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME submit_gate_wiring COMMAND test_submit_gate_wiring)
 
       # GPU-executor core (Stage A): GpuState -> execute_gpustate() -> render -> present round-trip.
       add_executable(test_gpu_execute tests/gpu/execute/test_gpu_execute.cpp)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -89,6 +89,19 @@ guest caused a reproducible Windows access violation when static teardown raced 
 The remaining lifecycle work is a guest flip-boundary check followed by a real join and normal
 teardown (#352).
 
+**A second, non-obvious cost of that missing join, and the partial answer to it (#3225).** `_Exit`
+becomes `exit_group()`, and a thread that is inside a syscall at that moment cannot be torn down
+until it returns from the kernel. When the syscall is an amdgpu command submission the task parks in
+`__drm_exec_lock_obj` on a GEM reservation nobody will now release: the process becomes an unreapable
+zombie (`SIGKILL` is a no-op) and the compositor's own DRM work queues behind it — a frozen desktop
+that only a root-forced GPU reset clears. Because there is no ordering on this path at all, that
+in-flight submission is abandoned on *every* close; that it usually costs nothing is luck about where
+the guest thread happened to be. `src/host/platform/gpu_submit_gate.hpp` bounds it: the frontend
+closes a gate that every guest-thread submission enters, so new submissions are refused
+(`VK_ERROR_DEVICE_LOST`) and a bounded drain can wait for the ones already inside. It is a
+mitigation, not the fix — a thread that never returns still expires the drain — and the fix remains
+the join above.
+
 ## Where the dump path comes from (#1469)
 
 `boot_program()` needs an app0 directory. Argv supplies it for every agent route, snapshot run, and CI
@@ -272,7 +285,12 @@ Handle swapchain resize (`present_width/height` change or window resize → recr
 
 Target shutdown ordering: `request_stop` → guest thread observes the flag at its loop boundary and
 returns → join → tear down GPU/window. Until that check exists, direct process exit deliberately
-skips frontend/HLE static teardown so it cannot race the detached guest.
+skips frontend/HLE static teardown so it cannot race the detached guest — preceded, since #3225, by
+`gpu_submit_gate_begin_shutdown()` → `gpu_submit_gate_drain()` → `vkDeviceWaitIdle`, which bounds the
+window in which that exit can kill a thread inside a GPU submission. The drain is also what makes the
+`vkDeviceWaitIdle` legal: it is the external synchronization of every `VkQueue` that call requires, so
+a drain that TIMES OUT deliberately skips the wait rather than racing a live submit. `tools/screenshot`
+runs the same two steps before its own `_exit` (`screenshot.cpp`), for the same reason.
 
 ## Target / build layout
 
@@ -739,6 +757,18 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
   Native Windows build/run packaging is done via `scripts/run-windows.ps1`. Cooperative guest-stop
   at a flip boundary is a follow-up (today the
   guest thread is detached at window-close and reclaimed by process exit).
+
+## Ruled out
+
+- **"The headless path is safer by design."** The issue observed that `tools/screenshot` had never
+  taken the desktop down and read that as a property of the frontend. It is not: `screenshot.cpp`
+  detaches its guest thread and calls `_exit` in exactly the same shape `prosper-app` does, so it can
+  abandon an in-flight submission identically. What differs is the consequence — no compositor is
+  sharing the device with a headless run, so a stuck reservation has nothing to block. Both frontends
+  now take the gate (#3225).
+- **"A GPU hang / driver fault is involved."** No fault is logged at all: nothing in `journalctl -k`
+  for 30 minutes around the freeze, and the amdgpu hang detector never fires — there is no stuck job
+  to detect, only a held lock, which is why there is no self-recovery and no timeout (#3225).
 
 ## Risks & open questions
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -23,6 +23,7 @@
 #include "shared/present/present_blit_policy.hpp"    // reject stale CPU/GPU representations of guest flips
 #include "hle/sync/sync_futex.hpp"         // dump_guest_sync_trace (PROSPER_SYNC_RING deadlock history)
 #include "host/platform/lifecycle.hpp"          // frontend-owned stop/pause gates
+#include "host/platform/gpu_submit_gate.hpp"     // #3225: drain guest GPU submits before _Exit
 #include "host/image/boot_program.hpp"       // boot_program (shared guest-boot path, also used by boot_trace)
 #include "host/image/exec_image.hpp"         // run_entry
 #include "host/memory/guest_write_watch.hpp"  // flush dmem writer diagnostic before deliberate _Exit
@@ -2957,6 +2958,38 @@ int main(int argc, char** argv) {
     // let the OS reclaim process state without running destructors under the live guest.
     if (g_guest_thread.joinable()) {
         g_guest_thread.detach();
+
+        // #3225: bound the window in which the detached guest thread can be inside a GPU submission
+        // when std::_Exit fires. _Exit becomes exit_group(), and a thread that is inside an amdgpu
+        // command submission at that moment cannot be torn down until it returns from the kernel —
+        // it parks in __drm_exec_lock_obj on a GEM reservation nobody will now release, the process
+        // becomes an unreapable zombie, and the compositor's own DRM work blocks behind it. That
+        // froze the developer's desktop twice in one day, recoverable only by a root-forced GPU
+        // reset.
+        //
+        // Closing the gate stops NEW guest submissions (they return VK_ERROR_DEVICE_LOST, which
+        // every submission site already handles as "not submitted"), which is what lets the drain
+        // reach zero instead of chasing a moving count. This BOUNDS the window; it does not close
+        // it. A thread already inside vkQueueSubmit is waited for, and if it never comes out the
+        // drain times out and we exit exactly as before. The real fix is the cooperative stop the
+        // comment above names as unimplemented — observe the flag, stop at a submission boundary,
+        // and JOIN.
+        prosper::gpu_submit_gate_begin_shutdown();
+        constexpr int kGuestSubmitDrainMs = 2000;
+        if (prosper::gpu_submit_gate_drain(kGuestSubmitDrainMs)) {
+            // Only after a SUCCESSFUL drain. vkDeviceWaitIdle requires host access to every VkQueue
+            // of the device to be externally synchronized, and the drain is what provides that here
+            // (the main loop uses the shared-present submit mutex for the same reason at the
+            // swapchain-resize wait above). A timed-out drain means a guest submit may still be
+            // live, so waiting would both violate that and be the very block we are avoiding.
+            if (vk.device) vkDeviceWaitIdle(vk.device);
+        } else {
+            fprintf(stderr,
+                    "[app] guest GPU submissions did not drain within %d ms (%d still in flight); "
+                    "exiting anyway\n",
+                    kGuestSubmitDrainMs, prosper::gpu_submit_gate_in_flight());
+        }
+
 #ifdef PROSPER_HAVE_LIVE_RENDERER
         // _Exit skips RuntimeComputeTimingSelector's destructor. Publish its validity verdict here;
         // the report is idempotent so a future cooperative teardown cannot duplicate it.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -2982,6 +2982,14 @@ int main(int argc, char** argv) {
             // (the main loop uses the shared-present submit mutex for the same reason at the
             // swapchain-resize wait above). A timed-out drain means a guest submit may still be
             // live, so waiting would both violate that and be the very block we are avoiding.
+            //
+            // Note what this wait does and does not cost. It is UNBOUNDED — on a title that has
+            // hung a GPU job it returns only when the amdgpu watchdog resets the device, adding
+            // seconds to a close — and it is not protecting a teardown, because the _Exit below
+            // destroys no Vulkan object. What it buys is that already-submitted guest work is off
+            // the device before the process dies. That is a deliberate trade of a bounded, visible
+            // delay against the unbounded, invisible one this whole path exists to prevent; if it
+            // ever becomes the bigger nuisance, deleting it is safe and loses only that guarantee.
             if (vk.device) vkDeviceWaitIdle(vk.device);
         } else {
             fprintf(stderr,

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -9224,12 +9224,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // uncontended CAS per dispatch. On a refusal nothing reaches the driver and
         // `submission_entered` deliberately stays false: no submission happened, so the ordinary
         // cleanup() below is correct rather than the retain-everything device-lost path.
-        VkResult compute_submit_rc;
+        VkResult compute_submit_rc = VK_SUCCESS;
+        bool submit_gate_refused = false;
         {
             prosper::GpuSubmitRegion submit_gate;
             std::unique_lock<std::mutex> lk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
             if (!submit_gate.admitted()) {
-                compute_submit_rc = VK_ERROR_DEVICE_LOST;
+                submit_gate_refused = true;
             } else {
                 if (prosper::gpu::shared_present_active()) lk.lock();
                 g_live_compute_queue_submit_attempts.fetch_add(1, std::memory_order_relaxed);
@@ -9239,6 +9240,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     ? VK_ERROR_DEVICE_LOST
                     : vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
             }
+        }
+        if (submit_gate_refused) {
+            // Leave the loop WITHOUT routing this through vk_ok(). A refusal is not a device loss
+            // and must not be reported as one: vk_note_failure would latch ctx.device_lost and print
+            // "fatal Vulkan device loss stage=queue-submit ... disabling live compute for this
+            // process", and decline() would add a `reason=queue-submit` row to the decline census --
+            // a census whose counts are quoted as evidence elsewhere in this project. Manufacturing
+            // one of those at every shutdown would be exactly the phantom-defect instrument the
+            // charter warns about. `submission_entered` stays false, so the ordinary cleanup() below
+            // runs, which is correct: nothing was submitted.
+            if (trace) std::fprintf(stderr, "[compute]   dispatch not submitted: shutting down\n");
+            break;
         }
         if (!vk_ok(compute_submit_rc, "queue-submit")) break;
         if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -26,6 +26,7 @@
 #include "gpu/texture/tile.hpp"
 #include "gpu/capture/writer_provenance.hpp"
 #include "host/memory/guest_write_watch.hpp"
+#include "host/platform/gpu_submit_gate.hpp"  // #3225: refuse submits once the frontend shuts down
 
 #include <vulkan/vulkan.h>
 
@@ -9216,16 +9217,28 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (trace) std::fprintf(stderr, "[compute]   submitting dispatch\n");
         // #1270: when prosper-app presents on this same (shared) queue, serialize the submit CALL against
         // its present submits. No-op relaxed atomic load until the app adopts the shared queue.
+        // #3225: the GPU submit gate refuses a NEW dispatch once prosper-app has begun shutting
+        // down, so its bounded drain can reach zero before std::_Exit — a thread caught inside an
+        // amdgpu submission at exit_group() parks in __drm_exec_lock_obj and freezes the host
+        // compositor. The gate is open for the whole life of a running title, so this is one
+        // uncontended CAS per dispatch. On a refusal nothing reaches the driver and
+        // `submission_entered` deliberately stays false: no submission happened, so the ordinary
+        // cleanup() below is correct rather than the retain-everything device-lost path.
         VkResult compute_submit_rc;
         {
+            prosper::GpuSubmitRegion submit_gate;
             std::unique_lock<std::mutex> lk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
-            if (prosper::gpu::shared_present_active()) lk.lock();
-            g_live_compute_queue_submit_attempts.fetch_add(1, std::memory_order_relaxed);
-            submission_entered = true;
-            compute_submit_rc = g_force_next_queue_submit_device_lost_for_test.exchange(
-                                    false, std::memory_order_acq_rel)
-                ? VK_ERROR_DEVICE_LOST
-                : vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
+            if (!submit_gate.admitted()) {
+                compute_submit_rc = VK_ERROR_DEVICE_LOST;
+            } else {
+                if (prosper::gpu::shared_present_active()) lk.lock();
+                g_live_compute_queue_submit_attempts.fetch_add(1, std::memory_order_relaxed);
+                submission_entered = true;
+                compute_submit_rc = g_force_next_queue_submit_device_lost_for_test.exchange(
+                                        false, std::memory_order_acq_rel)
+                    ? VK_ERROR_DEVICE_LOST
+                    : vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
+            }
         }
         if (!vk_ok(compute_submit_rc, "queue-submit")) break;
         if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -9278,7 +9278,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
             // to success; this item stays failed either way, which is the conservative choice for a
             // dispatch whose results we can no longer trust.
-            if (!ctx.device_lost) {
+            // #3225: gated like the submit above, and for a second reason as well as the first.
+            // This is a guest-thread queue call, so the frontend's drain must be able to see it and
+            // wait for it; and vkDeviceWaitIdle (which the frontend runs after that drain) requires
+            // host access to every VkQueue to be externally synchronized, which an ungated
+            // vkQueueWaitIdle here would break. Refused, we simply do not drain — `completion_proven`
+            // stays false, which is the same conservative outcome this path already takes when the
+            // device is lost.
+            prosper::GpuSubmitRegion drain_gate;
+            if (!ctx.device_lost && drain_gate.admitted()) {
                 std::unique_lock<std::mutex> qlk(
                     prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
                 if (prosper::gpu::shared_present_active()) qlk.lock();

--- a/prosper/frontends/shared/present/present_blit.cpp
+++ b/prosper/frontends/shared/present/present_blit.cpp
@@ -3,6 +3,7 @@
 #include "shared/present/present_blit_policy.hpp"
 #include "fixtures/render_runner.h"            // render_vk_ctx()
 #include "gpu/execute/gpu_execute.hpp"        // shared_present_submit_mutex / shared_present_active
+#include "host/platform/gpu_submit_gate.hpp"    // #3225: refuse submits once the frontend shuts down
 #include <mutex>
 #include <cstdio>
 #include <cstring>
@@ -194,6 +195,12 @@ bool present_blit_publish(VkImage src, VkImageLayout src_layout, VkFormat src_fo
     vkResetFences(s.dev, 1, &s.blit_fence);
     VkResult sr;
     {
+        // #3225: this runs on the GUEST thread (see the header), so it is a chokepoint the shutdown
+        // gate has to cover too. Refused once prosper-app begins shutting down, and then nothing
+        // reaches the driver — the caller falls back to the CPU present path, which is the existing
+        // behaviour for any failed blit submit and is harmless on the last frame before exit.
+        prosper::GpuSubmitRegion submit_gate;
+        if (!submit_gate.admitted()) return false;
         // Serialize the host submit CALL against prosper-app's present submits on the shared queue.
         std::unique_lock<std::mutex> qlk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
         if (prosper::gpu::shared_present_active()) qlk.lock();

--- a/prosper/src/host/platform/AGENTS.md
+++ b/prosper/src/host/platform/AGENTS.md
@@ -1,0 +1,28 @@
+# `prosper/src/host/platform/` — process-wide host primitives with no OS-integration deps
+
+The small pieces of *host* behaviour that the core needs but that must not drag a window system, a
+graphics API, or a frontend into `prosper_core`: cooperative lifecycle signals, a precise sleep, the
+POSIX shims Windows lacks, a raw-syscall escape hatch, and `immortal.hpp` for objects that must
+outlive static destruction.
+
+The unifying constraint is the dependency arrow `FRONTEND_APP.md` describes: everything here is
+callable from `prosper_core`, from the offscreen backend, from `boot_trace`, from `tools/screenshot`
+and from `prosper-app` alike, so **nothing here may include Vulkan, SDL, or anything under
+`frontends/`**. Signals are declared here and *observed* by whoever cares; the frontend sets them.
+That is why the files are deliberately tiny and header-plus-one-source: a dependency added here is
+one every consumer inherits.
+
+Two of them are shutdown-related and are easy to confuse:
+
+- **`lifecycle.hpp`** — boolean cooperative signals (`prosper_request_stop`, pause/resume). "Please
+  wind down at your next boundary." Nothing is forced; a signal nobody polls does nothing, which is
+  exactly the situation `run_entry` is still in.
+- **`gpu_submit_gate.hpp`** — a *counted region* plus a bounded drain, for the case where asking
+  nicely is not enough. It exists because the frontend cannot join the guest thread and so exits with
+  `_Exit` while that thread may be inside a GPU submission; closing the gate refuses new submissions
+  so the drain can reach zero (#3225). It bounds that window rather than closing it, and its own
+  header says so — do not let it be described as the fix for the missing join.
+
+New code belongs here only if it is genuinely process-wide, genuinely host-level, and genuinely free
+of OS-integration dependencies. Per-platform *image* mapping and execution live in `src/host/image/`;
+memory and TLS have their own sibling folders.

--- a/prosper/src/host/platform/gpu_submit_gate.cpp
+++ b/prosper/src/host/platform/gpu_submit_gate.cpp
@@ -1,0 +1,111 @@
+// gpu_submit_gate.cpp — see gpu_submit_gate.hpp (#3225).
+#include "host/platform/gpu_submit_gate.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+namespace prosper {
+
+namespace {
+
+// One word carries both halves so admission is a single atomic decision. Bit 0 is the shutdown
+// flag; the rest is the admitted-region count. Packing them is what makes "admit only while open"
+// atomic: a compare-exchange that succeeds with bit 0 clear cannot interleave with the fetch_or
+// that sets it, so after begin_shutdown() no further region can appear. Keeping them in two
+// separate atomics would need a Dekker-style argument instead, and would let a REFUSED enter
+// transiently bump the count a drain could see.
+constexpr uint64_t kShutdownBit = 1u;
+constexpr uint64_t kOneRegion   = 2u;   // count lives in bits 1..63
+
+std::atomic<uint64_t> g_state{0};
+
+// Waiters exist only during shutdown, so the admitted path never touches the mutex. The count is
+// what lets leave() skip the lock when nobody is draining; it is read with seq_cst against the
+// waiter's seq_cst store for the usual store-buffer reason (see the comment in notify_if_idle).
+std::atomic<int> g_waiters{0};
+std::mutex g_mx;
+std::condition_variable g_cv;
+
+int region_count(uint64_t state) { return static_cast<int>(state >> 1); }
+
+void notify_if_idle() {
+    // A leaving region and an arriving drain race: the leaver writes the count then reads the
+    // waiter count; the drain writes the waiter count then reads the region count. Both pairs are
+    // sequentially consistent, so at least one side observes the other and the wakeup cannot be
+    // lost. Taking the mutex (even empty) before notifying closes the remaining window where the
+    // waiter has evaluated its predicate but has not yet slept.
+    if (g_waiters.load(std::memory_order_seq_cst) == 0) return;
+    if (region_count(g_state.load(std::memory_order_seq_cst)) != 0) return;
+    { std::lock_guard<std::mutex> lk(g_mx); }
+    g_cv.notify_all();
+}
+
+} // namespace
+
+bool gpu_submit_gate_try_enter() {
+    uint64_t state = g_state.load(std::memory_order_acquire);
+    for (;;) {
+        if (state & kShutdownBit) return false;
+        if (g_state.compare_exchange_weak(state, state + kOneRegion,
+                                          std::memory_order_acq_rel,
+                                          std::memory_order_acquire))
+            return true;
+    }
+}
+
+void gpu_submit_gate_leave() {
+    g_state.fetch_sub(kOneRegion, std::memory_order_seq_cst);
+    notify_if_idle();
+}
+
+void gpu_submit_gate_begin_shutdown() {
+    // Under the waiter's mutex so a drain cannot check the flag, decide to sleep, and miss this
+    // transition — the same reason prosper_request_stop() takes the lifecycle mutex.
+    {
+        std::lock_guard<std::mutex> lk(g_mx);
+        g_state.fetch_or(kShutdownBit, std::memory_order_seq_cst);
+    }
+    g_cv.notify_all();
+}
+
+bool gpu_submit_gate_shutting_down() {
+    return (g_state.load(std::memory_order_acquire) & kShutdownBit) != 0;
+}
+
+int gpu_submit_gate_in_flight() {
+    return region_count(g_state.load(std::memory_order_acquire));
+}
+
+bool gpu_submit_gate_drain(int timeout_ms) {
+    const auto idle = [] { return region_count(g_state.load(std::memory_order_seq_cst)) == 0; };
+    if (idle()) return true;
+    if (timeout_ms == 0) return false;
+
+    // Published before the predicate is first evaluated under the lock, so any leaver that runs
+    // from here on will take the notify path.
+    g_waiters.fetch_add(1, std::memory_order_seq_cst);
+    bool drained = false;
+    {
+        std::unique_lock<std::mutex> lk(g_mx);
+        if (timeout_ms < 0) {
+            g_cv.wait(lk, idle);
+            drained = true;
+        } else {
+            drained = g_cv.wait_for(lk, std::chrono::milliseconds(timeout_ms), idle);
+        }
+    }
+    g_waiters.fetch_sub(1, std::memory_order_seq_cst);
+    return drained;
+}
+
+void gpu_submit_gate_reset() {
+    {
+        std::lock_guard<std::mutex> lk(g_mx);
+        g_state.store(0, std::memory_order_seq_cst);
+    }
+    g_cv.notify_all();
+}
+
+} // namespace prosper

--- a/prosper/src/host/platform/gpu_submit_gate.cpp
+++ b/prosper/src/host/platform/gpu_submit_gate.cpp
@@ -56,7 +56,20 @@ bool gpu_submit_gate_try_enter() {
 }
 
 void gpu_submit_gate_leave() {
-    g_state.fetch_sub(kOneRegion, std::memory_order_seq_cst);
+    // Saturating rather than a bare fetch_sub. A mispaired leave would otherwise wrap the count to
+    // ~2^62, after which every drain in the process times out (or, with a negative timeout, never
+    // returns) — a silent, permanent breakage of the one thing this file exists to do. Unreachable
+    // today (GpuSubmitRegion is the only caller and it leaves only when it was admitted), so this
+    // guards a future misuse rather than a live defect. The successful exchange is seq_cst because
+    // notify_if_idle()'s argument depends on it.
+    uint64_t state = g_state.load(std::memory_order_acquire);
+    for (;;) {
+        if (region_count(state) == 0) return;   // mispaired leave: refuse to underflow
+        if (g_state.compare_exchange_weak(state, state - kOneRegion,
+                                          std::memory_order_seq_cst,
+                                          std::memory_order_acquire))
+            break;
+    }
     notify_if_idle();
 }
 

--- a/prosper/src/host/platform/gpu_submit_gate.hpp
+++ b/prosper/src/host/platform/gpu_submit_gate.hpp
@@ -14,11 +14,22 @@
 // already inside to come out. The frontend runs both before its _Exit.
 //
 // What it does NOT do, stated plainly so nobody mistakes it for the fix. It BOUNDS the window; it
-// does not close it. A thread that is already inside vkQueueSubmit when shutdown begins is still
-// waited for, and if it never returns the drain times out and we _Exit exactly as before — no worse
-// than today, but no better either. The real fix is the cooperative stop the frontend's own comment
-// names as unimplemented: run_entry() observes the stop flag, stops at a submission boundary, and
-// the thread is JOINED, after which an ordinary drain and teardown are safe.
+// does not close it, in two separate senses.
+//
+//   1. A thread that is already inside vkQueueSubmit when shutdown begins is still waited for, and
+//      if it never returns the drain times out and we _Exit exactly as before — no worse than today,
+//      but no better either.
+//   2. It covers VkQueue calls only. `__drm_exec_lock_obj` is amdgpu's GEM reservation-lock helper,
+//      and command submission is not the only ioctl that reaches it: the GEM-VA path behind
+//      vkAllocateMemory / vkBind*Memory / vkFreeMemory does too, and the guest thread makes those
+//      calls ungated on every batch. So a drained gate does not prove the guest thread is outside
+//      every drm_exec ioctl. CONFIDENCE: MED — argued from the driver's structure, not measured
+//      here. Recorded because if the freeze recurs after this landed, the honest first reading is
+//      "the gate never covered that path", not "the gate failed".
+//
+// The real fix for both is the cooperative stop the frontend's own comment names as unimplemented:
+// run_entry() observes the stop flag, stops at a submission boundary, and the thread is JOINED,
+// after which an ordinary drain and teardown are safe.
 //
 // Deliberately dependency-free (no Vulkan, no OS/windowing headers) so it lives in prosper_core and
 // is callable from the offscreen backend, the live compute path, the present blit and the app

--- a/prosper/src/host/platform/gpu_submit_gate.hpp
+++ b/prosper/src/host/platform/gpu_submit_gate.hpp
@@ -1,0 +1,88 @@
+// gpu_submit_gate.hpp — admit/refuse GPU submissions across process shutdown (#3225).
+//
+// The problem this exists for. prosper-app cannot join the guest thread (run_entry() does not yet
+// observe the cooperative stop flag), so it detaches it and calls std::_Exit. std::_Exit becomes
+// exit_group(), and a thread that is *inside a syscall* at that moment cannot be torn down until it
+// returns from the kernel. When that syscall is an amdgpu command submission, the task parks in
+// __drm_exec_lock_obj holding/awaiting a GEM reservation, the process cannot be reaped (it shows as
+// a zombie whose SIGKILL is a no-op), and the compositor's own DRM work blocks behind it — a frozen
+// desktop that only a root-forced GPU reset clears. It cost the developer two sessions in one day.
+//
+// What this gate does. Every guest-thread GPU submission enters a counted region first. Once
+// gpu_submit_gate_begin_shutdown() has run, no NEW region is admitted, so the in-flight count can
+// actually reach zero; gpu_submit_gate_drain() then waits, bounded, for the submissions that were
+// already inside to come out. The frontend runs both before its _Exit.
+//
+// What it does NOT do, stated plainly so nobody mistakes it for the fix. It BOUNDS the window; it
+// does not close it. A thread that is already inside vkQueueSubmit when shutdown begins is still
+// waited for, and if it never returns the drain times out and we _Exit exactly as before — no worse
+// than today, but no better either. The real fix is the cooperative stop the frontend's own comment
+// names as unimplemented: run_entry() observes the stop flag, stops at a submission boundary, and
+// the thread is JOINED, after which an ordinary drain and teardown are safe.
+//
+// Deliberately dependency-free (no Vulkan, no OS/windowing headers) so it lives in prosper_core and
+// is callable from the offscreen backend, the live compute path, the present blit and the app
+// alike. It is a sibling of lifecycle.hpp rather than part of it: that file carries boolean
+// cooperative signals, this one is a counted region with a drain.
+#pragma once
+
+#include <cstdint>
+
+namespace prosper {
+
+// Try to enter a GPU-submission region. Returns true when admitted — the caller MUST then pair it
+// with exactly one gpu_submit_gate_leave(). Returns false once shutdown has begun, in which case
+// the caller must not submit and nothing needs to be released. Thread-safe, lock-free on the
+// admitted path. Nesting is allowed (the count is a depth, not a flag), though an inner region
+// entered after shutdown began is refused while its outer one stays admitted — which is the
+// intended behaviour: refuse new work, wait for what is already running.
+bool gpu_submit_gate_try_enter();
+
+// Leave a region admitted by gpu_submit_gate_try_enter(). Never call after a refusal.
+void gpu_submit_gate_leave();
+
+// RAII wrapper for the pair above. Declare one immediately before a queue submission and check
+// admitted():
+//
+//     GpuSubmitRegion region;
+//     if (!region.admitted()) return VK_ERROR_DEVICE_LOST;   // shutting down; the device is going
+//     return vkQueueSubmit(...);
+class GpuSubmitRegion {
+public:
+    GpuSubmitRegion() : admitted_(gpu_submit_gate_try_enter()) {}
+    ~GpuSubmitRegion() { if (admitted_) gpu_submit_gate_leave(); }
+    GpuSubmitRegion(const GpuSubmitRegion&) = delete;
+    GpuSubmitRegion& operator=(const GpuSubmitRegion&) = delete;
+    GpuSubmitRegion(GpuSubmitRegion&&) = delete;
+    GpuSubmitRegion& operator=(GpuSubmitRegion&&) = delete;
+
+    // True when this region was admitted, i.e. the caller may submit.
+    bool admitted() const { return admitted_; }
+
+private:
+    bool admitted_;
+};
+
+// Close the gate: after this, gpu_submit_gate_try_enter() always refuses. Idempotent, thread-safe.
+// Without this the count cannot be relied on to reach zero, so a drain would be a race rather than
+// a wait.
+void gpu_submit_gate_begin_shutdown();
+
+// True once gpu_submit_gate_begin_shutdown() has run.
+bool gpu_submit_gate_shutting_down();
+
+// Wait for every admitted region to leave. Returns true when the count reached zero, false when
+// `timeout_ms` expired first (a caller that is about to _Exit should say so on stderr rather than
+// wait longer — an unbounded wait here is the freeze this file exists to avoid, moved earlier).
+// A negative timeout waits indefinitely; 0 polls once. Call gpu_submit_gate_begin_shutdown() first.
+bool gpu_submit_gate_drain(int timeout_ms);
+
+// Number of regions currently admitted. Exact (a refused enter never appears in it), but only a
+// snapshot — for diagnostics and tests, not for control flow.
+int gpu_submit_gate_in_flight();
+
+// Reopen the gate and clear the count (tests, and an in-process session restart). Mirrors
+// prosper_reset_stop(). Not for use while regions are live.
+void gpu_submit_gate_reset();
+
+} // namespace prosper

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -10,6 +10,7 @@
 #include "diagnostics/env_cache.hpp"       // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
 #include "gpu/state/render_state.hpp"
 #include "gpu/resources/shader_resources.hpp"
+#include "host/platform/gpu_submit_gate.hpp"   // refuse submits once the frontend shuts down (#3225)
 #include "shared/rtt/rtt_scale.hpp"
 #include "shared/device/vulkan_device_select.hpp"
 #include "shared/perf/performance_timing_gate.hpp"
@@ -1482,7 +1483,18 @@ inline const RenderVkCtx& render_vk_ctx() {
 // every non-shared device are unaffected. vkQueueSubmit returns without waiting for GPU work; the
 // wait-idle wrapper (used only on the batch fence-timeout and compute-drain ERROR paths) does drain the
 // queue under the lock, which briefly blocks the peer thread's submits -- acceptable on those rare paths.
+//
+// Both wrappers also take a GPU submit-gate region (#3225). Until the frontend begins shutting
+// down the gate always admits, so this is one uncontended CAS on a path that is about to enter the
+// driver; after shutdown begins it refuses, and the call returns VK_ERROR_DEVICE_LOST WITHOUT
+// entering the driver. That refusal is what lets prosper-app's drain reach zero before it _Exit()s
+// a process whose guest thread it cannot join — a thread caught inside an amdgpu submission at
+// exit_group() parks in __drm_exec_lock_obj and takes the host compositor down with it.
+// VK_ERROR_DEVICE_LOST is the honest result: the device really is going away, and every caller
+// here already treats a failed submit as "not submitted" and cleans up accordingly.
 inline VkResult render_locked_queue_submit(VkQueue q, uint32_t n, const VkSubmitInfo* s, VkFence f) {
+    prosper::GpuSubmitRegion gate;
+    if (!gate.admitted()) return VK_ERROR_DEVICE_LOST;
     if (prosper::gpu::shared_present_active()) {
         std::lock_guard<std::mutex> lk(prosper::gpu::shared_present_submit_mutex());
         return vkQueueSubmit(q, n, s, f);
@@ -1490,6 +1502,8 @@ inline VkResult render_locked_queue_submit(VkQueue q, uint32_t n, const VkSubmit
     return vkQueueSubmit(q, n, s, f);
 }
 inline VkResult render_locked_queue_wait_idle(VkQueue q) {
+    prosper::GpuSubmitRegion gate;
+    if (!gate.admitted()) return VK_ERROR_DEVICE_LOST;
     if (prosper::gpu::shared_present_active()) {
         std::lock_guard<std::mutex> lk(prosper::gpu::shared_present_submit_mutex());
         return vkQueueWaitIdle(q);

--- a/prosper/tests/gpu/test_submit_gate_wiring.cpp
+++ b/prosper/tests/gpu/test_submit_gate_wiring.cpp
@@ -1,0 +1,54 @@
+// test_submit_gate_wiring — the offscreen backend's queue wrappers really consult the shutdown gate
+// (#3225).
+//
+// test_gpu_submit_gate asserts the gate's own logic. This asserts the WIRING, which is the half a
+// pure test cannot see: render_locked_queue_submit / render_locked_queue_wait_idle
+// (tests/fixtures/render_runner.h — the live offscreen backend, not a test harness; see
+// tests/fixtures/AGENTS.md) must refuse once prosper-app has begun shutting down, and must refuse
+// BEFORE entering the driver. Passing VK_NULL_HANDLE is how that second half is asserted: the call
+// can only return without faulting if it never reached vkQueueSubmit.
+//
+// The positive arm runs first and on a REAL queue, so "the wrapper always returns DEVICE_LOST"
+// cannot pass this test. It is skipped, loudly, when the host has no usable render device.
+#include "fixtures/render_runner.h"
+#include "host/platform/gpu_submit_gate.hpp"
+
+#include <cstdio>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_submit_gate_wiring ==\n");
+    gpu_submit_gate_reset();
+    CHECK(!gpu_submit_gate_shutting_down(), "the gate starts open");
+
+    // Positive arm: with the gate open the wrapper reaches the driver and succeeds on an idle
+    // queue. Without this, a wrapper hard-coded to fail would satisfy the refusal arm below.
+    const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
+    if (ctx.ok && ctx.queue != VK_NULL_HANDLE) {
+        CHECK(prosper::test::render_locked_queue_wait_idle(ctx.queue) == VK_SUCCESS,
+              "with the gate OPEN the wrapper reaches the driver and succeeds");
+    } else {
+        printf("  [note] no render device on this host; the open-gate arm did not run\n");
+    }
+
+    gpu_submit_gate_begin_shutdown();
+
+    // Refusal arm. Null handles are deliberate: reaching Vulkan with them would fault, so a clean
+    // VK_ERROR_DEVICE_LOST is proof the gate short-circuited the call.
+    CHECK(prosper::test::render_locked_queue_submit(VK_NULL_HANDLE, 0, nullptr, VK_NULL_HANDLE) ==
+              VK_ERROR_DEVICE_LOST,
+          "render_locked_queue_submit refuses after begin_shutdown, without entering the driver");
+    CHECK(prosper::test::render_locked_queue_wait_idle(VK_NULL_HANDLE) == VK_ERROR_DEVICE_LOST,
+          "render_locked_queue_wait_idle refuses after begin_shutdown, without entering the driver");
+    CHECK(gpu_submit_gate_in_flight() == 0, "a refused wrapper call leaves no region behind");
+
+    gpu_submit_gate_reset();
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/gpu/test_submit_gate_wiring.cpp
+++ b/prosper/tests/gpu/test_submit_gate_wiring.cpp
@@ -31,9 +31,15 @@ int main() {
     const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
     if (ctx.ok && ctx.queue != VK_NULL_HANDLE) {
         CHECK(prosper::test::render_locked_queue_wait_idle(ctx.queue) == VK_SUCCESS,
-              "with the gate OPEN the wrapper reaches the driver and succeeds");
+              "with the gate OPEN render_locked_queue_wait_idle reaches the driver and succeeds");
+        // Both wrappers need an open-gate arm, or one of them could be hard-coded to fail and still
+        // pass the refusal arm below. An empty submit (submitCount 0, pSubmits ignored, no fence) is
+        // a legal no-op that reaches the driver and returns VK_SUCCESS.
+        CHECK(prosper::test::render_locked_queue_submit(ctx.queue, 0, nullptr, VK_NULL_HANDLE) ==
+                  VK_SUCCESS,
+              "with the gate OPEN render_locked_queue_submit reaches the driver and succeeds");
     } else {
-        printf("  [note] no render device on this host; the open-gate arm did not run\n");
+        printf("  [note] no render device on this host; the open-gate arms did not run\n");
     }
 
     gpu_submit_gate_begin_shutdown();

--- a/prosper/tests/host/platform/test_gpu_submit_gate.cpp
+++ b/prosper/tests/host/platform/test_gpu_submit_gate.cpp
@@ -148,9 +148,12 @@ int main() {
 
     // --- the frontend's own sequence: close, then drain to zero with live traffic --------------
     //
-    // This is the shape prosper-app uses. Threads are submitting when shutdown begins; the drain
-    // must reach zero, which is only possible BECAUSE new regions are refused. Without the refusal
-    // this is exactly the race the issue describes, and the drain below would time out.
+    // This is the shape prosper-app uses. Threads are submitting when shutdown begins and the drain
+    // must still reach zero, which in a build that did not refuse would be a race rather than a
+    // guarantee. Note honestly which assertion carries that: the drain check below is
+    // PROBABILISTIC — an un-refusing build could in principle be sampled at a transient all-out
+    // instant — while `refusals > 0` is the deterministic one, and it is what goes red when
+    // begin_shutdown() is mutated to a no-op.
     {
         gpu_submit_gate_reset();
         constexpr int kThreads = 6;

--- a/prosper/tests/host/platform/test_gpu_submit_gate.cpp
+++ b/prosper/tests/host/platform/test_gpu_submit_gate.cpp
@@ -1,0 +1,188 @@
+// test_gpu_submit_gate — the shutdown gate (src/host/platform/gpu_submit_gate.hpp) that keeps
+// prosper-app from calling std::_Exit while the detached guest thread is inside a GPU submission
+// (#3225: an unreapable zombie parked in __drm_exec_lock_obj froze the host compositor).
+//
+// Everything the frontend relies on is asserted here, because the defect it prevents cannot be
+// reproduced in a test: admission before shutdown, refusal after, a drain that returns when the
+// last region leaves, a drain that TIMES OUT rather than blocking forever when one does not, and a
+// count that survives concurrent enters and leaves. Pure — no Vulkan, no dump, no GPU.
+#include "host/platform/gpu_submit_gate.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+using Clock = std::chrono::steady_clock;
+
+static int64_t elapsed_ms(Clock::time_point since) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - since).count();
+}
+
+int main() {
+    printf("== test_gpu_submit_gate ==\n");
+
+    gpu_submit_gate_reset();
+    CHECK(!gpu_submit_gate_shutting_down(), "open after reset");
+    CHECK(gpu_submit_gate_in_flight() == 0, "no regions after reset");
+
+    // --- admitted while the gate is open -----------------------------------------------------
+    {
+        GpuSubmitRegion region;
+        CHECK(region.admitted(), "a region is admitted while the gate is open");
+        CHECK(gpu_submit_gate_in_flight() == 1, "an admitted region is counted");
+        {
+            GpuSubmitRegion nested;
+            CHECK(nested.admitted(), "regions nest");
+            CHECK(gpu_submit_gate_in_flight() == 2, "the count is a depth, not a flag");
+        }
+        CHECK(gpu_submit_gate_in_flight() == 1, "leaving the inner region decrements once");
+    }
+    CHECK(gpu_submit_gate_in_flight() == 0, "leaving the outer region returns the count to zero");
+
+    // A drain with nothing in flight is immediate, even with a zero timeout.
+    CHECK(gpu_submit_gate_drain(0), "drain succeeds immediately when nothing is in flight");
+
+    // --- refused once shutdown begins --------------------------------------------------------
+    gpu_submit_gate_begin_shutdown();
+    CHECK(gpu_submit_gate_shutting_down(), "shutting_down is true after begin_shutdown");
+    {
+        GpuSubmitRegion refused;
+        CHECK(!refused.admitted(), "a region is REFUSED once shutdown has begun");
+        CHECK(gpu_submit_gate_in_flight() == 0, "a refused region is not counted");
+    }
+    gpu_submit_gate_begin_shutdown();   // idempotent
+    CHECK(gpu_submit_gate_shutting_down(), "begin_shutdown is idempotent");
+    {
+        GpuSubmitRegion still_refused;
+        CHECK(!still_refused.admitted(), "still refused after a second begin_shutdown");
+    }
+
+    gpu_submit_gate_reset();
+    CHECK(!gpu_submit_gate_shutting_down() && gpu_submit_gate_in_flight() == 0,
+          "reset reopens the gate and clears the count");
+    {
+        GpuSubmitRegion reopened;
+        CHECK(reopened.admitted(), "a region is admitted again after reset");
+    }
+
+    // --- a region entered BEFORE shutdown stays admitted, and the drain waits for it ----------
+    {
+        std::atomic<bool> inside{false};
+        std::atomic<bool> release{false};
+        std::atomic<bool> was_admitted{false};
+        std::thread worker([&] {
+            GpuSubmitRegion region;                    // entered while the gate is still open
+            was_admitted.store(region.admitted());
+            inside.store(true);
+            while (!release.load()) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        });
+        while (!inside.load()) std::this_thread::yield();
+        CHECK(was_admitted.load(), "a region entered before shutdown is admitted");
+
+        gpu_submit_gate_begin_shutdown();
+        CHECK(gpu_submit_gate_in_flight() == 1,
+              "shutdown does not evict a region that is already inside");
+        {
+            GpuSubmitRegion after;
+            CHECK(!after.admitted(), "new regions are refused while an old one is still inside");
+        }
+
+        // The drain must TIME OUT rather than block forever while that region is held. This is the
+        // assertion the whole design turns on: an unbounded wait here would move the freeze earlier
+        // rather than remove it.
+        const auto t0 = Clock::now();
+        const bool drained_while_held = gpu_submit_gate_drain(120);
+        const int64_t waited = elapsed_ms(t0);
+        CHECK(!drained_while_held, "drain reports failure while a region is still held");
+        CHECK(waited >= 100, "drain actually waited for its timeout (>=100 ms of a 120 ms budget)");
+        CHECK(waited < 5000, "drain returned rather than blocking indefinitely");
+
+        // Now let it out: the drain must observe the region leaving and return true well inside its
+        // budget, i.e. it is woken rather than polling to the deadline.
+        const auto t1 = Clock::now();
+        std::thread releaser([&] {
+            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            release.store(true);
+        });
+        const bool drained = gpu_submit_gate_drain(5000);
+        const int64_t drain_ms = elapsed_ms(t1);
+        CHECK(drained, "drain returns true once the last region leaves");
+        CHECK(drain_ms < 4000, "drain returns when woken, not at its deadline");
+        CHECK(gpu_submit_gate_in_flight() == 0, "no regions remain after the drain");
+        releaser.join();
+        worker.join();
+    }
+
+    // --- concurrency: the count is exact under many threads -----------------------------------
+    {
+        gpu_submit_gate_reset();
+        constexpr int kThreads = 8;
+        constexpr int kIterations = 5000;
+        std::atomic<int> admitted{0};
+        std::atomic<int> refused{0};
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+        for (int i = 0; i < kThreads; i++)
+            threads.emplace_back([&] {
+                for (int n = 0; n < kIterations; n++) {
+                    GpuSubmitRegion region;
+                    if (region.admitted()) admitted.fetch_add(1, std::memory_order_relaxed);
+                    else                   refused.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+        for (auto& t : threads) t.join();
+        CHECK(admitted.load() == kThreads * kIterations,
+              "every region is admitted while the gate stays open");
+        CHECK(refused.load() == 0, "no region is refused while the gate stays open");
+        CHECK(gpu_submit_gate_in_flight() == 0,
+              "the count returns to exactly zero after concurrent enter/leave");
+    }
+
+    // --- the frontend's own sequence: close, then drain to zero with live traffic --------------
+    //
+    // This is the shape prosper-app uses. Threads are submitting when shutdown begins; the drain
+    // must reach zero, which is only possible BECAUSE new regions are refused. Without the refusal
+    // this is exactly the race the issue describes, and the drain below would time out.
+    {
+        gpu_submit_gate_reset();
+        constexpr int kThreads = 6;
+        std::atomic<bool> stop{false};
+        std::atomic<int> refusals{0};
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+        for (int i = 0; i < kThreads; i++)
+            threads.emplace_back([&] {
+                while (!stop.load(std::memory_order_relaxed)) {
+                    GpuSubmitRegion region;
+                    if (!region.admitted()) {
+                        refusals.fetch_add(1, std::memory_order_relaxed);
+                        continue;   // a real caller returns VK_ERROR_DEVICE_LOST here
+                    }
+                    std::this_thread::sleep_for(std::chrono::microseconds(50));   // "in the driver"
+                }
+            });
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));   // let traffic build up
+        gpu_submit_gate_begin_shutdown();
+        const bool drained = gpu_submit_gate_drain(2000);
+        CHECK(drained, "drain reaches zero against live submitting threads once the gate is closed");
+        CHECK(gpu_submit_gate_in_flight() == 0, "nothing is in flight after that drain");
+        stop.store(true);
+        for (auto& t : threads) t.join();
+        CHECK(refusals.load() > 0, "the closed gate really refused work the threads then skipped");
+        CHECK(gpu_submit_gate_in_flight() == 0,
+              "refused regions after the drain never re-enter the count");
+    }
+
+    gpu_submit_gate_reset();
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -50,6 +50,7 @@
 #include "host/memory/guest_write_watch.hpp"
 #include "host/image/boot_program.hpp"       // boot_program
 #include "host/image/exec_image.hpp"         // run_entry
+#include "host/platform/gpu_submit_gate.hpp" // #3225: drain guest GPU submits before _exit
 #include "gpu/present/videoout_present.hpp"    // present_count / present_readback / present_width/height
 #include "gpu/present/present_frame_rate.hpp" // distinct-guest-frame framerate (NOT a present rate)
 #include "overlay_text.hpp"                   // --fps-overlay: burn the rate into the image
@@ -972,5 +973,20 @@ int main(int argc, char** argv) {
     // reports here; the asymmetry was silent, because a diagnostic that produces no output looks
     // exactly like one that found nothing. Report before exiting, as prosper-app does.
     prosper::host::guest_dmem_write_trace_report();
+    // #3225: same shape as prosper-app's exit -- a detached guest thread and a raw _exit. _exit
+    // becomes exit_group(), and a thread inside an amdgpu command submission at that moment cannot
+    // be torn down until it returns from the kernel; it parks in __drm_exec_lock_obj on a GEM
+    // reservation nobody will release, leaving an unreapable process whose lock the rest of the
+    // system's DRM work queues behind. Closing the gate stops NEW guest submissions (they return
+    // VK_ERROR_DEVICE_LOST, which every submission site handles as "not submitted") so this bounded
+    // drain can reach zero. It BOUNDS the window rather than closing it: a thread already inside
+    // vkQueueSubmit is waited for, and if it never returns the drain expires and we exit as before.
+    prosper::gpu_submit_gate_begin_shutdown();
+    constexpr int kGuestSubmitDrainMs = 2000;
+    if (!prosper::gpu_submit_gate_drain(kGuestSubmitDrainMs))
+        fprintf(stderr,
+                "[shot] guest GPU submissions did not drain within %d ms (%d still in flight); "
+                "exiting anyway\n",
+                kGuestSubmitDrainMs, prosper::gpu_submit_gate_in_flight());
     _exit(verdict.exit_code);   // the guest thread is detached and running guest code; don't block on teardown
 }


### PR DESCRIPTION
Fixes #3225.

## The failure

`prosper-app` can exit leaving a **zombie process with a thread wedged in
`__drm_exec_lock_obj`**. `SIGKILL` is a no-op on it, the compositor's own DRM work blocks behind the
reservation it holds, and the developer's whole desktop freezes. It happened **twice in one day** and
needed a root-forced GPU reset (`echo 1 > /sys/kernel/debug/dri/*/amdgpu_gpu_recover`) — i.e. a
reboot on a machine you cannot reach over SSH. Nothing is logged, because nothing is *hung*: it is a
held lock, so neither the amdgpu watchdog nor any timeout fires and there is no self-recovery path.

## The mechanism, from source

`run_entry()` never reads the cooperative stop flag (`main.cpp:1081`, `game_path.hpp:82`; the only
reader of `prosper_stop_requested()` is prosper-app's own main loop at `main.cpp:2171`), so a booted
guest cannot be joined. The shutdown path therefore was:

```cpp
prosper_request_stop();          // nothing on the guest side observes this
...
if (g_guest_thread.joinable()) {
    g_guest_thread.detach();     // still running
    ...
    std::_Exit(exitCode);        // no drain
}
```

and the `vkDeviceWaitIdle(vk.device)` a few lines below is on the **other** branch — the one taken
only when no guest booted. **Every real game session exited with no drain at all.**

`_Exit` becomes `exit_group()`. A thread already inside a syscall cannot be torn down until it
returns from the kernel; inside an amdgpu command submission it parks on a `dma_resv` nobody will
now release. So this is not an occasional race: there is **no ordering on this path**, and an
in-flight submission is abandoned on *every* close. That it usually costs nothing is luck about
where the guest thread happened to be.

## What this change does

`prosper/src/host/platform/gpu_submit_gate.{hpp,cpp}` — a counted region plus a bounded drain,
beside `lifecycle.hpp` and with the same constraints (no Vulkan, no OS-integration deps, lives in
`prosper_core`):

- `GpuSubmitRegion` — RAII; entering increments a counter **unless shutdown has begun**, and reports
  whether it was admitted.
- `gpu_submit_gate_begin_shutdown()` — after this no new region is admitted, which is what lets the
  count actually reach zero instead of chasing a moving target.
- `gpu_submit_gate_drain(timeout_ms)` — waits for the regions already inside; returns whether it
  drained.

State is one atomic word (bit 0 = shutdown, the rest = region count), so admission is a single CAS
and a *refused* enter never perturbs the count a drain is reading. The admitted path never touches
the mutex; only a leaving region with a waiter present does.

**Chokepoints wired** — every guest-thread `VkQueue` call:

| site | on refusal |
| --- | --- |
| `tests/fixtures/render_runner.h` `render_locked_queue_submit` | `VK_ERROR_DEVICE_LOST`, driver not entered |
| `tests/fixtures/render_runner.h` `render_locked_queue_wait_idle` | `VK_ERROR_DEVICE_LOST`, driver not entered |
| `frontends/shared/live/live_compute.cpp` compute dispatch submit | `VK_ERROR_DEVICE_LOST`; `submission_entered` stays false, so ordinary cleanup runs |
| `frontends/shared/live/live_compute.cpp` post-fence-timeout queue drain | no drain; `completion_proven` stays false, as on the device-lost path |
| `frontends/shared/present/present_blit.cpp` `present_blit_publish` | `false` → the existing CPU-present fallback |

Two of these were not in the original three. `present_blit.hpp:10` documents `present_blit_publish`
as running on the guest thread. The compute **drain** is a wait rather than a submit, so it is not
itself the `__drm_exec_lock_obj` hazard — but leaving it ungated would have broken the claim the
rest of this change rests on: an ungated queue call is invisible to the drain, so the drain could
report success while it was still running and the `vkDeviceWaitIdle` below would then run
concurrently with it. (`render_runner.h` is the live offscreen backend despite its directory —
`tests/fixtures/AGENTS.md`. Guest-thread `vkWaitForFences` calls are deliberately **not** gated:
fences are externally synchronized per-fence, not per-queue, and they do not take the reservation
locks.)

**Frontends.** `prosper-app` now does `begin_shutdown()` → `drain(2000 ms)` → `vkDeviceWaitIdle`
before `_Exit`, and prints to stderr when the drain expires. The wait is **deliberately skipped when
the drain times out**: `vkDeviceWaitIdle` requires host access to every `VkQueue` to be externally
synchronized, and the drain is what provides that here — waiting after a failed drain would both
violate that and be the very block being avoided. `tools/screenshot` has the identical
detach-and-`_exit` shape (`screenshot.cpp:628`, `:975`) and takes the same two steps; `boot_trace`
returns from `main` normally and is untouched.

## What this does NOT close

**It bounds the window; it does not close it.** A thread that is *already inside* `vkQueueSubmit`
when shutdown begins is still waited for, and if it never returns the drain expires and we `_Exit`
exactly as today — no worse, but no better. The real fix is the cooperative stop the existing comment
names as unimplemented: `run_entry()` observes the flag, stops at a submission boundary, and the
thread is **joined**, after which an ordinary drain and teardown are safe (#352). The header, the
call-site comments and `FRONTEND_APP.md` all say this, so a future reader cannot mistake the
mitigation for the fix.

## Risks

- **A false refusal would drop a real submission.** The gate closes only in `begin_shutdown()`, whose
  only non-test callers are the two frontends' exit paths (grep in the commit), so during a running
  title it is one uncontended CAS per submission and can never refuse. If it ever *did* refuse
  early, the cost would be a dropped draw/dispatch/present-blit for the remainder of the process —
  which is why the refusal is bound to an explicit one-way shutdown flag rather than to any
  heuristic.
- **The drain adds up to 2 s to a close**, and only when a guest submission genuinely has not
  returned. Observed cost in verification: zero timeouts in 15 runs.
- **The `vkDeviceWaitIdle` that follows it is UNBOUNDED**, and this is the honest cost of the change.
  On a title that has hung a GPU job — a documented state for GTA V — it returns only when the
  amdgpu watchdog resets the device, adding seconds more. It also protects no teardown, since the
  `_Exit` below destroys no Vulkan object; what it buys is that already-submitted guest work is off
  the device before the process dies. That is a deliberate trade of a bounded, visible delay against
  the unbounded, invisible one this path exists to prevent, and the code says so — deleting it is
  safe and loses only that guarantee. It runs only after a successful drain, so no guest submit can
  be concurrent with it.

## Verification

Container `ps5ys`, Linux, AMD Radeon 8060S (RADV STRIX_HALO). Re-run at head after the
fifth chokepoint was added.

```
cmake -S prosper -B prosper/build-linux -DPROSPER_APP=ON      # rc=0
cmake --build prosper/build-linux -j6                          # rc=0
ctest --no-tests=error                                         # rc=0, 336/336 passed
```
336 = master's 334 plus the two new cases; both verified by name with `ctest -N`
(`#47 gpu_submit_gate`, `#326 submit_gate_wiring`), not by the total.

**Unit coverage** (`gpu_submit_gate`, pure — no Vulkan, no dump, 32 assertions): admits while open,
counts depth on nesting, refuses after `begin_shutdown`, a refused region is not counted,
`begin_shutdown` is idempotent, a region entered *before* shutdown stays admitted, **the drain times
out rather than blocking** while one is held (≥100 ms of a 120 ms budget), the drain returns when
*woken* rather than at its deadline, the count is exact under 8 threads × 5000 enter/leave, and — the
shape the frontend actually uses — **the drain reaches zero against 6 live submitting threads once
the gate is closed**, which is only possible because new regions are refused.

**Wiring coverage** (`submit_gate_wiring`): the backend wrappers really consult the gate. Its
positive arm runs **first and on a real queue** (skipped with a printed note where there is no
device), so a wrapper hard-coded to fail cannot pass; the refusal arm passes `VK_NULL_HANDLE`, so a
clean `VK_ERROR_DEVICE_LOST` is itself proof the call never reached Vulkan.

**Mutation arms** (each built to rc=0 first, so a silently non-applied edit cannot masquerade as a
non-load-bearing test):

| arm | build | `ctest` | effect |
| --- | --- | --- | --- |
| `begin_shutdown()` made a no-op | rc=0 | rc=8, 2/2 red | 9 assertions fail, incl. "drain reaches zero against live submitting threads"; `submit_gate_wiring` aborts — it reached `vkQueueSubmit` with a null queue, which is the wiring assertion doing its job |
| `drain()` returns `true` unconditionally | rc=0 | rc=8, 1/2 red | 5 assertions fail, incl. the timeout and "nothing is in flight after that drain" |

**Runs.** Deliberately **no attempt to reproduce the freeze** — the cause is established from source
and a reproduction costs the owner their desktop.

- `tools/screenshot`, 5 runs (3 × `PPSA02664`, 2 × `PPSA24651`): all `rc=0`, `status=ok`, 3/3
  screenshots each. `pgrep -x screenshot` empty after every run, no `Z`-state process, and **0
  drain-timeout lines** across all five.
- `prosper-app --frames 240`, 3 runs offscreen (`PPSA02664`): `rc=0`, clean
  `[app] shutting down after 240 presented frame(s)`, no leftover process, no zombie, no drain
  timeout. This exercises the changed `_Exit` branch.
- `prosper-app --frames 300`, 1 **interactive windowed** run on the live Wayland session: `rc=0`, no
  leftover process, no zombie, `vulkaninfo --summary` still enumerates the Radeon 8060S afterwards,
  and `journalctl -k` shows no new amdgpu/DRM lines. Desktop unaffected.

Snapshots not run — this changes no rendering path; the gate is open for the entire life of a
running title.

## Docs

`docs/FRONTEND_APP.md` gets the mechanism under its lifecycle and threading sections, plus a new
`## Ruled out`:

- *"The headless path is safer by design"* — falsified. `tools/screenshot` detaches and `_exit`s in
  exactly the same shape; what differs is that no compositor shares the device with it, so a stuck
  reservation has nothing to block.
- *"A GPU hang / driver fault is involved"* — falsified. No fault is logged at all and the hang
  detector never fires; there is no stuck job, only a held lock.

`src/host/platform/AGENTS.md` is new, and spells out the distinction that is easy to get wrong:
`lifecycle.hpp` is a boolean *request*, `gpu_submit_gate.hpp` is a counted region with a drain for
when asking nicely is not enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB

---

## Independent review

Reviewed by a separate agent against the memory-ordering argument, every wired call site's failure
handling, the completeness of the `vkDeviceWaitIdle` justification, and whether each test would fail
without the fix. Verdict **APPROVED**; four findings addressed in `4a815724` and `5201188d`:

- **A refusal was manufacturing a device loss it had not observed.** The compute refusal returned
  `VK_ERROR_DEVICE_LOST` into `vk_ok`, which latched `ctx.device_lost`, printed
  `fatal Vulkan device loss stage=queue-submit … disabling live compute for this process`, and added
  a `reason=queue-submit` row to the decline census — counts this project quotes as evidence. Every
  shutdown would have fabricated one of each. It now breaks directly; `submission_entered` still
  stays false, so cleanup is unchanged.
- **The wiring test's positive arm covered one wrapper, not both**, so a `render_locked_queue_submit`
  hard-coded to fail would have passed. Added an open-gate arm using an empty submit, and confirmed
  by a new mutation arm (hard-code that wrapper to fail → build `rc=0`, `ctest` `rc=8`, exactly the
  new assertion red).
- **The bound is narrower than the header implied.** `__drm_exec_lock_obj` is also reachable through
  the GEM-VA ioctls behind `vkAllocateMemory` / `vkBind*Memory` / `vkFreeMemory`, which the guest
  thread calls ungated. Recorded in the header at `CONFIDENCE: MED` so a recurrence reads as "never
  covered that path" rather than "the gate failed".
- **The risk section understated the close cost** (this section, now corrected), and
  `gpu_submit_gate_leave()` could wrap the count on a mispair and silently break every later drain —
  it now saturates.

The reviewer independently enumerated every `vkQueueSubmit` / `vkQueueWaitIdle` / `vkQueuePresentKHR`
/ `vkQueueBindSparse` / `vkQueueSubmit2` in the tree and confirmed the five gated sites are exactly
the guest-thread ones, and that `library_media.cpp:675` — the one that looks like a worker-thread
submit — is reached only from the app/UI thread. Non-blocking nits left as-is: the negative-timeout
drain mode has no production caller, and the concurrency test's drain assertion is probabilistic
(its comment now says so; the deterministic anchor beside it is `refusals > 0`).