### PR TITLE
zerowatch: the tail of #3243's review that the merge missed -- including a silent 239-byte overread

### DIFF
--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2762,6 +2762,9 @@ struct ZeroWatchEntry {
     int reprofiles_done = 0;
     bool find_control_done = false;      // the "the data IS findable" arm has run
     bool find_control_found = false;
+    // The control did not run at all (every needle it had was degenerate), which is a different
+    // reason to skip the second scan than "the control looked and found nothing".
+    bool find_control_refused = false;
 };
 std::mutex g_zw_mx;
 std::vector<ZeroWatchEntry> g_zw;
@@ -2858,7 +2861,7 @@ size_t zerowatch_find_prefix() {
 }
 
 void zw_find(const ZeroWatchEntry& e, const char* when, const uint8_t* needle, uint64_t needle_off,
-             const char* window, bool* found_out) {
+             const char* window, bool* found_out, bool* refused_out) {
     // A needle whose leading prefix_len bytes are all zero matches essentially everywhere, so both
     // its hits and its misses are meaningless. The arming code below picks a non-zero start where
     // one exists inside the window; this is the backstop for when none does, and it refuses rather
@@ -2868,6 +2871,9 @@ void zw_find(const ZeroWatchEntry& e, const char* when, const uint8_t* needle, u
         if (needle[k]) degenerate = false;
     if (degenerate) {
         if (found_out) *found_out = false;
+        // REFUSED is not the same as "found nothing", and the difference decides whether a later
+        // scan is worth running. Reported separately so the skip line downstream can say which.
+        if (refused_out) *refused_out = true;
         fprintf(stderr, "[zerowatch-find] t=%llu %s dst=0x%llx window=%s seed-off=0x%llx "
                         "DEGENERATE NEEDLE (first %zu bytes all zero) -- NOT scanned\n",
                 (unsigned long long)prosper::diagnostics::diag_now_us(), when,
@@ -3062,23 +3068,37 @@ void zerowatch_poll_forever() {
                     if (e.find_control_done && e.find_control_found)
                         pending_find.push_back({e, "AFTER-ZERO"});
                     else if (e.find_control_done)
-                        fprintf(stderr, "[zerowatch-find] dst=0x%llx AFTER-ZERO scan SKIPPED -- its "
-                                        "control scan found nothing, so a null here would be void\n",
-                                (unsigned long long)e.dst);
+                        fprintf(stderr, "[zerowatch-find] dst=0x%llx AFTER-ZERO scan SKIPPED -- %s, "
+                                        "so a null here would be void\n",
+                                (unsigned long long)e.dst,
+                                e.find_control_refused
+                                    ? "its control was REFUSED (every needle degenerate) and never ran"
+                                    : "its control scan ran and found nothing");
                 }
             }
         }
         // Outside the lock: see the note at the top of this function.
         for (auto& p : pending_find) {
-            bool found = false, found_deep = false;
-            zw_find(p.first, p.second, p.first.seed, p.first.find_off, "first", &found);
+            bool found = false, found_deep = false, refused = false, refused_deep = false;
+            zw_find(p.first, p.second, p.first.seed, p.first.find_off, "first", &found, &refused);
             if (p.first.has_seed_deep)
                 zw_find(p.first, p.second, p.first.seed_deep, p.first.find_deep_off, "deep",
-                        &found_deep);
+                        &found_deep, &refused_deep);
+            else if (strcmp(p.second, "CONTROL") == 0)
+                // A missing deep needle is as much a limit on the scan as a refused one, and it was
+                // silent: the payload had no second non-zero window past the first, so only the
+                // chunk header is being followed. Say so, or a reader counts two scans and gets one.
+                fprintf(stderr, "[zerowatch-find] dst=0x%llx has NO deep window -- the payload's only "
+                                "non-zero 256B window is the first, so this range is followed by its "
+                                "head alone\n",
+                        (unsigned long long)p.first.dst);
             if (strcmp(p.second, "CONTROL") == 0) {
                 std::lock_guard<std::mutex> lk(g_zw_mx);
                 for (auto& e : g_zw)
-                    if (e.dst == p.first.dst) e.find_control_found = found || found_deep;
+                    if (e.dst == p.first.dst) {
+                        e.find_control_found = found || found_deep;
+                        e.find_control_refused = refused && (!p.first.has_seed_deep || refused_deep);
+                    }
             }
         }
         pending_find.clear();

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2737,10 +2737,11 @@ struct ZeroWatchEntry {
     uint64_t seed_off = 0;
     const char* path = "?";
     bool seen_nonzero = false, reported = false;
-    // #3142: a verbatim copy of the SOURCE bytes at seed_off, so that after the range goes quiet the
-    // guest's whole address space can be searched for them. Kept from the source rather than read
-    // back from the destination, for the same reason the seed scan uses the source: the payload is
-    // the oracle, and re-reading the destination would sample whatever is there now.
+    // #3142: a verbatim copy of the SOURCE bytes at `find_off` (NOT at seed_off -- see find_off
+    // below), so that after the range goes quiet the guest's whole address space can be searched for
+    // them. Kept from the source rather than read back from the destination, for the same reason the
+    // seed scan uses the source: the payload is the oracle, and re-reading the destination would
+    // sample whatever is there now.
     uint8_t seed[256] = {0};
     // A SECOND window, taken from the LAST non-zero place in the payload rather than the first.
     // Window 0 of a streamed UE4 chunk is its serialization header, and a header is exactly the part
@@ -2858,6 +2859,22 @@ size_t zerowatch_find_prefix() {
 
 void zw_find(const ZeroWatchEntry& e, const char* when, const uint8_t* needle, uint64_t needle_off,
              const char* window, bool* found_out) {
+    // A needle whose leading prefix_len bytes are all zero matches essentially everywhere, so both
+    // its hits and its misses are meaningless. The arming code below picks a non-zero start where
+    // one exists inside the window; this is the backstop for when none does, and it refuses rather
+    // than publishing a number.
+    bool degenerate = true;
+    for (size_t k = 0; k < zerowatch_find_prefix() && degenerate; ++k)
+        if (needle[k]) degenerate = false;
+    if (degenerate) {
+        if (found_out) *found_out = false;
+        fprintf(stderr, "[zerowatch-find] t=%llu %s dst=0x%llx window=%s seed-off=0x%llx "
+                        "DEGENERATE NEEDLE (first %zu bytes all zero) -- NOT scanned\n",
+                (unsigned long long)prosper::diagnostics::diag_now_us(), when,
+                (unsigned long long)e.dst, window, (unsigned long long)needle_off,
+                zerowatch_find_prefix());
+        return;
+    }
     std::vector<prosper::host::MemorySearchHit> hits;
     // The GUEST's address space only: [0x100000000, kGuestAutoMapLimit). prosper's own host
     // allocations sit at 0x7f... on this host and a wider scan does find the payload there -- in
@@ -2911,11 +2928,12 @@ void zw_find(const ZeroWatchEntry& e, const char* when, const uint8_t* needle, u
 // is not mistaken for one that lost its data.
 void zw_profile(const ZeroWatchEntry& e, const char* when) {
     char prof[640]; int used = 0;
-    uint32_t zero_windows = 0, live_windows = 0;
+    uint32_t zero_windows = 0, live_windows = 0, unreadable_windows = 0;
     for (uint32_t w = 0; w < 16; ++w) {
         const uint64_t off = (((e.size - 256ull) / 15ull) * w) & ~(uint64_t)3;
         uint32_t dw[64], nzw = 0;
         if (!zw_read256(e.dst + off, dw)) {
+            ++unreadable_windows;
             used += snprintf(prof + used, sizeof prof - (size_t)used, " w%u=??", w);
             continue;
         }
@@ -2924,11 +2942,23 @@ void zw_profile(const ZeroWatchEntry& e, const char* when) {
         used += snprintf(prof + used, sizeof prof - (size_t)used, " w%u=%u/%u", w, nzw,
                          e.src_profile[w]);
     }
+    // A range that has become UNREADABLE scores lost=0 kept=0 on the counters above, because neither
+    // branch runs -- which reads as "nothing happened" for the most complete kind of loss there is.
+    // Say `unreadable=N` in the line and, when the whole range is gone, replace the summary rather
+    // than printing a pair of zeros beside it.
+    if (unreadable_windows == 16) {
+        fprintf(stderr,
+                "[zerowatch] t=%llu dst=0x%llx zero-profile(%s) RANGE UNREADABLE -- all 16 windows "
+                "failed to read; this is a total loss, not `lost=0`\n",
+                (unsigned long long)prosper::diagnostics::diag_now_us(),
+                (unsigned long long)e.dst, when);
+        return;
+    }
     fprintf(stderr,
             "[zerowatch] t=%llu dst=0x%llx zero-profile(%s) payload-windows lost=%u kept=%u "
-            "(dst/src non-zero dwords per 256B window):%s\n",
+            "unreadable=%u (dst/src non-zero dwords per 256B window):%s\n",
             (unsigned long long)prosper::diagnostics::diag_now_us(),
-            (unsigned long long)e.dst, when, zero_windows, live_windows, prof);
+            (unsigned long long)e.dst, when, zero_windows, live_windows, unreadable_windows, prof);
 }
 
 // Runs until the process ends, and is never joined. That is safe here only because every exit path
@@ -3099,6 +3129,20 @@ void zerowatch_arm(uint64_t dst, const void* src, uint64_t size, const char* pat
     // WENT-ZERO probe keeps using seed_off, which stays comparable with the window formula the other
     // APR instruments use; only the FIND needle moves.
     e.find_off = e.seed_off & ~(uint64_t)15;
+    // ...and move forward, still 16-aligned, to a start whose first 16 bytes are not all zero. The
+    // window was chosen for holding data SOMEWHERE in its 256 bytes; a needle is only evidence if
+    // the bytes the search actually compares are distinctive, and an all-zero 16-byte lead matches
+    // everywhere. The shift is bounded by BOTH the window (240 = 256 - 16) and the payload: the
+    // last window starts at size-256, where no shift at all is possible without reading past the
+    // source buffer.
+    {
+        const uint64_t room = (size - 256ull) - e.find_off;   // find_off <= seed_off <= size-256
+        for (uint64_t d = 0; d <= 240 && d <= room; d += 16) {
+            bool nz = false;
+            for (uint32_t k = 0; k < 16 && !nz; ++k) if (p8[e.find_off + d + k]) nz = true;
+            if (nz) { e.find_off += d; break; }
+        }
+    }
     memcpy(e.seed, p8 + e.find_off, sizeof e.seed);
     for (uint32_t w = 0; w < 16; ++w) {
         const uint64_t off = (((size - 256ull) / 15ull) * w) & ~(uint64_t)3;
@@ -3113,12 +3157,17 @@ void zerowatch_arm(uint64_t dst, const void* src, uint64_t size, const char* pat
     for (int w = 7; w >= 0; --w) {
         const uint64_t off = ((((size - 256ull) / 7ull) * (uint32_t)w) & ~(uint64_t)3) & ~(uint64_t)15;
         if (off <= e.find_off) break;
-        bool nz = false;
-        for (uint32_t k = 0; k < 256 && !nz; ++k) if (p8[off + k]) nz = true;
+        // Same rule as find_off: the leading 16 bytes must be distinctive, not merely some byte in
+        // the window. A window whose first 16 bytes are zero is stepped forward inside itself.
+        uint64_t start = off; bool nz = false;
+        const uint64_t room = (size - 256ull) - off;          // off <= size-256 by construction
+        for (uint64_t d = 0; d <= 240 && d <= room && !nz; d += 16) {
+            for (uint32_t k = 0; k < 16 && !nz; ++k) if (p8[off + d + k]) { nz = true; start = off + d; }
+        }
         if (!nz) continue;
-        e.find_deep_off = off;
+        e.find_deep_off = start;
         e.has_seed_deep = true;
-        memcpy(e.seed_deep, p8 + off, sizeof e.seed_deep);
+        memcpy(e.seed_deep, p8 + start, sizeof e.seed_deep);
         break;
     }
     g_zw.push_back(e);

--- a/prosper/src/host/memory/guest_memory_search.cpp
+++ b/prosper/src/host/memory/guest_memory_search.cpp
@@ -95,7 +95,10 @@ MemorySearchScope memory_search_ranges(const std::vector<MemorySearchRange>& ran
                         h.addr = addr;
                         // `full` needs the whole needle to be PRESENT as well as equal. At a range
                         // end it may not be, and claiming a full match over bytes that were never
-                        // read is the one answer this instrument must never give.
+                        // read is the one answer this instrument must never give. It is also a
+                        // BOUNDS guard, not only a correctness one: when a range's last chunk is
+                        // exactly `chunk` bytes, an unguarded memcmp of needle_len from `off` reads
+                        // past the end of `buf`.
                         h.full = off + needle_len <= want &&
                                  memcmp(hit, needle, needle_len) == 0;
                         out.push_back(h);

--- a/prosper/src/host/memory/guest_memory_search.hpp
+++ b/prosper/src/host/memory/guest_memory_search.hpp
@@ -14,7 +14,11 @@
 // The scan is split in two so the interesting half is testable without a live guest:
 //   * memory_search_ranges() is pure -- it takes the ranges, a fetch callback and the needle, and
 //     owns the chunking, the overlap that keeps a needle straddling a chunk boundary from being
-//     missed, the hit de-duplication that overlap otherwise creates, and the budget accounting.
+//     missed, the range-end handling that prefix mode needs, and the budget accounting. It does NOT
+//     need to de-duplicate: consecutive chunks' searched START windows are contiguous and disjoint,
+//     so the overlap cannot produce a repeat. (There is a high-water guard in the loop, kept as an
+//     invariant against a future change to those bounds; it is not reachable as written, and no test
+//     pins it. This line used to claim the opposite.)
 //   * guest_memory_search() is the thin POSIX half: enumerate this process's readable mappings from
 //     /proc/self/maps and read them with process_vm_readv (never a raw dereference -- a mapping can
 //     disappear under a diagnostic, and a diagnostic must not fault the run).

--- a/prosper/tests/host/memory/test_guest_memory_search.cpp
+++ b/prosper/tests/host/memory/test_guest_memory_search.cpp
@@ -118,8 +118,15 @@ int main() {
 
     // --- 2b. Every placement across the boundary, not just one --------------------------------
     // One placement can be right by luck; the whole crossing window cannot. Each offset is asserted
-    // to be found exactly once at the right address, which covers the de-duplication as well as the
-    // coverage: an overlap without de-duplication reports two hits somewhere in this sweep.
+    // to be found exactly once at the right address.
+    //
+    // It does NOT test the `accept_from` de-duplication, and saying it did was wrong: with the
+    // bounds as written the searched start windows of consecutive chunks are contiguous and
+    // disjoint, so no placement can be reported twice and removing the guard leaves this sweep
+    // green. Measured in review of #3243. The guard is an invariant against a future change to
+    // `limit` or `advance`, not a fix for a hazard this arithmetic can produce -- and it is
+    // deliberately unpinned, because a test that could redden without it would have to introduce
+    // the overlap the design excludes.
     {
         const size_t lo = kChunk - kNeedle - 2, hi = kChunk + 2;
         for (size_t at = lo; at <= hi; ++at) {
@@ -194,6 +201,23 @@ int main() {
                                  std::to_string(hits.size()));
                 break;
             }
+        }
+        // The `full` flag must require the needle to be PRESENT, not merely to compare equal
+        // against whatever the fetch buffer happens to hold beyond the range. This arm pins that:
+        // the needle's tail is all zeros and the fetch buffer is zero-initialised, so a full-needle
+        // memcmp that ran past `want` would SUCCEED and report full=true. Only the
+        // `off + needle_len <= want` guard makes the answer false here.
+        {
+            std::vector<uint8_t> zero_tail = needle;
+            for (size_t k = kPrefix; k < kNeedle; ++k) zero_tail[k] = 0;
+            FakeSpace z{0x600000000ull, filler(kChunk / 8)};
+            const size_t at = z.bytes.size() - kPrefix;      // only the prefix fits
+            memcpy(z.bytes.data() + at, zero_tail.data(), kPrefix);
+            std::vector<MemorySearchHit> zh;
+            memory_search_ranges(z.ranges(), z.fetch(), zero_tail.data(), kPrefix, kNeedle, 0, 64, zh);
+            check(zh.size() == 1 && zh[0].addr == z.base + at, "zero-tail: prefix hit found");
+            check(!zh.empty() && !zh[0].full,
+                  "zero-tail: full=false -- the needle does not FIT, whatever the buffer holds");
         }
         // ...and a range too short for the whole needle but long enough for the prefix is still
         // scanned rather than skipped.


### PR DESCRIPTION
## What this is

The tail of #3243's review that did not make it into the merge. `#3243` was merged from head
`fd1dbb92`, but the branch had moved to `1144bea7` — the PR's API head record lagged the branch ref
and no CI run was ever created for the two later commits. So `main` currently carries **the version
the third review rejected**, plus none of the fourth review's notes.

Two commits, cherry-picked cleanly onto current `main`. No behaviour change to the scan itself; one
reporting change and one new guard.

## What is missing from `main` today

**The rejected claim.** `main`'s `test_guest_memory_search.cpp` case 2b says the boundary sweep
covers the `accept_from` de-duplication. It does not — the searched start windows of consecutive
chunks are contiguous and disjoint, so replacing `if (addr >= accept_from)` with `if (true)` leaves
the suite green. That was the single blocking finding on the third review, and it is the same failure
as the PR's own subject: a measured-sounding claim that was never measured. `guest_memory_search.hpp`
carried the last copy of the same claim.

**An unreadable range scored `lost=0 kept=0`.** Neither counter's branch runs when every window fails
to read, so the most complete loss there is printed as "nothing happened". The line now carries
`unreadable=N`, and a range whose sixteen windows all fail prints `RANGE UNREADABLE … this is a total
loss, not lost=0` instead of a pair of zeros.

**Nothing checked that the FIND needle's leading bytes were distinctive.** A seed window is chosen
for holding data *somewhere* in its 256 bytes, so an all-zero 16-byte lead was reachable — and such a
needle matches everywhere, making both its hits and its misses meaningless. Arming now steps the
16-aligned start forward *inside* the window to the first non-zero 16 bytes, and `zw_find` refuses to
scan a still-degenerate needle rather than publishing a number for it.

**Writing that guard exposed a buffer overrun in the shift itself.** The last seed window starts at
`size - 256`, so *any* forward shift reads past the source buffer — up to 239 bytes, inside the
page-rounded staging mmap and therefore silent. Both shift loops are now bounded by the remaining
payload as well as by the window. Verified in review against a payload whose last byte abuts a
`PROT_NONE` guard page: as written, 32 of 32 shapes clean; with the bound removed it SIGSEGVs on the
guard page and violates `off + 256 <= size` in 17 of 32.

**A refused control is not an empty one.** The AFTER-ZERO skip line said "its control scan found
nothing" in the case where the control never ran at all because every needle it had was degenerate.
Different facts, different next steps; the line now names which. Reachable when a payload's only
non-zero bytes sit past the first 16 of window 7, where no shift is possible.

**A missing deep needle was silent** where a degenerate one is loud. A range with no second non-zero
window is followed by its header alone — a real limit on the result, now stated.

**The `full` fit guard is a bounds guard too.** When a range's last chunk is exactly `chunk` bytes an
unguarded `memcmp` of `needle_len` reads past the end of the fetch buffer. The comment said only the
correctness half.

## Verification (exact head, this branch)

```
cmake -S prosper -B prosper/build-linux -DPROSPER_APP=ON    CFG_RC=0
cmake --build prosper/build-linux -j6                        BUILD_RC=0
ctest --no-tests=error                                       CTEST_RC=0
```

344 tests, 100% passed — `main` has gained three cases from other lanes since #3243, which is why this is not the 341 quoted there. `git diff --check` clean. Diff against `main` touches four files and
`--stat` shows insertions dominating deletions in each, so nothing of another lane's was taken along
with the cherry-picks.

### Mutation arm for the new pin

The `full` fit test had no arm; it does now, and it cannot pass for the wrong reason — the needle's
tail is all zeros and the fetch buffer is zero-initialised, so a full-needle `memcmp` running past
`want` would **succeed** and report `full=true`.

Drop `off + needle_len <= want`, build exit 0:

```
FAIL: zero-tail: full=false -- the needle does not FIT, whatever the buffer holds
guest_memory_search: 1 failure(s)
```

Exactly one arm moves, with the hit count and address assertions still green. Reverted; green again.

The three arms from #3243 still hold on this head: `overlap = 0` → 4 failures;
`overlap = 0` **and** `kChunkBytes = 8<<20` → 4 failures; last chunk's `need = prefix_len` →
`needle_len` → 3 failures.

### Live

Re-measured on *Stray* (`PPSA02101`, `tools/screenshot`, `PROSPER_NULL_PAGE=1`, no pad input) after
the needle shift, since it changes which bytes the needle is: CONTROL finds the payload at exactly
one guest address (the destination), the post-flip first-window scan finds it at none, the deep
window is still at the destination — the same result #3243 reports. No degenerate needles and no
unreadable ranges occurred in that run, so those two paths are backstops rather than the expected
case and are untested live.

## Risks

Low. Everything here is behind `PROSPER_ZEROWATCH` / `PROSPER_ZEROWATCH_FIND`, which default off. The
overrun fix is the only change that could matter with the switch on, and it strictly narrows a read.

Refs #3142, #3243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
