### PR TITLE
shader_conformance: replace scan.py's ported MIMG length rules with the real decoder

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,22 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-02
 
+### The shader-conformance scanner stopped carrying its own copy of the RDNA2 decoder
+
+No picture in this one — the finding is that `shader_histo` has been reading past the end of an
+array on every eboot with an undecodable instruction, and segfaulting outright on 4 of the 55 local
+dumps. Its hand-written list of RDNA2 format names went one entry short when `VOP3P` was added to
+the enum, so `VOP3P` printed as "UNK" and `Unknown` indexed off the end
+([#3229](https://github.com/mattias800/prosper/issues/3229)).
+
+We found it while deleting a different copy of decoder knowledge: `shader_conformance/scan.py`
+carried a Python port of the recompiler's instruction-length rules so it could tell an image
+instruction from an operand dword that looks like one. It now calls prosper's real decoder instead
+([#3184](https://github.com/mattias800/prosper/issues/3184)). The port turned out to be exactly
+right — 11,266 real shaders out of the dump library, 199,521 image instructions, zero disagreements
+— which is the point: a copy that is correct today is still the one nobody updates tomorrow.
+
+
 ### Astro Bot's world map is lit, and no longer takes the GPU down with it
 
 The world map now renders and keeps animating for the whole run, where before it froze on a white

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -408,14 +408,24 @@ if(Python3_Interpreter_FOUND)
   # The shader-conformance scanner (#3036), registered because its whole value is a CLEAN result
   # and its original failure mode was manufacturing one: a capture that yielded zero examined
   # shaders exited 0, and findings could be attributed to a capture whose dumps had all failed.
-  # The suite is hermetic -- it drives the scanner end to end against a stub gpu_replay and a
-  # `spirv-dis` shim, so it needs neither a GPU nor the Vulkan toolchain, and it pins the exit
-  # contract (0 clean / 1 mismatch / 2 could-not-scan) rather than only the two parsers. Ten
-  # mutations of the logic it covers, including `DIM_ARRAYED` dropping the 2D_ARRAY case that is
-  # the tool's entire reason to exist, each turn it red.
-  add_test(NAME shader_conformance_scan_logic
-           COMMAND "${Python3_EXECUTABLE}"
-                   "${CMAKE_SOURCE_DIR}/tools/shader_conformance/scan.py" "--self-test")
+  # It drives the scanner end to end against a stub gpu_replay and a `spirv-dis` shim, so it needs
+  # neither a GPU nor the Vulkan toolchain, and it pins the exit contract (0 clean / 1 mismatch /
+  # 2 could-not-scan) rather than only the two parsers. Ten mutations of the logic it covers,
+  # including `DIM_ARRAYED` dropping the 2D_ARRAY case that is the tool's entire reason to exist,
+  # each turn it red.
+  #
+  # It needs the BUILT `shader_inspect` since #3184: the scanner's MIMG walk is now prosper's own
+  # RDNA2 decoder rather than a Python port of its length rules, so the decode arms exercise
+  # `rdna2_decode.cpp` itself and a change to its length dispatch reddens this suite. Guarded on
+  # `TARGET prosper_core` because that is what governs the executable; the generator expression
+  # resolves against the target added later in this file. Without the binary the suite exits 2
+  # (could not test) rather than reporting a pass.
+  if(TARGET prosper_core)
+    add_test(NAME shader_conformance_scan_logic
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_SOURCE_DIR}/tools/shader_conformance/scan.py" "--self-test"
+                     "--mimg-decoder" "$<TARGET_FILE:shader_inspect>")
+  endif()
   # stack_profile's frame classifier, against RECORDED gdb output. Deliberately needs no gdb and no
   # ptrace: an end-to-end variant would skip silently wherever ptrace is unavailable, and a silently
   # skipped test is indistinguishable from a passing one. What it pins is the case that already

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -405,6 +405,11 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`shader_inspect/`** — decode one raw `PROSPER_SHADER_DUMP` binary offline. It prints bounded
   instruction PCs, operands, raw words, signed branch immediates, and resolved branch targets so a
   failed shader's CFG can be mapped without hand-counting variable-length instructions.
+  **`--mimg-sites` is the machine-readable half (#3184)**: one `mimg-site pc=… op=… dim=…` line per
+  image instruction and nothing else, so a tool that needs to know where the MIMG instructions are
+  never has to carry its own port of the RDNA2 length rules. `shader_conformance/scan.py` did carry
+  one, and now consumes this instead. The trailing `mimg-sites-end` line is a completion sentinel —
+  a real empty census must never look like a process that died before printing.
   **And it answers "which opcode?", never "which value?" (#2132).** A fold that stops early looks
   identical whether it ran out of modelled opcodes or out of *readable data* — the reject line is the
   same — and a disassembler can only see the first. Sonic Racing: CrossWorlds' failing vertex fetch

--- a/prosper/tools/shader_conformance/AGENTS.md
+++ b/prosper/tools/shader_conformance/AGENTS.md
@@ -30,9 +30,14 @@ Both halves are already cheap and headless, which is what makes this scale:
 
 ```bash
 python3 tools/shader_conformance/scan.py <capture.prgbundle|.prgcap> \
-        --gpu-replay ./build-linux/gpu_replay
-python3 tools/shader_conformance/scan.py --self-test     # no capture, no GPU needed
+        --gpu-replay ./build-linux/gpu_replay --mimg-decoder ./build-linux/shader_inspect
+python3 tools/shader_conformance/scan.py --self-test \
+        --mimg-decoder ./build-linux/shader_inspect          # no capture, no GPU needed
 ```
+
+Both binaries are required, and both default to `./build-linux/…`. `shader_inspect` is not an
+optional accelerator: since #3184 it **is** the ISA walk (see below), so without it the scanner
+cannot find a single image instruction — and it exits 2 rather than reporting a clean run.
 
 Exit codes are the interface: **0** scanned and clean, **1** mismatches found, **2** could not scan.
 `--json` for machine consumption.
@@ -68,35 +73,49 @@ those counts alongside any clean result** — an exit code alone is not falsifia
 
 ### What a finding is, and what a clean result is
 
-**The ISA walk is length-aware (#3040).** `decode_mimg_sites` decodes each instruction's real
-per-instruction length — mirroring the format dispatch and length rules in prosper's own
-`rdna2_decode.cpp` (`rdna2_decode_one` / `rdna2_walk`) — and only ever tests a dword for the MIMG
-top-6-bit encoding when it is genuinely the first dword of an instruction. An operand or trailing
-literal dword can no longer be misread as an instruction start, and a real MIMG's own address/NSA
-dwords can no longer be misread as separate instructions either.
+**The ISA walk IS prosper's decoder (#3184).** `decode_mimg_sites` shells out to
+`shader_inspect --mimg-sites`, which is `rdna2_walk` over `rdna2_decode_one`
+(`src/gpu/recompiler/rdna2_decode.cpp`) and nothing else, and reads back one
+`mimg-site pc=… op=… dim=…` line per image instruction. There is no RDNA2 decoding left in
+`scan.py`: where an instruction boundary is, where DIM sits, and how the opcode's split MSB is
+reassembled are stated in exactly one place in this repository. So the walk only ever tests a dword
+for MIMG-ness when it is genuinely the first dword of an instruction, and it cannot fall behind the
+recompiler when the decoder learns a new literal-forcing opcode or a wider NSA field.
 
-Before #3040 the walk tested *every* dword unconditionally, which was deliberately over-approximating
-in one direction (never hide a real MIMG) but paid for that by inventing MIMG instructions from
-operand and literal dwords whose top bits happened to alias the encoding — a finding for a defect
-that did not exist. Review of #3039 had already found the opposite failure mode in the pre-#3039
-walk (a phantom swallowing a real MIMG that followed it, scanning CLEAN); the length-aware walk fixes
-both directions at once, because both come from the same root cause — testing a dword that is not
-actually an instruction boundary. `self_test` pins both: a hand-built literal aliasing an arrayed DIM
-that must NOT be found, and the #3039 swallow sequence whose real MIMG must still be found (and, now,
-found *alone*).
+Two earlier failure modes are therefore gone by construction rather than by two decoders happening
+to agree. Before #3040 the walk tested *every* dword unconditionally, over-approximating in one
+direction (never hide a real MIMG) but inventing MIMG instructions from operand and literal dwords
+whose top bits happened to alias the encoding — a finding for a defect that did not exist. Review of
+#3039 had found the opposite failure in that same walk: a phantom swallowing a real MIMG that
+followed it, scanning CLEAN. Both came from one root cause, testing a dword that is not an
+instruction boundary. `self_test` still pins both, and now pins them against the real decoder — a
+hand-built literal aliasing an arrayed DIM that must NOT be found, and the #3039 swallow sequence
+whose real MIMG must still be found, and found alone.
 
-Residual risk is different in kind, not degree: this Python walk is a **second, independent
-implementation** of `rdna2_decode_one`'s length dispatch rather than a call into it, so a future
-change to the real decoder's length rules needs a matching update here or the two can drift apart
-silently. #3040's own suggested fix — teaching `shader_histo` to emit real per-instruction `(pc,
-opcode, dim)` and having `scan.py` consume that instead — removes the duplication entirely and
-remains the more robust direction; it just was not required to fix the length-awareness defect
-itself. Until it lands:
+#3040 fixed those by **porting** `rdna2_decode_one`'s length dispatch into Python, and that port is
+what #3184 removed. It was correct — see *Ruled out* below — and correctness was never the argument
+against it: a copy of a decoding rule is the thing nobody updates when the original changes, and it
+fails by silently returning a plausible instruction stream, which is precisely the failure this tool
+exists to make impossible. The same folder had already drifted that way in the other direction, and
+it surfaced while landing #3184: `shader_histo`'s hand-maintained `Rdna2Format` name table lost
+track of the enum when `VOP3P` was added, mislabelling every VOP3P instruction as unknown and
+reading out of bounds for `Unknown` itself (#3229).
+
+What that leaves:
 
 - **A finding is still a candidate**, not a defect — confirm it against the shader before acting on
-  it. The remaining reason is `classify()`'s module-wide match (below), not the ISA walk.
+  it. The reason is `classify()`'s module-wide match (below); it was never the ISA walk.
 - **A clean result is sound for the classes it checks** — the walk can neither invent an instruction
-  nor miss a real one it can decode.
+  nor miss a real one the recompiler itself can decode. That last clause is now exact rather than
+  approximate: it is the same walk, not an equivalent one.
+- **A shader whose census could not be taken is not an examined shader.** The decoder prints a
+  `mimg-sites-end` sentinel and the scanner refuses any output without one, so a decoder that dies
+  before printing anything can never be read as "this shader has no image instruction". The sentinel
+  carries the decoder's own site count and the scanner cross-checks it against the lines it parsed,
+  which closes the same hole on the reading side: a site line the regex stops matching would
+  otherwise be dropped silently, and an under-count reads as a cleaner shader. A raw dump that is
+  empty, or not a whole number of dwords, is likewise refused rather than truncated — the
+  in-process walk used to truncate it silently.
 
 Two further recall limits, both deliberate and unrelated to the ISA walk: `OpTypeImage` is parsed
 module-wide, so a shader that declares *any* arrayed image clears *every* arrayed sample in it
@@ -106,12 +125,48 @@ coordinate is not built by `OpCompositeConstruct`.
 
 ## Self-test
 
-`scan.py --self-test` is hermetic: it drives the scanner end to end against a stub `gpu_replay` and a
-`spirv-dis` shim, so it needs no GPU and no Vulkan toolchain. It is registered with ctest as
-`shader_conformance_scan_logic`. It covers both parsers, the classifier in both directions, and the
-exit contract; ten mutations of the covered logic each turn it red, including `DIM_ARRAYED` dropping
-the 2D_ARRAY case that is the tool's entire reason to exist.
+`scan.py --self-test` drives the scanner end to end against a stub `gpu_replay` and a `spirv-dis`
+shim, so it needs no GPU and no Vulkan toolchain. It is registered with ctest as
+`shader_conformance_scan_logic`. It covers both parsers, the classifier in both directions, the exit
+contract, and the decode arms; ten mutations of the covered logic each turn it red, including
+`DIM_ARRAYED` dropping the 2D_ARRAY case that is the tool's entire reason to exist.
+
+It does need the **built `shader_inspect`**, which is why ctest passes
+`--mimg-decoder $<TARGET_FILE:shader_inspect>`. That is a deliberate loss of hermeticity and it is
+the point of #3184: the decode arms now exercise `rdna2_decode.cpp` itself, so reverting the real
+decoder's MIMG NSA length to a flat 2 dwords reddens this suite. It could not before — the arms
+tested the Python copy, and a suite that only tests the copy is exactly how a copy drifts unnoticed.
+Without the binary the suite exits **2** (could not test); it never reports a pass it did not earn.
 
 The suite it replaced passed under all of those mutations. Its MIMG fixture was assembled from the
 same constant it was checking, so mutating the constant mutated the fixture — a same-source positive
 control, which tests the discriminator and never the domain.
+
+## Ruled out
+
+One line per already-falsified hypothesis, the evidence that killed it, and the issue — so nobody
+re-derives a dead answer at full cost.
+
+- **"The Python length port and the real decoder have already drifted, so the scan has been
+  reporting wrong MIMG sites"** — false, measured before the swap. Differential over the whole local
+  dump library: every `.shader_text` embedded in all 55 `PPSA*-app0` eboots (30 of them carry any),
+  **11,266 shaders carrying 199,521 MIMG sites**, decoded by the pre-#3184 `scan.py:decode_mimg_sites` and by
+  `shader_inspect --mimg-sites`, with `(pc, opcode, dim)` compared elementwise: **0 disagreements,
+  0 decoder failures**. So the swap is output-equivalent on real input, and no historical finding is
+  invalidated by it. The argument for #3184 is the drift a copy invites, never a defect it had
+  (#3184).
+- **"Deleting the port is a recall risk, because the decoder may refuse streams the Python walk
+  accepted"** — false for whole-dword streams, which is every real dump: the same 11,266-shader
+  differential ran the decoder over all of them with zero refusals. It IS true for a zero-byte or
+  partial-dword dump, and that difference is deliberate — those are now refused as unreadable rather
+  than truncated into a clean-looking empty census (#3184).
+
+**And one limit of that differential, so nobody reads more coverage into it than it has: the eboot
+corpus contains no NSA MIMG instruction.** Mutating the real decoder to ignore the NSA extra-dword
+count produced *zero* disagreements over all 11,266 shaders, which is only possible if every MIMG in
+them has `NSA == 0`. Dropping two of the six VOP2 K-literal opcodes likewise produced zero. So the
+equivalence result above covers the length rules this corpus exercises, and the `self_test` NSA arm
+is hand-built precisely because the corpus cannot supply one. The instrument itself is not blind —
+lengthening MIMG by one dword makes the same differential report **5,680 of 11,266 shaders
+disagreeing across 29 titles** — which is the control that makes the zero a real null rather than a
+same-source one (#3184; CLAUDE.md's instrument-trap 122).

--- a/prosper/tools/shader_conformance/scan.py
+++ b/prosper/tools/shader_conformance/scan.py
@@ -14,168 +14,95 @@ whole world from one 256-slice array and rendered flat for exactly that reason -
 several hours, and mechanically detectable in seconds.
 
 Usage:
-    scan.py <capture.prgcap|.prgbundle> [more...] [--gpu-replay PATH] [--json] [--self-test]
+    scan.py <capture.prgcap|.prgbundle> [more...] [--gpu-replay PATH] [--mimg-decoder PATH]
+            [--json] [--self-test]
 
 Exit codes: 0 = scanned, no mismatch. 1 = mismatches found. 2 = could not scan (see below).
 
+The ISA walk is prosper's OWN RDNA2 decoder, reached through `shader_inspect --mimg-sites` (#3184).
+Nothing in this file decodes an instruction: a second implementation of a decoding rule is the one
+that drifts, and it drifts silently, which is the failure this tool exists to make impossible.
+
 It refuses to report "clean" without having parsed something. A run that dumps no shader, or whose
-disassembler is missing, exits 2 and says so rather than printing zero findings -- a silent scanner
-is indistinguishable from a clean codebase, and that failure has cost this project real time.
+disassembler or decoder is missing, exits 2 and says so rather than printing zero findings -- a
+silent scanner is indistinguishable from a clean codebase, and that failure has cost this project
+real time.
 """
 import argparse, json, os, re, shutil, struct, subprocess, sys, tempfile
 
-# MIMG DIM field (SQ_RSRC): the encoding prosper's own decoder uses, rdna2_decode.cpp `(w >> 3) & 0x7`.
+# MIMG DIM values (SQ_RSRC), as reported by prosper's decoder in `Rdna2Inst::mimg_dim`. This is a
+# naming and classification table, not a decode: nothing here reads an instruction word. Which bits
+# hold DIM, where the opcode's split MSB lives and how long an instruction is are all stated once,
+# in `src/gpu/recompiler/rdna2_decode.cpp`, and reach this tool through `--mimg-sites` (#3184).
 DIM_NAMES = {0: "1D", 1: "2D", 2: "3D", 3: "CUBE",
              4: "1D_ARRAY", 5: "2D_ARRAY", 6: "2D_MSAA", 7: "2D_MSAA_ARRAY"}
 DIM_ARRAYED = {4, 5, 7}
 DIM_3D = {2}
-MIMG_ENCODING = 0b111100          # dword0[31:26]
-S_ENDPGM = 0xBF810000             # SOPP encoding of s_endpgm -- terminates the walk, as it terminates
-                                   # the real program (rdna2_decode.cpp's S_ENDPGM).
 
 
-class Step:
-    """One decoded instruction's length and (if it is one) MIMG identity. See `rdna2_instr_len`."""
-    __slots__ = ("length", "is_mimg", "opcode", "dim", "is_end", "is_unknown")
-
-    def __init__(self, length, is_mimg=False, opcode=None, dim=None, is_end=False, is_unknown=False):
-        self.length, self.is_mimg, self.opcode, self.dim = length, is_mimg, opcode, dim
-        self.is_end, self.is_unknown = is_end, is_unknown
+class DecoderUnavailable(Exception):
+    """The MIMG census could not be obtained. Never confusable with an empty census (see below)."""
 
 
-def _sop_has_literal(w, nsrc):
-    """A scalar source operand field == 255 selects a trailing 32-bit literal constant dword."""
-    if (w & 0xFF) == 0xFF:
-        return True
-    if nsrc >= 2 and ((w >> 8) & 0xFF) == 0xFF:
-        return True
-    return False
+def decoder_cmd(decoder):
+    """The MIMG-site decoder, as an argv prefix. A `.py` value is run with this interpreter.
 
-
-def rdna2_instr_len(words, i):
-    """Decode the LENGTH (in dwords) of the instruction at `words[i]`, plus its MIMG identity if any.
-
-    #3040: `decode_mimg_sites` used to test every dword for the MIMG top-6-bit encoding regardless of
-    what instruction it actually belonged to, so an operand or trailing-literal dword whose top bits
-    happened to alias the encoding (0b111100) read as an instruction start -- a phantom finding for a
-    MIMG that was never in the program. The fix is to walk real instruction boundaries: decode each
-    instruction's length from its format, exactly as the guest's own wavefront would, and only ever
-    test a dword for MIMG-ness when it is actually the first dword of an instruction.
-
-    This mirrors the length computation in `rdna2_decode_one` / `rdna2_walk`
-    (`src/gpu/recompiler/rdna2_decode.cpp`) -- every format bucket that instruction actually
-    dispatches on, so this walk lands on the same instruction boundaries the real recompiler does. It
-    intentionally ports only the LENGTH rule, not full operand decode (register fields, DPP/SDWA
-    sub-modes, condition codes): that is all a boundary-accurate walk needs, and it is a small,
-    self-contained piece of the ~1,200-line decoder, not a port of the whole thing.
-
-    Being a second, independent implementation of that dispatch is itself a drift risk -- if
-    `rdna2_decode_one`'s length rules change, this walk needs a matching update or it can silently
-    fall out of sync. #3040's own suggested fix (teaching `shader_histo` to emit real per-instruction
-    MIMG sites and having `scan.py` consume that) removes the duplication entirely and remains the
-    more robust long-term direction; this is the length-aware fix within the existing Python-only
-    tool, not a replacement for that suggestion.
-
-    RDNA2 ISA reference: AMD document 70648 ("RDNA 2" Instruction Set Architecture: Reference Guide).
+    Same shape as `replay_cmd`, and for the same Windows reason: `CreateProcess` cannot execute a
+    `.py` by path the way a POSIX shebang can.
     """
-    n = len(words)
-    w = words[i]
-    max_dwords = n - i
-
-    if (w & 0x80000000) == 0:
-        # Vector ALU group (bit31 == 0): VOP1 (0x7E prefix), VOPC (0x7C prefix), else VOP2.
-        is_vop2 = (w & 0xFE000000) != 0x7E000000 and (w & 0xFE000000) != 0x7C000000
-        src0 = w & 0x1FF
-        # A VOP src0 field selects an extra dword four ways: 0xFF = trailing literal; 0xF9 = SDWA,
-        # 0xFA = DPP16, 0xE9/0xEA = DPP8 = a control word. All make the instruction 2 dwords.
-        if src0 in (0xF9, 0xFA, 0xE9, 0xEA):
-            length = 2 if max_dwords >= 2 else 1
-        else:
-            lit = (src0 == 0xFF)
-            if is_vop2:
-                # The six K-carrying VOP2 mul-adds embed a mandatory 32-bit literal K:
-                # v_madmk_f32(0x20) v_madak_f32(0x21) v_fmamk_f32(0x2C) v_fmaak_f32(0x2D)
-                # v_fmamk_f16(0x37) v_fmaak_f16(0x38).
-                if ((w >> 25) & 0x3F) in (0x20, 0x21, 0x2C, 0x2D, 0x37, 0x38):
-                    lit = True
-            length = (2 if max_dwords >= 2 else 1) if lit else 1
-        return Step(min(length, max_dwords))
-
-    if (w & 0xC0000000) == 0x80000000:
-        # Scalar group (bits[31:30] == 10): SOPP/SOPC/SOP1/SOPK carved out before the SOP2 default.
-        if (w & 0xFF800000) == 0xBF800000:
-            return Step(min(1, max_dwords), is_end=(w == S_ENDPGM))
-        if (w & 0xFF800000) == 0xBF000000:      # SOPC
-            lit = _sop_has_literal(w, 2)
-        elif (w & 0xFF800000) == 0xBE800000:    # SOP1
-            lit = _sop_has_literal(w, 1)
-        elif (w & 0xF0000000) == 0xB0000000:    # SOPK, except S_SETREG_IMM32_B32 (opcode 21) whose
-            lit = ((w >> 23) & 0x1F) == 21       # 32-bit register data trails as a mandatory literal.
-        else:                                    # SOP2
-            lit = _sop_has_literal(w, 2)
-        length = (2 if max_dwords >= 2 else 1) if lit else 1
-        return Step(min(length, max_dwords))
-
-    # Remaining top-bit patterns (bits[31:30] == 11) dispatch on dword0[31:26].
-    bucket = w >> 26
-    if bucket == 0x32:                                          # VINTRP
-        return Step(min(1, max_dwords))
-    if bucket in (0x33, 0x34, 0x35):                             # VOP3P, VOP3 (old-gen/RDNA2)
-        # 2 dwords, plus a trailing literal when any of dword1's three 9-bit src fields is 0xFF.
-        if max_dwords < 2:
-            return Step(min(1, max_dwords))
-        d1 = words[i + 1]
-        lit = ((d1 & 0x1FF) == 0xFF or ((d1 >> 9) & 0x1FF) == 0xFF or ((d1 >> 18) & 0x1FF) == 0xFF)
-        length = 3 if (lit and max_dwords >= 3) else 2
-        return Step(min(length, max_dwords))
-    if bucket in (0x36, 0x37, 0x38, 0x3A, 0x3D, 0x3E):           # DS, FLAT, MUBUF, MTBUF, SMEM, EXP
-        return Step(min(2, max_dwords) if max_dwords >= 2 else 1)
-    if bucket == MIMG_ENCODING:                                  # 0x3C -- MIMG
-        # 2 dwords, plus NSA (Non-Sequential Address) extra dwords holding the split address VGPRs.
-        # dword0[2:1] gives the extra-dword count (0..3), so total length is 2..5 dwords. Opcode and
-        # DIM are both dword0-only fields, so they are exact even when the buffer ends mid-instruction.
-        extra = (w >> 1) & 0x3
-        opcode = ((w & 1) << 7) | ((w >> 18) & 0x7F)
-        dim = (w >> 3) & 0x7
-        return Step(min(2 + extra, max_dwords), is_mimg=True, opcode=opcode, dim=dim)
-    return Step(min(1, max_dwords), is_unknown=True)
+    return [sys.executable, decoder] if str(decoder).endswith(".py") else [decoder]
 
 
-def decode_mimg_sites(raw: bytes):
-    """(dword_index, opcode, dim) for every MIMG instruction found by a LENGTH-AWARE walk of `raw`.
+def decode_mimg_sites(decoder, path):
+    """(dword_index, opcode, dim) for every MIMG instruction in the raw RDNA2 stream at `path`.
 
-    Each dword is visited only once, as either the first dword of an instruction (tested for MIMG-
-    ness) or an operand/literal dword of the instruction that precedes it (never tested) -- see
-    `rdna2_instr_len`. The walk stops at `s_endpgm` or an undecodable encoding, exactly as
-    `rdna2_walk` does, since nothing after either is reachable guest code.
+    The walk is prosper's OWN decoder -- `shader_inspect --mimg-sites`, which is `rdna2_walk` over
+    `rdna2_decode_one` (`src/gpu/recompiler/rdna2_decode.cpp`) and nothing else. There is no second
+    implementation of the RDNA2 length rules in this file, and that is the point (#3184).
+
+    What used to be here was a Python port of `rdna2_decode_one`'s format/length dispatch: enough of
+    it to tell a real instruction boundary from an operand or trailing-literal dword whose top six
+    bits happen to alias the MIMG encoding. It was correct -- 11,266 real shaders out of the local
+    dump library, carrying 199,521 MIMG sites, decode identically through both -- but correct is not
+    the property that matters for a copy. The copy is the one nobody updates when the decoder learns
+    a new literal-forcing opcode or a wider NSA field, and it fails by *silently* returning a
+    plausible instruction stream, which is the failure this whole tool exists to make impossible.
+    The same folder had already drifted this way once, in the other direction: shader_histo's
+    hand-maintained format-name table lost track of `Rdna2Format` when VOP3P was added (#3229).
+
+    Raises `DecoderUnavailable` rather than returning [] when the census could not be taken. A
+    scanner whose entire product is a CLEAN result must never let "this shader has no image
+    instruction" and "the decoder did not run" reduce to the same value -- so the decoder prints a
+    `mimg-sites-end` sentinel and this refuses any output without one, whatever the exit code said.
+
+    The sentinel also carries the decoder's OWN site count, and this cross-checks it against the
+    number of lines actually parsed. Without that, the remaining silent failure is on this side of
+    the pipe rather than the far side: a site line the regex stops matching -- a widened field, a
+    renamed key -- would be dropped while the sentinel still arrived, and an under-count reads as a
+    cleaner shader. Two independent statements of the same number make that loud instead.
     """
-    n = len(raw) // 4
-    if not n:
-        return []
-    words = struct.unpack(f"<{n}I", raw[:n * 4])
-    out = []
-    pc = 0
-    while pc < n:
-        step = rdna2_instr_len(words, pc)
-        if step.is_mimg:
-            out.append((pc, step.opcode, step.dim))
-        if step.length <= 0:
-            break                                # safety: never loop on a zero-length step
-        pc += step.length
-        if step.is_end or step.is_unknown:
-            break
-    return out
+    r = run(decoder_cmd(decoder) + [path, "--mimg-sites"])
+    sites, claimed = [], None
+    for ln in r.stdout.splitlines():
+        m = re.match(r"^mimg-site pc=(\d+) op=0x([0-9a-fA-F]+) dim=(\d+)$", ln)
+        if m:
+            sites.append((int(m.group(1)), int(m.group(2), 16), int(m.group(3))))
+            continue
+        m = re.match(r"^mimg-sites-end .*\bsites=(\d+)\b", ln)
+        if m:
+            claimed = int(m.group(1))
+    if r.returncode != 0 or claimed is None:
+        why = "no mimg-sites-end sentinel" if claimed is None else "exit " + str(r.returncode)
+        raise DecoderUnavailable(f"mimg decoder {why}: {(r.stderr or r.stdout).strip()[:160]}")
+    if claimed != len(sites):
+        raise DecoderUnavailable(f"mimg decoder reported sites={claimed} but {len(sites)} site "
+                                 f"line(s) parsed -- the census and its own count disagree")
+    return sites
 
 
-def decode_mimg(raw: bytes):
-    """Every MIMG instruction in a raw RDNA2 shader, as (opcode, dim).
-
-    A length-aware walk (see `decode_mimg_sites`) can only ever test a dword for the MIMG encoding
-    when it is genuinely the first dword of an instruction, so it can neither invent an MIMG from an
-    operand/literal dword (#3040) nor let a phantom match swallow a real one that follows it (#3039;
-    both directions are exercised in `self_test`).
-    """
-    return [(op, dim) for _, op, dim in decode_mimg_sites(raw)]
+def decode_mimg(decoder, path):
+    """Every MIMG instruction in a raw RDNA2 shader file, as (opcode, dim)."""
+    return [(op, dim) for _, op, dim in decode_mimg_sites(decoder, path)]
 
 
 def parse_spirv_images(dis: str):
@@ -328,7 +255,7 @@ def materialize(replay, path, tmp):
     return out, None
 
 
-def scan_capture(replay, capture, tmp):
+def scan_capture(replay, decoder, capture, tmp):
     findings, examined, skipped = [], 0, 0
     skip_reasons = []
     capture, err = materialize(replay, capture, tmp)
@@ -360,14 +287,22 @@ def scan_capture(replay, capture, tmp):
             skipped += 1
             skip_reasons.append(f"draw[{draw}] {stage}: spirv-dis exit {dis.returncode}")
             continue
-        raw = open(raw_p, "rb").read()
-        if not raw:
+        if os.path.getsize(raw_p) == 0:
             # An empty ISA dump is a shader we did NOT read. Counting it as examined is how a
             # capture that yielded nothing still reports a clean scan.
             skipped += 1
             skip_reasons.append(f"draw[{draw}] {stage}: empty ISA dump")
             continue
-        mimg = decode_mimg(raw)
+        try:
+            mimg = decode_mimg(decoder, raw_p)
+        except DecoderUnavailable as e:
+            # An unreadable census is a shader we did NOT examine, exactly like an unreadable dump.
+            # The decoder also refuses a dump that is not a whole number of dwords, which the old
+            # in-process walk silently truncated instead -- a partial dword is a truncated dump, and
+            # a scanner that reports on one is reporting on bytes it does not have.
+            skipped += 1
+            skip_reasons.append(f"draw[{draw}] {stage}: {e}")
+            continue
         if not mimg:
             examined += 1
             continue
@@ -418,7 +353,7 @@ sys.exit(0)
 """
 
 
-def _run_self_test_case(tmp, script, captures):
+def _run_self_test_case(tmp, script, decoder, captures):
     """Drive scan.py end-to-end against the stub. Returns (returncode, stdout, stderr)."""
     stub = os.path.join(tmp, "stub_replay.py")
     with open(stub, "w") as f:
@@ -438,21 +373,35 @@ def _run_self_test_case(tmp, script, captures):
         q = os.path.join(tmp, f"{name}.prgcap")
         open(q, "wb").write(b"\0")
         paths.append(q)
-    r = subprocess.run([sys.executable, script, "--gpu-replay", stub] + paths,
+    r = subprocess.run([sys.executable, script, "--gpu-replay", stub,
+                        "--mimg-decoder", decoder] + paths,
                        capture_output=True, text=True, env=env)
     return r.returncode, r.stdout, r.stderr
 
 
-def self_test():
+def self_test(decoder):
     """Every check below is written to FAIL under a mutation of the thing it claims to cover.
 
-    The previous suite did not. It built its MIMG fixture out of `MIMG_ENCODING`, so mutating that
-    constant mutated the fixture too and the check passed either way -- a same-source positive
-    control, which tests the discriminator and never the domain. It also never touched the
-    classifier, the exit contract, or either parser's caller, so nine separate mutations (including
-    `DIM_ARRAYED = {4, 7}`, which drops the entire #325 class this tool exists to find) all still
-    printed PASSED.
+    The previous suite did not. It built its MIMG fixture out of the encoding constant it was
+    checking, so mutating that constant mutated the fixture too and the check passed either way -- a
+    same-source positive control, which tests the discriminator and never the domain. It also never
+    touched the classifier, the exit contract, or either parser's caller, so nine separate mutations
+    (including `DIM_ARRAYED = {4, 7}`, which drops the entire #325 class this tool exists to find)
+    all still printed PASSED.
+
+    Since #3184 the decode arms are no longer hermetic, and that is the improvement rather than a
+    regression: the walk they exercise is prosper's REAL decoder, reached through
+    `shader_inspect --mimg-sites`, so a change to `rdna2_decode.cpp`'s length dispatch now reddens
+    this suite. It could not before -- the Python port was a separate implementation, and a suite
+    that only tested the copy is exactly how the copy drifts unnoticed. A missing decoder is
+    reported as exit 2 (could not test), never as a pass.
     """
+    if not decoder or not os.path.exists(decoder):
+        print(f"self-test: no shader_inspect at {decoder!r}. That binary IS the ISA walk under\n"
+              f"           test, so this suite cannot run without it and must not report a pass.\n"
+              f"           Build it (cmake --build <dir> --target shader_inspect) and pass\n"
+              f"           --mimg-decoder <path>.", file=sys.stderr)
+        return 2
     ok = True
 
     def check(cond, label):
@@ -460,56 +409,110 @@ def self_test():
         print(f"  [{'ok' if cond else 'FAIL'}]   {label}")
         ok = ok and cond
 
-    # --- MIMG decode. Literal words, computed by hand, NOT built from the constants under test.
-    # 0xF0800028: encoding 0b111100, opcode 0x20, DIM 5. 0xF0800029 sets the opcode MSB -> 0xa0.
-    # 0xF4800028 is encoding 0b111101 and must decode to nothing.
-    mimg2 = struct.pack("<II", 0xF0800028, 0)
-    check(decode_mimg(mimg2) == [(0x20, 5)], "literal 0xF0800028 decodes as opcode 0x20 / DIM 5")
-    check(decode_mimg(struct.pack("<II", 0xF0800029, 0)) == [(0xa0, 5)],
-          "opcode MSB (bit 0) is reconstructed -- 0xF0800029 is opcode 0xa0, not 0x20")
-    check(decode_mimg(struct.pack("<II", 0xF4800028, 0)) == [],
-          "encoding 0b111101 is NOT MIMG (pins MIMG_ENCODING against an off-by-one)")
-    check(decode_mimg(struct.pack("<I", 0x12345678)) == [], "a non-MIMG word decodes to nothing")
-    # A real 2-dword MIMG's SECOND dword (VADDR/SRSRC/SSAMP operand fields) is consumed as part of
-    # that SAME instruction by the length-aware walk, not re-tested as a new instruction start --
-    # #3040. This is the load-bearing behavior change from the pre-#3040 walk, which tested every
-    # dword unconditionally and would have reported TWO hits here.
-    check(decode_mimg(struct.pack("<II", 0xF0800028, 0xF0800028)) == [(0x20, 5)],
-          "a real MIMG's own dword1 is consumed by that instruction, not read as a second one (#3040)")
-    # The exact sequence review of #3039 used: a literal aliasing the encoding, then a REAL
-    # 2D_ARRAY sample. The real one must survive the phantom, AND (#3040) the phantom itself must be
-    # gone: `0x7E0002FF` is `v_mov_b32 v0, <literal>` (VOP1, src0=0xFF forces a trailing literal), so
-    # the length-aware walk consumes dwords 0-1 as ONE instruction and never tests dword1 in
-    # isolation -- unlike the pre-#3040 walk, which read dword1 as its own MIMG candidate (DIM 0).
-    swallow = struct.pack("<III", 0x7E0002FF, 0xF0000000, 0xF0800028)
-    check(decode_mimg(swallow) == [(0x20, 5)],
-          "a real MIMG immediately after an aliasing literal is found, and ONLY it is (#3039 + #3040)")
-    check(decode_mimg(b"") == [] and decode_mimg(b"\x01\x02") == [], "short/empty input is safe")
+    with tempfile.TemporaryDirectory() as fixtures:
+        # Hand-built ISA streams, decoded THE WAY scan_capture decodes a real dump: written to a
+        # file and handed to prosper's own decoder. The words below are computed by hand, never
+        # assembled from a constant this file also uses to judge the answer.
+        def sites(words):
+            path = os.path.join(fixtures, "fixture.bin")
+            with open(path, "wb") as f:
+                f.write(words)
+            return decode_mimg_sites(decoder, path)
 
-    # --- #3040's own positive control, built BY HAND rather than from `MIMG_ENCODING`/`DIM_ARRAYED`
-    # (a same-source control tests the discriminator, not the domain -- see CLAUDE.md). This is a
-    # single real instruction -- `v_mov_b32 v0, 0xF0000028` (VOP1, forced literal) -- and NO MIMG
-    # instruction anywhere in it. The literal's value is hand-picked so ITS OWN top 6 bits alias the
-    # MIMG encoding (0b111100) with DIM=5 (2D_ARRAY, an arrayed shape) sitting in bits [5:3]: exactly
-    # the pattern a dword-by-dword scan mistakes for `image_sample dim:2D_ARRAY`. Before #3040, this
-    # decoded as one MIMG finding and classify() reported a phantom `array-layer-dropped` defect
-    # against a "shader" that samples no image at all.
-    phantom_literal = struct.pack("<II", 0x7E0002FF, 0xF0000028)
-    check(decode_mimg(phantom_literal) == [],
-          "a literal operand aliasing an ARRAYED MIMG encoding is not read as an instruction (#3040)")
-    check(classify(decode_mimg(phantom_literal), [("2D", 0)], []) == [],
-          "...and so the full pipeline reports no phantom array-layer-dropped finding either")
+        def mimg(words):
+            return [(op, dim) for _, op, dim in sites(words)]
 
-    # --- NSA (Non-Sequential Address) length: a real MIMG can be 2-5 dwords (dword0[2:1] gives the
-    # extra-dword count), and each extra dword must be skipped too, not just dword1. Here the NSA
-    # instruction's own extra dwords are themselves crafted to alias the MIMG encoding -- if the walk
-    # advanced by a fixed 2 dwords instead of reading the NSA field, it would misread them as two
-    # more (phantom) MIMG instructions, and would then desync and miss the real one that follows.
-    nsa_dim1 = 0xF0000000 | (1 << 1) | (1 << 3)          # MIMG, NSA=1 extra dword, DIM=1 (plain 2D)
-    nsa = struct.pack("<IIII", nsa_dim1, 0xF0800028, 0xF0800028, 0xF0800028)
-    check(decode_mimg_sites(nsa) == [(0, 0x00, 1), (3, 0x20, 5)],
-          "NSA's extra dwords (dword0[2:1]) are skipped, not read as instructions, and the real MIMG "
-          "that follows is found at the correct offset (#3040)")
+        def refused(words):
+            try:
+                mimg(words)
+            except DecoderUnavailable:
+                return True
+            return False
+
+        # --- MIMG identity. 0xF0800028: encoding 0b111100, opcode 0x20, DIM 5. 0xF0800029 sets the
+        # opcode MSB -> 0xa0. 0xF4800028 is encoding 0b111101 and must decode to nothing.
+        check(mimg(struct.pack("<II", 0xF0800028, 0)) == [(0x20, 5)],
+              "literal 0xF0800028 decodes as opcode 0x20 / DIM 5")
+        check(mimg(struct.pack("<II", 0xF0800029, 0)) == [(0xa0, 5)],
+              "opcode MSB (bit 0) is reconstructed -- 0xF0800029 is opcode 0xa0, not 0x20")
+        check(mimg(struct.pack("<II", 0xF4800028, 0)) == [],
+              "encoding 0b111101 is NOT MIMG (pins the encoding against an off-by-one)")
+        check(mimg(struct.pack("<I", 0x12345678)) == [], "a non-MIMG word decodes to nothing")
+        # A real 2-dword MIMG's SECOND dword (VADDR/SRSRC/SSAMP operand fields) is consumed as part
+        # of that SAME instruction by the length-aware walk, not re-tested as a new instruction
+        # start -- #3040. This is the load-bearing behavior of a real walk: a scan that tested every
+        # dword unconditionally would report TWO hits here.
+        check(mimg(struct.pack("<II", 0xF0800028, 0xF0800028)) == [(0x20, 5)],
+              "a real MIMG's own dword1 is consumed by that instruction, not read as a second one")
+        # The exact sequence review of #3039 used: a literal aliasing the encoding, then a REAL
+        # 2D_ARRAY sample. The real one must survive the phantom, AND the phantom itself must be
+        # gone: `0x7E0002FF` is `v_mov_b32 v0, <literal>` (VOP1, src0=0xFF forces a trailing
+        # literal), so the walk consumes dwords 0-1 as ONE instruction and never tests dword1 in
+        # isolation -- unlike a dword-by-dword scan, which reads dword1 as its own MIMG candidate.
+        check(mimg(struct.pack("<III", 0x7E0002FF, 0xF0000000, 0xF0800028)) == [(0x20, 5)],
+              "a real MIMG immediately after an aliasing literal is found, and ONLY it is (#3039)")
+
+        # --- #3040's positive control, built BY HAND rather than from `DIM_ARRAYED` (a same-source
+        # control tests the discriminator, not the domain -- see CLAUDE.md). This is a single real
+        # instruction -- `v_mov_b32 v0, 0xF0000028` (VOP1, forced literal) -- and NO MIMG
+        # instruction anywhere in it. The literal's value is hand-picked so ITS OWN top 6 bits alias
+        # the MIMG encoding (0b111100) with DIM=5 (2D_ARRAY, an arrayed shape) in bits [5:3]:
+        # exactly the pattern a dword-by-dword scan mistakes for `image_sample dim:2D_ARRAY`. Such a
+        # scan decodes one MIMG here and classify() reports a phantom `array-layer-dropped` defect
+        # against a "shader" that samples no image at all.
+        phantom_literal = struct.pack("<II", 0x7E0002FF, 0xF0000028)
+        check(mimg(phantom_literal) == [],
+              "a literal operand aliasing an ARRAYED MIMG encoding is not read as an instruction")
+        check(classify(mimg(phantom_literal), [("2D", 0)], []) == [],
+              "...and so the full pipeline reports no phantom array-layer-dropped finding either")
+
+        # --- NSA (Non-Sequential Address) length: a real MIMG can be 2-5 dwords (dword0[2:1] gives
+        # the extra-dword count), and each extra dword must be skipped too, not just dword1. Here
+        # the NSA instruction's own extra dwords are themselves crafted to alias the MIMG encoding
+        # -- if the walk advanced by a fixed 2 dwords instead of reading the NSA field, it would
+        # misread them as two more (phantom) MIMG instructions, then desync and miss the real one
+        # that follows. Reverting `rdna2_decode.cpp`'s `2 + extra` to a flat `2` reddens this.
+        nsa_dim1 = 0xF0000000 | (1 << 1) | (1 << 3)     # MIMG, NSA=1 extra dword, DIM=1 (plain 2D)
+        check(sites(struct.pack("<IIII", nsa_dim1, 0xF0800028, 0xF0800028, 0xF0800028))
+              == [(0, 0x00, 1), (3, 0x20, 5)],
+              "NSA's extra dwords (dword0[2:1]) are skipped, not read as instructions, and the real "
+              "MIMG that follows is found at the correct dword offset")
+
+        # --- A stream the decoder cannot read is REFUSED, not answered with an empty census. This
+        # is the half that keeps a clean result honest, and it is a real behavior change from the
+        # in-process walk, which truncated a partial dword and returned []. A partial dword is a
+        # truncated dump; a scanner that reports on one is reporting on bytes it does not have.
+        check(refused(b""), "a zero-byte ISA dump is refused, not decoded as 'no MIMG'")
+        check(refused(b"\x01\x02"), "half a dword is refused, not silently truncated")
+
+        # --- The sentinel contract, with a stub decoder. `mimg-sites-end` is what separates "this
+        # shader has no image instruction" -- the answer that certifies a clean scan -- from "the
+        # decoder died before printing anything". Without this arm, a decoder that crashed on
+        # startup would certify every shader in a run as clean.
+        fixture = os.path.join(fixtures, "fixture.bin")
+        with open(fixture, "wb") as f:
+            f.write(struct.pack("<II", 0xF0800028, 0))
+        silent = os.path.join(fixtures, "silent_decoder.py")
+        with open(silent, "w") as f:
+            f.write("import sys\nsys.exit(0)\n")          # exits 0 having printed nothing
+        truncated = os.path.join(fixtures, "truncated_decoder.py")
+        with open(truncated, "w") as f:                     # prints a site, then dies before the end
+            f.write("import sys\nprint('mimg-site pc=0 op=0x20 dim=5')\nsys.exit(0)\n")
+        undercount = os.path.join(fixtures, "undercount_decoder.py")
+        with open(undercount, "w") as f:                    # sentinel claims 5, one line parseable
+            f.write("import sys\n"
+                    "print('mimg-site pc=0 op=0x20 dim=5')\n"
+                    "print('mimg-site pc=2 op=0xZZ dim=5')\n"
+                    "print('mimg-sites-end dwords=8 consumed=8 instructions=2 sites=5 endpgm=1')\n")
+        for stub, label in ((silent, "a decoder that exits 0 having printed nothing"),
+                            (truncated, "a decoder that prints sites but no mimg-sites-end"),
+                            (undercount, "a census whose sentinel count disagrees with its lines")):
+            raised = False
+            try:
+                decode_mimg_sites(stub, fixture)
+            except DecoderUnavailable:
+                raised = True
+            check(raised, f"{label} is refused, not read as a census")
 
     # --- SPIR-V parse, both directions.
     arrayed = "%1 = OpTypeImage %float 2D 0 1 0 1 Unknown"
@@ -540,7 +543,7 @@ def self_test():
     # --- The exit contract, end to end. These are what make a clean result mean anything.
     script = os.path.abspath(__file__)
     with tempfile.TemporaryDirectory() as tmp:
-        rc, out, err = _run_self_test_case(tmp, script, ["good"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["good"])
         # The positive count matters as much as the exit code. Every `rc == 2` arm below would pass
         # if the stub could not START -- a stub that never runs is indistinguishable from a capture
         # that could not be scanned -- so at least one arm has to assert that the stub really
@@ -549,36 +552,36 @@ def self_test():
         check(rc == 0 and "examined=2" in out,
               "a capture whose module IS arrayed exits 0 AND reports its 2 examined shaders")
 
-        rc, out, err = _run_self_test_case(tmp, script, ["bad"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["bad"])
         check(rc == 1 and "array-layer-dropped" in out, "a real mismatch exits 1 and is printed")
 
-        rc, out, err = _run_self_test_case(tmp, script, ["empty"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["empty"])
         check(rc == 2, "a capture with no shaders exits 2, not 0")
 
-        rc, out, err = _run_self_test_case(tmp, script, ["broken"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["broken"])
         check(rc == 2, "a capture gpu_replay could not inspect exits 2")
 
-        rc, out, err = _run_self_test_case(tmp, script, ["nodump"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["nodump"])
         check(rc == 2 and "zero examined" in err,
               "dumps that exit non-zero are NOT counted as examined")
 
-        rc, out, err = _run_self_test_case(tmp, script, ["emptyisa"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["emptyisa"])
         check(rc == 2, "a zero-byte ISA dump is NOT an examined shader (it exits 0, so only its "
                        "emptiness distinguishes it)")
 
         # The finding that made the old exit contract unsound: one good capture certifying a run.
-        rc, out, err = _run_self_test_case(tmp, script, ["good", "empty"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["good", "empty"])
         check(rc == 2, "one readable capture does NOT certify a barren one alongside it")
 
-        rc, out, err = _run_self_test_case(tmp, script, ["bad", "nodump"])
+        rc, out, err = _run_self_test_case(tmp, script, decoder, ["bad", "nodump"])
         check(rc == 2, "a barren capture outranks findings elsewhere (2 beats 1)")
 
         # Cross-capture contamination: `nodump` writes nothing, so it must contribute no findings
         # even when a previous capture in the SAME run wrote files under the same shader hashes.
-        _, alone, _ = _run_self_test_case(tmp, script, ["bad"])
+        _, alone, _ = _run_self_test_case(tmp, script, decoder, ["bad"])
         finding_lines = lambda out: [ln for ln in out.splitlines() if "guest " in ln]
         for bad_tag in ("nodump", "partial", "silentzero"):
-            _, pair, _ = _run_self_test_case(tmp, script, ["bad", bad_tag])
+            _, pair, _ = _run_self_test_case(tmp, script, decoder, ["bad", bad_tag])
             attributed = [ln for ln in finding_lines(pair) if ln.startswith(bad_tag)]
             check(len(finding_lines(pair)) == len(finding_lines(alone)) and not attributed,
                   f"'{bad_tag}' contributes no findings of its own")
@@ -586,9 +589,9 @@ def self_test():
         # version did not: `partial` writes a file and exits non-zero, so ONLY the return-code check
         # rejects it; `silentzero` exits 0 having written nothing, so ONLY the per-capture temp
         # directory stops it inheriting the previous capture's file under the same shader hash.
-        rc, _, err = _run_self_test_case(tmp, script, ["partial"])
+        rc, _, err = _run_self_test_case(tmp, script, decoder, ["partial"])
         check(rc == 2, "a dump that writes a file but exits non-zero is not an examined shader")
-        rc, _, err = _run_self_test_case(tmp, script, ["silentzero"])
+        rc, _, err = _run_self_test_case(tmp, script, decoder, ["silentzero"])
         check(rc == 2, "a dump that exits 0 having written nothing is not an examined shader")
 
     print("== self-test PASSED ==" if ok else "== self-test FAILED ==")
@@ -600,12 +603,17 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("captures", nargs="*")
     ap.add_argument("--gpu-replay", default="./build-linux/gpu_replay")
+    # The MIMG walk is prosper's own decoder, invoked out of process (#3184). There is deliberately
+    # no in-process fallback: a fallback would be the duplicate implementation this replaced, and an
+    # untested one, so a missing decoder must stop the scan rather than quietly downgrade it.
+    ap.add_argument("--mimg-decoder", default="./build-linux/shader_inspect",
+                    help="shader_inspect binary, which supplies the real RDNA2 MIMG walk")
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--self-test", action="store_true")
     a = ap.parse_args()
 
     if a.self_test:
-        return self_test()
+        return self_test(a.mimg_decoder)
     if not a.captures:
         ap.error("give at least one capture, or --self-test")
     if not os.environ.get("PROSPER_SPIRV_DIS") and not shutil.which("spirv-dis"):
@@ -615,6 +623,12 @@ def main():
     if not os.path.exists(a.gpu_replay):
         print(f"scan: no gpu_replay at {a.gpu_replay} (--gpu-replay to point elsewhere)", file=sys.stderr)
         return 2
+    if not os.path.exists(a.mimg_decoder):
+        print(f"scan: no shader_inspect at {a.mimg_decoder} -- that binary IS the ISA walk, so\n"
+              f"      without it this tool cannot find a single image instruction and a clean\n"
+              f"      result would be meaningless. Build it (--target shader_inspect), or point\n"
+              f"      --mimg-decoder at it.", file=sys.stderr)
+        return 2
 
     all_f, total_examined, total_skipped, failed, per_capture = [], 0, 0, [], []
     for cap in a.captures:
@@ -623,7 +637,7 @@ def main():
         # against bytes the tool never read.
         with tempfile.TemporaryDirectory() as tmp:
             try:
-                res, err = scan_capture(a.gpu_replay, cap, tmp)
+                res, err = scan_capture(a.gpu_replay, a.mimg_decoder, cap, tmp)
             except Exception as e:                       # noqa: BLE001 -- must not exit 1
                 res, err = None, f"{type(e).__name__}: {e}"
         if res is None:

--- a/prosper/tools/shader_histo/shader_histo.cpp
+++ b/prosper/tools/shader_histo/shader_histo.cpp
@@ -13,6 +13,7 @@
 #include "gpu/recompiler/rdna2_to_spirv.hpp"
 #include <cstdio>
 #include <cstring>
+#include <iterator>
 #include <map>
 #include <vector>
 
@@ -84,9 +85,20 @@ int main(int argc, char** argv) {
     }
     printf("shaders=%d  total_insts=%zu  distinct(fmt,op)=%zu  unknown=%zu\n", shaders, total, histo.size(), unknown);
     // Memory/interp/export formats show op=0x0 (their sub-opcodes are not decoded yet — format count only).
-    const char* fn[] = {"SOP2","SOP1","SOPK","SOPC","SOPP","SMEM","VOP2","VOP1","VOPC","VOP3",
-                        "VINTRP","DS","MUBUF","MTBUF","MIMG","FLAT","EXP","UNK"};
-    for (auto& [k, c] : histo) printf("  %-6s op=0x%-4x x%u\n", fn[k.first], k.second, c);
+    // One entry per Rdna2Format value, in enum order, INCLUDING the terminal Unknown. This table is
+    // indexed by a decoded format, so it must cover the enum exactly: it went one short when VOP3P
+    // was inserted before Unknown, which labelled every VOP3P instruction "UNK" and read one past
+    // the end for Unknown itself -- 4 of 55 local dumps segfaulted on it, and the rest printed
+    // whatever the out-of-bounds pointer landed on (#3229). The static_assert is the guard that
+    // makes the next enum addition a build failure instead of a garbage label, and `format_name`
+    // bounds every lookup so even a bypassed assert is a visible "?" rather than a crash.
+    static const char* const fn[] = {"SOP2","SOP1","SOPK","SOPC","SOPP","SMEM","VOP2","VOP1","VOPC",
+                                     "VOP3","VINTRP","DS","MUBUF","MTBUF","MIMG","FLAT","EXP",
+                                     "VOP3P","UNK"};
+    static_assert(std::size(fn) == (size_t)Rdna2Format::Unknown + 1,
+                  "shader_histo's format names must cover every Rdna2Format value");
+    auto format_name = [](int f) { return f < 0 || (size_t)f >= std::size(fn) ? "?" : fn[f]; };
+    for (auto& [k, c] : histo) printf("  %-6s op=0x%-4x x%u\n", format_name(k.first), k.second, c);
 
     // --- Recompiler coverage report (how much of the real shaders we can translate today) ---
     // Two numbers: the table-LESS floor (what this compute-shell/no-table pass exercises), and the
@@ -102,6 +114,6 @@ int main(int argc, char** argv) {
            shaders_full, shaders_full_ctx, shaders);
     printf("  top blockers (first TRULY-unsupported inst per shader -- table-dependent shapes excluded):\n");
     for (auto& [k, c] : blockers)
-        printf("    %-6s op=0x%-4x blocks %u shader(s)\n", k.first < 0 ? "?" : fn[k.first], k.second, c);
+        printf("    %-6s op=0x%-4x blocks %u shader(s)\n", format_name(k.first), k.second, c);
     return 0;
 }

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -77,6 +77,40 @@ control-flow shape may remain listed there even when the vertex/fragment structu
 `--stage vertex|fragment|compute` additionally runs the complete stage translator, which exposes contextual
 resource and structured-control-flow failures that per-instruction coverage cannot decide.
 
+## `--mimg-sites`: the MIMG census, for tools that must not carry their own decoder
+
+```bash
+./build-linux/shader_inspect exec_ps_7f123400.bin --mimg-sites
+mimg-site pc=0042 op=0x20 dim=5
+mimg-site pc=0061 op=0x00 dim=1
+mimg-sites-end dwords=903 consumed=903 instructions=781 sites=2 endpgm=1
+```
+
+One line per image instruction — its dword PC, its 8-bit opcode with the split MSB already
+reassembled, and its `DIM` — and nothing else: no coverage, no stage recompile, no resource-table
+reasoning. The default listing is untouched; this replaces it, and combining it with `--stage` is a
+usage error so the exit code stays unambiguous.
+
+**Why it exists.** `tools/shader_conformance/scan.py` needs to know where the image instructions are
+in a raw dump, and to do that it needs real instruction lengths — otherwise an operand or a trailing
+literal dword whose top six bits alias the MIMG encoding reads as an instruction. It used to carry
+its own Python port of `rdna2_decode_one`'s format and length dispatch for exactly that (#3040). The
+port was correct, and that was never the problem: a copy of a decoding rule is the one nobody
+updates when the decoder learns a new literal-forcing opcode or a wider NSA field, and it fails by
+silently returning a plausible instruction stream. This flag deletes the copy (#3184).
+
+`mimg-sites-end` is a **completion sentinel, not decoration**. A consumer must be able to tell "this
+shader contains no image instruction" — the answer that certifies a clean conformance scan — from
+"this process printed nothing because it died", and those two must never look alike. `scan.py`
+refuses any census that arrives without it, and cross-checks its `sites=` count against the number
+of `mimg-site` lines it parsed — so a line the consumer's parser stops matching is loud rather than
+a quietly smaller census.
+
+Exit is `0` whenever the file was read and walked; `2` for usage or I/O errors, including an empty
+input or one that is not a whole number of dwords. A stream that stops short of `s_endpgm` is
+reported as `endpgm=0` rather than as a failure — a census over a truncated dump is still an exact
+census of what could be decoded.
+
 ## `--stage` cannot prove a shader is unsupported (#1571)
 
 **`shader_inspect` has no resource table, and a table-less stage rejection is NOT evidence of a shader

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -77,14 +77,39 @@ bool needs_resource_table(Rdna2Format fmt, const std::string& stage) {
 } // namespace
 
 int main(int argc, char** argv) {
+    // Flags are parsed rather than positionally matched, so a mode can be added without the arity
+    // of the previous one becoming load-bearing. `--mimg-sites` is exclusive: it replaces the
+    // listing with a machine-readable census (see below), and combining it with a stage recompile
+    // would make its exit code ambiguous between "the census ran" and "the stage recompiled".
     std::string stage;
-    if (argc == 4 && std::strcmp(argv[2], "--stage") == 0) stage = argv[3];
-    if ((argc != 2 && argc != 4) ||
+    std::string input_path;
+    bool mimg_sites = false;
+    bool bad_usage = false;
+    for (int i = 1; i < argc && !bad_usage; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--stage") {
+            if (i + 1 >= argc) bad_usage = true;
+            else stage = argv[++i];
+        } else if (arg == "--mimg-sites") {
+            mimg_sites = true;
+        } else if (!arg.empty() && arg[0] == '-') {
+            bad_usage = true;
+        } else if (input_path.empty()) {
+            input_path = arg;
+        } else {
+            bad_usage = true;
+        }
+    }
+    if (input_path.empty() || bad_usage || (mimg_sites && !stage.empty()) ||
         (!stage.empty() && stage != "vertex" && stage != "fragment" && stage != "compute")) {
         std::fprintf(stderr, "usage: %s <raw-rdna2.bin> [--stage vertex|fragment|compute]\n", argv[0]);
+        std::fprintf(stderr, "       %s <raw-rdna2.bin> --mimg-sites\n", argv[0]);
         std::fprintf(stderr,
             "\n"
             "Decodes a raw RDNA2 shader dump. With --stage it also attempts a stage recompile.\n"
+            "--mimg-sites prints ONLY a machine-readable MIMG census (pc, opcode, dim) from the same\n"
+            "rdna2_walk, terminated by a `mimg-sites-end` line so a consumer can tell a real empty\n"
+            "census from a run that died before printing one.\n"
             "\n"
             "IMPORTANT: shader_inspect has NO resource table (a raw dump carries no descriptors), so\n"
             "the recompiler cannot lower MIMG/MUBUF/MTBUF -- nor SMEM in the vertex/fragment stages.\n"
@@ -97,9 +122,9 @@ int main(int argc, char** argv) {
         return 2;
     }
 
-    std::ifstream input(argv[1], std::ios::binary);
+    std::ifstream input(input_path.c_str(), std::ios::binary);
     if (!input) {
-        std::fprintf(stderr, "shader_inspect: cannot open %s\n", argv[1]);
+        std::fprintf(stderr, "shader_inspect: cannot open %s\n", input_path.c_str());
         return 2;
     }
     constexpr size_t kMaxBytes = 16u << 20;
@@ -116,7 +141,7 @@ int main(int argc, char** argv) {
     input.seekg(0, std::ios::beg);
     std::vector<uint8_t> bytes(static_cast<size_t>(input_size));
     if (!input.read(reinterpret_cast<char*>(bytes.data()), input_size)) {
-        std::fprintf(stderr, "shader_inspect: failed to read %s\n", argv[1]);
+        std::fprintf(stderr, "shader_inspect: failed to read %s\n", input_path.c_str());
         return 2;
     }
 
@@ -124,6 +149,38 @@ int main(int argc, char** argv) {
     std::memcpy(words.data(), bytes.data(), bytes.size());
     std::vector<Rdna2Inst> instructions;
     const size_t consumed = rdna2_walk(words.data(), words.size(), instructions);
+
+    // --mimg-sites: the MIMG census, and nothing else. This exists so a consumer never has to carry
+    // its own port of the RDNA2 length rules to find where the image instructions are. Before it,
+    // `tools/shader_conformance/scan.py` reimplemented `rdna2_decode_one`'s whole format/length
+    // dispatch in Python so it could tell an instruction boundary from an operand or literal dword
+    // that happens to alias the MIMG encoding -- a second implementation of a decoding rule, which
+    // is the thing that drifts (#3184; the same folder's `fn[]` name table drifted exactly this way,
+    // #3229). The fields come straight off the decoded instruction, so opcode's split MSB and the
+    // DIM position are stated in exactly one place in this repository.
+    //
+    // It deliberately walks and prints, nothing more: no coverage, no recompile, no resource-table
+    // reasoning. Everything a census consumer can be wrong about is then a property of rdna2_walk.
+    //
+    // `mimg-sites-end` is a completion sentinel, not decoration. Without it a consumer cannot
+    // distinguish "this shader contains no image instruction" -- the answer that certifies a clean
+    // conformance scan -- from "this process printed nothing because it died", and those two must
+    // never look alike. Exit is 0 whenever the stream was read and walked: a stream that stops
+    // short of s_endpgm is reported as `endpgm=0` rather than as a failure, because a census over
+    // a truncated dump is still an exact census of what could be decoded.
+    if (mimg_sites) {
+        const bool walk_ended = !instructions.empty() && instructions.back().is_end;
+        size_t sites = 0;
+        for (const Rdna2Inst& in : instructions) {
+            if (in.fmt != Rdna2Format::MIMG) continue;
+            ++sites;
+            std::printf("mimg-site pc=%u op=0x%x dim=%u\n", in.pc, in.opcode, in.mimg_dim);
+        }
+        std::printf("mimg-sites-end dwords=%zu consumed=%zu instructions=%zu sites=%zu endpgm=%d\n",
+                    words.size(), consumed, instructions.size(), sites, walk_ended ? 1 : 0);
+        return 0;
+    }
+
     std::vector<RecompileUnsupportedSite> unsupported_sites;
     const RecompileCoverage coverage =
         recompile_coverage(words.data(), words.size(), &unsupported_sites);


### PR DESCRIPTION
Fixes #3184
Fixes #3229
Refs #3040

## What was duplicated

`tools/shader_conformance/scan.py` needs to know where the MIMG instructions are in a raw RDNA2
dump, and to do that it needs real per-instruction lengths — otherwise an operand or a trailing
literal dword whose top six bits alias the MIMG encoding (`0b111100`) reads as an instruction start.
#3040 gave it that by **porting** `rdna2_decode_one`'s format and length dispatch into Python:
`rdna2_instr_len` + `_sop_has_literal` + `class Step`, ~90 lines covering the VOP src0 modifier and
literal rules, the six K-carrying VOP2 mul-adds, the SOP literal fields, `S_SETREG_IMM32_B32`, the
VOP3/VOP3P 9-bit literal markers, the two-dword bucket, and the MIMG NSA extra-dword count.

Every one of those is a rule that also lives in `src/gpu/recompiler/rdna2_decode.cpp`. #3040's own
body flagged the port as the weaker fix and named this one.

## Did the two implementations agree?

**Yes, everywhere, on the whole local corpus — and that is why the copy had to go rather than why it
could stay.**

Differential over every `.shader_text` section embedded in all 55 `PPSA*-app0` eboots in the local
dump library, extracted with `shader_histo`:

| | |
| --- | --- |
| eboots scanned | **55** (30 carry embedded shader ELFs) |
| shaders compared | **11,266** |
| MIMG sites decoded | **199,521** |
| `(pc, opcode, dim)` disagreements | **0** |
| decoder failures | **0** |

So no historical `scan.py` finding is invalidated by this change, and no recall is lost. The
argument for #3184 is the drift a copy *invites*: it is the thing nobody updates when the real
decoder changes, and it fails by silently returning a plausible instruction stream — which is the
exact failure mode this tool exists to make impossible.

**That is not a hypothetical.** While extracting the corpus, the same folder turned out to have
already drifted in the other direction: `shader_histo`'s hand-maintained `Rdna2Format` name table
went one entry short when `VOP3P` was inserted before `Unknown`, so VOP3P printed as `UNK` (29,776
instructions on PPSA21564 alone) and `Unknown` read one past the end of the array — **4 of the 55
local dumps segfault**. Filed as #3229 and fixed here in its own commit. Re-extracting the whole
corpus with the fixed binary afterwards: **55 of 55 eboots, 0 crashes**, and PPSA21564's 29,776
VOP3P instructions now carry their real name instead of `UNK`.

## Approach

`shader_inspect` gains `--mimg-sites`:

```text
$ shader_inspect exec_ps_7f123400.bin --mimg-sites
mimg-site pc=42 op=0x20 dim=5
mimg-site pc=61 op=0x0 dim=1
mimg-sites-end dwords=903 consumed=903 instructions=781 sites=2 endpgm=1
```

One line per image instruction, straight off `rdna2_walk`, and nothing else — no coverage, no stage
recompile, no resource-table reasoning. `scan.py` parses those lines; `rdna2_instr_len`, `Step`,
`_sop_has_literal`, `MIMG_ENCODING` and `S_ENDPGM` are deleted. `DIM_NAMES` / `DIM_ARRAYED` /
`DIM_3D` stay: they are the classifier's naming and grouping of a value the decoder hands over, and
they read no instruction word.

**Why `shader_inspect` and not `shader_histo`, which #3184 names.** `shader_histo`'s input is an
*eboot* — it scans a module for embedded shader ELFs. `scan.py` holds raw dumps written by
`gpu_replay`, which is precisely `shader_inspect`'s input, and `shader_inspect` already walks them
with `rdna2_walk` and already prints per-instruction `pc`/`fmt`/`opcode` rows. Adding a raw-stream
mode to `shader_histo` would have been a second input contract for the same job. The issue offers
"`shader_histo` (or `gpu_replay`)"; this is the same fix in the tool the folder layout points at.

**`mimg-sites-end` is a completion sentinel, not decoration.** "This shader has no image
instruction" is the answer that certifies a clean conformance scan, and it must never be
indistinguishable from "the decoder died before printing anything". The scanner refuses any census
that arrives without the sentinel, whatever the exit code said — and cross-checks the sentinel's own
`sites=` count against the number of `mimg-site` lines it parsed, which closes the same hole on the
*reading* side: a line the regex stops matching (a widened field, a renamed key) would otherwise be
dropped silently, and an under-count reads as a cleaner shader.

**There is deliberately no in-process fallback.** A fallback would be this same duplicate
implementation, now also untested; a missing `shader_inspect` stops the scan (exit 2) instead.

## Deliberately unaffected

* `shader_inspect`'s existing output, exit codes and `--stage` behaviour. `--mimg-sites` replaces the
  listing and refuses to combine with `--stage`, so no existing invocation changes shape.
  `shader_inspect_resource_table_honesty` passes untouched.
* `classify()`, `parse_spirv_images()`, the 0/1/2 exit contract, the per-capture temp-directory and
  return-code rules from #3039, and the barren-capture guard. Verified by output diff, below.
* `rdna2_decode.cpp` itself — not one line. This PR moves a consumer onto it.

## Behaviour change (one, intended)

A raw ISA dump that is empty or **not a whole number of dwords** is now counted as *not readable*,
with a stated reason, instead of being silently truncated to whole dwords and scanned. A partial
dword is a truncated dump, and a scanner that reports on one is reporting on bytes it does not have.
Zero-byte dumps were already skipped by an earlier guard, so in practice this only reaches a dump
whose size is not a multiple of 4.

## Risks

* **The self-test is no longer hermetic.** It needs the built `shader_inspect`, so ctest passes
  `--mimg-decoder $<TARGET_FILE:shader_inspect>` and the registration moved under
  `if(TARGET prosper_core)`. This is the point rather than a cost — the decode arms now exercise
  `rdna2_decode.cpp` — but a bare-checkout `python3 scan.py --self-test` now exits **2** (could not
  test) where it used to run. It never reports a pass it did not earn.
* **One subprocess per shader** is added to a scan that already spawns three.
* **The corpus contains no NSA MIMG.** Mutating the real decoder to ignore the NSA extra-dword count
  produced *zero* differential disagreements, which means that specific rule is not exercised by any
  of the 11,266 shaders. The `self_test` NSA arm is hand-built precisely because the corpus cannot
  supply one; the equivalence claim above is therefore about the rules the corpus does exercise, and
  the instrument control below establishes that it exercises them.

## Build / test / evidence

Built and tested in the `ps5ys` container, worktree-local build dir, at the exact pushed head.

```bash
PROSPER_GAME_ROOT=<DUMP_ROOT> cmake -S prosper -B prosper/build-linux   # rc 0
cmake --build prosper/build-linux -j6                                                # rc 0
cd prosper/build-linux && ctest --no-tests=error                                     # rc 0
```

`ctest`: **335 tests, 100% passed, exit 0** — identical count to the pre-change baseline on
`origin/main` (335, 100%, exit 0) measured in the same worktree.

Both affected tests confirmed **by name**, not by total:

```bash
ctest -N | grep -iE 'shader_conformance|shader_inspect'
#   Test  #36: shader_conformance_scan_logic
#   Test #231: shader_inspect_resource_table_honesty
ctest --no-tests=error -R 'shader_conformance_scan_logic|shader_inspect_resource_table_honesty'
# 100% tests passed out of 2, exit 0
```

`scan.py --self-test` reports **37 arms, all ok**, including five new ones: a zero-byte dump and a
half-dword dump are refused rather than decoded as "no MIMG", and a stub decoder that exits 0 having
printed nothing, prints sites without the sentinel, or prints a sentinel whose `sites=` count
disagrees with the lines it printed, is refused rather than read as a census.

### Output equivalence, before and after

**1. ISA walk, real input.** Pre-change `scan.py:decode_mimg_sites` vs `--mimg-sites`, `(pc, opcode,
dim)` compared elementwise over 11,266 shaders / 199,521 sites from all 55 local dumps: **0
disagreements, 0 decoder failures**. The harness imports the *pre-change file* rather than a retyped
copy of it.

**2. Whole scanner, end to end.** Both scanners driven over 14 combinations of the self-test stub's
capture shapes (`good`, `bad`, `empty`, `broken`, `nodump`, `emptyisa`, `partial`, `silentzero`, and
mixtures), comparing the complete `--json` report and the process exit code, with only per-run temp
paths normalised: **14 identical, 0 differing.**

### Mutation arms (with build exit codes)

| # | Mutation | Expected | Observed |
| --- | --- | --- | --- |
| A1 | `rdna2_decode.cpp`: MIMG length `2 + extra` → `2` (build rc **0**) | `shader_conformance_scan_logic` red | **ctest exit 8**, failing arm named: *"NSA's extra dwords … are skipped …"* |
| A2 | same mutated decoder, **pre-change** `scan.py --self-test` | shows the old suite was blind | **exit 0, `== self-test PASSED ==`** |
| B | `rdna2_decode.cpp`: MIMG length `2 + extra` → `3 + extra` (build rc **0**) | differential detects it | **5,680 of 11,266 shaders disagree, across 29 titles** |
| C | `shader_histo.cpp`: name table back to 18 entries | build fails | **`cmake --build` exit 2**, `static_assert` at `shader_histo.cpp:97` |
| D | `scan.py`: disable the sentinel/line-count cross-check | new arm red | **`--self-test` exit 1**, `[FAIL] a census whose sentinel count disagrees with its lines …` |

A1 + A2 together are the load-bearing pair: a change to the *real* decoder now reddens the
conformance suite, and could not before — the arms tested the Python copy, which is exactly how a
copy drifts unnoticed.

B is the domain control for the clean zero in the equivalence table. A same-source positive control
would only have shown the harness runs; this shows the corpus can *express* a length divergence, so
the 0 is a real null rather than a blind instrument. (It also explains why the more realistic drift
mutations — dropping the NSA count, dropping two VOP2 K-literal opcodes — showed 0: those rules
happen not to be exercised by this corpus. Stated in Risks above rather than hidden.)

### Docs gate

```bash
python3 prosper/tools/docs/check_numbered_table.py --ordered --table-header Instrument \
    --baseline <origin/main copy> prosper/docs/GAME_COMPAT_ORCHESTRATION.md   # rc 0
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py  # rc 0
```

`git diff --check` clean.

## Recorded

`tools/shader_conformance/AGENTS.md` gains a **`## Ruled out`** section carrying both falsified
hypotheses with their evidence — "the port has already drifted" and "deleting the port costs
recall" — plus the rewritten walk description and the self-test's new dependency.
`tools/shader_inspect/README.md` documents `--mimg-sites` and why the sentinel exists. `BLOG.md` has
an entry for the `shader_histo` finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB