### PR TITLE
kernel: select()/pselect() stop sleeping on the Windows tick, and their guest timeout stops passing through a 32-bit long

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,15 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-02
 
+### A guest asking to sleep for 584 years was served in zero milliseconds
+
+No picture — the finding is that prosper's guest sleeps saturate a hostile interval to the largest
+unsigned nanosecond count, and the clock underneath then reads that as a *signed* one and hands back
+a deadline in the past. So the clamp written to stop a long sleep becoming a short one produced the
+shortest sleep there is. Fixed alongside `select()`-as-sleep, which was the last guest sleep still
+resolving on Windows' ~15.6 ms scheduler tick.
+[#3038](https://github.com/mattias800/prosper/issues/3038)
+
 ### The "exotic" image instruction blocking a Stray draw was an ordinary one, spelled differently
 
 A three-dword `image_load_mip` had been rejecting a whole Stray fragment shader, and the extra dword

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -869,6 +869,13 @@ if(TARGET prosper_core)
   add_executable(test_select_sleep tests/hle/kernel/test_select_sleep.cpp)
   target_link_libraries(test_select_sleep PRIVATE prosper_core)
   add_test(NAME select_sleep COMMAND test_select_sleep)
+  # This test drives real sleeps through the HLE, and its #3038 arms feed it timeouts a regression
+  # would take LITERALLY: carrying an out-of-range tv_nsec into the total makes 0x7fff... a
+  # 292-year wait, so the failure mode is a wedge rather than a red. Measured while mutation-testing
+  # this PR -- with the range rule removed, test_select_sleep does not return. A bound turns that
+  # into a legible timeout instead of ctest's 25-minute default. The whole run is ~0.5 s, so 60 s is
+  # a hundredfold headroom and cannot flake under load.
+  set_tests_properties(select_sleep PROPERTIES TIMEOUT 60)
 
   # Opt-in flip-paced monotonic clock (#240): exact frame steps, thread-safe first-flip anchor,
   # and no coupling into CLOCK_REALTIME while virtual time is paused between flips.

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -639,6 +639,32 @@ One line per falsified hypothesis, per `CLAUDE.md`. This is the cross-title home
   a realtime nor a monotonic clock can discriminate that in a test, because the old path was
   self-consistent for both; the virtual clock can, and does.
 
+- **"`sleep_full` is on the winpthreads tick, and its `select`/`pselect` callers truncate the guest
+  timespec through a 32-bit host `long`."** BOTH halves held on `origin/main` at `637e65f9`, and
+  they are not the same kind of defect. The tick half was real and is fixed (#3038): `sleep_full`
+  was the last guest sleep still on a bare `nanosleep`, so an inter-pass sleep of a few
+  milliseconds through `select(0, NULL, NULL, NULL, &tv)` — the idiom #1660 caught live — was
+  served in ~15.6 ms on Windows. The truncation half is real *as written* and its practical
+  consequence is **smaller than it reads**: every LEGAL value fits in 32 bits of nanoseconds
+  (`tv_nsec < 1e9`, `tv_usec * 1000 < 1e9`), so no in-range guest value was ever mis-served by it
+  on any platform. What it actually produced was a platform DIVERGENCE on out-of-range input —
+  Windows re-mapped such a value back INTO range and slept a wrong short interval (a `tv_usec` of
+  4,294,968, i.e. 4.29 s, became 704 ns), where Linux refused it. Do not quote it as a live
+  wrong-duration defect for any observed title; the platform-independent consequence of the same
+  expression is the other one, that `tv_usec * 1000` was a signed multiply on a guest-controlled
+  `int64_t` with no prior range check.
+- **"Saturating a guest-supplied interval to `UINT64_MAX` is a safe upper clamp."** It was not, and
+  the guard handed back its own failure mode: `sleep_until_steady_ns` takes an unsigned nanosecond
+  deadline while its POSIX backend converts to `std::chrono::nanoseconds`, whose rep is **signed**,
+  so any deadline past `INT64_MAX` wrapped into the past and the sleep returned **instantly**.
+  Measured on Linux/glibc before the fix — `sleep_until_steady_ns(INT64_MAX + 1)` and
+  `sleep_until_steady_ns(UINT64_MAX)` both returned in 0 ms — so a 584-year request became a busy
+  spin, which is exactly the short sleep the saturation exists to prevent, and on the
+  `select`/`pselect` path it is #1660's defect verbatim. Windows was already correct here (its
+  backend's arithmetic is unsigned throughout and its millisecond safety net saturates to
+  `INFINITE`). Fixed in #3038 by clamping the deadline to `INT64_MAX` in the POSIX backend; the
+  same probe then blocks past a 20 s bound instead of returning at 0 ms.
+
 **Reproducing the local compile loop (macOS → Windows):** `brew install mingw-w64`, then
 `cmake -S prosper -B build-win -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
 -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -444,9 +444,16 @@ static inline void guest_sleep_ns(uint64_t ns) {
 }
 
 // Saturating, for the same reason k_nanosleep saturates: the argument is guest-controlled and a wrap
-// turns a long sleep into a short one. Benign in consequence here -- a wrapped deadline lands in the
-// past and precise_sleep returns at once -- but having one of these three saturate and the others
-// wrap is an inconsistency the next reader has to re-derive, so they all do.
+// turns a long sleep into a short one. Having one of these three saturate and the others wrap would
+// be an inconsistency the next reader has to re-derive, so they all do.
+//
+// This comment used to add that saturating was "benign in consequence here -- a wrapped deadline
+// lands in the past and precise_sleep returns at once". That was TRUE and was not benign: it meant
+// the clamp handed its own failure mode straight back, since an instant return for a 584-year
+// request is exactly the short sleep being prevented. #3038 measured it (0 ms for both INT64_MAX+1
+// and UINT64_MAX) and fixed it in precise_sleep's POSIX backend, which now clamps the deadline to
+// the largest its signed chrono rep can hold rather than wrapping it. A saturated interval now
+// blocks, on Linux as it already did on Windows.
 static inline uint64_t guest_ns_from(uint64_t value, uint64_t ns_per_unit) {
     const uint64_t kNsMax = ~0ull;
     return value > kNsMax / ns_per_unit ? kNsMax : value * ns_per_unit;
@@ -482,7 +489,11 @@ HLE(k_sleep_s)  { const uint64_t ns = guest_ns_from(a0, 1000000000ull);
 HLE(k_nanosleep){
     if (!a0) return 0;
     const int64_t* req = (const int64_t*)P(a0);
-    const int64_t  sec = req[0], nsec = req[1];
+    // The range rule and the saturating conversion both live in guest_interval_from_timespec
+    // (precise_sleep.hpp) since #3038, where select()/pselect() call the same function rather than
+    // carrying a second, narrower copy of this arithmetic. The behaviour is unchanged; what moved
+    // is where it can be tested from.
+    //
     // A malformed request returns WITHOUT sleeping, which is what this entry point already did: the
     // old body handed the guest struct straight to the host nanosleep, and POSIX makes a tv_nsec
     // outside [0, 1e9) EINVAL -- so the host refused instantly and the HLE returned 0 having slept
@@ -491,23 +502,15 @@ HLE(k_nanosleep){
     // sleep: a hang where there used to be an immediate return. Returning an error instead would be
     // the opposite new failure mode, for guests that currently see success. Same range rule as
     // hle_kernel.cpp:1313, which validates the guest timespec it is handed.
-    if (sec < 0 || nsec < 0 || nsec >= 1000000000ll) {
+    const prosper::host::GuestInterval want =
+        prosper::host::guest_interval_from_timespec(req[0], req[1]);
+    if (!want.valid) {
         // Zeroed rather than left untouched (the host would have left it) so a guest reading the
         // remainder after a refused request cannot resume on uninitialised memory.
         if (a1) { int64_t* rem = (int64_t*)P(a1); rem[0] = 0; rem[1] = 0; }
         return 0;
     }
-    // Saturating, and the second disjunct is the boundary the first one misses: sec == kNsMax/1e9
-    // passes a bare `sec > kNsMax/1e9` test, and then `+ nsec` overflows for nsec > kNsMax%1e9 and
-    // wraps a 584-year sleep into a short one -- the long-to-short direction this clamp exists to
-    // prevent. tv_sec is guest-controlled, so the boundary is reachable by a hostile value.
-    const uint64_t kNsMax   = ~0ull;
-    const uint64_t kSecMax  = kNsMax / 1000000000ull;      // 18446744073
-    const uint64_t kNsecRem = kNsMax % 1000000000ull;      // 709551615
-    const uint64_t want_ns =
-        ((uint64_t)sec > kSecMax || ((uint64_t)sec == kSecMax && (uint64_t)nsec > kNsecRem))
-            ? kNsMax : (uint64_t)sec * 1000000000ull + (uint64_t)nsec;
-    { hle::WaitCensusScope c(hle::WaitKind::Nanosleep, want_ns); guest_sleep_ns(want_ns); }
+    { hle::WaitCensusScope c(hle::WaitKind::Nanosleep, want.ns); guest_sleep_ns(want.ns); }
     if (a1) { int64_t* rem = (int64_t*)P(a1); rem[0] = 0; rem[1] = 0; }   // slept in full
     return 0;
 }
@@ -536,26 +539,42 @@ HLE(k_nanosleep){
 // success-shaped answer-we-cannot-honour that caused this bug. Log it loudly and fail.
 // CONFIDENCE: HIGH on the sleep shape (arguments observed live); the descriptor shape is
 // intentionally unimplemented, not unknown.
+//
+// #3038: honouring the timeout means honouring the length of it, on both platforms. The timeout is
+// now converted in 64 bits and waited out on an absolute steady-clock deadline like the rest of the
+// guest sleep family (#3022), not on a host `struct timespec` handed to nanosleep. The Oregon Trail
+// evidence below is a 3 s sleep, where a ~15.6 ms tick is noise; an inter-pass sleep of a few
+// milliseconds through the same call is where it is not.
 namespace {
 // True for the pure-sleep shape: no descriptor may be examined.
 bool select_is_pure_sleep(uint64_t nfds, uint64_t readfds, uint64_t writefds, uint64_t exceptfds) {
     return (int64_t)nfds <= 0 && readfds == 0 && writefds == 0 && exceptfds == 0;
 }
 
-// Sleep the FULL duration. A bare nanosleep returns early on a signal, and prosper delivers signals
-// on its own (the SIGSEGV fault handler), so a short sleep would reintroduce a faster spin.
-void sleep_full(struct timespec want) {
-    while (want.tv_sec > 0 || want.tv_nsec > 0) {
-        struct timespec rem{0, 0};
-        if (nanosleep(&want, &rem) == 0) return;
-        if (errno != EINTR) return;
-        want = rem;
-    }
-}
+// Sleep the FULL interval the guest asked for, on an ABSOLUTE deadline.
+//
+// This was a raw `nanosleep` retry loop until #3038, and the loop's own purpose survives its
+// removal. It existed because a bare nanosleep returns early on a signal and prosper delivers
+// signals of its own (the SIGSEGV fault handler), so a short sleep would reintroduce the spin #1660
+// removed. An absolute deadline subsumes that: on POSIX guest_sleep_ns ends in libstdc++'s own
+// EINTR-restarting nanosleep loop, and on Windows sleep_until_steady_ns re-reads the clock after
+// every wait and goes again. What the loop could NOT do is get off the winpthreads ~15.6 ms master
+// tick that #3013 measured and #3022 routed the other three sleep entry points off -- an inter-pass
+// sleep of a few milliseconds through select() was served in ~15.6 ms, and this path was the last
+// one still on it.
+//
+// One caveat, because it is a real difference rather than a wash: PROSPER_GUEST_SLEEP_LEGACY=1
+// restores guest_sleep_ns's single pre-#3013 `nanosleep`, which does NOT restart on EINTR -- so
+// under that lever a signal can truncate this wait where the loop above resumed it. The lever
+// exists only to keep #3013's A/B reproducible and is not a supported runtime configuration
+// (CLAUDE.md's PROSPER_UD_TAIL_ALIGN precedent).
+void sleep_full_ns(uint64_t ns) { guest_sleep_ns(ns); }
 
 // A NULL timeout in the pure-sleep shape means "block forever". Sleep in bounded chunks rather than
-// one unbounded call so the process still responds to termination.
-void sleep_forever() { for (;;) sleep_full(timespec{1, 0}); }
+// one unbounded call so the process still responds to termination. Not censused: the requested
+// interval here is prosper's own chunk size, not anything the guest asked for, so counting it would
+// report a 1.00 ratio for a wait that has no guest-supplied duration at all.
+void sleep_forever() { for (;;) sleep_full_ns(1000000000ull); }
 
 uint64_t select_unsupported(const char* fn, uint64_t nfds,
                             uint64_t readfds, uint64_t writefds, uint64_t exceptfds) {
@@ -595,8 +614,23 @@ HLE(k_select) {
     if (!select_is_pure_sleep(a0, a1, a2, a3)) return select_unsupported("select", a0, a1, a2, a3);
     if (!a4) sleep_forever();
     else {
-        const int64_t* tv = (const int64_t*)P(a4);   // struct timeval { time_t sec; suseconds_t usec; }
-        sleep_full(timespec{ (time_t)tv[0], (long)(tv[1] * 1000) });
+        // Indexed as two int64s and converted in 64 bits, never assembled into a HOST timespec:
+        // `(long)(tv[1] * 1000)` narrowed the product to 32 bits on Windows x64 and multiplied
+        // before it narrowed, so an out-of-range tv_usec could land back INSIDE the legal range as
+        // a far shorter sleep (#3038). An out-of-range field is now REFUSED -- no sleep, and still
+        // return 0 -- which is what this call already did on a host wide enough to see the value,
+        // because the host nanosleep saw the out-of-range tv_nsec and returned EINVAL instantly.
+        // Returning -1/EINVAL instead would be the more POSIX answer and is deliberately not done
+        // here: it is a guest-visible contract change for titles that currently see success, with
+        // no way to verify it from this side.
+        // struct timeval { int64 tv_sec; int64 tv_usec; }
+        const int64_t* tv = (const int64_t*)P(a4);
+        const prosper::host::GuestInterval want =
+            prosper::host::guest_interval_from_timeval(tv[0], tv[1]);
+        if (want.valid) {
+            hle::WaitCensusScope c(hle::WaitKind::Select, want.ns);
+            sleep_full_ns(want.ns);
+        }
     }
     return 0;   // timed out with nothing ready — the correct answer for a descriptor-free wait
 }
@@ -607,8 +641,14 @@ HLE(k_pselect) {
     if (!select_is_pure_sleep(a0, a1, a2, a3)) return select_unsupported("pselect", a0, a1, a2, a3);
     if (!a4) sleep_forever();
     else {
+        // struct timespec { int64 tv_sec; int64 tv_nsec; }
         const int64_t* ts = (const int64_t*)P(a4);
-        sleep_full(timespec{ (time_t)ts[0], (long)ts[1] });
+        const prosper::host::GuestInterval want =
+            prosper::host::guest_interval_from_timespec(ts[0], ts[1]);
+        if (want.valid) {
+            hle::WaitCensusScope c(hle::WaitKind::Select, want.ns);
+            sleep_full_ns(want.ns);
+        }
     }
     return 0;
 }

--- a/prosper/src/hle/kernel/timedwait_census.hpp
+++ b/prosper/src/hle/kernel/timedwait_census.hpp
@@ -29,7 +29,7 @@
 
 namespace prosper::hle {
 
-enum class WaitKind { Usleep, Nanosleep, SleepSeconds, SemTimedwait, CondTimedwait,
+enum class WaitKind { Usleep, Nanosleep, SleepSeconds, Select, SemTimedwait, CondTimedwait,
                      CondTimedwaitSce, MutexTimedlock, Count };
 
 inline const char* wait_kind_name(WaitKind k) {
@@ -37,6 +37,12 @@ inline const char* wait_kind_name(WaitKind k) {
     case WaitKind::Usleep:        return "usleep";
     case WaitKind::Nanosleep:     return "nanosleep";
     case WaitKind::SleepSeconds:  return "sleep(s)";
+    // select() and pselect() share ONE bucket. They are the same idiom -- the descriptor-free
+    // pure-sleep shape #1660 records -- reached through two spellings, and this census answers
+    // "which primitive does this title pace on", to which the spelling is not the answer. Added by
+    // #3038, which took this path off the winpthreads tick: before that it was the one sleep entry
+    // point the census could not see.
+    case WaitKind::Select:        return "select";
     case WaitKind::SemTimedwait:  return "sem_timedwait";
     case WaitKind::CondTimedwait: return "cond_timedwait";
     case WaitKind::CondTimedwaitSce: return "sceCondTimedwait";

--- a/prosper/src/host/platform/AGENTS.md
+++ b/prosper/src/host/platform/AGENTS.md
@@ -23,6 +23,15 @@ Two of them are shutdown-related and are easy to confuse:
   so the drain can reach zero (#3225). It bounds that window rather than closing it, and its own
   header says so — do not let it be described as the fix for the missing join.
 
+One of them is half something else, and worth knowing before you go looking:
+**`precise_sleep.hpp` also holds this family's PURE ARITHMETIC** — deadline conversion, poll
+cadence, saturating guest-interval conversion — extracted from the callers in `src/hle/kernel/` and
+`src/hle/sync/` that use it. That is not scope creep. The arithmetic those callers need is mostly guarded by
+`#ifdef _WIN32` or buried inside an `HLE()` body, so in its original home it could not be compiled
+on a POSIX host at all, let alone driven through its saturating and out-of-range cases; here it is
+`constexpr`, platform-neutral, and exercised by `tests/host/platform/test_precise_sleep.cpp` with a
+fake clock on every platform. Put the next one here too rather than inline at a call site.
+
 New code belongs here only if it is genuinely process-wide, genuinely host-level, and genuinely free
 of OS-integration dependencies. Per-platform *image* mapping and execution live in `src/host/image/`;
 memory and TLS have their own sibling folders.

--- a/prosper/src/host/platform/precise_sleep.cpp
+++ b/prosper/src/host/platform/precise_sleep.cpp
@@ -65,9 +65,13 @@ uint64_t steady_now_ns() {
 }
 
 void sleep_until_with_std(uint64_t deadline_ns) {
+    // std::chrono::nanoseconds' rep is SIGNED, so a deadline past INT64_MAX would wrap to a
+    // time_point in the past and this sleep would return instantly. See
+    // clamp_deadline_to_signed_rep() in the header for why that is reachable and why clamping ~292
+    // years out is indistinguishable from the deadline it replaces (#3038).
     std::this_thread::sleep_until(std::chrono::steady_clock::time_point(
         std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-            std::chrono::nanoseconds(deadline_ns))));
+            std::chrono::nanoseconds(clamp_deadline_to_signed_rep(deadline_ns)))));
 }
 
 }  // namespace

