### PR TITLE
render backend: the persistent-resource caches are one domain with one owner (#2953)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2694,6 +2694,20 @@ if(TARGET prosper_core)
       set_tests_properties(gds_scan_memo_disabled PROPERTIES
                            ENVIRONMENT "PROSPER_NO_GDS_SCAN_MEMO=1")
 
+      # The backend's persistent-resource domain lock (#2953). Carries its own positive control --
+      # an unguarded arm that proves the overlap detector fires at all -- so a clean zero in the
+      # guarded arms cannot be read as "the threads never overlapped".
+      add_executable(test_backend_persistent_resource_lock
+                     tests/render/test_backend_persistent_resource_lock.cpp)
+      # Includes a shared fixture, which resolves from the `tests` root.
+      target_include_directories(test_backend_persistent_resource_lock PRIVATE tests)
+      # Reaches `shared/...` through render_runner.h, which resolves from `frontends`.
+      target_include_directories(test_backend_persistent_resource_lock PRIVATE frontends)
+      target_link_libraries(test_backend_persistent_resource_lock
+                            PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME backend_persistent_resource_lock
+               COMMAND test_backend_persistent_resource_lock)
+
       # The address-watch matcher's edge cases (exclusive end, empty range, UINT64_MAX wrap).
       add_executable(test_compute_address_watch tests/gpu/test_compute_address_watch.cpp)
       target_link_libraries(test_compute_address_watch PRIVATE prosper_core Vulkan::Vulkan)

--- a/prosper/docs/METAPHOR_STATUS.md
+++ b/prosper/docs/METAPHOR_STATUS.md
@@ -288,6 +288,17 @@ One line per hypothesis this work killed, so nobody re-derives it at full cost.
   appeared to falsify the fix under that lever was executed against a **stale `screenshot` binary**
   — only the `boot_trace` target had been rebuilt. Recorded because the arm looked like a clean
   negative and was not; rebuild every frontend, not the one you are about to run.
+- **The `job_render_0` crash inside `persistent_texture_images.find()` cannot have come from two
+  concurrent `sceAgcDriverSubmitDcb` folds — that path is already serialised, and had been since
+  #278.** Both AGC submit entry points (`agc_driver_submit_dcb` and `submit_dcb_stream`, i.e.
+  `SubmitDcb`/`SubmitDcbFinal`/`SubmitAcb`) take `g_agc_state_mu` before folding and hold it across
+  `execute_submit_work`, which is what invokes the render backend; the 2 ms deferred-flush watchdog
+  thread takes the same mutex. So a second thread reaching the backend's persistent caches has to
+  arrive by some other route, and looking for one *between two submits* is a dead end. The lock
+  added in #2953 is not a duplicate of that one: it lives in `render_runner.h`, which `gpu_replay`,
+  `boot_trace` and every Vulkan test compile **without linking the HLE at all**, so on those
+  frontends nothing was serialising the domain. What remains open is which route the observed
+  thread took; `backend_persistent_resource_peak_in_flight()` now answers that on any run. #2953.
 
 ## Instruments this work added
 

--- a/prosper/tests/fixtures/AGENTS.md
+++ b/prosper/tests/fixtures/AGENTS.md
@@ -29,6 +29,16 @@ Two consequences for anything you change in it:
   false trigger would cost.
 - **It cannot depend on the app** — no capture singleton, no frontend state — because it is also
   compiled into Vulkan tests that link none of that.
