### PR TITLE
wt_stash: fix the hook installer on Windows/MSYS and make it prove git honours the hook

### DIFF
--- a/prosper/tools/test_wt_stash.py
+++ b/prosper/tools/test_wt_stash.py
@@ -353,6 +353,19 @@ def arm_hook():
         hook = Path(main) / '.git' / 'hooks' / 'reference-transaction'
         check('hook landed in the common dir', hook.exists(), True, str(hook))
         check('and is executable', os.access(hook, os.X_OK), True)
+        # The installer proves git honours the hook rather than trusting its own write, and says
+        # so. Assert the claim is present: an installer that reports success on the strength of a
+        # successful `write()` is what shipped a silently-absent guard to Windows in the first
+        # place.
+        check('install verified itself against git', 'verified: git refused' in out, True, out)
+        check('the sentinel it wrote was cleaned up', rev(main, 'refs/stash'), None)
+        # LF endings, asserted on the BYTES. Text-mode writing translates '\n' to os.linesep, so
+        # on Windows the hook lands with CRLF and the shell running it sees a stray CR inside every
+        # token -- present, unrunnable, silent. This arm is the one that catches that directly, and
+        # it is checkable from every platform rather than only from the one that breaks.
+        raw = hook.read_bytes()
+        check('hook is written with LF endings only', b'\r\n' in raw, False)
+        check('and ends in an explicit refusal', raw.rstrip().endswith(b'exit 1'), True)
 
         write(a / 'shared.txt', 'LANE-A\n')
         rc, out, err = git_rc(a, 'stash', 'push', '-m', 'blocked')

--- a/prosper/tools/wt_stash.py
+++ b/prosper/tools/wt_stash.py
@@ -361,19 +361,65 @@ def cmd_check(args):
 
 
 def _hook_path():
+    """Where git looks for this repository's reference-transaction hook, as PYTHON spells it.
+
+    Asking git for an absolute path is the obvious way and it is wrong wherever git and the
+    interpreter disagree about path spelling -- an MSYS git under native Windows python answers
+    `/tmp/...`, which python then resolves against the current drive. The install lands somewhere
+    real, git never looks there, and the guard is silently absent. Measured on this project's
+    Windows MinGW CI, where install-hook returned 0 and `git stash` went on working. A RELATIVE
+    answer has no root spelling to disagree about and survives the crossing; the absolute form
+    stays as a fallback, and a candidate that is not a directory here is a refusal rather than a
+    guess -- a hook installer that cannot prove where it wrote is worse than none.
+    """
     configured = git('config', '--default', '', '--get', 'core.hooksPath').strip()
     if configured:
         raise Fail('core.hooksPath is set to {!r}; this installer only manages the default '
                    'hooks directory. Install the hook there by hand, or unset the config.'
                    .format(configured))
-    common = git('rev-parse', '--path-format=absolute', '--git-common-dir').strip()
-    return os.path.join(common, 'hooks', 'reference-transaction')
+    tried = []
+    for fmt in ('relative', 'absolute'):
+        rc, out, _ = git_rc('rev-parse', '--path-format=' + fmt, '--git-common-dir')
+        if rc != 0 or not out.strip():
+            continue
+        cand = os.path.abspath(os.path.join(os.getcwd(), out.strip()))
+        tried.append(cand)
+        if os.path.isdir(cand):
+            return os.path.join(cand, 'hooks', 'reference-transaction')
+    raise Fail('could not locate this repository\'s common git directory as this interpreter '
+               'spells it; git offered {} and none of it exists here. Install the hook by hand.'
+               .format(', '.join(repr(t) for t in tried) or '(nothing)'))
+
+
+def _hook_is_live():
+    """Did git actually run the hook we just wrote? True / False / None when it cannot be asked.
+
+    An installer that reports success on the strength of its own `write()` is the shape this
+    project keeps a list about: it reads as coverage and cannot fail. So prove it instead, by
+    asking git to do the one thing the hook exists to refuse -- a sentinel write to `refs/stash`.
+
+    Skipped, rather than forced, when `refs/stash` already holds something: that entry is somebody's
+    work, and racing it to test a guard against losing work would be its own answer. The cleanup
+    passes the sentinel as the expected old value, so it can only ever delete the ref this function
+    created.
+    """
+    if resolve('refs/stash') is not None:
+        return None
+    rc, head, _ = git_rc('rev-parse', '--verify', '--quiet', 'HEAD')
+    sentinel = head.strip()
+    if rc != 0 or not sentinel:
+        return None
+    rc, _, _ = git_rc('update-ref', 'refs/stash', sentinel)
+    if rc != 0:
+        return True
+    git_rc('update-ref', '-d', 'refs/stash', sentinel)
+    return False
 
 
 def cmd_install_hook(args):
     path = _hook_path()
     if os.path.exists(path):