--- a/prosper/src/host/platform/precise_sleep.hpp
+++ b/prosper/src/host/platform/precise_sleep.hpp
@@ -22,6 +22,30 @@ enum class SleepBackend {
 // immediately if the deadline has already passed.
 void sleep_until_steady_ns(uint64_t deadline_ns);
 
+// The largest steady-clock deadline the POSIX backend can actually WAIT for, applied to every
+// deadline it is handed (#3038).
+//
+// `sleep_until_steady_ns` takes an UNSIGNED nanosecond count, while the `std::chrono::nanoseconds`
+// its POSIX backend converts to has a SIGNED rep -- so a deadline past INT64_MAX wraps to a
+// time_point in the PAST and the sleep returns instantly. Measured, not inferred: before this
+// clamp, `sleep_until_steady_ns(INT64_MAX + 1)` and `sleep_until_steady_ns(UINT64_MAX)` both
+// returned in 0 ms on Linux/glibc.
+//
+// It is reachable, because the whole guest-sleep family SATURATES a guest-supplied interval to
+// UINT64_MAX rather than wrapping it (guest_interval_from_timespec below, guest_ns_from and
+// timeout_ns_from_us) -- deliberately, so a hostile value cannot turn a long sleep into a short
+// one. Without this clamp that saturation lands right back on an instant return, which is the
+// failure it was written to prevent, and on the select()/pselect() path it is #1660's defect
+// exactly: a sleep that returns at once becomes a 9-million-call-per-second spin.
+//
+// INT64_MAX nanoseconds is ~292 years of steady-clock uptime, so no wait a caller can distinguish
+// from "forever" is shortened by the clamp. It also makes the two platforms agree: the Windows
+// backend already blocks for such a deadline (its arithmetic is unsigned throughout and its
+// millisecond safety net saturates to INFINITE).
+constexpr uint64_t clamp_deadline_to_signed_rep(uint64_t deadline_ns) {
+    return deadline_ns > (uint64_t)INT64_MAX ? (uint64_t)INT64_MAX : deadline_ns;
+}
+
 // The post-condition sleep_until_steady_ns() promises on EVERY backend: never return before
 // `now_ns() >= deadline_ns`. A single OS sleep primitive is not trusted to hit this on its own -- a
 // waitable timer can signal marginally early, and so can the ::Sleep()-backed fallback used when no
@@ -284,6 +308,72 @@ constexpr uint64_t wait_timeout_ms_ceil(WaitDeadline now, WaitDeadline deadline,
     // whole purpose is to saturate should not have a reachable-only-by-luck wrap in it (raised in
     // review of #3235).
     return frac_ms > max_ms - whole_ms ? max_ms : whole_ms + frac_ms;
+}
+
+
+// ---------------------------------------------------------------------------
+// The RELATIVE guest sleep intervals' conversion (#3038).
+//
+// nanosleep() and select()/pselect()'s pure-sleep shape are all handed a guest {seconds,
+// sub-seconds} pair and have to turn it into one nanosecond count. Two things go wrong when that
+// is written inline at the call site, and hle_kernel_time.cpp's select()/pselect() had both:
+//
+//  1. TRUNCATION. Assembling a HOST `struct timespec` out of guest fields narrows tv_nsec through
+//     `long`, which is 32 bits on Windows x64 (MinGW-w64 is LLP64) against the guest's 64. Every
+//     LEGAL value fits in the low half, so it is correct by luck; an out-of-range one is silently
+//     re-mapped INTO range instead of being refused. A tv_usec of 4,294,968 -- 4.29 s -- becomes a
+//     704 ns sleep that way, six million times short. Taking int64_t parameters and returning a
+//     uint64_t count removes the host layout from the path entirely, and the same expression is
+//     then exercised on both platforms rather than only on the one that happens to be wide enough.
+//     Same class as the WaitDeadline fields above, and the reason those are int64_t too.
+//  2. NO RANGE RULE. k_nanosleep and k_cond_timedwait (hle_kernel.cpp) both refuse a negative or
+//     out-of-[0, 1e9) guest field before touching it; select()/pselect() did not, and left the
+//     host nanosleep to notice -- which is the same answer only for as long as the narrowing above
+//     leaves the value out of range.
+//
+// `valid` is a REFUSAL, not an error code: the caller must not sleep at all. That is what these
+// call sites already did on a host wide enough to see the value, because the host nanosleep
+// returned EINVAL instantly, and preserving it matters in both directions. Carrying an
+// out-of-range field into the total instead turns a garbage 0x7fff... into a near-infinite sleep,
+// i.e. a hang where there used to be an immediate return -- the comment on k_nanosleep's own guard
+// records that being got wrong once already.
+struct GuestInterval {
+    bool     valid = false;   // false: out of range -- do not sleep at all
+    uint64_t ns    = 0;       // saturating total; meaningless unless `valid`
+};
+
+// A guest `struct timespec` -- the guest is FreeBSD x86-64, so both fields are 64-bit, and they are
+// taken here as the two int64s they are rather than through any host struct.
+//
+// Saturating, for the reason guest_ns_from() (#3022) and timeout_ns_from_us() (#3069) already state
+// for this family: the fields arrive from guest memory and a wrap turns a long sleep into a short
+// one. Consequence-free at the one call site that can reach it -- a saturated count is 584 years,
+// and the sleep it produces is indistinguishable from the one the guest asked for -- and having one
+// member of the family saturate while its siblings wrap is an inconsistency the next reader has to
+// re-derive.
+constexpr GuestInterval guest_interval_from_timespec(int64_t sec, int64_t nsec) {
+    constexpr uint64_t kNsMax   = ~0ull;
+    constexpr uint64_t kSecMax  = kNsMax / 1000000000ull;   // 18446744073
+    constexpr uint64_t kNsecRem = kNsMax % 1000000000ull;   // 709551615
+    if (sec < 0 || nsec < 0 || nsec >= 1000000000ll) return GuestInterval{false, 0};
+    const uint64_t s = (uint64_t)sec, n = (uint64_t)nsec;
+    // The second disjunct is the boundary the first one misses: s == kSecMax passes a bare
+    // `s > kSecMax` test, and then `+ n` overflows for n > kNsecRem and wraps a 584-year sleep into
+    // a short one -- the long-to-short direction this clamp exists to prevent.
+    if (s > kSecMax || (s == kSecMax && n > kNsecRem)) return GuestInterval{true, kNsMax};
+    return GuestInterval{true, s * 1000000000ull + n};
+}
+
+// A guest `struct timeval`, whose sub-second field is MICROseconds; POSIX puts select()'s tv_usec
+// in [0, 1e6).
+//
+// The range check happens BEFORE the multiply and the multiply is 64-bit, which is the whole of
+// #3038's second defect: `(long)(tv_usec * 1000)` multiplied first and narrowed second, so a
+// tv_usec above ~2.1e6 overflowed the 32-bit product with nothing having refused it. Here the
+// product of an accepted tv_usec is below 1e9 by construction, so it cannot overflow at all.
+constexpr GuestInterval guest_interval_from_timeval(int64_t sec, int64_t usec) {
+    if (usec < 0 || usec >= 1000000ll) return GuestInterval{false, 0};
+    return guest_interval_from_timespec(sec, usec * 1000ll);
 }
 
 }  // namespace prosper::host