+- **It cannot depend on the HLE's locks either, and that one is easy to miss** (#2953). The live
+  route reaches this backend only under `g_agc_state_mu` (`src/hle/graphics/hle_agc.cpp`, #278), so
+  reading the live path alone makes the persistent caches look safely single-threaded. `gpu_replay`,
+  `boot_trace` and every Vulkan test compile this header and link no HLE, so on them that invariant
+  simply does not exist. Process-lifetime state declared here carries its own synchronisation:
+  `render_draw_pass_rgba` holds `BackendPersistentResourceGuard` for its whole body, which covers
+  every `static` that function owns. It does **not** cover the colour-target and depth/stencil
+  caches' other entry points (`invalidate_persistent_color_target*`,
+  `readback_persistent_color_target`, `snapshot_persistent_ds_images`, and the frontend's direct
+  iteration of both), so do not add a new one without reading #3240.
 
 ## Adding to it
 

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -739,7 +739,7 @@ struct PersistentPipeline {
 // static that function owns. It does NOT cover the colour-target and depth/stencil caches' OTHER
 // entry points -- `invalidate_persistent_color_target*`, `readback_persistent_color_target`,
 // `snapshot_persistent_ds_images` and the frontend's direct iteration of both caches -- which are
-// reachable without this lock and are tracked separately. Nor is the multi-segment loop in
+// reachable without this lock and are tracked in #3240. Nor is the multi-segment loop in
 // `render_draws_rgba` atomic: the guard is released between segments, which is the same granularity
 // two consecutive submits already have.
 //

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -564,8 +564,14 @@ struct BackendTextureUploadStats {
     uint64_t persistent_cached_bytes = 0;
 };
 
+// thread_local like every other per-call stats storage in this file (#2953). It was the one
+// exception: a plain static written inside `render_draw_pass_rgba` and read by the caller after the
+// call returns, so a second rendering thread could clobber it between the write and the read -- a
+// data race on a non-atomic object, and silently wrong numbers even where it did not tear. Every
+// reader in the tree reads it on the thread that just rendered, so per-thread storage is what the
+// contract already was.
 inline BackendTextureUploadStats& backend_texture_upload_stats_storage() {
-    static BackendTextureUploadStats stats;
+    static thread_local BackendTextureUploadStats stats;
     return stats;
 }
 
@@ -698,6 +704,115 @@ struct PersistentPipelineKeyHash {
 struct PersistentPipeline {
     VkPipeline pipeline = VK_NULL_HANDLE;
     uint64_t last_use = 0;
+};
+
+// --- The backend's persistent-resource domain lock (#2953) --------------------------------------
+//
+// The process-lifetime caches this backend owns -- the persistent pipeline, pipeline-layout,
+// colour-target, depth/stencil and texture caches, their byte totals and their generation counters
+// -- are ONE domain with ONE owner at a time, and `render_draw_pass_rgba` is the critical section.
+// There is no finer granularity that would be honest: that function looks an entry up, keeps the
+// iterator or the reference across dozens of Vulkan calls, mutates through it, evicts through it,
+// and updates a byte total by read-modify-write. A per-container lock taken and released around
+// each individual access would describe none of that while reading as if it did.
+//
+// WHY IT EXISTS. #2953 recorded a host SIGSEGV on a guest job thread inside
+// `persistent_texture_images.find()` -- libstdc++'s `_M_equals`, reached through
+// `_M_find_before_node`, dereferencing a null node. A `find()` racing another thread's rehash reads
+// torn bucket pointers, which is that crash shape; #278 already fixed the same shape once, one
+// layer up, on the folded GpuState.
+//
+// WHY IT IS NOT SOMEBODY ELSE'S JOB. On the live route this backend is reached only from
+// `agc_driver_submit_dcb` / `submit_dcb_stream`, which hold `g_agc_state_mu` (#278), so that route
+// is already serialised -- by an invariant that lives in `src/hle/graphics/hle_agc.cpp`, a
+// different layer, in a library this header is not compiled against. `gpu_replay`, `boot_trace` and
+// every Vulkan test include `render_runner.h` and link no HLE at all. Nothing here stated the
+// invariant, nothing enforced it, and nothing could detect its violation. State that owns
+// process-lifetime Vulkan objects carries its own contract.
+//
+// COST. One uncontended mutex acquire/release plus four relaxed atomics per `render_draw_pass_rgba`
+// call. That is a per-SUBMIT cost, not a per-draw one, against a call that records a command
+// buffer, submits it and waits on a fence -- tens of nanoseconds against tens of microseconds at
+// the very least. On the live route it is uncontended by construction, for the reason above.
+//
+// SCOPE. The guard makes `render_draw_pass_rgba` mutually exclusive with itself, which covers every
+// static that function owns. It does NOT cover the colour-target and depth/stencil caches' OTHER
+// entry points -- `invalidate_persistent_color_target*`, `readback_persistent_color_target`,
+// `snapshot_persistent_ds_images` and the frontend's direct iteration of both caches -- which are
+// reachable without this lock and are tracked separately. Nor is the multi-segment loop in
+// `render_draws_rgba` atomic: the guard is released between segments, which is the same granularity
+// two consecutive submits already have.
+//
+// IT MEASURES ITS OWN PREMISE. `in_flight` is incremented BEFORE the mutex acquire, so a blocked
+// thread is counted: `backend_persistent_resource_peak_in_flight()` reports how many threads have
+// ever wanted this domain at once, which is precisely the question #2953 left open and could not
+// settle by reading code. A run ending at 1 has shown the single-thread assumption held for that
+// run; above 1 has shown it false, and says so once on stderr.
+// `backend_persistent_resource_overlaps()` counts threads observed inside the critical section
+// simultaneously -- always 0 while this guard is taken, and non-zero the moment it is not, which is
+// what the regression test asserts on.
+inline std::mutex& backend_persistent_resource_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+inline std::atomic<int>& backend_persistent_resource_in_flight() {
+    static std::atomic<int> in_flight{0};
+    return in_flight;
+}
+
+inline std::atomic<int>& backend_persistent_resource_peak_in_flight() {
+    static std::atomic<int> peak{0};
+    return peak;
+}
+
+inline std::atomic<int>& backend_persistent_resource_depth() {
+    static std::atomic<int> depth{0};
+    return depth;
+}
+
+inline std::atomic<uint64_t>& backend_persistent_resource_overlaps() {
+    static std::atomic<uint64_t> overlaps{0};
+    return overlaps;
+}
+
+// One line, once per process, the first time two threads want this domain at once. Deliberately not
+// behind an environment variable: it is the discovery that a design assumption is false, and the run
+// that most needs to report it is the one nobody thought to arm a diagnostic for.
+inline void backend_report_persistent_resource_contention(int in_flight) {
+    static std::atomic<bool> reported{false};
+    bool expected = false;
+    if (!reported.compare_exchange_strong(expected, true)) return;
+    std::fprintf(stderr,
+                 "[render] %d threads are inside the backend's persistent-resource domain at once; "
+                 "they are being serialised by its own lock (#2953)\n",
+                 in_flight);
+}
+
+class BackendPersistentResourceGuard {
+public:
+    BackendPersistentResourceGuard() {
+        const int in_flight =
+            backend_persistent_resource_in_flight().fetch_add(1, std::memory_order_acq_rel) + 1;
+        int peak = backend_persistent_resource_peak_in_flight().load(std::memory_order_relaxed);
+        while (peak < in_flight &&
+               !backend_persistent_resource_peak_in_flight().compare_exchange_weak(
+                   peak, in_flight, std::memory_order_relaxed)) {
+        }
+        if (in_flight > 1) backend_report_persistent_resource_contention(in_flight);
+        backend_persistent_resource_mutex().lock();
+        if (backend_persistent_resource_depth().fetch_add(1, std::memory_order_acq_rel) != 0)
+            backend_persistent_resource_overlaps().fetch_add(1, std::memory_order_relaxed);
+    }
+
+    ~BackendPersistentResourceGuard() {
+        backend_persistent_resource_depth().fetch_sub(1, std::memory_order_acq_rel);
+        backend_persistent_resource_mutex().unlock();
+        backend_persistent_resource_in_flight().fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    BackendPersistentResourceGuard(const BackendPersistentResourceGuard&) = delete;
+    BackendPersistentResourceGuard& operator=(const BackendPersistentResourceGuard&) = delete;
 };
 
 inline std::unordered_map<PersistentPipelineKey, PersistentPipeline, PersistentPipelineKeyHash>&
@@ -4749,6 +4864,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         draws = std::span<const BackendDraw>(proven_storage);
     }
     if (backend_has_unproven_submission()) return out;
+    // #2953. Everything from here on reads and writes the backend's persistent-resource domain --
+    // the pipeline, pipeline-layout, colour-target, depth/stencil and texture caches, their byte
+    // totals and their generation counters. Taken BEFORE `direct_submission` is constructed, so the
+    // batch destructor (which submits, and whose failure cleanups touch the texture cache) still
+    // runs inside the critical section; a guard declared after it would be destroyed first and
+    // leave exactly those accesses outside. See the block comment on the guard for why the lock
+    // lives here rather than being inherited from `g_agc_state_mu`.
+    const BackendPersistentResourceGuard persistent_resource_guard;
     const RenderVkCtx& ctx = render_vk_ctx();
     if (!ctx.ok) return out;
     BackendSubmissionBatch direct_submission;

--- a/prosper/tests/render/test_backend_persistent_resource_lock.cpp
+++ b/prosper/tests/render/test_backend_persistent_resource_lock.cpp
@@ -1,0 +1,234 @@
+// The backend's persistent-resource domain lock (#2953).
+//
+// THE DEFECT. `render_draw_pass_rgba` owns a set of process-lifetime `static` containers -- the
+// persistent pipeline, pipeline-layout, colour-target, depth/stencil and texture caches, their byte
+// totals and their generation counters -- and reached every one of them with no synchronisation.
+// #2953 recorded a host SIGSEGV on a guest job thread inside `persistent_texture_images.find()`,
+// in libstdc++'s `_M_equals` reached through `_M_find_before_node` with a null node: the shape a
+// `find()` takes when it races another thread's rehash.
+//
+// WHAT THESE ARMS PROVE, AND IN WHICH ORDER.
+//
+//   Arm 1 is the POSITIVE CONTROL, and it runs first on purpose. It drives the same threads through
+//   the same shape with NO guard and asserts the detector fires. Without it, arms 2 and 3 are
+//   unfalsifiable: a clean zero would be equally well explained by "the guard works" and by "these
+//   threads never actually overlapped", and the second explanation is the one a passing test would
+//   quietly adopt. It is built by hand out of atomics rather than by removing the guard from the
+//   production path, so it observes no undefined behaviour of its own.
+//
+//   Arm 2 asserts the guard's contract directly: N threads, a shared `std::unordered_map` mutated
+//   under the guard, no observed overlap, and the map intact afterwards.
+//
+//   Arm 3 is the one that binds the PRODUCTION path. N threads call `render_triangle_rgba`
+//   concurrently, each with a persistent-texture resource so the exact `find()` from the crash
+//   report is on every thread's route. It asserts (a) the domain really was contended --
+//   `peak_in_flight >= 2`, so the arm cannot pass vacuously -- and (b) zero overlaps, which is only
+//   possible if `render_draw_pass_rgba` takes the guard. Remove the guard from that function and
+//   this arm reddens.
+//
+// HONESTY ABOUT DETERMINISM. Arms 1 and 3 depend on threads genuinely running at the same time, so
+// they are probabilistic in principle. Two things make them reliable in practice, and one makes
+// them safe when they are not. `in_flight` is incremented BEFORE the mutex acquire, so a thread
+// blocked on the guard still counts -- with a rendezvous before the call and a critical section
+// that records and submits a command buffer, every waiting thread is observed. And the
+// `peak_in_flight >= 2` assertion is what turns "the threads did not overlap" from a silent pass
+// into a visible failure: this test cannot report success on a run that never exercised the case.
+// What would make it fully deterministic is a scheduling hook inside the critical section, which
+// would mean shipping a test-only seam through the live render path; the in-flight assertion buys
+// the same protection without one.
+
+#include "fixtures/render_runner.h"
+#include "fixtures/spirv_triangle.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+static int failures = 0;
+static void check(bool ok, const char* what) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++failures; }
+    else std::fprintf(stderr, "ok: %s\n", what);
+}
+
+namespace {
+
+constexpr int kThreads = 4;
+constexpr int kIterations = 64;
+
+// Release every thread at once, so the window in which they can overlap is as wide as the work
+// itself rather than as narrow as the thread-creation loop.
+class Rendezvous {
+public:
+    explicit Rendezvous(int expected) : expected_(expected) {}
+    void arrive_and_wait() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (++arrived_ >= expected_) { open_ = true; cv_.notify_all(); return; }
+        cv_.wait(lock, [this] { return open_; });
+    }
+private:
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    int expected_;
+    int arrived_ = 0;
+    bool open_ = false;
+};
+
+// The same depth/overlap detector the production guard uses, over storage this test owns. Arm 1
+// runs it WITHOUT a lock to show it can report an overlap at all.
+struct OverlapDetector {
+    std::atomic<int> depth{0};
+    std::atomic<int> peak{0};
+    std::atomic<uint64_t> overlaps{0};
+
+    void enter() {
+        const int now = depth.fetch_add(1, std::memory_order_acq_rel) + 1;
+        int seen = peak.load(std::memory_order_relaxed);
+        while (seen < now && !peak.compare_exchange_weak(seen, now, std::memory_order_relaxed)) {}
+        if (now > 1) overlaps.fetch_add(1, std::memory_order_relaxed);
+    }
+    void leave() { depth.fetch_sub(1, std::memory_order_acq_rel); }
+};
+
+}  // namespace
+
+int main() {
+    // ---- 1. POSITIVE CONTROL: the detector reports an overlap when nothing excludes ------------
+    // Built by hand out of atomics, outside the production guard, so this cannot inherit whatever
+    // the guard does. A zero here would mean the following two arms are measuring nothing.
+    {
+        OverlapDetector unguarded;
+        Rendezvous gate(kThreads);
+        std::vector<std::thread> threads;
+        for (int t = 0; t < kThreads; ++t)
+            threads.emplace_back([&] {
+                gate.arrive_and_wait();
+                for (int i = 0; i < kIterations; ++i) {
+                    unguarded.enter();
+                    std::this_thread::sleep_for(std::chrono::microseconds(50));
+                    unguarded.leave();
+                }
+            });
+        for (auto& thread : threads) thread.join();
+        check(unguarded.peak.load() >= 2,
+              "control: unguarded threads are inside the section together");
+        check(unguarded.overlaps.load() > 0,
+              "control: the overlap detector reports a non-zero count when nothing excludes");
+    }
+
+    // ---- 2. The guard excludes, and a shared map survives the same contention -------------------
+    // The map operation is the one from the crash report: repeated find() against another thread's
+    // insertions, which is what rehashes under a lock-free reader.
+    {
+        const uint64_t overlaps_before = prosper::test::backend_persistent_resource_overlaps().load();
+        prosper::test::backend_persistent_resource_peak_in_flight().store(0);
+
+        std::unordered_map<uint64_t, uint64_t> shared;
+        std::atomic<uint64_t> found{0};
+        Rendezvous gate(kThreads);
+        std::vector<std::thread> threads;
+        for (int t = 0; t < kThreads; ++t)
+            threads.emplace_back([&, t] {
+                gate.arrive_and_wait();
+                for (int i = 0; i < kIterations; ++i) {
+                    const prosper::test::BackendPersistentResourceGuard guard;
+                    const uint64_t key = static_cast<uint64_t>(t) * kIterations + i;
+                    shared.emplace(key, key * 3 + 1);
+                    for (int probe = 0; probe <= t; ++probe) {
+                        const auto entry = shared.find(static_cast<uint64_t>(probe) * kIterations + i);
+                        if (entry != shared.end() && entry->second == entry->first * 3 + 1) ++found;
+                    }
+                }
+            });
+        for (auto& thread : threads) thread.join();
+
+        check(prosper::test::backend_persistent_resource_peak_in_flight().load() >= 2,
+              "guarded threads really contended for the domain (the arm is not vacuous)");
+        check(prosper::test::backend_persistent_resource_overlaps().load() == overlaps_before,
+              "no two threads were ever inside the guarded section at once");
+        check(shared.size() == static_cast<size_t>(kThreads) * kIterations,
+              "every insertion survived the contention -- the shared map is intact");
+        check(found.load() > 0, "the guarded find() returned live entries (the probes ran)");
+        check(prosper::test::backend_persistent_resource_depth().load() == 0 &&
+                  prosper::test::backend_persistent_resource_in_flight().load() == 0,
+              "the guard's counters return to zero when every thread has left");
+    }
+
+    // ---- 3. THE PRODUCTION ARM: render_draw_pass_rgba takes the guard ---------------------------
+    // Each thread renders a triangle that samples a PERSISTENT texture, so
+    // `persistent_texture_images.find()` -- the exact call in the #2953 backtrace -- is on every
+    // thread's route. Distinct persistent ids per thread keep the workload realistic (four
+    // identities competing for one cache) rather than four lookups of one key.
+    if (!prosper::test::render_vk_ctx().ok) {
+        std::fprintf(stderr,
+                     "note: no usable Vulkan device -- skipping the concurrent render arm; arms 1 "
+                     "and 2 above still ran\n");
+    } else {
+        const uint64_t overlaps_before = prosper::test::backend_persistent_resource_overlaps().load();
+        prosper::test::backend_persistent_resource_peak_in_flight().store(0);
+
+        const std::vector<uint32_t> vert(kTriVertSpv, kTriVertSpv + sizeof(kTriVertSpv) / 4);
+        const std::vector<uint32_t> frag(kTriFragSpv, kTriFragSpv + sizeof(kTriFragSpv) / 4);
+        constexpr uint32_t W = 32, H = 32;
+        constexpr uint32_t kTexW = 8, kTexH = 8;
+        constexpr int kRenderIterations = 6;
+
+        std::vector<std::vector<uint8_t>> images(kThreads);
+        std::vector<uint8_t> texels(static_cast<size_t>(kTexW) * kTexH * 4, 0x40);
+        Rendezvous gate(kThreads);
+        std::vector<std::thread> threads;
+        for (int t = 0; t < kThreads; ++t)
+            threads.emplace_back([&, t] {
+                gate.arrive_and_wait();
+                for (int i = 0; i < kRenderIterations; ++i) {
+                    std::vector<prosper::test::FrameResource> resources;
+                    for (uint32_t set = 0; set < 2; ++set) {
+                        prosper::test::FrameResource cbuf;
+                        cbuf.binding = 2; cbuf.set = set;
+                        resources.push_back(std::move(cbuf));
+                        prosper::test::FrameResource vbuf;
+                        vbuf.binding = 3; vbuf.set = set;
+                        resources.push_back(std::move(vbuf));
+                    }
+                    prosper::test::FrameResource tex;
+                    tex.binding = 0;
+                    tex.set = 1;
+                    tex.tex_rgba = texels.data();
+                    tex.tex_byte_size = texels.size();
+                    tex.tw = kTexW;
+                    tex.th = kTexH;
+                    // Non-zero: this is what routes the upload through the persistent texture cache
+                    // and therefore through the find() that crashed.
+                    tex.persistent_texture_id = 0x2953'0000ull + static_cast<uint64_t>(t);
+                    resources.push_back(std::move(tex));
+                    images[t] = prosper::test::render_triangle_rgba(
+                        vert, frag, W, H, nullptr, nullptr, nullptr, nullptr, &resources);
+                }
+            });
+        for (auto& thread : threads) thread.join();
+
+        const int peak = prosper::test::backend_persistent_resource_peak_in_flight().load();
+        std::fprintf(stderr, "note: peak threads wanting the domain during the render arm: %d\n", peak);
+        check(peak >= 2,
+              "concurrent render_draws_rgba calls really contended for the domain "
+              "(the arm is not vacuous)");
+        check(prosper::test::backend_persistent_resource_overlaps().load() == overlaps_before,
+              "render_draw_pass_rgba never ran two threads through its persistent caches at once");
+        bool every_frame_rendered = true;
+        for (int t = 0; t < kThreads; ++t)
+            if (images[t].size() != static_cast<size_t>(W) * H * 4) every_frame_rendered = false;
+        check(every_frame_rendered, "every concurrent render returned a complete frame");
+        check(prosper::test::backend_persistent_resource_depth().load() == 0 &&
+                  prosper::test::backend_persistent_resource_in_flight().load() == 0,
+              "the render path leaves the guard's counters at zero");
+    }
+
+    if (failures) { std::fprintf(stderr, "== FAIL: %d ==\n", failures); return 1; }
+    std::fprintf(stderr, "== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #2953

## The race

`render_draw_pass_rgba` (`prosper/tests/fixtures/render_runner.h` — a **live render path**, compiled
into `frontends/shared/live/live_renderer.cpp`, `live_compute.cpp` and `present/present_blit.cpp`,
see `tests/fixtures/AGENTS.md`) owns a set of process-lifetime `static` containers with no
synchronisation of any kind: the persistent **texture** cache and its nested per-image `bindings`
maps, the persistent **pipeline** and **pipeline-layout** caches, the persistent **colour-target**
and **depth/stencil** caches, plus `persistent_texture_bytes`, `persistent_color_target_bytes` and
three generation counters that are all updated by read-modify-write.

#2953 recorded a host SIGSEGV on a guest job thread (`job_render_0`) inside
`persistent_texture_images.find()` — libstdc++'s `_M_equals`, reached through
`_M_find_before_node`, dereferencing a null node — deterministic 5 of 5 under `boot_trace` on
*Metaphor: ReFantazio*. A `find()` racing another thread's rehash reads torn bucket pointers, which
is that crash's shape; #278 fixed the same shape once already, one layer up, on the folded
`GpuState`.

## What I checked before choosing a fix

**The live route is already serialised, and that is why this looked safe for so long.** Both AGC
submit entry points — `agc_driver_submit_dcb` and `submit_dcb_stream` (`SubmitDcb` /
`SubmitDcbFinal` / `SubmitAcb`) — take `g_agc_state_mu` before folding and hold it across
`execute_submit_work`, which is what invokes the render backend; the 2 ms deferred-flush watchdog
thread takes the same mutex. So on a live boot, two concurrent Dcb folds cannot both be in the
backend, and I could not construct the "two threads in `render_draw_pass_rgba` at once" case from
the live path by reading code. That is recorded as a `## Ruled out` row rather than left implicit,
because it is the first place the next investigator would look.

**That does not make the state safe, for a reason that is structural rather than incidental.**
`g_agc_state_mu` lives in `src/hle/graphics/hle_agc.cpp` — a different layer, in a library this
header is *not compiled against*. `gpu_replay`, `boot_trace` and every Vulkan test include
`render_runner.h` and link no HLE at all, so on those frontends nothing serialises the domain.
Nothing in the header stated the invariant, nothing enforced it, and nothing could detect its
violation. State that owns process-lifetime Vulkan objects has to carry its own contract. If two
threads *could* reach it, the code would also be violating Vulkan's external-synchronisation
requirement on `VkQueue` — which the mutation arm below demonstrates it does, loudly.

## The fix

One mutex for the whole domain, taken for the duration of `render_draw_pass_rgba`
(`BackendPersistentResourceGuard`).

**Why coarse.** There is no finer granularity that would be honest: the function looks an entry up,
keeps the iterator or the reference across dozens of Vulkan calls, mutates and evicts through it,
and updates byte totals by read-modify-write. A per-container lock taken and released around each
individual access would describe none of that while reading as if it did.

**Why there.** The guard is constructed **before** `direct_submission`, so the batch destructor —
which submits, and whose failure cleanups touch the texture cache — still runs inside the critical
section. A guard declared after it would be destroyed first and leave exactly those accesses
outside.

**Cost.** One uncontended mutex acquire/release plus four relaxed atomics per call. This is a
per-**submit** cost, not a per-draw one, against a call that records a command buffer, submits it
and waits on a fence — tens of nanoseconds against tens of microseconds at the very least. On the
live route it is uncontended by construction, per the section above. I did not measure a delta
because there is no measurement that could resolve it: `PROSPER_RENDER_TIMING`'s own buckets are in
milliseconds.

**It measures its own premise.** `in_flight` is incremented *before* the mutex acquire, so
`backend_persistent_resource_peak_in_flight()` reports how many threads have ever wanted the domain
at once. That is precisely the question #2953 left open ("what is *not* established: that two
threads are provably inside `render_draw_pass_rgba` at the same moment") and could not settle by
reading code — any run can now answer it. One unconditional stderr line, once per process, reports
the first time it exceeds one. `backend_persistent_resource_overlaps()` counts threads seen inside
the critical section simultaneously; it is 0 while the guard is taken and non-zero the moment it is
not, which is what the regression test asserts on.

## Alternatives rejected

- **`thread_local` caches.** Rejected on semantics, not on cost. Each thread would get its own
  cache, so hit rates fall and — the part that actually disqualifies it — every `VkImage`,
  `VkDeviceMemory`, `VkImageView`, `VkSampler` and `VkPipeline` in it is duplicated per thread, with
  each copy's lifetime now tied to a thread rather than to the eviction budget. The budgets
  (`persistent_texture_cache_limit()`, `persistent_color_target_limit()` — 4 GiB each on this box)
  are per-cache, so N threads means N budgets. It would also break the caches' actual job: a
  persistent target written by one submit and sampled by the next stops being findable if the two
  submits land on different guest threads, which turns a memory-safety bug into a rendering bug.
- **Confining the accesses to one thread.** This is the outcome I would have preferred and it is
  *nearly* what already happens — but the confinement would be enforced by a mutex three layers away
  in a library half this header's consumers do not link (above). Making it real would mean giving
  the backend its own render thread and marshalling every call onto it, which is a much larger
  change with its own latency consequences, and it does not become correct without still knowing
  that nothing else can touch the caches.
- **A `std::recursive_mutex` also taken in `render_draws_rgba`**, so a multi-segment split is one
  atomic critical section. Rejected: a recursive mutex hides re-entrancy rather than documenting it,
  and the segment boundary is safe — no cache iterator or reference is carried across it; the only
  cross-segment carriers are CPU pixel vectors and a colour-target *identity* that each segment
  re-looks-up by key. That is the same granularity two consecutive submits already have.

## Second finding, fixed here because it is one word

`backend_texture_upload_stats_storage()` was the only per-call stats storage in the file that was
**not** `thread_local` (its five siblings — colour-target, resource-reuse, hash totals, pipeline
cache, render timing — all are). It is written inside `render_draw_pass_rgba` and read by the caller
after the call returns, so a second rendering thread could clobber it in between: a data race on a
non-atomic object, and silently wrong numbers even where it did not tear. Every reader in the tree
reads it on the thread that just rendered, so per-thread storage is what the contract already was.

## Deliberately unaffected

- **Single-threaded behaviour is bit-identical.** No cache policy, key, budget, eviction order or
  Vulkan call changed; the diff to `render_draw_pass_rgba` is one declaration.
- **No new environment variable, and no way to switch the guard off.** A lock with an opt-out is a
  lock nobody can rely on.
- **The colour-target and depth/stencil caches' *other* entry points are still unguarded** —
  `invalidate_persistent_color_target*`, `readback_persistent_color_target`,
  `snapshot_persistent_ds_images`, and `live_renderer.cpp`'s direct iteration of both maps. Two
  concurrent `render_draw_pass_rgba` calls can no longer collide over them, but a call racing one of
  those helpers still can. Extending the guard there needs the frontend to participate and has a
  real self-deadlock failure mode (some of those helpers are called from *inside* the guarded
  region), so it is filed as **#3240** rather than bundled here. #3240 also records a raw-pointer
  discipline problem in the same area found while reading.

## Risks

- **Deadlock.** The guard is non-recursive, so a re-entrant call into `render_draw_pass_rgba` would
  hang. There are exactly two call sites in the tree, both in `render_draws_rgba`, both at top level
  and sequential. The one callback the guarded region does invoke into the frontend
  (`persistent_color_target_evict_sink()`) touches only the frontend's own `g_rtt` and takes no
  backend lock. #3240's follow-up work is where this needs care.
- **Held across a fence wait.** The critical section includes `submit_and_wait`. That is not new
  latency on the live route — `g_agc_state_mu` is already held across the same work — but it does
  mean a second thread would block for a whole submit rather than for a map operation. That is the
  correct trade: the alternative is undefined behaviour.
- **The `[render] N threads ...` line is unconditional.** One line per process, maximum. It is the
  discovery that a design assumption is false, and the run that most needs to report it is the one
  nobody armed a diagnostic for. `check_diag_gates.py` passes.

## Verification

Linux, AMD Radeon 8060S (RADV STRIX_HALO), in the `ps5ys` container. Configure carried
`PROSPER_GAME_ROOT` so the dump-gated cases really run.

| arm | build | ctest |
| --- | --- | --- |
| baseline (`origin/main`'s `render_runner.h`, same worktree/build dir) | exit **0** | **339/339 passed**, exit **0** |
| this branch | exit **0** | **340/340 passed**, exit **0** |

```
cmake -S prosper -B prosper/build-linux            # PROSPER_GAME_ROOT set; Vulkan found, dump PPSA24651
cmake --build prosper/build-linux -j6              # exit 0
ctest --no-tests=error                             # 340/340, exit 0, 96.80s
```

New case, verified **by name**:

```
ctest --no-tests=error -R backend_persistent_resource_lock   # 1/1 passed, exit 0
```

Ran 5x back to back for flakiness: exit codes `0 0 0 0 0`. The render arm reports
`peak threads wanting the domain during the render arm: 4`, i.e. all four threads were in flight
together — the arm cannot have passed vacuously.

### Mutation arm

Deleted the single `const BackendPersistentResourceGuard persistent_resource_guard;` line from
`render_draw_pass_rgba` and rebuilt only the test target:

```
cmake --build prosper/build-linux --target test_backend_persistent_resource_lock -j6   # exit 0
```

Then four runs of the binary and one ctest run:

| run | result |
| --- | --- |
| 1 | exit **134** — `test_...: ../amdgpu/amdgpu_internal.h:178: update_references: Assertion 'atomic_read(dst) > 0' failed.` |
| 2 | exit **134** (same assertion) |
| 3 | exit **134** (same assertion) |
| 4 | exit **139** (SIGSEGV) |
| ctest | exit **8**, `backend_persistent_resource_lock (SEGFAULT)` |

4 of 4 fatal. The failure lands inside **libdrm's amdgpu reference counting**, which is a second,
independent statement of the same thing the map corruption says: without the guard, concurrent calls
also drive `vkQueueSubmit` on one `VkQueue` from several threads, which Vulkan requires the
application to synchronise externally. Arms 1 and 2 still pass in the mutant, correctly — the
mutation removes the guard from the production function only, and those two arms test the guard
object itself.

### Repository gates

`check_diag_gates.py` (108 findings, all baselined), `check_ascii_output.py`, `check_cached_env.py`,
`check_ctest_gate.py`, `check_contribution_shape.py --selftest`, `check_numbered_table.py` over all
tracked `.md`, and `git diff --check` — all exit 0.

## Test design, and where it is honest about its limits

The concurrency arms are probabilistic in principle. Three things bound that:

1. **A positive control that runs first.** Arm 1 drives the same thread shape with no guard and
   asserts the overlap detector reports a non-zero count. It is built by hand out of atomics rather
   than by removing the production guard, so it draws from a different source than the null it
   validates and observes no undefined behaviour of its own. Without it, a clean zero in arms 2 and 3
   would be equally well explained by "the guard works" and by "these threads never overlapped".
2. **`peak_in_flight >= 2` is asserted, not assumed.** A run in which the threads failed to overlap
   *fails* rather than passing quietly. Because `in_flight` is incremented before the mutex acquire,
   a thread blocked on the guard still counts, and the critical section is a full command-buffer
   record + submit + fence wait against a microsecond-scale rendezvous release — which is why the
   measured peak is the full 4 of 4.
3. **What would make it fully deterministic** is a scheduling hook inside the critical section, which
   would mean shipping a test-only seam through the live render path. The in-flight assertion buys
   the same protection against a vacuous pass without one.

## `## Ruled out` rows added

- `docs/METAPHOR_STATUS.md` — the crash cannot have come from two concurrent `sceAgcDriverSubmitDcb`
  folds; both entry points and the deferred-flush watchdog already hold `g_agc_state_mu` (#278), so
  looking for the second thread *between two submits* is a dead end. What remains open is which route
  the observed thread took, and `backend_persistent_resource_peak_in_flight()` now answers that on
  any run.
- `tests/fixtures/AGENTS.md` — the header cannot inherit the HLE's locks, with the reason (three of
  its consumers link no HLE) and the boundary of what the new guard covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