-        with open(path, 'r', encoding='utf-8', errors='replace') as fh:
+        with open(path, 'r', encoding='utf-8', errors='replace', newline='') as fh:
             existing = fh.read()
         if HOOK_MARKER in existing:
             print('already installed: {}'.format(path))
@@ -382,10 +428,26 @@ def cmd_install_hook(args):
             raise Fail('a different reference-transaction hook already exists at {}\n'
                        '  refusing to overwrite it; merge by hand or pass --force'.format(path))
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, 'w', encoding='utf-8') as fh:
+    # newline='' -- text mode otherwise translates every '\n' to os.linesep, so on Windows the
+    # hook lands with CRLF endings and the shell running it sees a stray CR inside every token
+    # ('then\r' is not 'then'). The guard would then be present, unrunnable, and silent.
+    with open(path, 'w', encoding='utf-8', newline='') as fh:
         fh.write(HOOK_BODY)
     os.chmod(path, 0o755)
+
+    live = _hook_is_live()
+    if live is False:
+        os.remove(path)
+        raise Fail('wrote {} but git did not honour it -- a sentinel refs/stash write went '
+                   'through anyway. The hook has been removed again rather than left there '
+                   'reading as protection. Park changes with `wt_stash.py push` instead.'
+                   .format(path))
     print('installed {}'.format(path))
+    if live is None:
+        print('  NOT verified: refs/stash is already occupied (or HEAD is unborn), so the')
+        print('  sentinel check was skipped rather than raced against somebody else\'s entry.')
+    else:
+        print('  verified: git refused a sentinel refs/stash write through this hook.')
     print('  `git stash` now fails repo-wide, for every worktree AND for interactive use.')
     print('  Bypass once: git -c core.hooksPath=/dev/null stash ...')
     return 0
@@ -396,7 +458,7 @@ def cmd_uninstall_hook(args):
     if not os.path.exists(path):
         print('not installed: {}'.format(path))
         return 0
-    with open(path, 'r', encoding='utf-8', errors='replace') as fh:
+    with open(path, 'r', encoding='utf-8', errors='replace', newline='') as fh:
         existing = fh.read()
     if HOOK_MARKER not in existing:
         raise Fail('{} was not written by wt_stash; refusing to remove it'.format(path))


### PR DESCRIPTION
`main` is red on **Windows MinGW** (`wt_stash_tool`) after #3234 merged. This fixes it. Refs #3174.

## What actually failed

The job log leads with a `pop` failure, and that is a knock-on rather than the defect:

```
FAIL hook landed in the common dir: got False, want True (...\main-checkout\.git\hooks\reference-transaction)
FAIL git stash is refused: got False, want True (Saved working directory and index state ...)
FAIL refs/stash was not created: got 0, want 1
  ok  wt_stash push works with the hook installed
FAIL wt_stash pop works with the hook installed: got 2, want 0 (wt_stash: no such slot: 'default')
```

`install-hook` reported success while writing the file somewhere git never looks. With the guard
absent, `git stash push` really did stash, so the working tree was clean, so `wt_stash push`
correctly reported *"nothing to park"* and created no ref -- and `pop` then had nothing to find.
Every failing line follows from the one cause.