--- a/prosper/tests/hle/kernel/test_select_sleep.cpp
+++ b/prosper/tests/hle/kernel/test_select_sleep.cpp
@@ -16,6 +16,10 @@
 //
 // Both halves fail without the fix: (1) elapses ~0 ms against the unimplemented stub, and (2)
 // returns 0 rather than -1.
+//
+// Section 1b (#3038) adds a third: an out-of-range timeout must be REFUSED, and refusing must mean
+// returning promptly rather than sleeping. Its own comment says what it can and cannot discriminate
+// on a 64-bit-`long` host, which is not the same question as what it is worth pinning.
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/kernel/sce_errno.hpp"
 #include "hle/dispatch/nid.hpp"
@@ -90,6 +94,84 @@ int main() {
         });
         CHECK(ms < 100, "select with a zero timeout returns promptly");
         CHECK(rc == 0, "select with a zero timeout returns 0");
+    }
+
+    // --- 1b. an OUT-OF-RANGE timeout is refused, and refusing means not sleeping (#3038) --------
+    //
+    // POSIX puts tv_usec in [0, 1e6) and tv_nsec in [0, 1e9). Before #3038 these call sites applied
+    // no range rule of their own: they built a host `struct timespec` and let the host nanosleep
+    // notice, which returned EINVAL instantly. That is the behaviour pinned here, because the
+    // tempting "fix" is to carry the out-of-range field into the total instead -- which turns a
+    // garbage 0x7fff... into a near-infinite sleep, i.e. a HANG where there used to be an immediate
+    // return. k_nanosleep's own guard comment records that being got wrong once already; these arms
+    // make the same mistake in select()/pselect() a red test rather than a wedged title.
+    //
+    // Deliberately stated: on a 64-bit-`long` host these arms pass both before and after #3038, so
+    // they are a REGRESSION pin, not a discriminator for that fix. The half they can discriminate
+    // is the one above -- a value carried into the total -- and the half they cannot is the 32-bit
+    // narrowing, which this host cannot express at all. That one is tested as pure arithmetic in
+    // tests/host/platform/test_precise_sleep.cpp arms 18-21.
+    {
+        int64_t tv[2] = { 0, 1500000 };                      // 1.5e6 us: out of range, and > 1 s
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = select_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)tv, 0);
+        });
+        printf("  select(0,NULL,NULL,NULL,{0,1500000}) -> %llu in %lld ms\n",
+               (unsigned long long)rc, (long long)ms);
+        CHECK(ms < 100, "an out-of-range tv_usec returns promptly, never as a 1.5 s sleep");
+        CHECK(rc == 0, "...and still returns 0, the answer this call already gave");
+    }
+    {
+        // The value that the pre-#3038 32-bit narrowing mapped back INTO range as a 704 ns sleep on
+        // Windows: 4,294,968 us is 4.29 s. Out of range by any reading, so the answer is a refusal.
+        int64_t tv[2] = { 0, 4294968 };
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = select_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)tv, 0);
+        });
+        CHECK(ms < 100, "the 4.29 s out-of-range tv_usec is refused, not slept and not re-mapped");
+        CHECK(rc == 0, "...returning 0");
+    }
+    {
+        // A tv_usec whose x1000 product would overflow a signed 64-bit multiply. Before #3038 the
+        // multiply happened BEFORE any range check, on a value read straight from guest memory --
+        // undefined behaviour on every platform, not merely a narrowing. Now it cannot be reached.
+        int64_t tv[2] = { 0, INT64_MAX };
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = select_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)tv, 0);
+        });
+        CHECK(ms < 100, "a tv_usec that would overflow the x1000 multiply is refused before it");
+        CHECK(rc == 0, "...returning 0");
+    }
+    {
+        int64_t ts[2] = { 0, 1000000000 };                   // exactly 1e9 ns: out of range
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = pselect_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)ts, 0);
+        });
+        CHECK(ms < 100, "pselect refuses a tv_nsec of exactly 1e9 rather than sleeping a second");
+        CHECK(rc == 0, "...returning 0");
+    }
+    {
+        int64_t ts[2] = { 0, INT64_MAX };                    // the garbage-value hang direction
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = pselect_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)ts, 0);
+        });
+        CHECK(ms < 100,
+              "a 0x7fff... tv_nsec returns at once; carrying it would be a 292-year wait");
+        CHECK(rc == 0, "...returning 0");
+    }
+    {
+        int64_t ts[2] = { -5, 0 };                           // a negative tv_sec
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = pselect_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)ts, 0);
+        });
+        CHECK(ms < 100, "a negative tv_sec returns promptly");
+        CHECK(rc == 0, "...returning 0");
     }
 
     // --- 2. a descriptor-set query stays fail-visible --------------------------------------------

