### PR TITLE
live compute: a dispatch result the host maps needs an availability op, not just a fence (#3249)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,15 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-02
 
+### The same thing was true of every compute dispatch, and the doc said that half was already right
+
+No picture again. The note we filed while fixing the graphics readback said the compute backend was
+one of the two places in the tree that already got this right — it isn't: the barrier it has is on
+the comparator's one-word flag, not on the dispatch results that become guest memory. Deleting the
+new barrier leaves a 439-assertion compute test, including a byte-exact image writeback, entirely
+green.
+[#3249](https://github.com/mattias800/prosper/issues/3249)
+
 ### Every frame we have ever read back was read without asking the GPU to hand it over
 
 No picture, and that is the finding: on this hardware a readback with no host-availability barrier

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2694,6 +2694,18 @@ if(TARGET prosper_core)
       target_link_libraries(test_live_compute_descriptor_array PRIVATE prosper_live_renderer)
       add_test(NAME live_compute_descriptor_array COMMAND test_live_compute_descriptor_array)
 
+      # #3249: a dispatch result the host maps and reads needs an AVAILABILITY operation, not just a
+      # fence. Registered beside the descriptor-array case because both drive the real backend
+      # through execute_live_compute_items; it cannot live in the platform-independent block since
+      # prosper_live_renderer exists only where Vulkan was found.
+      add_executable(test_live_compute_host_read_barrier
+                     tests/shared/live/test_live_compute_host_read_barrier.cpp)
+      # Spells a `shared/...` include, which resolves from `frontends`.
+      target_include_directories(test_live_compute_host_read_barrier PRIVATE frontends)
+      target_link_libraries(test_live_compute_host_read_barrier PRIVATE prosper_live_renderer)
+      add_test(NAME live_compute_host_read_barrier
+               COMMAND test_live_compute_host_read_barrier)
+
       # Prove our own SPIR-V emitter produces valid, correct, runnable SPIR-V (execution-differential).
       add_executable(test_spirv_builder tests/gpu/recompiler/test_spirv_builder.cpp)
       # Includes a shared fixture, which resolves from the `tests` root.

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -817,6 +817,32 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   operation. The two halves are independent, and the backend had only the second: three of the seven
   readback sites already invalidated (they may be backed by non-coherent HOST_CACHED memory) while
   none had the barrier. #2944.
+- **The same blindness holds for the COMPUTE backend, and it is measured there too.** A dispatch
+  result is checked by VALUE rather than by pixel, so it is tempting to think a byte-exact assertion
+  would catch a missing availability operation. It does not. With `live_compute.cpp`'s dispatch-result
+  barrier deleted, `game_compute_exec` (**439 assertions**, including a byte-exact Unorm8 storage-image
+  writeback) and `live_compute_descriptor_array` both still **pass**, and so does
+  `live_compute_host_read_barrier`'s own "wrote the result back to guest memory" arm — only its
+  structural arm goes red. #3249.
+- **The live compute allocator cannot hand out non-coherent memory, so NO compute site needed a new
+  invalidate.** A real negative result, and the opposite of the render backend's: `host_memory_type`
+  tries `HOST_VISIBLE|HOST_COHERENT|HOST_CACHED` and falls back to `HOST_VISIBLE|HOST_COHERENT` — the
+  cached tier is `wanted | HOST_CACHED`, not `HOST_CACHED` alone — so every allocation the compute
+  path maps is coherent. 0 of its 6 host-read sites want `vkInvalidateMappedMemoryRanges`; all of
+  them want the dependency. #3249.
+- **The compute path's end-of-command-buffer image restore does not incidentally supply the
+  dependency.** Every borrowed image is handed back with a `COMPUTE_SHADER|TRANSFER -> ALL_COMMANDS`
+  barrier before `vkEndCommandBuffer`, which looks like it would cover everything.
+  `VK_PIPELINE_STAGE_ALL_COMMANDS_BIT` does **not** include `VK_PIPELINE_STAGE_HOST_BIT`, and that
+  barrier's destination access mask does not include `VK_ACCESS_HOST_READ_BIT`. #3249.
+- **A device write with no host read in its OWN dispatch is still not exempt, because the compute
+  memory POOL recycles host-visible allocations across bindings and submits.** This is why #3249's
+  own producer list was short. `release_memory` returns an allocation to `memory_pool.available` and
+  `allocate_memory` hands it to any later binding of the same memory type, where the host maps it and
+  reads the retained contents to decide whether an upload is needed ("Pooled host-visible allocations
+  retain their previous contents"). So the comparator baselines and the depth-bits bridge staging
+  buffer — neither of which is mapped by the binding that writes it — are host-read later anyway. The
+  invariant is per-allocation, not per-binding. #3249.
 
 ## The renderer is not deterministic on frozen input (2026-08-23) — #2945
 

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -1,0 +1,42 @@
+# `frontends/shared/live/` — the two live Vulkan backends
+
+What turns a decoded guest submit into real GPU work at runtime, shared by every frontend
+(`prosper-app`, `boot_trace`, `tools/screenshot`) so they all drive the *same* backend rather than
+three that drift. Built as the `prosper_live_renderer` static library, which exists only where CMake
+found Vulkan.
+
+- `live_renderer.cpp` — the graphics half: DrawItem → Vulkan compositor, render-target/RTT authority,
+  present. It is a *driver* for the offscreen backend rather than the backend itself; the pipeline,
+  pass and readback code it calls lives in `tests/fixtures/render_runner.h` (whose directory name is
+  a trap — see that folder's `AGENTS.md`).
+- `live_compute.cpp` — the compute half, and a **separate Vulkan backend**, not a caller of the
+  render one. It builds its own device (or adopts the renderer's when one is published), its own
+  pipeline cache, descriptor pools, memory pool and command buffers, and does not include
+  `render_runner.h` at all. Reflected storage buffers and storage images are materialized from guest
+  memory, dispatched, and written back into guest memory synchronously.
+- `live_target_format.hpp` — the guest↔Vulkan pixel-format mapping. Compiled with `-Werror=switch`
+  on purpose: a silent RGBA8 fallback has cost two titles a whole render layer.
+
+## The boundary that is easy to get wrong
+
+The compute backend is where *guest memory* and *device memory* meet twice per dispatch — an upload
+before, a writeback after — and both directions have a synchronization contract that no output check
+can verify:
+
+- **A host READ of anything the device wrote needs `record_host_read_barrier()`**
+  (`src/gpu/execute/host_read_barrier.hpp`). Waiting the dispatch fence orders execution; it does not
+  perform the availability operation into the host domain. Every writable storage buffer, every
+  storage image's staging buffer, the comparator's flag word and every retained result baseline is
+  device-written host-visible memory, so every one of them carries the dependency (#3249).
+- **The scope is the ALLOCATION, not the binding.** `allocate_memory`/`release_memory` run a pool
+  that recycles host-visible allocations across bindings and submits, and a later binding maps a
+  recycled allocation and *reads its retained contents* to decide whether an upload is needed. So a
+  buffer this dispatch never maps still needs the barrier if the device wrote it.
+- **Neither can be checked by asserting the result.** Every allocation here is `HOST_COHERENT` (both
+  tiers of `host_memory_type` require it), and on the drivers this project runs on the unsynchronized
+  code returns byte-identical results. The guard is `live_compute_host_read_barrier`, which asserts
+  the barrier was *recorded*; synchronization validation cannot see this class either (#3248).
+
+`execute_live_compute_items()` is the one entry point exposed for tests, which is how
+`game_compute_exec`, `live_compute_descriptor_array` and `live_compute_host_read_barrier` drive the
+production backend without a frontend or a game dump.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -15,6 +15,7 @@
 #include "gpu/texture/bc_decode.hpp"
 #include "gpu/capture/gpu_capture.hpp"
 #include "gpu/execute/gpu_execute.hpp"
+#include "gpu/execute/host_read_barrier.hpp"  // #3249: a host read of a dispatch result needs an availability op
 #include "gpu/recompiler/rdna2_decode.hpp"
 #include "gpu/recompiler/gta5/rdna2_gta5_cf9200_contract.hpp"
 #include "gpu/resources/shader_resources.hpp"
@@ -8656,7 +8657,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (bi.depth_bits_source) {
                 // D32 and R32_UINT have the same four-byte texel payload but are not Vulkan
                 // view-compatible. Preserve the guest's raw-bit alias with two transfer copies:
-                // depth image -> device buffer -> integer image. The buffer is never host-mapped.
+                // depth image -> device buffer -> integer image. This binding never host-maps the
+                // buffer -- but its ALLOCATION returns to the shared host-visible pool, where a
+                // later binding maps it and reads the retained contents to decide whether an upload
+                // is needed (`compute_buffers_equal(mapped, source, ...)`). So the transfer write
+                // below still needs the #3249 availability operation before the submit ends.
                 const bool source_already_general = [&] {
                     for (size_t prior = 0; prior < i; ++prior) {
                         const BoundImage& candidate = images[prior];
@@ -8711,6 +8716,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 vkCmdCopyImageToBuffer(command, bi.depth_bits_image,
                                        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                        staging[i], 1, &source_copy);
+                prosper::gpu::record_host_read_barrier(command, staging[i]);   // #3249
                 VkBufferMemoryBarrier buffer_ready{
                     VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
                 buffer_ready.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -8945,6 +8951,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (perf_gpu_timing)
             vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                 ctx.dispatch_timestamp_pool, 2);
+        // #3249: the guest writeback below maps every writable buffer and READS it. The fence
+        // proves the shader finished; it does not make those writes available to the host domain.
+        // Recorded here because the dispatch is the last device WRITE to these buffers -- the
+        // comparator and the baseline copy that follow only read them. Nothing later in this
+        // command buffer invalidates that, so the dependency is correct at this point.
+        for (const BoundBuffer& buffer : buffers) {
+            if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
+            prosper::gpu::record_host_read_barrier(command, buffer.buffer,
+                                                   VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                                   VK_ACCESS_SHADER_WRITE_BIT);
+        }
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
         // When this private image was seeded from an exact borrowed renderer target, copy the final
         // result back to that same image as well. The CPU writeback below remains mandatory for
@@ -8972,6 +8989,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                   bi.array_layers > 1 ? 1u : bi.texel_depth};
             vkCmdCopyImageToBuffer(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                    staging[i], 1, &region);
+            // #3249: the storage-image writeback maps this staging buffer and reads every texel.
+            // TRANSFER, not COMPUTE_SHADER: the shader wrote the IMAGE, the copy above wrote this
+            // buffer, and the source scope has to name the write that actually produced the bytes.
+            prosper::gpu::record_host_read_barrier(command, staging[i]);
             if (bi.mirror_result_to_imported) {
                 const BoundImage& mirror = images[bi.seed_from_imported];
                 VkImageMemoryBarrier mirror_to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
@@ -9100,6 +9121,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 2, barriers, 0, nullptr);
             VkBufferCopy copy{0, 0, bytes};
             vkCmdCopyBuffer(command, current, baseline, 1, &copy);
+            // #3249: a retained baseline is compared on the GPU and never mapped through THIS
+            // binding, but its allocation is pooled and recycled into buffers that the host does
+            // map and read. Every device write into pooled host-visible memory is made available
+            // before the submit ends, so no later reader can see it stale.
+            prosper::gpu::record_host_read_barrier(command, baseline);
         };
         for (BoundBuffer& buffer : buffers) {
             if (buffer.alias_of != SIZE_MAX || !buffer.writable || !buffer.result_baseline ||
@@ -9118,15 +9144,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  image.exact_result_bytes, VK_ACCESS_TRANSFER_WRITE_BIT);
         }
         if (!compare_targets.empty()) {
-            VkBufferMemoryBarrier flags{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
-            flags.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-            flags.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
-            flags.srcQueueFamilyIndex = flags.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            flags.buffer = compare_flags;
-            flags.size = compare_targets.size() * ctx.compare_flag_stride();
-            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                                 VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr, 1, &flags,
-                                 0, nullptr);
+            // The comparator's flag word is the one host read on this path that always had its
+            // availability operation (it is the site #2944 cited as correct). Routed through the
+            // shared helper since #3249 so the file has ONE spelling of the rule; whole-buffer
+            // scope replaces the exact flag span, which is wider and equally valid.
+            prosper::gpu::record_host_read_barrier(command, compare_flags,
+                                                   VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                                   VK_ACCESS_SHADER_WRITE_BIT);
+            // The comparator also REWRITES each differing baseline in place, so that shader write
+            // is the last device write to those buffers. Same pooled-recycling reason as the
+            // transfer-written baselines above.
+            for (const CompareTarget& target : compare_targets)
+                prosper::gpu::record_host_read_barrier(command, target.baseline,
+                                                       VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                                       VK_ACCESS_SHADER_WRITE_BIT);
         }
         if (perf_gpu_timing)
             vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,

--- a/prosper/src/gpu/execute/AGENTS.md
+++ b/prosper/src/gpu/execute/AGENTS.md
@@ -9,6 +9,13 @@ Where a decoded draw or dispatch becomes real GPU work.
   const-fold, keyed by the `s_load` immediate byte offset. Read this before assuming prosper cannot
   see a descriptor channel.
 - `gpu_dependency_graph` — ordering and dependencies between submitted work.
+- `host_read_barrier` — the availability half of a GPU→CPU readback: the `HOST_READ`/`HOST_BIT`
+  dependency that a fence wait does **not** perform (#2944/#3249). Header-only and deliberately
+  backend-agnostic, because both Vulkan backends need it and they live in different trees — the
+  offscreen render backend (`tests/fixtures/render_runner.h`, which re-exports it into
+  `prosper::test`) and the live compute backend (`frontends/shared/live/live_compute.cpp`). The
+  *other* half, `vkInvalidateMappedMemoryRanges`, is not here: it belongs with whichever allocator
+  can hand out non-coherent memory, which today is only the render backend's.
 - `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block". **Nothing in this
   folder calls it**: `gpu_executor.cpp` has no reference, and the callers are
   `src/gpu/pm4/command_processor.cpp`, `src/hle/graphics/hle_agc.cpp`,

--- a/prosper/src/gpu/execute/host_read_barrier.hpp
+++ b/prosper/src/gpu/execute/host_read_barrier.hpp
@@ -1,0 +1,81 @@
+// host_read_barrier.hpp — the availability half of a GPU->CPU readback, shared by every backend.
+//
+// Waiting a fence -- or vkQueueWaitIdle -- orders EXECUTION. It does not perform the availability
+// operation that moves a transfer (or shader, or transform-feedback) write into the HOST domain.
+// Vulkan requires an explicit dependency for that: dstStageMask = VK_PIPELINE_STAGE_HOST_BIT with
+// dstAccessMask = VK_ACCESS_HOST_READ_BIT (#2944, #3249).
+//
+// Coherent memory does not exempt a readback from it. HOST_COHERENT removes the need for
+// vkInvalidateMappedMemoryRanges; it does not remove the need for the dependency. So the two halves
+// are independent: non-coherent memory needs both, coherent memory needs this one. The invalidate
+// half lives with whichever allocator can hand out non-coherent memory (today only
+// `invalidate_mapped_readback` in tests/fixtures/render_runner.h); this half is universal, which is
+// why it lives here rather than beside it.
+//
+// Every driver this project runs on completes the availability anyway, which is exactly why the gap
+// survived unnoticed -- the pixels and the dispatch results come back correct and nothing says the
+// code was wrong. The fix is spec conformance, not a chase after a visible symptom. Nor can
+// synchronization validation see it: measured 2026-09-02, syncval cannot observe a CPU read through
+// a mapped pointer (#3248). A structural assertion that the barrier was RECORDED is the only
+// discriminator that fails without the fix.
+//
+// Consumers: the offscreen render backend (tests/fixtures/render_runner.h, which re-exports these
+// into `prosper::test`) and the live compute backend (frontends/shared/live/live_compute.cpp).
+// Keep it one helper: two spellings of this rule is how the next readback site gets missed.
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+#include <atomic>
+
+namespace prosper::gpu {
+
+struct HostReadBarrier {
+    VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    VkPipelineStageFlags src_stages = 0;
+    VkPipelineStageFlags dst_stages = 0;
+};
+
+// Pure, so the masks can be asserted with no device (`host_read_barrier` ctest case). The buffer
+// scope is whole-buffer: a readback buffer holding several slots (the MRT frame buffer writes up to
+// eight colour offsets into one allocation) is made available in one dependency.
+inline HostReadBarrier host_read_barrier_for(
+        VkBuffer buffer,
+        VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VkAccessFlags src_access = VK_ACCESS_TRANSFER_WRITE_BIT) {
+    HostReadBarrier host_read{};
+    host_read.barrier.srcAccessMask = src_access;
+    host_read.barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+    host_read.barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    host_read.barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    host_read.barrier.buffer = buffer;
+    host_read.barrier.offset = 0;
+    host_read.barrier.size = VK_WHOLE_SIZE;
+    host_read.src_stages = src_stages;
+    host_read.dst_stages = VK_PIPELINE_STAGE_HOST_BIT;
+    return host_read;
+}
+
+// How many host-read barriers this process has recorded. Exists so a test can prove the barrier
+// reached the command buffer on a path it drives: without it the fix is unfalsifiable here, because
+// on a coherent desktop driver the UNFIXED code reads back correct pixels and correct dispatch
+// results. Relaxed and process-wide -- it is an instrument, never a control input.
+inline std::atomic<uint64_t>& backend_host_read_barrier_count() {
+    static std::atomic<uint64_t> count{0};
+    return count;
+}
+
+// Record the availability dependency for one readback buffer. Call it after the LAST device write
+// into that buffer in a command buffer, and before the host maps and reads it.
+inline void record_host_read_barrier(
+        VkCommandBuffer command, VkBuffer buffer,
+        VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VkAccessFlags src_access = VK_ACCESS_TRANSFER_WRITE_BIT) {
+    if (!command || !buffer) return;
+    const HostReadBarrier host_read = host_read_barrier_for(buffer, src_stages, src_access);
+    vkCmdPipelineBarrier(command, host_read.src_stages, host_read.dst_stages, 0,
+                         0, nullptr, 1, &host_read.barrier, 0, nullptr);
+    backend_host_read_barrier_count().fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace prosper::gpu

--- a/prosper/tests/fixtures/AGENTS.md
+++ b/prosper/tests/fixtures/AGENTS.md
@@ -17,8 +17,10 @@ Two kinds live here and they are worth telling apart:
 ## `render_runner.h` is NOT test-only, and the directory name is the trap
 
 It is the project's **offscreen Vulkan backend**, and the shipping frontend compiles it:
-`frontends/shared/live/live_renderer.cpp`, `live_compute.cpp` and `present/present_blit.cpp` all
-include it. `render_draw_pass_rgba` is therefore a live render path — a wrong failure path in it
+`frontends/shared/live/live_renderer.cpp` and `present/present_blit.cpp` include it. (This line used
+to name `live_compute.cpp` as a third includer. It is not one — checked with the preprocessor, not
+with grep: `-M` over that translation unit's own compile command lists no `render_runner.h`. The
+compute backend is a separate Vulkan backend that shares the device, not this header.) `render_draw_pass_rgba` is therefore a live render path — a wrong failure path in it
 silently drops real rendered content in a real game, and "it is under `tests/`" has misled reviewers
 into treating changes here as test-only (#3210 had to say so explicitly in its own body).
 
@@ -45,6 +47,12 @@ Consequences for anything you change in it:
   `invalidate_mapped_readback()`. Coherent memory still needs the first. Neither half can be checked
   by reading the pixels back: on every driver here the unsynchronized code returns correct bytes, so
   the guard is `host_read_barrier`, which asserts the barrier was RECORDED.
+  Since #3249 the availability half lives in `src/gpu/execute/host_read_barrier.hpp` and is only
+  **re-exported** into `prosper::test` here, because the live compute backend needs the identical
+  rule for its dispatch results and two spellings of it is how the next site gets missed. The
+  invalidate half stays in this header, with the allocator that can actually return non-coherent
+  memory. Its counter is process-wide and shared with the compute guard,
+  `live_compute_host_read_barrier`.
 
 ## Adding to it
 

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -6,6 +6,7 @@
 #include "shared/rtt/mrt_extent.hpp"
 #include <vulkan/vulkan.h>
 #include "gpu/capture/gpu_capture.hpp"
+#include "gpu/execute/host_read_barrier.hpp"   // the availability half of a readback (#2944/#3249)
 #include "gpu/diagnostics/diagnostic_selectors.hpp"
 #include "diagnostics/env_cache.hpp"       // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
 #include "gpu/state/render_state.hpp"
@@ -3947,67 +3948,16 @@ inline bool invalidate_mapped_readback(const RenderVkCtx& ctx, VkDeviceMemory me
     return vkInvalidateMappedMemoryRanges(ctx.dev, 1, &range) == VK_SUCCESS;
 }
 
-// The OTHER half of a readback, and a separate operation from the invalidate above.
-//
-// Waiting a fence -- or vkQueueWaitIdle -- orders EXECUTION. It does not perform the availability
-// operation that moves a transfer (or shader, or transform-feedback) write into the HOST domain.
-// Vulkan requires an explicit dependency for that: dstStageMask = VK_PIPELINE_STAGE_HOST_BIT with
-// dstAccessMask = VK_ACCESS_HOST_READ_BIT (#2944).
-//
-// Coherent memory does not exempt a readback from it. HOST_COHERENT removes the need for
-// vkInvalidateMappedMemoryRanges; it does not remove the need for the dependency. So the two halves
-// are independent: non-coherent memory needs both, coherent memory needs this one.
-//
-// Every driver this project runs on completes the availability anyway, which is exactly why the gap
-// survived unnoticed -- the pixels come back correct and nothing says the code was wrong. The fix is
-// spec conformance, not a chase after a visible symptom.
-struct HostReadBarrier {
-    VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
-    VkPipelineStageFlags src_stages = 0;
-    VkPipelineStageFlags dst_stages = 0;
-};
-
-// Pure, so the masks can be asserted with no device (`host_read_barrier` ctest case). The buffer
-// scope is whole-buffer: a readback buffer holding several slots (the MRT frame buffer writes up to
-// eight colour offsets into one allocation) is made available in one dependency.
-inline HostReadBarrier host_read_barrier_for(
-        VkBuffer buffer,
-        VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TRANSFER_BIT,
-        VkAccessFlags src_access = VK_ACCESS_TRANSFER_WRITE_BIT) {
-    HostReadBarrier host_read{};
-    host_read.barrier.srcAccessMask = src_access;
-    host_read.barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
-    host_read.barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    host_read.barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    host_read.barrier.buffer = buffer;
-    host_read.barrier.offset = 0;
-    host_read.barrier.size = VK_WHOLE_SIZE;
-    host_read.src_stages = src_stages;
-    host_read.dst_stages = VK_PIPELINE_STAGE_HOST_BIT;
-    return host_read;
-}
-
-// How many host-read barriers this process has recorded. Exists so a test can prove the barrier
-// reached the command buffer on a path it drives: without it the fix is unfalsifiable here, because
-// on a coherent desktop driver the UNFIXED code reads back correct pixels. Relaxed and process-wide
-// -- it is an instrument, never a control input.
-inline std::atomic<uint64_t>& backend_host_read_barrier_count() {
-    static std::atomic<uint64_t> count{0};
-    return count;
-}
-
-// Record the availability dependency for one readback buffer. Call it after the LAST device write
-// into that buffer in a command buffer, and before the host maps and reads it.
-inline void record_host_read_barrier(
-        VkCommandBuffer command, VkBuffer buffer,
-        VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TRANSFER_BIT,
-        VkAccessFlags src_access = VK_ACCESS_TRANSFER_WRITE_BIT) {
-    if (!command || !buffer) return;
-    const HostReadBarrier host_read = host_read_barrier_for(buffer, src_stages, src_access);
-    vkCmdPipelineBarrier(command, host_read.src_stages, host_read.dst_stages, 0,
-                         0, nullptr, 1, &host_read.barrier, 0, nullptr);
-    backend_host_read_barrier_count().fetch_add(1, std::memory_order_relaxed);
-}
+// The OTHER half of a readback, and a separate operation from the invalidate above: the
+// availability dependency into the HOST domain that a fence wait does not perform (#2944). It lives
+// in src/gpu/execute/host_read_barrier.hpp because the live COMPUTE backend needs exactly the same
+// rule for its dispatch results (#3249), and two spellings of one rule is how the next site gets
+// missed. Re-exported here so this header's call sites and the `host_read_barrier` ctest case keep
+// naming it through `prosper::test`.
+using prosper::gpu::HostReadBarrier;
+using prosper::gpu::host_read_barrier_for;
+using prosper::gpu::backend_host_read_barrier_count;
+using prosper::gpu::record_host_read_barrier;
 
 // CONTRACT: a pure TRANSFER_DST (readback) buffer may be backed by HOST_CACHED memory that is NOT
 // HOST_COHERENT. Call invalidate_mapped_readback() after mapping and before reading one, and do not

--- a/prosper/tests/shared/live/test_live_compute_host_read_barrier.cpp
+++ b/prosper/tests/shared/live/test_live_compute_host_read_barrier.cpp
@@ -1,0 +1,289 @@
+// test_live_compute_host_read_barrier — #3249: the live compute backend host-reads every dispatch
+// result through a mapped pointer after a fence wait. A fence orders EXECUTION; it does not perform
+// the availability operation that moves the shader's (or the image copy's) writes into the HOST
+// domain. That needs a dependency with dstStageMask = VK_PIPELINE_STAGE_HOST_BIT and
+// dstAccessMask = VK_ACCESS_HOST_READ_BIT.
+//
+// WHAT THIS TEST CANNOT DO, and why it is shaped the way it is.
+//
+// It cannot detect the defect from the dispatch's RESULT. Every allocation the compute backend maps
+// is HOST_VISIBLE|HOST_COHERENT (both tiers of `host_memory_type` require it), and on this
+// platform's driver the UNFIXED code returns byte-identical results — which is exactly why the gap
+// survived. `live_compute_descriptor_array` and `game_compute_exec` both assert dispatch results
+// and both stayed green with no barrier recorded anywhere. Synchronization validation cannot see it
+// either: it does not observe a CPU read through a mapped pointer (#3248, measured on #3250).
+//
+// So the discriminator is structural: the barrier must be RECORDED into the dispatch command
+// buffer. Arm 2 fails without the fix (delta 0, not 1); arm 3 is the negative control that stops a
+// counter incremented anywhere on the compute path from satisfying arm 2 for the wrong reason.
+#include "shared/live/live_compute.hpp"
+#include "gpu/execute/host_read_barrier.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/resources/shader_resources.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int failures = 0;
+#define CHECK(condition, message)                                                   \
+    do {                                                                            \
+        if (!(condition)) {                                                         \
+            std::printf("  [FAIL] %s\n", message);                                  \
+            ++failures;                                                             \
+        } else {                                                                    \
+            std::printf("  [ok]   %s\n", message);                                  \
+        }                                                                           \
+    } while (0)
+
+static uint64_t barriers() {
+    return prosper::gpu::backend_host_read_barrier_count().load(std::memory_order_relaxed);
+}
+
+static ShaderResource scalar_buffer(uint32_t binding, uint32_t sgpr_base, uint32_t* storage,
+                                    uint32_t bytes) {
+    ShaderResource resource;
+    resource.cls = ResourceClass::ConstantBuffer;
+    resource.format = DataFormat::Uint32;
+    resource.num_components = 1;
+    resource.binding = binding;
+    resource.gpu_addr = reinterpret_cast<uint64_t>(storage);
+    resource.size = bytes;
+    resource.stride = sizeof(uint32_t);
+    resource.sgpr_base = sgpr_base;
+    resource.host_data = reinterpret_cast<uint8_t*>(storage);
+    resource.host_data_size = bytes;
+    return resource;
+}
+
+int main() {
+    std::printf("== test_live_compute_host_read_barrier ==\n");
+
+    // ---- Arm 1: the exact masks, with no device -----------------------------------------------
+    // The helper is shared with the render backend (`host_read_barrier` pins it there too). What is
+    // asserted here is that the COMPUTE source scope — a shader write, not a transfer write — does
+    // not disturb the host half, since #3249's whole point is that the two producers differ.
+    {
+        VkBuffer buffer = reinterpret_cast<VkBuffer>(uintptr_t{0x3249});
+        const HostReadBarrier shader_write = prosper::gpu::host_read_barrier_for(
+            buffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_ACCESS_SHADER_WRITE_BIT);
+        CHECK(shader_write.barrier.srcAccessMask == VK_ACCESS_SHADER_WRITE_BIT &&
+                  shader_write.src_stages == VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+              "a dispatch result names the compute shader write as its source scope");
+        CHECK(shader_write.barrier.dstAccessMask == VK_ACCESS_HOST_READ_BIT &&
+                  shader_write.dst_stages == VK_PIPELINE_STAGE_HOST_BIT,
+              "the host half is exactly HOST_READ at the HOST stage");
+        CHECK(shader_write.barrier.buffer == buffer && shader_write.barrier.offset == 0 &&
+                  shader_write.barrier.size == VK_WHOLE_SIZE &&
+                  shader_write.barrier.srcQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED &&
+                  shader_write.barrier.dstQueueFamilyIndex == VK_QUEUE_FAMILY_IGNORED,
+              "whole-buffer scope with no queue-family ownership transfer");
+
+        const HostReadBarrier transfer_write = prosper::gpu::host_read_barrier_for(buffer);
+        CHECK(transfer_write.barrier.srcAccessMask == VK_ACCESS_TRANSFER_WRITE_BIT &&
+                  transfer_write.src_stages == VK_PIPELINE_STAGE_TRANSFER_BIT,
+              "a storage-image staging readback defaults to the transfer write scope");
+        CHECK(transfer_write.barrier.dstAccessMask == shader_write.barrier.dstAccessMask &&
+                  transfer_write.dst_stages == shader_write.dst_stages,
+              "the host half does not change with the producer");
+    }
+
+    // ---- The fixture both execution arms share -------------------------------------------------
+    uint32_t input = 0x5a5aa5a5u;
+    uint32_t output = 0u;
+
+    // load v1 = input[0]; store it through the writable output binding.
+    const uint32_t write_code[] = {
+        0xe0300000u, 0x80000100u, // buffer_load_dword v1, off, s[0:3]
+        0xbf8c3f70u,              // s_waitcnt vmcnt(0)
+        0xe0700000u, 0x80010100u, // buffer_store_dword v1, off, s[4:7]
+        0xbf810000u,              // s_endpgm
+    };
+    // The same kernel with the store removed: one READ-ONLY binding and nothing the host reads back.
+    const uint32_t read_only_code[] = {
+        0xe0300000u, 0x80000100u, // buffer_load_dword v1, off, s[0:3]
+        0xbf8c3f70u,              // s_waitcnt vmcnt(0)
+        0xbf810000u,              // s_endpgm
+    };
+
+    auto build = [](const uint32_t* code, size_t words, ShaderResourceTable resources,
+                    std::vector<uint32_t>& spirv, ComputeShaderConfig& config) {
+        config.user_sgprs.resize(8);
+        config.local_x = config.local_y = config.local_z = 1;
+        spirv = recompile_compute(code, words, &resources, config);
+    };
+
+    ShaderResourceTable write_resources;
+    write_resources.resources = {scalar_buffer(0, 0, &input, sizeof(input)),
+                                 scalar_buffer(1, 4, &output, sizeof(output))};
+    std::vector<uint32_t> write_spirv;
+    ComputeShaderConfig write_config;
+    build(write_code, std::size(write_code), write_resources, write_spirv, write_config);
+    CHECK(!write_spirv.empty(), "the writable-result fixture recompiles");
+
+    ShaderResourceTable read_resources;
+    read_resources.resources = {scalar_buffer(0, 0, &input, sizeof(input))};
+    std::vector<uint32_t> read_spirv;
+    ComputeShaderConfig read_config;
+    build(read_only_code, std::size(read_only_code), read_resources, read_spirv, read_config);
+    CHECK(!read_spirv.empty(), "the read-only control fixture recompiles");
+    if (write_spirv.empty() || read_spirv.empty()) {
+        std::printf("== FAIL ==\n");
+        return 1;
+    }
+
+    // The negative control is only a control if its binding really is reflected as read-only: a
+    // dispatch that reflects NO descriptor at all would record no barrier for a reason that has
+    // nothing to do with the fix.
+    const DescriptorValidationReport read_report = validate_spirv_descriptor_interface(
+        read_spirv, &read_resources, 0, SpirvShaderStage::Compute, false);
+    const bool read_only_binding_present =
+        read_report.ok() && !read_report.descriptors.empty() &&
+        std::none_of(read_report.descriptors.begin(), read_report.descriptors.end(),
+                     [](const SpirvDescriptorBinding& binding) { return binding.writable; });
+    CHECK(read_only_binding_present,
+          "the control reflects a storage-buffer binding and reflects it as READ-ONLY");
+
+    const DescriptorValidationReport write_report = validate_spirv_descriptor_interface(
+        write_spirv, &write_resources, 0, SpirvShaderStage::Compute, false);
+    const size_t writable_bindings =
+        static_cast<size_t>(std::count_if(
+            write_report.descriptors.begin(), write_report.descriptors.end(),
+            [](const SpirvDescriptorBinding& binding) { return binding.writable; }));
+    CHECK(write_report.ok() && writable_bindings == 1,
+          "the writable fixture reflects exactly one writable binding, so one barrier is expected");
+
+    auto make_item = [](const std::vector<uint32_t>& spirv, const ComputeShaderConfig& config,
+                        const ShaderResourceTable& resources) {
+        ComputeItem item;
+        item.spirv = spirv;
+        item.user_sgprs = config.user_sgprs;
+        item.resources = std::make_shared<ShaderResourceTable>(resources);
+        item.launch.threads_x = item.launch.threads_y = item.launch.threads_z = 1;
+        item.launch.local_x = item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_x = item.launch.groups_y = item.launch.groups_z = 1;
+        item.recompile_config = config;
+        item.recompile_config_available = true;
+        return item;
+    };
+
+    // ---- Arm 2: a real dispatch records the availability dependency ----------------------------
+    ComputeItem write_item = make_item(write_spirv, write_config, write_resources);
+    write_item.code_addr = 0x32490000u;
+    const uint64_t before_write = barriers();
+    const bool wrote = prosper::frontend::execute_live_compute_items({write_item});
+    const uint64_t write_delta = barriers() - before_write;
+    CHECK(wrote && output == input,
+          "the production backend ran the dispatch and wrote the result back to guest memory");
+    std::printf("  host-read barriers recorded by one writable-buffer dispatch: %llu\n",
+                static_cast<unsigned long long>(write_delta));
+    CHECK(write_delta == 1,
+          "a writable dispatch result records exactly one host-read barrier before the host maps it");
+
+    // ---- Arm 3: negative control ---------------------------------------------------------------
+    ComputeItem read_item = make_item(read_spirv, read_config, read_resources);
+    read_item.code_addr = 0x32490100u;
+    const uint64_t before_read = barriers();
+    const bool read = prosper::frontend::execute_live_compute_items({read_item});
+    const uint64_t read_delta = barriers() - before_read;
+    std::printf("  host-read barriers recorded by one read-only dispatch: %llu\n",
+                static_cast<unsigned long long>(read_delta));
+    CHECK(read, "the read-only control dispatch also executes");
+    CHECK(read_delta == 0,
+          "a dispatch the host never reads back records no host-read barrier");
+
+    // ---- Arm 4: the OTHER producer — a storage image, whose staging buffer is written by
+    // vkCmdCopyImageToBuffer rather than by the shader. Same helper, different source scope, and it
+    // is the site the guest writeback reads to restore a texture into guest memory.
+    {
+        // v4 = x from the shell input; image_load from binding 4; image_store into binding 5.
+        static const uint32_t image_copy[] = {
+            0x7E080300u, 0xF0000F00u, 0x00000004u, 0xBF8C3F70u,
+            0xF0200F00u, 0x00020004u, 0xBF810000u,
+        };
+        constexpr uint32_t texels = 64;
+        std::vector<uint32_t> lane_index(texels);
+        for (uint32_t i = 0; i < texels; ++i) lane_index[i] = i;
+        std::vector<uint32_t> unused(4, 0);
+        std::vector<uint8_t> source(texels * 4), destination(texels * 4, 0xee);
+        for (uint32_t i = 0; i < texels * 4; ++i) source[i] = static_cast<uint8_t>(i * 37 + 5);
+
+        ShaderResourceTable table;
+        auto add_buffer = [&](uint32_t binding, void* data, uint32_t bytes) {
+            ShaderResource resource{};
+            resource.cls = ResourceClass::ConstantBuffer;
+            resource.binding = binding;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(data);
+            resource.size = bytes;
+            table.resources.push_back(resource);
+        };
+        add_buffer(0, lane_index.data(), texels * sizeof(uint32_t));
+        add_buffer(1, unused.data(), 16);
+        add_buffer(2, unused.data(), 16);
+        add_buffer(3, unused.data(), 16);
+        auto add_image = [&](uint32_t binding, uint32_t sgpr, void* data, uint32_t bytes) {
+            ShaderResource image{};
+            image.cls = ResourceClass::StorageImage;
+            image.img_dim = 0;                     // 1D
+            image.binding = binding;
+            image.sgpr_base = sgpr;
+            image.format = DataFormat::Unorm8;
+            image.num_components = 4;
+            image.width = texels;
+            image.height = 1;
+            image.gpu_addr = reinterpret_cast<uint64_t>(data);
+            image.size = bytes;
+            table.resources.push_back(image);
+        };
+        add_image(4, 0, source.data(), texels * 4);
+        add_image(5, 8, destination.data(), texels * 4);
+
+        const std::vector<uint32_t> image_spirv =
+            recompile_valu(image_copy, std::size(image_copy), 1, 0, &table);
+        CHECK(!image_spirv.empty(), "the storage-image fixture recompiles");
+        // Derive the expectation instead of hardcoding it. The VALU shell this fixture uses also
+        // binds its own writable output buffer, so the dispatch has BOTH producers: one shader
+        // write into a storage buffer and one transfer write into each storage image's staging
+        // buffer. Both storage images are copied back regardless of shader writability, because the
+        // guest writeback maps and reads both.
+        const DescriptorValidationReport image_report = validate_spirv_descriptor_interface(
+            image_spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const uint64_t expected_image_barriers = static_cast<uint64_t>(std::count_if(
+            image_report.descriptors.begin(), image_report.descriptors.end(),
+            [](const SpirvDescriptorBinding& binding) {
+                return binding.kind == SpirvDescriptorKind::StorageImage ||
+                       (binding.kind == SpirvDescriptorKind::StorageBuffer && binding.writable);
+            }));
+        CHECK(image_report.ok() && expected_image_barriers == 3,
+              "the storage-image fixture reflects two storage images and one writable buffer");
+        if (!image_spirv.empty()) {
+            ComputeItem image_item;
+            image_item.spirv = image_spirv;
+            image_item.resources = std::make_shared<ShaderResourceTable>(table);
+            image_item.launch.threads_x = texels;
+            image_item.launch.local_x = 64;
+            image_item.launch.local_y = image_item.launch.local_z = 1;
+            image_item.launch.groups_x = 1;
+            image_item.launch.groups_y = image_item.launch.groups_z = 1;
+            image_item.code_addr = 0x32490200u;
+            const uint64_t before_image = barriers();
+            const bool copied = prosper::frontend::execute_live_compute_items({image_item});
+            const uint64_t image_delta = barriers() - before_image;
+            CHECK(copied && destination == source,
+                  "the production backend ran the storage-image copy and wrote guest memory");
+            std::printf("  host-read barriers recorded by a two-storage-image dispatch: %llu"
+                        " (expected %llu)\n",
+                        static_cast<unsigned long long>(image_delta),
+                        static_cast<unsigned long long>(expected_image_barriers));
+            CHECK(image_delta == expected_image_barriers,
+                  "every staging readback and every writable buffer records its own barrier");
+        }
+    }
+
+    std::printf(failures ? "== FAIL ==\n" : "== PASS ==\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #3249

## The defect

The live compute backend maps every dispatch result after the fence wait and reads it into guest
memory. Per the Vulkan spec a fence signal orders **execution**; it does not perform the
**availability** operation that moves those writes into the host domain. That needs an explicit
dependency with `dstStageMask = VK_PIPELINE_STAGE_HOST_BIT` and
`dstAccessMask = VK_ACCESS_HOST_READ_BIT`.

#2944 named `live_compute.cpp` as one of the two places in the tree that already got this right.
That is true of the site it pointed at — the comparator's one-word flag buffer — and not of the
bytes that become guest memory.

## Re-derived site list — the issue's is incomplete, and in a way worth recording

The issue names two producers (writable storage buffers, storage-image staging). Re-derived against
current `origin/main`, there are **six host reads of device-written mapped memory** in
`live_compute.cpp` and **five producers** behind them.

The reason the issue's list is short is structural rather than an oversight: **the compute memory
pool recycles host-visible allocations across bindings and submits.** `release_memory` returns an
allocation to `memory_pool.available` and `allocate_memory` hands it to any later binding of the
same memory type, which then maps it and reads its retained contents to decide whether an upload is
needed — the code's own comment is *"Pooled host-visible allocations retain their previous
contents. Compare them with current guest memory before uploading."* So a buffer that the binding
which WROTE it never maps is still host-read later. **The invariant is per-allocation, not
per-binding.**

Host reads:

| # | host read | producer | in the issue |
| --- | --- | --- | --- |
| R1 | guest writeback of each writable storage buffer | P1 | yes |
| R2 | guest writeback of each storage image's `staging[i]` | P2 | yes |
| R3 | comparator flag word | P3 | named as the correct site |
| R4 | `acquire_cached_buffer`'s `memcmp` of a retained cached buffer against guest bytes | P1 (an earlier submit) | no |
| R5 | `compute_buffers_equal(mapped, source, …)` on a freshly bound **pooled** allocation | P1/P2/P4/P5 (any earlier submit) | no |
| R6 | `cached_image_result_matches` / `remember_cached_image_result` over the staging mapping | P2 | no |

Producers, with the source scope each needs:

| # | producer | source scope | memory | barrier before this PR |
| --- | --- | --- | --- | --- |
| P1 | the dispatch itself, writing storage buffers | `SHADER_WRITE` @ `COMPUTE_SHADER` | `HOST_COHERENT` (required) | **absent** |
| P2 | `vkCmdCopyImageToBuffer` → storage-image staging | `TRANSFER_WRITE` @ `TRANSFER` | `HOST_COHERENT` (required) | **absent** |
| P3 | comparator shader → `compare_flags` | `SHADER_WRITE` @ `COMPUTE_SHADER` | `HOST_COHERENT` (required) | **present** (#2944's cited site) |
| P4 | `copy_result_baseline`'s `vkCmdCopyBuffer` → retained baseline | `TRANSFER_WRITE` @ `TRANSFER` | `HOST_COHERENT` (required) | **absent** — not in the issue |
| P5 | depth-bits bridge `vkCmdCopyImageToBuffer` → `staging[i]` | `TRANSFER_WRITE` @ `TRANSFER` | `HOST_COHERENT` (required) | **absent** — not in the issue |

P4 has a second source scope: the comparator **rewrites** each differing baseline in place
(`build_compute_compare_uvec4` emits `OpStore` into the baseline on the `different` branch), so that
baseline's last device write is a shader write, not the transfer copy. Both are covered.

**Coherent vs non-coherent — a real negative result, and the opposite of the render backend's.**
`host_memory_type` tries `HOST_VISIBLE|HOST_COHERENT|HOST_CACHED` and falls back to
`HOST_VISIBLE|HOST_COHERENT`; the cached tier is `wanted | HOST_CACHED`, not `HOST_CACHED` alone. So
**every** allocation the compute path maps is coherent, **0 of the 6 sites need
`vkInvalidateMappedMemoryRanges`**, and there is no second bug of that shape here. (#3250 found 3 of
8 render sites genuinely non-coherent; this backend has none.)

Also confirmed and not incidental cover: the end-of-command-buffer
`COMPUTE_SHADER|TRANSFER -> ALL_COMMANDS` image restore does **not** supply the dependency —
`VK_PIPELINE_STAGE_ALL_COMMANDS_BIT` does not include `VK_PIPELINE_STAGE_HOST_BIT`, and its
destination access mask does not include `VK_ACCESS_HOST_READ_BIT`.

## Reusing the helper rather than writing a second one

**The render backend's helper was not reachable from `live_compute.cpp`.** Checked with the
preprocessor rather than with grep — `-M` over that translation unit's own compile command lists no
`render_runner.h`. (`tests/fixtures/AGENTS.md` claimed `live_compute.cpp` was one of its three
includers. It is not; that line is corrected here.)

Including a 10.6k-line offscreen render backend into an 11k-line compute translation unit for a
20-line helper is the wrong fix, so the first commit is a **pure move**:
`record_host_read_barrier` / `host_read_barrier_for` / `backend_host_read_barrier_count` move
verbatim into `src/gpu/execute/host_read_barrier.hpp` (namespace `prosper::gpu`), and
`render_runner.h` re-exports them into `prosper::test` with four `using` declarations. Every
existing call site and the `host_read_barrier` ctest case are untouched. Both backends now record
the identical barrier through the identical call, and the counter is shared.

The **invalidate** half deliberately stays in `render_runner.h`, beside the only allocator in the
tree that can return non-coherent memory.

## The fix

Five `record_host_read_barrier` call sites in `live_compute.cpp`, each placed after the LAST device
write to its buffer, plus P3's existing hand-rolled barrier folded into the helper so the file has
one pattern. Whole-buffer scope replaces P3's exact flag span — wider and equally valid.

## What the test can and cannot detect

`prosper/tests/shared/live/test_live_compute_host_read_barrier.cpp`, registered as
`live_compute_host_read_barrier`. It drives the **production** backend through
`execute_live_compute_items`, the same entry `game_compute_exec` and `live_compute_descriptor_array`
use.

**Cannot**: detect the defect from the dispatch's result. Every compute allocation is
`HOST_COHERENT` and this driver returns byte-identical results without the barrier. **Measured, not
assumed** — with the P1 barrier deleted:

```
game_compute_exec ................ Passed   (== PASS == (439 assertions executed))
live_compute_descriptor_array .... Passed
```

and inside the new test itself, `"the production backend ran the dispatch and wrote the result back
to guest memory"` still `[ok]`.

**Cannot**: be caught by synchronization validation either. #3250 measured that syncval cannot
observe a CPU read through a mapped pointer, and proved the layer was armed by finding 5
`SYNC-HAZARD` messages elsewhere with the same setting (#3248). Not re-litigated here; not used as
an oracle.

**Can**: fail without the fix, structurally.

* **Arm 1** (no device) — the exact masks for the compute source scope: `dstAccessMask` exactly
  `VK_ACCESS_HOST_READ_BIT`, `dstStageMask` exactly `VK_PIPELINE_STAGE_HOST_BIT`, whole-buffer, no
  ownership transfer, and the host half unchanged between the `SHADER_WRITE` and `TRANSFER_WRITE`
  producers.
* **Arm 2** — one real dispatch with one writable storage buffer: the counter must move by exactly 1.
* **Arm 3 (negative control)** — a dispatch whose only binding is reflected **read-only**: the host
  reads nothing back, so no barrier may be recorded. Without it a counter incremented anywhere on
  the compute path would satisfy arm 2 and prove nothing. The arm asserts the control really does
  reflect a storage-buffer binding and reflects it as read-only, so it cannot pass vacuously by
  reflecting no descriptor at all.
* **Arm 4** — the *other* producer: a two-storage-image copy dispatch. Its expectation is **derived
  from reflection** (storage images + writable storage buffers = 3) rather than hardcoded, so it
  states the rule instead of a number.

**Coverage**: 2 of the 5 producers are driven end to end (P1, P2). P4 and P5 need a retained
baseline and a borrowed renderer depth plane respectively, neither of which a fixture-only test can
build; P3 was already correct. All five share the helper, and arm 1 pins the helper.

### Measured mutation arms

Both rebuild only `--target test_live_compute_host_read_barrier`.

**M1 — delete the P1 loop** (writable storage buffers):

```
  [ok]   the production backend ran the dispatch and wrote the result back to guest memory   <- BLIND
  host-read barriers recorded by one writable-buffer dispatch: 0
  [FAIL] a writable dispatch result records exactly one host-read barrier before the host maps it
  [ok]   a dispatch the host never reads back records no host-read barrier                   <- control holds
== FAIL ==     ctest exit 8, 0/1 passed
```

**M2 — delete the P2 call** (storage-image staging):

```
  [ok]   the production backend ran the storage-image copy and wrote guest memory            <- BLIND
  host-read barriers recorded by a two-storage-image dispatch: 1 (expected 3)
  [FAIL] every staging readback and every writable buffer records its own barrier
== FAIL ==     ctest exit 8, 0/1 passed
```

Restored, both arms pass with 1 and 3.

## Risks

* **Extra barriers on a hot path.** At most one `vkCmdPipelineBarrier` per writable buffer, per
  storage image, per retained baseline and per compare target, on a path that already records
  roughly ten per dispatch and ends in a fence wait. `COMPUTE_SHADER → HOST` and `TRANSFER → HOST`
  are the cheapest dependencies there are, and nothing waits on a queue that was not about to be
  waited on.
* **Placement.** Each is recorded after the last device write to its buffer: the comparator and the
  baseline copy that follow the dispatch only READ the storage buffers and staging buffers, so the
  post-dispatch and post-copy positions remain correct. The depth-bits barrier precedes that path's
  own `TRANSFER_WRITE → TRANSFER_READ` dependency; the two are independent.
* **A shared process-wide counter.** One relaxed `fetch_add`. It is an instrument, never a control
  input, and it is now shared with the render guard — both tests read deltas, not absolutes.
* **The pure move.** `render_runner.h` compiles into ~25 targets; all of them already include
  `gpu/...` headers, so `src` is on every include path that needed it. Full build is green.
* **Behaviour change is intended to be none.** This lands as spec conformance, like #3250.

## Also updated

* `docs/GRAPHICS.md` § Ruled out — five rows: the compute backend is blind to this by value too
  (with the measurement); the compute allocator cannot hand out non-coherent memory so no site needs
  a new invalidate; the `ALL_COMMANDS` image restore does not incidentally cover it; a device write
  with no host read in its own dispatch is still not exempt, because the pool recycles allocations.
* `tests/fixtures/AGENTS.md` — corrects the claim that `live_compute.cpp` includes `render_runner.h`
  (it does not, checked with `-M`), and points the availability half at its new home.
* `src/gpu/execute/AGENTS.md` — the new file, and why only one of the two halves lives there.
* `frontends/shared/live/AGENTS.md` — **new**; the folder had none. Says what the two live backends
  are, that the compute one is a separate Vulkan backend rather than a caller of the render one, and
  records the readback contract where the next person editing `live_compute.cpp` will see it.
* `BLOG.md` — one entry, no picture.

## Build / test

Container `ps5ys`, Fedora 44, Mesa RADV STRIX_HALO (Radeon 8060S).

```
cmake -S prosper -B prosper/build-linux                              # exit 0
cmake --build prosper/build-linux -j6                                # exit 0
ctest --no-tests=error                                               # 344/344 passed, exit 0
python3 tools/vkval/vk_validation_scan.py --build-dir build-linux    # PASS, exit 0
                                                                     # 5 ids, all pre-existing + allow-listed
python3 prosper/tools/docs/check_numbered_table.py (all *.md)         # exit 0
git diff --check                                                     # exit 0
```

`origin/main` baseline measured in the same worktree before any change: configure exit 0, build exit
0, **343/343 passed, ctest exit 0**. The delta is the one registered case,
`live_compute_host_read_barrier` (test #306, Passed) — verified by name in the run log, not by the
count alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