## Three changes

1. **`_hook_path` asked git for an absolute path.** An MSYS git under native Windows python answers
   `--path-format=absolute --git-common-dir` with an MSYS path (`/tmp/...`), which python then
   resolves against the current drive. A **relative** answer has no root spelling for the two to
   disagree about and survives the crossing; the absolute form stays as a fallback, and a candidate
   that is not a directory from python's own view is now a refusal naming what git offered, never a
   guess.

2. **The hook was written through text mode**, which translates every `\n` to `os.linesep` -- so on
   Windows it lands with CRLF and the shell running it sees a stray CR inside every token (`then\r`
   is not `then`): present, unrunnable, and silent. Written with `newline=''` now, and asserted on
   the **bytes**, which makes the arm catchable from every platform rather than only from the one
   that breaks.

3. **The class fix: `install-hook` now proves git honours the hook** instead of reporting success on
   the strength of its own `write()`. It asks git to do the one thing the hook exists to refuse -- a
   sentinel write to `refs/stash` -- and if that goes through it **removes the hook again and
   fails**, rather than leaving a file that reads as protection. The check is skipped rather than
   forced when `refs/stash` is already occupied, because racing somebody's entry to test a guard
   against losing work would be its own answer; the cleanup passes the sentinel as the expected old
   value, so it can only ever delete the ref it created.

## Two hypotheses checked and found clean

Recorded rather than changed, since both were raised and both are worth having settled:

* **The hook body does end in an explicit `exit 1`** after its stderr block, so it does not fall off
  the end with the status of the last `echo`. A new arm asserts that on the bytes.
* **The hook cannot abort `wt_stash`'s own ref writes.** It exits 0 for every ref that is not
  `refs/stash`, and the suite asserts an ordinary commit, a branch creation, and `wt_stash push`/
  `pop` all still work with it installed. (That blast-radius arm predates this PR and reddens under
  a mutation that widens the hook to every ref.)
* **CRLF on the hook's stdin** is not a factor -- git writes LF there. The CRLF problem was in the
  hook **file**, which is change 2.

## Verification

```
python3 prosper/tools/test_wt_stash.py     101 assertions, rc=0
ctest --no-tests=error                     100% tests passed out of 337   rc=0
ctest --no-tests=error -R wt_stash_tool    9/337 wt_stash_tool Passed 1.65s
git diff --check                           rc=0
```

Mutation arms re-run against the unmodified suite. The interesting change is that three mutations
that used to reach the behavioural assertions now fail at **install time** instead -- which is the
installer's self-verification doing its job:

| mutation | caught by |
| --- | --- |
| hook written with platform newlines (CRLF) | `hook is written with LF endings only` |
| installer trusts its own write, no verification | `install verified itself against git` |
| hook installed where git never looks (the Windows bug) | `install exit: got 2` -- *"wrote ... but git did not honour it"* |
| hook guard deleted (always allows) | `install exit: got 2` (previously only `git stash is refused`) |
| hook body's final `exit 1` becomes `exit 0` | `install exit: got 2` |
| `push` writes the shared `refs/stash` | `lane A parked into the per-worktree namespace` |
| `push` overwrites an occupied slot | `second push into the same slot is refused` |
| `check` always fires | `own entry alone does not fire` |

Unchanged and deliberately untouched: the positive control that reproduces the original #3174
collision with two linked worktrees and plain `git stash`, and every arm covering the core
`refs/worktree` parking. Only the hook path, its byte-level encoding, and the installer's honesty
changed.

## If Windows MinGW is still red

Then the honest reading is that a `reference-transaction` hook is not reliable on the MSYS route,
and the follow-up is to gate the **hook-installed arms only** to non-Windows with that stated
plainly, plus an issue for the real behaviour -- the hook is opt-in and off by default, so that is a
legitimate outcome. The parking arms and the positive control would stay enabled everywhere
regardless. With change 3 in place a Windows user gets the truth at run time either way: the
installer now refuses rather than reporting a guard it did not establish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