--- a/prosper/tests/host/platform/test_precise_sleep.cpp
+++ b/prosper/tests/host/platform/test_precise_sleep.cpp
@@ -23,6 +23,13 @@
 // them -- the only handle on that arithmetic was to call the real HLE and time it, which
 // test_kernel_sem_timedwait.cpp's header records at length cannot discriminate anything here.
 //
+// ARMS 18-21 (#3038) cover a THIRD set, the conversion from a guest {seconds, sub-seconds} pair to
+// one nanosecond count that nanosleep(), select() and pselect() now share. What they replace was a
+// HOST `struct timespec` assembled at the call site, whose `long tv_nsec` is 32 bits on Windows x64
+// against the guest's 64 -- so the case under test is one this host's own types cannot express, and
+// arm 21 models the narrowing explicitly (and asserts the model narrows) rather than relying on a
+// cast that is a no-op here.
+//
 // The cases the fake clock buys, none of which a wall-clock test can produce on demand: an early
 // wakeup, a deadline already in the past, a clock that runs backwards, the slice clamp binding, and
 // arithmetic within a few nanoseconds of UINT64_MAX. Mutation results are in the PR.
@@ -56,6 +63,12 @@ static void fake_sleep_fixed_step(uint64_t /*deadline_ns*/) {
     ++g_sleep_calls;
     g_fake_now_ns += g_sleep_step_ns;
 }
