### PR TITLE
render backend: a readback needs an availability operation, not just a fence (#2944)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,15 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-02
 
+### Every frame we have ever read back was read without asking the GPU to hand it over
+
+No picture, and that is the finding: on this hardware a readback with no host-availability barrier
+comes back looking perfectly correct, so nothing has ever complained. Deleting the barrier we just
+added leaves the pixel check green and only the structural check red — and Vulkan's synchronization
+validation, which is armed and reporting five other hazards in the same run, cannot see it either,
+because it has no way to watch the CPU read a mapped pointer.
+[#2944](https://github.com/mattias800/prosper/issues/2944)
+
 ### A guest asking to sleep for 584 years was served in zero milliseconds
 
 No picture — the finding is that prosper's guest sleeps saturate a hostile interval to the largest

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2715,6 +2715,20 @@ if(TARGET prosper_core)
       add_test(NAME backend_persistent_resource_lock
                COMMAND test_backend_persistent_resource_lock)
 
+      # #2944: every GPU readback in the render backend is host-read after a fence wait, and a fence
+      # orders execution rather than performing the availability operation into the host domain.
+      # Structural by necessity -- on a coherent desktop driver the UNFIXED code returns correct
+      # pixels, so the assertion is that the barrier is RECORDED, with a no-readback negative control
+      # so the counter cannot be satisfied by any render at all. Same include roots and same real
+      # Vulkan device as the render_runner.h tests above.
+      add_executable(test_host_read_barrier tests/render/test_host_read_barrier.cpp)
+      # Includes a shared fixture, which resolves from the `tests` root.
+      target_include_directories(test_host_read_barrier PRIVATE tests)
+      # Reaches `shared/...` through render_runner.h, which resolves from `frontends`.
+      target_include_directories(test_host_read_barrier PRIVATE frontends)
+      target_link_libraries(test_host_read_barrier PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME host_read_barrier COMMAND test_host_read_barrier)
+
       # The address-watch matcher's edge cases (exclusive end, empty range, UINT64_MAX wrap).
       add_executable(test_compute_address_watch tests/gpu/test_compute_address_watch.cpp)
       target_link_libraries(test_compute_address_watch PRIVATE prosper_core Vulkan::Vulkan)

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -795,6 +795,28 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   than a dozen samples per arm to say anything — twelve-run arms of one unchanged binary produced
   10/12 and 5/12 for `descriptor_array_render` on the same afternoon. Only the 0/30 pair is a stable
   discriminator. #2937.
+- **Correct pixels are not evidence that a readback is synchronized, and this is the reason #2944
+  survived unnoticed for the life of the backend.** Every readback buffer in the render backend is
+  host-visible memory this platform's driver keeps coherent enough that the *unfixed* code returns
+  the right bytes. Measured directly: with the host-read barrier deleted from the composited-frame
+  readback, `test_host_read_barrier`'s pixel assertion ("the pass rendered and read back a full
+  frame") still **passes** while the structural assertion goes red. So a readback test that checks
+  content can never discriminate here — assert that the barrier is RECORDED. #2944.
+- **Synchronization validation does not detect a missing host-read barrier — do not reach for it as
+  the oracle for this class.** Measured 2026-09-02, Fedora 44 / validation layers 1.4.341 / Mesa
+  RADV STRIX_HALO, with the composited-frame barrier deleted so the defect was live:
+  `VK_LAYER_VALIDATE_SYNC=1` over `test_pipeline_render` and `test_host_read_barrier` produced
+  **zero** messages. The lever is proven to move — the same setting over the whole ctest suite
+  produced **5 SYNC-HAZARD messages** (one READ-AFTER-WRITE in `vulkan_triangle_render`, four
+  WRITE-AFTER-WRITE in `texture_mip_render`), so syncval was armed and reporting; it simply cannot
+  observe a CPU read through a mapped pointer, which is the access the missing dependency protects.
+  Those 5 are a separate, real finding (#3248) and are invisible to `tools/vkval`, which does not
+  enable syncval. #2944.
+- **HOST_COHERENT memory does NOT exempt a readback from the host-domain dependency.** Coherence
+  removes the need for `vkInvalidateMappedMemoryRanges`; it does not perform the availability
+  operation. The two halves are independent, and the backend had only the second: three of the seven
+  readback sites already invalidated (they may be backed by non-coherent HOST_CACHED memory) while
+  none had the barrier. #2944.
 
 ## The renderer is not deterministic on frozen input (2026-08-23) — #2945
 

--- a/prosper/tests/fixtures/AGENTS.md
+++ b/prosper/tests/fixtures/AGENTS.md
@@ -22,7 +22,7 @@ include it. `render_draw_pass_rgba` is therefore a live render path — a wrong 
 silently drops real rendered content in a real game, and "it is under `tests/`" has misled reviewers
 into treating changes here as test-only (#3210 had to say so explicitly in its own body).
 
-Two consequences for anything you change in it:
+Consequences for anything you change in it:
 
 - **Dropping a pass or skipping a draw is a VISIBLE regression** when the condition can fire on a
   healthy device. Guard on the API's own `VkResult`, not on a heuristic, and say in the PR what a
@@ -39,6 +39,12 @@ Two consequences for anything you change in it:
   caches' other entry points (`invalidate_persistent_color_target*`,
   `readback_persistent_color_target`, `snapshot_persistent_ds_images`, and the frontend's direct
   iteration of both), so do not add a new one without reading #3240.
+- **A readback has TWO halves and they are independent** (#2944). Any device write the CPU then maps
+  and reads needs `record_host_read_barrier()` — the availability operation into the host domain,
+  which a fence wait does not perform — and, when the memory may be non-coherent,
+  `invalidate_mapped_readback()`. Coherent memory still needs the first. Neither half can be checked
+  by reading the pixels back: on every driver here the unsynchronized code returns correct bytes, so
+  the guard is `host_read_barrier`, which asserts the barrier was RECORDED.
 
 ## Adding to it
 

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -3947,6 +3947,68 @@ inline bool invalidate_mapped_readback(const RenderVkCtx& ctx, VkDeviceMemory me
     return vkInvalidateMappedMemoryRanges(ctx.dev, 1, &range) == VK_SUCCESS;
 }
 
+// The OTHER half of a readback, and a separate operation from the invalidate above.
+//
+// Waiting a fence -- or vkQueueWaitIdle -- orders EXECUTION. It does not perform the availability
+// operation that moves a transfer (or shader, or transform-feedback) write into the HOST domain.
+// Vulkan requires an explicit dependency for that: dstStageMask = VK_PIPELINE_STAGE_HOST_BIT with
+// dstAccessMask = VK_ACCESS_HOST_READ_BIT (#2944).
+//
+// Coherent memory does not exempt a readback from it. HOST_COHERENT removes the need for
+// vkInvalidateMappedMemoryRanges; it does not remove the need for the dependency. So the two halves
+// are independent: non-coherent memory needs both, coherent memory needs this one.
+//
+// Every driver this project runs on completes the availability anyway, which is exactly why the gap
+// survived unnoticed -- the pixels come back correct and nothing says the code was wrong. The fix is
+// spec conformance, not a chase after a visible symptom.
+struct HostReadBarrier {
+    VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    VkPipelineStageFlags src_stages = 0;
+    VkPipelineStageFlags dst_stages = 0;
+};
+
+// Pure, so the masks can be asserted with no device (`host_read_barrier` ctest case). The buffer
+// scope is whole-buffer: a readback buffer holding several slots (the MRT frame buffer writes up to
+// eight colour offsets into one allocation) is made available in one dependency.
+inline HostReadBarrier host_read_barrier_for(
+        VkBuffer buffer,
+        VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VkAccessFlags src_access = VK_ACCESS_TRANSFER_WRITE_BIT) {
+    HostReadBarrier host_read{};
+    host_read.barrier.srcAccessMask = src_access;
+    host_read.barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+    host_read.barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    host_read.barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    host_read.barrier.buffer = buffer;
+    host_read.barrier.offset = 0;
+    host_read.barrier.size = VK_WHOLE_SIZE;
+    host_read.src_stages = src_stages;
+    host_read.dst_stages = VK_PIPELINE_STAGE_HOST_BIT;
+    return host_read;
+}
+
+// How many host-read barriers this process has recorded. Exists so a test can prove the barrier
+// reached the command buffer on a path it drives: without it the fix is unfalsifiable here, because
+// on a coherent desktop driver the UNFIXED code reads back correct pixels. Relaxed and process-wide
+// -- it is an instrument, never a control input.
+inline std::atomic<uint64_t>& backend_host_read_barrier_count() {
+    static std::atomic<uint64_t> count{0};
+    return count;
+}
+
+// Record the availability dependency for one readback buffer. Call it after the LAST device write
+// into that buffer in a command buffer, and before the host maps and reads it.
+inline void record_host_read_barrier(
+        VkCommandBuffer command, VkBuffer buffer,
+        VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VkAccessFlags src_access = VK_ACCESS_TRANSFER_WRITE_BIT) {
+    if (!command || !buffer) return;
+    const HostReadBarrier host_read = host_read_barrier_for(buffer, src_stages, src_access);
+    vkCmdPipelineBarrier(command, host_read.src_stages, host_read.dst_stages, 0,
+                         0, nullptr, 1, &host_read.barrier, 0, nullptr);
+    backend_host_read_barrier_count().fetch_add(1, std::memory_order_relaxed);
+}
+
 // CONTRACT: a pure TRANSFER_DST (readback) buffer may be backed by HOST_CACHED memory that is NOT
 // HOST_COHERENT. Call invalidate_mapped_readback() after mapping and before reading one, and do not
 // host-WRITE through such a mapping without a flush. Any usage including TRANSFER_SRC is always
@@ -4066,6 +4128,10 @@ inline BackendSubmissionState submit_persistent_ds_transfer(
                                static_cast<VkDeviceSize>(width) * height * 4);
     if (copy_stencil) copy_plane(VK_IMAGE_ASPECT_STENCIL_BIT,
                                  static_cast<VkDeviceSize>(width) * height);
+    // #2944: on the READBACK direction the caller maps `buffer` and reads it after the fence below.
+    // The fence orders execution; this makes the copy available to the host. The UPLOAD direction is
+    // the mirror image -- the host wrote and the device reads -- so it needs no host-read dependency.
+    if (!upload) record_host_read_barrier(command, buffer);
 
     barrier.oldLayout = transfer_layout;
     barrier.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -4178,6 +4244,7 @@ inline bool readback_persistent_color_target(uint64_t id, uint32_t width, uint32
     copy.imageExtent = {width, height, 1};
     vkCmdCopyImageToBuffer(command, target->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                            buffer, 1, &copy);
+    record_host_read_barrier(command, buffer);   // #2944
     barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     barrier.newLayout = saved_layout;
     barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
@@ -9021,6 +9088,17 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
     }
     vkCmdEndRenderPass(cmd);
+    // #2944: the geometry probe maps both transform-feedback buffers below. Transform feedback does
+    // not write through the transfer stage, so this pair carries its own source scope -- the vertex
+    // records and the counter the extension writes at vkCmdEndTransformFeedbackEXT. Recorded here
+    // rather than beside p_endxfb because a buffer memory barrier is not permitted inside a render
+    // pass instance.
+    if (geom_active) {
+        record_host_read_barrier(cmd, geom_buf, VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT,
+                                 VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT);
+        record_host_read_barrier(cmd, geom_counter, VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT,
+                                 VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT);
+    }
     // PROSPER_BUFFER_ECHO=1 (#2945) -- ground truth for "what did the GPU see in this draw's
     // storage buffers". Every other instrument reads the HOST side: PROSPER_BUFLOG prints the source
     // words, --dump-resource prints the capture's bytes, and both were byte-identical across runs
@@ -9099,12 +9177,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             ++echo_count;
             vkCmdCopyBuffer(cmd, dv[d].ibuf, echo_buffer, 1, &copy);
         }
-        VkMemoryBarrier host_read{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
-        host_read.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        host_read.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
-        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                             VK_PIPELINE_STAGE_HOST_BIT, 0, 1, &host_read,
-                             0, nullptr, 0, nullptr);
+        record_host_read_barrier(cmd, echo_buffer);   // #2944
     }
     backend_pass_timing_end(cmd);   // #2333
     // Fence waits used to provide the device-memory dependency between every target call. Batched
@@ -9222,6 +9295,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         copy.imageExtent = {upload.key.width, upload.key.height, upload.key.depth};
         vkCmdCopyImageToBuffer(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                upload.staging, 1, &copy);
+        record_host_read_barrier(cmd, upload.staging);   // #2944
         VkImageMemoryBarrier to_general{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         to_general.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -9273,6 +9347,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                    rb, 1, &extra_copy);
         }
+        // #2944: one whole-buffer dependency covers every colour slot copied above -- they are
+        // offsets into one allocation, which the host maps and reads once the batch completes.
+        record_host_read_barrier(cmd, rb);
         auto restore_persistent_color = [&](bool persistent, bool readback, VkImage image) {
             if (!persistent || !readback) return;
             VkImageMemoryBarrier to_sample{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
@@ -9779,6 +9856,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 }
                 vkCmdEndRenderPass(c2);
                 vkCmdCopyImageToBuffer(c2, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp2);
+                record_host_read_barrier(c2, rb);   // #2944
                 const bool recorded = vkEndCommandBuffer(c2) == VK_SUCCESS;
                 const bool fence_reset = recorded &&
                     vkResetFences(dev, 1, &iso_fence) == VK_SUCCESS;

--- a/prosper/tests/render/test_host_read_barrier.cpp
+++ b/prosper/tests/render/test_host_read_barrier.cpp
@@ -1,0 +1,141 @@
+// test_host_read_barrier — #2944: a GPU readback the CPU maps and reads needs an AVAILABILITY
+// operation into the host domain, and waiting a fence is not one.
+//
+// Waiting a fence (or vkQueueWaitIdle) orders EXECUTION. Making a transfer write available to the
+// host additionally requires a dependency with dstStageMask = VK_PIPELINE_STAGE_HOST_BIT and
+// dstAccessMask = VK_ACCESS_HOST_READ_BIT — equivalently, for non-coherent memory,
+// vkInvalidateMappedMemoryRanges, which this header already does at every mapped read. The two are
+// independent halves; the backend had only the second.
+//
+// WHAT THIS TEST CAN AND CANNOT DETECT, stated plainly because the honest answer is not "it proves
+// the fix works":
+//
+//   * It CANNOT detect the defect by its output. Every readback buffer in the backend is backed by
+//     HOST_VISIBLE memory that this platform's driver keeps coherent enough that the unfixed code
+//     returns correct pixels. A test that reads back a triangle and checks the colour passes
+//     identically with and without the barrier — that is precisely why the gap survived. So the
+//     assertion here is STRUCTURAL: the barrier must be RECORDED.
+//   * It DOES fail without the fix, on the path it drives. Deleting the
+//     `record_host_read_barrier(cmd, rb)` call from the colour readback in render_draw_pass_rgba
+//     leaves the counter at zero across arm 2 and the arm goes red.
+//   * The negative control is the discriminator, not decoration. Arm 3 renders the SAME draw with
+//     `want_color_readback = false`. No host read happens, so no barrier may be recorded. Without
+//     it, a counter incremented unconditionally somewhere on the render path would satisfy arm 2
+//     while proving nothing about the readback.
+//   * It covers ONE of the seven recorded sites — the composited-frame readback. The DS-plane
+//     transfer, the persistent colour-target readback, the storage-image writeback and the three
+//     env-gated diagnostics are not reachable from a fixture-only test without a title's resources;
+//     they share the same helper, and arm 1 pins that helper's masks.
+//
+// Arm 1 needs no device at all: `host_read_barrier_for` is pure, so the exact masks and stages are
+// asserted directly rather than inferred from a driver's behaviour.
+
+#include "fixtures/render_runner.h"
+#include "fixtures/spirv_triangle.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using prosper::test::BackendDraw;
+using prosper::test::FrameResource;
+
+static int failures = 0;
+#define CHECK(condition, message) do { \
+    if (!(condition)) { std::printf("  [FAIL] %s\n", message); ++failures; } \
+    else               { std::printf("  [ok]   %s\n", message); } \
+} while (0)
+
+namespace {
+
+// The same draw render_triangle_rgba() builds, spelled out here because the negative-control arm
+// needs the `want_color_readback` parameter that the convenience wrapper does not expose.
+std::vector<BackendDraw> one_triangle() {
+    BackendDraw draw;
+    draw.vs.assign(kTriVertSpv, kTriVertSpv + sizeof(kTriVertSpv) / 4);
+    draw.fs.assign(kTriFragSpv, kTriFragSpv + sizeof(kTriFragSpv) / 4);
+    draw.vcount = 3;
+    for (uint32_t set = 0; set < 2; ++set) {
+        FrameResource b2; b2.binding = 2; b2.set = set; draw.R.push_back(std::move(b2));
+        FrameResource b3; b3.binding = 3; b3.set = set; draw.R.push_back(std::move(b3));
+    }
+    return {std::move(draw)};
+}
+
+uint64_t barrier_count() {
+    return prosper::test::backend_host_read_barrier_count().load(std::memory_order_relaxed);
+}
+
+}  // namespace
+
+int main() {
+    std::printf("== test_host_read_barrier ==\n");
+
+    // --- Arm 1: the barrier descriptor itself (no device) --------------------------------------
+    {
+        auto* const buffer = reinterpret_cast<VkBuffer>(static_cast<uintptr_t>(0x1234));
+        const prosper::test::HostReadBarrier host_read =
+            prosper::test::host_read_barrier_for(buffer);
+        CHECK(host_read.barrier.sType == VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+              "the barrier is a VkBufferMemoryBarrier");
+        CHECK(host_read.barrier.dstAccessMask == VK_ACCESS_HOST_READ_BIT,
+              "dstAccessMask is exactly VK_ACCESS_HOST_READ_BIT");
+        CHECK(host_read.dst_stages == VK_PIPELINE_STAGE_HOST_BIT,
+              "dstStageMask is exactly VK_PIPELINE_STAGE_HOST_BIT");
+        CHECK(host_read.barrier.srcAccessMask == VK_ACCESS_TRANSFER_WRITE_BIT,
+              "the default source is the transfer write the copy performed");
+        CHECK(host_read.src_stages == VK_PIPELINE_STAGE_TRANSFER_BIT,
+              "the default source stage is the transfer stage");
+        CHECK(host_read.barrier.buffer == buffer, "the barrier names the buffer it was asked for");
+        CHECK(host_read.barrier.offset == 0 && host_read.barrier.size == VK_WHOLE_SIZE,
+              "the scope is the whole buffer, so every slot copied into it is covered");
+        CHECK(host_read.barrier.srcQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED &&
+              host_read.barrier.dstQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED,
+              "no ownership transfer is requested");
+    }
+
+    // The geometry probe reads transform-feedback output, which is not a transfer write. The source
+    // scope is a parameter for exactly that reason; the host half must not change with it.
+    {
+        auto* const buffer = reinterpret_cast<VkBuffer>(static_cast<uintptr_t>(0x5678));
+        const prosper::test::HostReadBarrier host_read = prosper::test::host_read_barrier_for(
+            buffer, VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT,
+            VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT);
+        CHECK(host_read.barrier.srcAccessMask == VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT &&
+              host_read.src_stages == VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT,
+              "a non-transfer producer keeps its own source scope");
+        CHECK(host_read.barrier.dstAccessMask == VK_ACCESS_HOST_READ_BIT &&
+              host_read.dst_stages == VK_PIPELINE_STAGE_HOST_BIT,
+              "the host half is the same whatever wrote the buffer");
+    }
+
+    const uint32_t W = 64, H = 64;
+
+    // --- Arm 2: a real readback records one ----------------------------------------------------
+    const uint64_t before_readback = barrier_count();
+    const std::vector<uint8_t> pixels = prosper::test::render_draws_rgba(one_triangle(), W, H);
+    const uint64_t after_readback = barrier_count();
+    CHECK(pixels.size() == static_cast<size_t>(W) * H * 4,
+          "the pass rendered and read back a full frame");
+    std::printf("  host-read barriers recorded by the readback pass: %llu\n",
+                static_cast<unsigned long long>(after_readback - before_readback));
+    CHECK(after_readback > before_readback,
+          "a colour readback records a host-read barrier before the host maps the buffer");
+
+    // --- Arm 3 (negative control): no readback, no barrier --------------------------------------
+    // Same draws, same extent, one flag. If the counter moved here it would be counting renders
+    // rather than readbacks, and arm 2 would be worthless.
+    const uint64_t before_no_readback = barrier_count();
+    const std::vector<uint8_t> none = prosper::test::render_draws_rgba(
+        one_triangle(), W, H, /*seed_rgba=*/nullptr, /*clear_rgba=*/nullptr,
+        /*persist_depth_stencil=*/false, /*color_target=*/nullptr, /*seed_rgba1=*/nullptr,
+        /*clear_rgba1=*/nullptr, /*out_rgba1=*/nullptr, /*submission_batch=*/nullptr,
+        /*flush_submission_batch=*/true, /*mrt_outputs=*/nullptr, /*want_color_readback=*/false);
+    const uint64_t after_no_readback = barrier_count();
+    CHECK(none.empty(), "a pass that asks for no colour readback returns no pixels");
+    CHECK(after_no_readback == before_no_readback,
+          "a pass with no host read records no host-read barrier");
+
+    std::printf("== %s ==\n", failures ? "FAILED" : "PASSED");
+    return failures ? 1 : 0;
+}

--- a/prosper/tools/vkval/README.md
+++ b/prosper/tools/vkval/README.md
@@ -22,6 +22,20 @@ Either fix in shader or update the VkImageViewType to VK_IMAGE_VIEW_TYPE_2D.
 
 That is the difference the guard buys.
 
+## What it does NOT cover
+
+**Synchronization validation is off.** The scan enables the layer's default (core) checks only, so
+nothing in this tree has ever gated on prosper's barriers. Turning it on
+(`VK_LAYER_VALIDATE_SYNC=1`) reports real hazards this guard cannot see — measured 2026-09-02, 5
+`SYNC-HAZARD` messages across 2 tests, filed as #3248 with the one that lives in the render backend.
+Enabling it here is a decision that has not been taken, because those findings would have to be
+fixed or allow-listed first.
+
+Syncval is also not a general oracle for synchronization. It cannot observe a CPU read through a
+mapped pointer, so it does not see a missing host-availability barrier on a readback (#2944):
+measured in the same session with that defect deliberately live, it produced zero messages while
+demonstrably armed. `docs/GRAPHICS.md` § Ruled out carries both halves of that measurement.
+
 ## Running it
 
 ```bash


### PR DESCRIPTION
Fixes #2944

## The defect

A `vkCmdCopy*` writes a `HOST_VISIBLE` buffer; the CPU maps it and reads it after a fence wait. Per
the Vulkan spec a fence signal orders **execution**. It does not perform the **availability**
operation that moves that write into the host domain — that needs an explicit dependency with
`dstStageMask = VK_PIPELINE_STAGE_HOST_BIT` and `dstAccessMask = VK_ACCESS_HOST_READ_BIT`
(equivalently, for non-coherent memory, `vkInvalidateMappedMemoryRanges`, which is a *separate*
half, not a substitute).

Every readback in the render backend did the second half where it was needed and none of the first.

## Re-derived site list — the issue's is stale, in both directions

The issue names four rows and says `VK_ACCESS_HOST_READ_BIT` appears nowhere in the render path.
Neither is still true. `render_runner.h` gained a correct site in #2949 (the `PROSPER_BUFFER_ECHO`
diagnostic) and `tools/vkprobe` gained one that cites this issue by number. Re-derived against
current `origin/main` — every host read of device-written mapped memory in `render_runner.h`:

| # | site | producer | memory | invalidate before this PR | barrier before this PR |
| --- | --- | --- | --- | --- | --- |
| 1 | `submit_persistent_ds_transfer` readback → `read_persistent_ds_depth` | `vkCmdCopyImageToBuffer` | **may be non-coherent** (`HOST_CACHED` preferred, `HOST_COHERENT` fallback) | present | **absent** |
| 2 | `submit_persistent_ds_transfer` readback → `capture_persistent_ds_seeds` | `vkCmdCopyImageToBuffer` | **may be non-coherent** | present | **absent** |
| 3 | `readback_persistent_color_target` | `vkCmdCopyImageToBuffer` | **may be non-coherent** | present | **absent** |
| 4 | `render_draw_pass_rgba` storage-image writeback (`upload.staging`) | `vkCmdCopyImageToBuffer` | `HOST_COHERENT` (required) | n/a | **absent** |
| 5 | `render_draw_pass_rgba` frame readback (`rb`/`bmem`) | `vkCmdCopyImageToBuffer` ×N slots | `HOST_COHERENT` (required in **both** tiers) | n/a | **absent** |
| 6 | `PROSPER_DRAW_ISO` per-kill readback (`rb`) | `vkCmdCopyImageToBuffer` | `HOST_COHERENT` | n/a | **absent** — not in the issue |
| 7 | `PROSPER_GEOM_PROBE` transform-feedback pair (`geom_buf`, `geom_counter`) | transform feedback, **not** a transfer write | `HOST_COHERENT` (the readback tier needs `TRANSFER_DST`, which these do not carry) | n/a | **absent** — not in the issue |
| 8 | `PROSPER_BUFFER_ECHO` (`echo_buffer`) | `vkCmdCopyBuffer` | `HOST_COHERENT` | n/a | **present** (#2949) |

So: the issue's four rows cover five of the eight host-read call sites; two more (6, 7) were missed;
one (8) was fixed after it was filed. Rows 1–3 collapse to one producer, `submit_persistent_ds_transfer`,
which is where the barrier is placed.

**Coherent vs non-coherent.** Rows 1–3 come from `persistent_ds_transfer_buffer`, whose readback tier
deliberately *prefers* `HOST_CACHED` and falls back to `HOST_CACHED` **without** `HOST_COHERENT` if a
coherent cached type is absent — so those can genuinely be non-coherent, and their invalidates were
already correct. Rows 4–8 all require `HOST_COHERENT` in every allocation tier, so
`vkInvalidateMappedMemoryRanges` is not required for them; the dependency still is. **No site needed a
new invalidate** — there is no second bug of that shape here.

Row 7's producer is not a transfer at all, which is why the helper takes the source stage/access as
parameters rather than hardcoding `TRANSFER`. `VK_EXT_transform_feedback` requires
`VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT` with `..._WRITE_BIT_EXT` / `..._COUNTER_WRITE_BIT_EXT`
as the source scope, and the barrier is recorded after `vkCmdEndRenderPass` because a buffer memory
barrier is not permitted inside a render pass instance.

## The fix

One helper beside `invalidate_mapped_readback()`, so the two halves of the readback contract sit
together and the comment can say they are independent:

* `host_read_barrier_for(buffer, src_stages, src_access)` — **pure**, returns the
  `VkBufferMemoryBarrier` plus its stage masks, so the masks can be asserted with no device;
* `record_host_read_barrier(command, buffer, ...)` — records it and bumps a process-wide counter;
* `backend_host_read_barrier_count()` — the instrument the test reads.

Whole-buffer scope (`offset 0`, `VK_WHOLE_SIZE`): row 5 copies up to eight colour slots at different
offsets into one allocation, and one dependency covers them all.

Pattern choice: `VkBufferMemoryBarrier`, matching the two correct sites the issue names
(`prosper-app/main.cpp`'s F9 grab and `live_compute.cpp`'s comparator writeback). `render_runner.h`'s
own already-correct site used a global `VkMemoryBarrier`; it is folded into the helper rather than
left as a second way of doing the same thing.

## What the test can and cannot detect

`prosper/tests/render/test_host_read_barrier.cpp`, registered as `host_read_barrier`.

**Cannot**: detect the defect from output. Every readback buffer here is host-visible memory this
platform's driver keeps coherent enough that the *unfixed* code returns correct pixels — which is
exactly why the gap survived. Measured, not assumed: with the row-5 barrier deleted, the arm
`"the pass rendered and read back a full frame"` still **passes**.

**Can**: fail without the fix, on the path it drives. Structural assertion that the barrier is
**recorded**.

* Arm 1 (no device): the exact masks — `dstAccessMask` is exactly `VK_ACCESS_HOST_READ_BIT`,
  `dstStageMask` exactly `VK_PIPELINE_STAGE_HOST_BIT`, whole-buffer scope, no ownership transfer —
  plus a second case proving the host half does not change when the source scope is transform
  feedback.
* Arm 2: `render_draws_rgba` with readback → the counter must move.
* Arm 3 (**negative control, the actual discriminator**): the same draw with
  `want_color_readback = false`. No host read happens, so no barrier may be recorded. Without this,
  a counter incremented anywhere on the render path would satisfy arm 2 and prove nothing.

**Coverage**: one of the seven fixed sites — the composited-frame readback. The DS-plane transfer,
the persistent colour-target readback, the storage-image writeback and the three env-gated
diagnostics are not reachable from a fixture-only test without a title's resources. They share the
helper, and arm 1 pins the helper.

### Measured mutation arm

Deleting `record_host_read_barrier(cmd, rb)` from the composited-frame readback, rebuilding only the
test target:

```
  [ok]   the pass rendered and read back a full frame          <- the pixel check is BLIND to it
  host-read barriers recorded by the readback pass: 0
  [FAIL] a colour readback records a host-read barrier before the host maps the buffer
  [ok]   a pass with no host read records no host-read barrier <- the negative control still holds
== FAILED ==     ctest exit 8
```

Restored, `1` barrier is recorded and the case passes.

### Synchronization validation was weighed and rejected as the oracle

`tools/vkval` runs **core** validation only. Enabling syncval by hand
(`VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation VK_LAYER_VALIDATE_SYNC=1`) with the defect
deliberately live produced **zero** messages on `test_pipeline_render` and `test_host_read_barrier`.
That null is not silent-instrument noise: the same setting over the whole suite produced **5
`SYNC-HAZARD` messages** across two other tests, so syncval was armed and reporting. It simply
cannot observe a CPU read through a mapped pointer, which is the access the missing dependency
protects. The five hazards are a real, separate finding — filed as #3248, including one in the
render backend's mip-assembly path (`vkCmdClearColorImage` then `vkCmdCopyImage` to the same image
with no barrier between the two writes).

## Risks

* **A barrier that is not free.** Seven extra `vkCmdPipelineBarrier` calls per frame at most, on
  paths that are already doing a full-surface copy plus a fence wait. `TRANSFER → HOST` is the
  cheapest dependency there is; nothing waits on a queue that was not already about to be waited on.
* **Row 7's stage flag needs the extension enabled.** It is guarded by `geom_active`, which implies
  `geom_probe`, which implies `ds_ctx.transform_feedback_enabled` — the same condition that created
  the buffers. Validation is clean on the full suite.
* **A process-wide counter on the render path.** One relaxed `fetch_add` per readback. It is an
  instrument and is never read as a control input.
* **Behaviour change is intended to be none.** #2944 measured its own prototype as changing nothing
  visible (BALAN WONDERWORLD, 15/110 vs 17/110 content frames, matched A/B), and that expectation is
  unchanged. This lands as spec conformance.

## Also updated

* `docs/GRAPHICS.md` § Ruled out — three rows: correct pixels are not evidence of synchronization;
  syncval does not detect this class (with its positive control); `HOST_COHERENT` does not exempt a
  readback from the dependency.
* `tests/fixtures/AGENTS.md` — the two-halves rule, in the map for the folder that owns the backend.
* `tools/vkval/README.md` — a "what it does not cover" section, since the guard's silence on
  barriers had never been written down.
* `BLOG.md` — one entry, no picture.
* Filed while here: **#3248** (syncval is off; 5 hazards when it is on, one in the backend) and
  **#3249** (`live_compute` host-reads every dispatch *result* with no barrier — the site #2944 cites
  as correct is the comparator flags, not the results).

## Build / test

Container `ps5ys`, Fedora 44, Mesa RADV STRIX_HALO (Radeon 8060S), validation layers 1.4.341.

```
cmake -S prosper -B prosper/build-linux            # exit 0
cmake --build prosper/build-linux -j6              # exit 0
ctest --no-tests=error                             # 341/341 passed, exit 0
python3 tools/vkval/vk_validation_scan.py --build-dir build-linux   # PASS, exit 0
                                                   # 5 ids / 52 messages, all pre-existing + allow-listed
```

`origin/main` baseline measured in the same worktree before the change: build exit 0, **340/340
passed, ctest exit 0**. The delta is the one registered case.

Mutation arm (row 5 barrier removed, `--target test_host_read_barrier`): build exit 0,
`ctest -R '^host_read_barrier$'` exit **8**, 0/1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