+
+// MinGW-w64's `long tv_nsec` (#3038), modelled rather than spelled `(long)`: on THIS host `long` is
+// 64 bits, so the platform whose behaviour is under test is the one platform where the real cast
+// does nothing. Written as a conversion through uint32_t and back so it is well-defined and
+// identical on every host, and asserted to actually narrow in arm 21 before it is trusted.
+static int64_t narrow_to_win_long(int64_t v) { return (int64_t)(int32_t)(uint32_t)v; }
 
 // ---------------------------------------------------------------------------
 // A driver for sem_poll_step() (#3069) that reproduces the real poll loop's structure exactly --
@@ -593,6 +606,214 @@ int main() {
         const host::WaitDeadline zero = host::abs_deadline_from_rel_us(now, 0);
         CHECK(host::wait_timeout_ms_ceil(now, zero, kMaxMs) == 0,
               "a zero-microsecond request is already expired, not rounded up to 1 ms");
+    }
+
+
+    // -----------------------------------------------------------------------
+    // ARMS 18-21 (#3038) — the RELATIVE guest sleep intervals' conversion:
+    // guest_interval_from_timespec() and guest_interval_from_timeval(), which nanosleep(),
+    // select() and pselect() all now share.
+    //
+    // Same extraction rationale as arms 5-11 and 12-17, one step further out: what these replace
+    // was not merely inline, it was a HOST `struct timespec` built out of guest fields at the call
+    // site. On this platform that struct is wide enough and the arithmetic is right; on Windows x64
+    // `long tv_nsec` is 32 bits and it is not. So the case being tested is one this host's own
+    // types cannot express — which is exactly why the narrowing is MODELLED explicitly below rather
+    // than left to the compiler to demonstrate, and why the model is asserted to actually narrow
+    // before it is used as a foil (CLAUDE.md: construct one positive instance of the class by hand,
+    // outside whatever produced the null).
+    //
+    // What these arms deliberately do NOT claim: that a title's observed behaviour changes. Every
+    // LEGAL guest value fits in 32 bits of nanoseconds, so the truncation was correct by luck for
+    // any in-range input, and the defect it produced is an out-of-range value being silently
+    // re-mapped INTO range on one platform and refused on the other. The consequence that is
+    // platform-independent is the other one: `tv_usec * 1000` was a signed multiply on a
+    // guest-controlled int64 with no prior range check, i.e. undefined behaviour, and the range
+    // check now precedes the multiply so it cannot overflow at all.
+
+    // 18. THE TIMESPEC RANGE RULE, which is the same one k_nanosleep and hle_kernel.cpp's
+    //     k_cond_timedwait already applied and select()/pselect() did not.
+    {
+        const host::GuestInterval ok = host::guest_interval_from_timespec(3, 500000000ll);
+        CHECK(ok.valid && ok.ns == 3500000000ull,
+              "an in-range timespec converts to the exact nanosecond total");
+        CHECK(host::guest_interval_from_timespec(0, 0).valid &&
+              host::guest_interval_from_timespec(0, 0).ns == 0,
+              "a zero interval is VALID and zero, not a refusal");
+        CHECK(host::guest_interval_from_timespec(0, 999999999ll).ns == 999999999ull,
+              "the largest legal nanosecond field converts exactly");
+        CHECK(!host::guest_interval_from_timespec(0, 1000000000ll).valid,
+              "one nanosecond past a whole second is out of range and REFUSED, not carried");
+        CHECK(!host::guest_interval_from_timespec(-1, 0).valid, "a negative tv_sec is refused");
+        CHECK(!host::guest_interval_from_timespec(0, -1).valid, "a negative tv_nsec is refused");
+        CHECK(!host::guest_interval_from_timespec(INT64_MIN, INT64_MIN).valid,
+              "the most negative pair representable is refused rather than reinterpreted");
+        CHECK(!host::guest_interval_from_timespec(5, INT64_MAX).valid,
+              "a garbage 0x7fff... tv_nsec is refused, NOT turned into a near-infinite sleep");
+        // A refusal carries no interval, so a caller that ignored `valid` would sleep zero rather
+        // than some arbitrary residue. Fail-safe in the direction that matters: an unslept wait is
+        // a spin (loud), a wrongly long one is a hang (silent).
+        CHECK(host::guest_interval_from_timespec(5, INT64_MAX).ns == 0,
+              "...and a refused conversion reports a zero interval, never a residue");
+    }
+
+    // 19. THE TIMESPEC SATURATION BOUNDARY. tv_sec is guest-controlled, so the boundary where
+    //     sec * 1e9 + nsec would wrap is reachable by a hostile value, and a wrap there is the
+    //     long-to-short direction (a 584-year sleep becoming a short one).
+    {
+        constexpr uint64_t kNsMax   = ~0ull;
+        constexpr int64_t  kSecMax  = (int64_t)(kNsMax / 1000000000ull);   // 18446744073
+        constexpr int64_t  kNsecRem = (int64_t)(kNsMax % 1000000000ull);   // 709551615
+
+        const host::GuestInterval exact = host::guest_interval_from_timespec(kSecMax, kNsecRem);
+        CHECK(exact.valid && exact.ns == kNsMax,
+              "the largest exactly representable interval converts to UINT64_MAX, not a wrap");
+        const host::GuestInterval below = host::guest_interval_from_timespec(kSecMax, kNsecRem - 1);
+        CHECK(below.valid && below.ns == kNsMax - 1,
+              "one nanosecond below it is still exact, so the clamp is not binding early");
+        // THE BOUNDARY THE SIMPLER GUARD MISSES: sec == kSecMax passes a bare `sec > kSecMax`, and
+        // the addition of nsec is then what overflows.
+        const host::GuestInterval over = host::guest_interval_from_timespec(kSecMax, kNsecRem + 1);
+        CHECK(over.valid && over.ns == kNsMax,
+              "one nanosecond ABOVE it saturates on the addition, never wrapping to a short sleep");
+        CHECK(host::guest_interval_from_timespec(kSecMax + 1, 0).ns == kNsMax,
+              "and a seconds field past the bound saturates on the multiply");
+        CHECK(host::guest_interval_from_timespec(INT64_MAX, 999999999ll).ns == kNsMax,
+              "the widest legal pair saturates instead of wrapping");
+        // Nothing in the legal domain ever shortens: monotonic in the seconds field. The list must
+        // be ASCENDING -- an earlier revision put 1e12 before kSecMax (1.8e10) and the arm reddened
+        // on its own input, which is the cheap end of the failure this file's arm-16 comment
+        // records: an arm whose input does not express the property it names.
+        bool monotonic = true;
+        uint64_t prev = 0;
+        const int64_t seconds[] = {0, 1, 3, 1000, 1000000, 1000000000, kSecMax, INT64_MAX};
+        for (int64_t s : seconds) {
+            const host::GuestInterval r = host::guest_interval_from_timespec(s, 0);
+            if (!r.valid || r.ns < prev) { monotonic = false; break; }
+            prev = r.ns;
+        }
+        CHECK(monotonic, "the conversion never decreases as the requested seconds grow");
+    }
+
+    // 20. THE TIMEVAL CONVERSION, and the multiply that used to precede its range check. select()'s
+    //     sub-second field is MICROseconds, and `(long)(tv_usec * 1000)` did the multiply first --
+    //     signed overflow on a guest-controlled int64 with nothing having refused it.
+    {
+        const host::GuestInterval ok = host::guest_interval_from_timeval(3, 0);
+        CHECK(ok.valid && ok.ns == 3000000000ull,
+              "the argument #1660 captured live -- select(0,NULL,NULL,NULL,{3,0}) -- is 3 s");
+        CHECK(host::guest_interval_from_timeval(0, 999999ll).ns == 999999000ull,
+              "the largest legal tv_usec converts exactly, with the multiply in 64 bits");
+        CHECK(host::guest_interval_from_timeval(0, 150000ll).ns == 150000000ull,
+              "the 150 ms request test_select_sleep drives through the HLE converts to 150 ms");
+        CHECK(!host::guest_interval_from_timeval(0, 1000000ll).valid,
+              "a whole second of tv_usec is out of POSIX range and refused");
+        CHECK(!host::guest_interval_from_timeval(0, -1).valid, "a negative tv_usec is refused");
+        CHECK(!host::guest_interval_from_timeval(-1, 0).valid, "a negative tv_sec is refused");
+        CHECK(!host::guest_interval_from_timeval(0, INT64_MAX).valid,
+              "a tv_usec whose x1000 product would overflow int64 is refused BEFORE the multiply");
+        // The two spellings must agree wherever their domains overlap; select() and pselect() are
+        // the same idiom and a divergence between them would be #1873's class one layer down.
+        bool agree = true;
+        for (int64_t us : {0ll, 1ll, 999ll, 1000ll, 5330ll, 16667ll, 150000ll, 999999ll}) {
+            for (int64_t s : {0ll, 3ll, 1000000ll}) {
+                const host::GuestInterval a = host::guest_interval_from_timeval(s, us);
+                const host::GuestInterval b = host::guest_interval_from_timespec(s, us * 1000ll);
+                if (a.valid != b.valid || a.ns != b.ns) { agree = false; break; }
+            }
+        }
+        CHECK(agree,
+              "select's timeval and pselect's timespec agree identically on the shared domain");
+    }
+
+    // 21. THE 32-BIT NARROWING ITSELF — the case this host's own `long` cannot produce.
+    //
+    // `narrow_to_win_long()` models MinGW-w64's `long tv_nsec` (LLP64: 32 bits, where the guest's
+    // FreeBSD x86-64 field is 64). It is asserted to actually narrow before it is used, so a
+    // no-op model cannot make these arms pass vacuously.
+    {
+        CHECK(narrow_to_win_long(4294967296ll + 500ll) == 500ll,
+              "the model narrows: 2^32 + 500 ns becomes 500 ns, as `long tv_nsec` does on Win64");
+        CHECK(narrow_to_win_long(999999999ll) == 999999999ll,
+              "...and leaves every LEGAL nanosecond value alone: that is the 'correct by luck'");
+
+        // pselect's shape. A guest tv_nsec of 2^32 + 500 is out of range by any reading, and the
+        // narrowing maps it back INSIDE the legal window as a 500 ns sleep -- accepted on Windows,
+        // refused on Linux, from identical guest bytes.
+        const int64_t nsec_hi = 4294967296ll + 500ll;
+        CHECK(narrow_to_win_long(nsec_hi) >= 0 && narrow_to_win_long(nsec_hi) < 1000000000ll,
+              "an out-of-range tv_nsec narrows back INTO the legal window (the defect itself)");
+        CHECK(!host::guest_interval_from_timespec(0, nsec_hi).valid,
+              "...and the 64-bit conversion refuses it on every platform instead");
+
+        // select's shape, where the multiply happened first. tv_usec = 4,294,968 is 4.29 SECONDS;
+        // its x1000 product narrows to 704, so the old expression served a 4.29 s request with a
+        // 704 ns sleep -- six million times short, and only on Windows.
+        const int64_t usec_hi = 4294968ll;
+        CHECK(narrow_to_win_long(usec_hi * 1000ll) == 704ll,
+              "4,294,968 us -> a 704 ns `long tv_nsec`: the six-million-fold shortening");
+        CHECK(!host::guest_interval_from_timeval(0, usec_hi).valid,
+              "...and the 64-bit conversion refuses it, on Linux and Windows alike");
+
+        // The other side of the same narrowing: a product just past INT32_MAX goes NEGATIVE, which
+        // the host nanosleep rejects -- a different wrong answer from the same expression.
+        CHECK(narrow_to_win_long(2147484ll * 1000ll) < 0,
+              "a tv_usec just above 2.147e6 narrows to a NEGATIVE tv_nsec");
+        CHECK(!host::guest_interval_from_timeval(0, 2147484ll).valid,
+              "...also refused, so one expression no longer has three platform-dependent answers");
+
+        // The whole legal domain, swept: the narrowing is the identity there. This is the arm that
+        // says what the defect was NOT -- no in-range guest value was ever mis-served by it, so
+        // this fix is a robustness and cross-platform-consistency change, not a behaviour change
+        // for any input a title has been observed to pass.
+        bool identity_on_legal = true;
+        for (int64_t nsec = 0; nsec < 1000000000ll; nsec += 7919ll) {
+            if (narrow_to_win_long(nsec) != nsec) { identity_on_legal = false; break; }
+        }
+        CHECK(identity_on_legal,
+              "across the whole legal [0, 1e9) nanosecond range the narrowing is the identity");
+    }
+
+
+    // 22. THE DEADLINE CLAMP (#3038). sleep_until_steady_ns takes an UNSIGNED nanosecond count and
+    //     its POSIX backend converts to std::chrono::nanoseconds, whose rep is SIGNED -- so before
+    //     the clamp a deadline past INT64_MAX wrapped into the past and the sleep returned at once.
+    //     Measured before the fix, not inferred: sleep_until_steady_ns(INT64_MAX + 1) and
+    //     sleep_until_steady_ns(UINT64_MAX) each returned in 0 ms on this host.
+    //
+    //     It is reachable because every conversion in this family SATURATES at UINT64_MAX rather
+    //     than wrapping, so the guard against "a long sleep becomes a short one" was handing back
+    //     the shortest sleep there is. Asserted here as arithmetic rather than as a duration, for
+    //     the reason this whole file exists.
+    {
+        CHECK(host::clamp_deadline_to_signed_rep(0) == 0,
+              "a zero deadline is untouched");
+        CHECK(host::clamp_deadline_to_signed_rep(1700000000000000000ull) == 1700000000000000000ull,
+              "an ordinary deadline (~54 years of uptime) passes through unchanged");
+        CHECK(host::clamp_deadline_to_signed_rep((uint64_t)INT64_MAX) == (uint64_t)INT64_MAX,
+              "the largest representable deadline is exactly on the boundary, not one past it");
+        CHECK(host::clamp_deadline_to_signed_rep((uint64_t)INT64_MAX + 1u) == (uint64_t)INT64_MAX,
+              "one nanosecond past it clamps instead of wrapping to a time_point in the PAST");
+        CHECK(host::clamp_deadline_to_signed_rep(~0ull) == (uint64_t)INT64_MAX,
+              "a saturated UINT64_MAX deadline clamps -- this is the value the family produces");
+        // The property that matters is the SIGN of what the conversion then sees: never negative.
+        bool never_negative = true;
+        const uint64_t probes[] = {0ull, 1ull, (uint64_t)INT64_MAX - 1u, (uint64_t)INT64_MAX,
+                                   (uint64_t)INT64_MAX + 1u, ~0ull / 2u, ~0ull - 1u, ~0ull};
+        for (uint64_t d : probes)
+            if ((int64_t)host::clamp_deadline_to_signed_rep(d) < 0)
+                { never_negative = false; break; }
+        CHECK(never_negative,
+              "no input yields a NEGATIVE signed deadline, which is the whole of the defect");
+        // And the clamp is monotone, so it cannot reorder two deadlines relative to each other.
+        bool monotone = true;
+        for (size_t i = 1; i < sizeof(probes) / sizeof(probes[0]); i++) {
+            const uint64_t lo = probes[i - 1] < probes[i] ? probes[i - 1] : probes[i];
+            const uint64_t hi = probes[i - 1] < probes[i] ? probes[i] : probes[i - 1];
+            if (host::clamp_deadline_to_signed_rep(lo) > host::clamp_deadline_to_signed_rep(hi))
+                { monotone = false; break; }
+        }
+        CHECK(monotone, "clamping never reorders two deadlines");
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);


### PR DESCRIPTION
Fixes #3038.

## Both halves of the premise held — and they are worth very different amounts

Verified against `origin/main` at `637e65f9` before writing anything, per #3235's example.

| #3038 said | on `main` | verdict |
| --- | --- | --- |
| `sleep_full` is a raw `nanosleep` loop (`hle_kernel_time.cpp:547`) | it is, verbatim | **held**, and it is the valuable half |
| its `select`/`pselect` callers narrow the guest field through a 32-bit host `long` (`:599`, `:611`) | they do, verbatim | **held as written**; its practical cost is smaller than it reads (below) |
| `:599` multiplies before narrowing | it does | **held**, and it is *undefined behaviour*, not merely a narrowing |
| neither caller validates its range where `k_nanosleep` does | correct | **held** |

The `long` width is measured rather than assumed. Under `x86_64-w64-mingw32-g++` (GCC 16.1.1)
`sizeof(long) == 4`, `sizeof(time_t) == 8`, `sizeof(timespec::tv_nsec) == 4`,
`(long)(2^32 + 500) == 500` and `(long)(2147484 * 1000) < 0` all compile clean; on the host `g++`
the two width assertions and both narrowing assertions fail. That split *is* the defect.

### What #3235 already subsumes, and what it does not

#3235 landed the pattern, not the fix: `WaitDeadline` is on `int64_t` fields and its own comment
names #3038's truncation class as the thing that shape prevents. Nothing in it touches
`hle_kernel_time.cpp`'s `sleep_full` or either `select` caller, which were outside its diff and
deliberately left. So this PR reuses `precise_sleep.hpp` rather than opening a second home for the
arithmetic, and puts the new conversion beside `abs_deadline_from_rel_us` for the same reason.

### The honest size of the truncation half

Every **legal** value fits in 32 bits of nanoseconds (`tv_nsec < 1e9`; `tv_usec * 1000 < 1e9`), so
**no in-range guest value was ever mis-served by it, on any platform** — asserted as a test arm, not
merely argued: a sweep over the whole `[0, 1e9)` range shows the narrowing is the identity there.
What it did produce is a platform **divergence** on out-of-range input: a `tv_usec` of 4,294,968
(4.29 s) narrows to a **704 ns** sleep on Windows, where Linux refused the same bytes. Do not quote
it as a live wrong-duration defect for an observed title. The consequence that *is*
platform-independent is the other one — `tv[1] * 1000` was a signed multiply on a guest-controlled
`int64_t` with no prior range check, i.e. UB, and this project builds with no `-fwrapv`.

## The fix

**1. `sleep_full` → `sleep_full_ns`, on an absolute deadline.** It routes through the file's own
`guest_sleep_ns`, so it inherits #3022's absolute `sleep_until_steady_ns` and the
`PROSPER_GUEST_SLEEP_LEGACY` A/B lever. The retry loop's purpose survives its removal: it existed to
resume across a signal, and the absolute deadline subsumes that (POSIX ends in libstdc++'s own
EINTR-restarting `nanosleep` loop; Windows re-reads the clock after every wait). One caveat is
stated at the code: under the legacy lever a signal can now truncate *this* wait, where the loop
resumed it.

**2. The conversion moves to `precise_sleep.hpp`** as `guest_interval_from_timespec` /
`guest_interval_from_timeval` on `int64_t` fields, applying the `[0, 1e9)` / non-negative rule
`k_nanosleep` and `hle_kernel.cpp:1313` already applied, and saturating rather than wrapping.
`k_nanosleep` now calls it instead of carrying its own copy — behaviour unchanged, and it gives the
extracted function a second production caller.

**3. `select`/`pselect` join `PROSPER_TIMEDWAIT_CENSUS`**, sharing one bucket: one idiom, two
spellings, and the census answers *which primitive a title paces on*. Before this they were the one
sleep entry point it could not see, which is also what makes the Windows verification below possible.

**4. A defect the family's own saturation created, found while writing the tests.** Every
conversion here saturates a guest interval at `UINT64_MAX` so a hostile value cannot turn a long
sleep into a short one — but `sleep_until_steady_ns` takes an *unsigned* deadline while its POSIX
backend converts to `std::chrono::nanoseconds`, whose rep is **signed**. Any deadline past
`INT64_MAX` wrapped into the past and the sleep returned **instantly**, i.e. the clamp handed back
the shortest sleep there is. **Measured, before and after:**

```
before:  sleep_until_steady_ns(INT64_MAX + 1) returned after 0 ms   backend=posix-sleep-until
         sleep_until_steady_ns(UINT64_MAX)    returned after 0 ms   backend=posix-sleep-until
after:   the same probe blocks past a 20 s bound (timeout rc 124)
```

This is in scope because routing `select` through the absolute-deadline path would otherwise have
extended it to the one call whose instant return is #1660's defect verbatim: a 9-million-call-per-
second spin. Windows was already correct here, so the clamp makes the two platforms agree. Fixed as
a pure `clamp_deadline_to_signed_rep` in the header, called by the POSIX backend, and the
`guest_ns_from` comment that called the old behaviour "benign in consequence" is corrected.

## What is verified here, and what is not

**This is a Windows defect and the work was done on Linux.**

| claim | status |
| --- | --- |
| The conversion, its range rule, its saturation, and the truncation it removes | **Verified here AND natively on Windows.** The `Windows MinGW` CI job on this head reports `100% tests passed out of 262` with `select_sleep` **Passed 0.32 s** (#72) and `precise_sleep_deadline_retry` **Passed 0.01 s** (#261) — so arm 21's narrowing model and every conversion arm ran on a real 32-bit-`long` host, not only in a cross-compile. Independently, all these functions are `constexpr`, so 22 `static_assert`s over `guest_interval_*` and `clamp_*` compile clean under `x86_64-w64-mingw32-g++` while the same file's 4 assertions *about the Windows ABI* fail under host `g++` — which is exactly the split being claimed. Three mutation arms below. |
| That the truncation never mis-served a legal value | **Verified**, by sweep (arm 21). Stated because it bounds the claim rather than inflating it. |
| The deadline clamp | **Verified here**, both as arithmetic (arm 22, mutation M3) and by the before/after probe above. Not verified on Windows, where the backend was already correct and the clamp is unreachable. |
| `sleep_full_ns` no longer resolving on the ~15.6 ms tick | **NOT measured anywhere.** No Windows host in this lane. What is verified is that the path now calls the same primitive #3013 measured at 5.64 ms mean against `nanosleep`'s 15.67 ms for the same request — the *substitution*, not its effect. |
| Any title-visible improvement | **Not claimed.** No title is known to pace a short sleep through `select`; #1660's live capture is a 3 s inter-pass sleep, where a 15.6 ms tick is noise. |

**What would settle the unverified row**, now possible only because of change 3: run
`PROSPER_TIMEDWAIT_CENSUS=1` on the Windows 11 / MinGW-w64 UCRT host #3013 was filed from, on this
branch and on `main`, and compare the new `select` row's requested-vs-actual ratio. A title that
never calls `select` prints no row at all, which is itself the answer to "is this path worth
measuring here".

## Linux impact: a no-op for every legal input, a fix for two illegal ones

- **In-range `select`/`pselect` timeouts:** identical. `sleep_until_steady_ns` on POSIX is
  `std::this_thread::sleep_until`, which for a steady clock is one `sleep_for` ending in the same
  EINTR-restarting `nanosleep` loop the old code hand-rolled. `test_select_sleep`'s existing 150 ms
  arms still measure 150 ms.
- **Out-of-range fields:** same observable (no sleep, return 0) — the host `nanosleep` used to
  refuse them with `EINVAL` and now our own guard does, before any multiply. **Improvement:** the
  signed-overflow UB on `tv_usec * 1000` is gone.
- **A saturated interval:** now blocks instead of returning instantly (change 4). This is the only
  Linux behaviour change, it is in the correct direction, and it is unreachable below ~292 years.
- **`k_usleep` / `k_sleep_s` / `k_nanosleep`:** unchanged, except that they too stop returning
  instantly for a saturated request.
- **Windows/macOS:** the conversion and the census are shared; the clamp is POSIX-only.

## Risks

- `clamp_deadline_to_signed_rep` sits under **every** `sleep_until_steady_ns` caller on POSIX,
  including the vblank pacer and the audio grain pacer. It is the identity for every deadline below
  `INT64_MAX` ns, which those are by nine orders of magnitude; the 339-test run is unchanged.
- Refusing rather than clamping an out-of-range `select` timeout preserves the current answer (`0`,
  no sleep) rather than the more POSIX `-1`/`EINVAL`. That is deliberate — an error return is a
  guest-visible contract change for titles that currently see success, unverifiable from this side.
- `WaitKind::Select` widens the census arrays by one. Off by default; report format unchanged.

## Build and test — exact commands, Linux/RADV, container `ps5ys`

```
cmake -S prosper -B prosper/build-linux            # PROSPER_GAME_ROOT=/…/testdata
cmake --build prosper/build-linux -j6
ctest --no-tests=error
```

| run | build rc | ctest rc | result |
| --- | --- | --- | --- |
| `origin/main` @ `637e65f9` baseline | **0** | **0** | **339/339 passed** |
| this branch | **0** | **0** | **339/339 passed** |

Test *count* is unchanged because both new suites are extensions of existing executables rather
than a fourth binary. By name: `select_sleep` **Passed 0.30 s** (#78) and
`precise_sleep_deadline_retry` **Passed 0.00 s** (#274). Both are registered inside
`if(TARGET prosper_core)` only, so both also run in the `Windows MinGW` CI job.

Cross-compile checks, `x86_64-w64-mingw32-g++ -std=c++20 -fsyntax-only`: `precise_sleep.hpp` **rc
0**, `test_precise_sleep.cpp` **rc 0**, `hle_kernel_time.cpp` **rc 0**.

**CI on head `7f7f717a`: all green** — `Linux`, `Windows MinGW`, `Windows App`, `Linux App`,
`Linux App Package`, `macOS (x86_64 / Rosetta 2)`, `macOS App (SDL3 + MoltenVK)`, `Docs` and
`Contribution shape` all **success**; `Progress tracker` and `Publish Release` skipped. `Windows
MinGW` ran the real ctest natively: **262/262 passed**.

Docs gate over every tracked `.md`: **rc 0**. `git diff --check`: **rc 0**.

## Mutation arms — with their build exit codes

Each mutation was applied by a script that asserts its pattern matched **exactly once** and aborts
otherwise, and the file was diffed against the good copy to confirm the edit landed, so "0 failing
arms" cannot be a regex that silently did not apply.

| mutation | build rc | `test_precise_sleep` | `test_select_sleep` |
| --- | --- | --- | --- |
| **M1** — drop `nsec >= 1e9` from the timespec guard | **0** | **rc 1**, 4 arms red | **rc 124 — wedges**, see below |
| **M2** — restore the pre-#3038 timeval expression (no range check, product narrowed to 32 bits) | **0** | **rc 1**, 1 arm red | rc 0 |
| **M3** — remove the deadline clamp | **0** | **rc 1**, 3 arms red | rc 0 |

M1's red arms: *"one nanosecond past a whole second is out of range and REFUSED, not carried"*, *"a
garbage 0x7fff... tv_nsec is refused, NOT turned into a near-infinite sleep"*, *"...and a refused
conversion reports a zero interval, never a residue"*, *"...and the 64-bit conversion refuses it on
every platform instead"*.

M2's single red arm is *"...and the 64-bit conversion refuses it, on Linux and Windows alike"* — the
4,294,968 µs → 704 ns case, and it is the **only** arm that moves. That precision is the point: the
mutation restores the real defect and exactly the arm built for it fires.

M3's red arms: *"one nanosecond past it clamps instead of wrapping to a time_point in the PAST"*,
*"a saturated UINT64_MAX deadline clamps"*, *"no input yields a NEGATIVE signed deadline"*.

**Two negative results, both kept because they bound what the tests prove.** `test_select_sleep`
survives M2 and M3 at rc 0: the HLE-level suite genuinely cannot discriminate the truncation on a
64-bit-`long` host, exactly as its own new comment says. And M1 makes it **wedge** rather than fail,
because a carried `0x7fff…` tv_nsec is a 292-year wait — which is why `select_sleep` now carries a
60 s ctest `TIMEOUT` (a 0.5 s run, so a hundredfold headroom).

## `## Ruled out`

Two rows added to `docs/PORTING.md` § *Ruled out — the Windows guest timed waits*, which #3235
established as the cross-title home for this family: one bounding what the truncation half of
#3038's premise is actually worth, and one recording that saturating to `UINT64_MAX` was **not** a
safe upper clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
