### PR TITLE
tools/ci: a merge gate that reads check buckets and verifies the head (#3259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -870,11 +870,11 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
       whether the approval still applies rather than assuming in either direction.
     - **The same detachment applies to CI CHECKS**, which the bullet above does not cover: a branch
       pushed after its checks started leaves `gh` reporting green for a commit that is no longer
-      what would merge. So compare `headRefOid` against `git ls-remote origin refs/heads/<branch>`
-      before merging, not only the reviews' `commit_id`. **No merge here is known to have been lost
-      this way** — #3243 was first written up as one and that was wrong on the dates (its head *was*
-      the tip at merge; the extra commits were authored minutes later), so treat this as a cheap
-      precaution rather than a scar. What actually let #3243 through was the review half above.
+      what would merge, and every lane here pushes after CI starts. So compare `headRefOid` against
+      `git ls-remote origin refs/heads/<branch>` before merging, not only the reviews' `commit_id`.
+      One command, and the state is routine. (As of 2026-09-02 no merge here is known to have been
+      lost this way; #3259 first cited #3243 and that was wrong on the dates. The rule stands on the
+      hazard, not on a scar — full account in `prosper/tools/ci/AGENTS.md`.)
     - **Never gate on the TEXT output of `gh pr checks`.** Its columns are tab-separated and this
       repository's check names contain spaces — `Windows App`, `Linux App Package`,
       `macOS (x86_64 / Rosetta 2)` — so splitting on whitespace puts the second *word of the name*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -868,6 +868,22 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
       reports rows, with a `commit_id` that is no longer on the branch. Compare each review's `commit_id`
       against the current head; if it is stale, establish by **content** (`git diff <reviewed-sha> <head>`)
       whether the approval still applies rather than assuming in either direction.
+    - **The same detachment applies to CI CHECKS, and that half cost a merge.** On #3243 GitHub's
+      recorded PR head froze while the branch advanced two commits; no run was ever queued for the
+      newer ones, `gh pr checks` reported green for the frozen head, and the merge carried code CI
+      had never seen. So compare `headRefOid` against `git ls-remote origin refs/heads/<branch>`
+      before merging, not only the reviews' `commit_id`.
+    - **Never gate on the TEXT output of `gh pr checks`.** Its columns are tab-separated and this
+      repository's check names contain spaces — `Windows App`, `Linux App Package`,
+      `macOS (x86_64 / Rosetta 2)` — so splitting on whitespace puts the second *word of the name*
+      where the status belongs. A shell gate doing that merged #3234 with a red `Windows MinGW`;
+      an `awk '$2=="pass"'` written the same day counted 2 passing checks where 8 passed. Both
+      answers look plausible, which is the whole danger. Use `--json name,state,bucket`.
+    - Both rules, plus "an empty check list is VOID rather than green", are implemented in
+      `prosper/tools/ci/pr_merge_gate.py` — `python3 prosper/tools/ci/pr_merge_gate.py <PR>` exits 0
+      only when every check passed, none is pending, at least one passed, and the head the checks
+      describe is the branch tip. It exits **2** when it could not evaluate, so "the gate could not
+      run" is never confused with "the gate said no".
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises
   parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -868,11 +868,13 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
       reports rows, with a `commit_id` that is no longer on the branch. Compare each review's `commit_id`
       against the current head; if it is stale, establish by **content** (`git diff <reviewed-sha> <head>`)
       whether the approval still applies rather than assuming in either direction.
-    - **The same detachment applies to CI CHECKS, and that half cost a merge.** On #3243 GitHub's
-      recorded PR head froze while the branch advanced two commits; no run was ever queued for the
-      newer ones, `gh pr checks` reported green for the frozen head, and the merge carried code CI
-      had never seen. So compare `headRefOid` against `git ls-remote origin refs/heads/<branch>`
-      before merging, not only the reviews' `commit_id`.
+    - **The same detachment applies to CI CHECKS**, which the bullet above does not cover: a branch
+      pushed after its checks started leaves `gh` reporting green for a commit that is no longer
+      what would merge. So compare `headRefOid` against `git ls-remote origin refs/heads/<branch>`
+      before merging, not only the reviews' `commit_id`. **No merge here is known to have been lost
+      this way** — #3243 was first written up as one and that was wrong on the dates (its head *was*
+      the tip at merge; the extra commits were authored minutes later), so treat this as a cheap
+      precaution rather than a scar. What actually let #3243 through was the review half above.
     - **Never gate on the TEXT output of `gh pr checks`.** Its columns are tab-separated and this
       repository's check names contain spaces — `Windows App`, `Linux App Package`,
       `macOS (x86_64 / Rosetta 2)` — so splitting on whitespace puts the second *word of the name*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -883,8 +883,8 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
       answers look plausible, which is the whole danger. Use `--json name,state,bucket`.
     - Both rules, plus "an empty check list is VOID rather than green", are implemented in
       `prosper/tools/ci/pr_merge_gate.py` — `python3 prosper/tools/ci/pr_merge_gate.py <PR>` exits 0
-      only when every check passed, none is pending, at least one passed, and the head the checks
-      describe is the branch tip. It exits **2** when it could not evaluate, so "the gate could not
+      only when every check passed, none is pending, at least one passed, and the PR's recorded
+      head is still the branch tip. It exits **2** when it could not evaluate, so "the gate could not
       run" is never confused with "the gate said no".
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -340,6 +340,16 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME tools_usage_text
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/ci/check_usage_text.py"
                    --selftest --root "${CMAKE_SOURCE_DIR}")
+  # The merge gate (#3259). Its arms are all REFUSALS, and a gate that refuses everything would
+  # satisfy every one of them -- so the suite leads with an all-pass positive control, and each
+  # refusal asserts on the REASON rather than on the boolean. Two arms reconstruct merges that
+  # actually went wrong: a red `Windows MinGW` read as green because a shell split the check NAME
+  # on whitespace and landed on `MinGW` where the status belongs (#3234), and an all-green result
+  # describing a PR head the branch had moved two commits past (#3243). Both are shapes this
+  # repository produces routinely -- check names here contain spaces, and every lane pushes after
+  # CI starts -- so neither arm is hypothetical.
+  add_test(NAME pr_merge_gate
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/ci/test_pr_merge_gate.py")
   # PROSPER_ENV_ON/_VALUE sample getenv once and return it forever. Applied to a name a TEST arms at
   # runtime, the arm becomes invisible -- and the test does not fail, it goes vacuous and keeps
   # printing [ok], which is why #2214 surfaced only as one unrelated-looking Vulkan binding error on

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -342,12 +342,11 @@ if(Python3_Interpreter_FOUND)
                    --selftest --root "${CMAKE_SOURCE_DIR}")
   # The merge gate (#3259). Its arms are all REFUSALS, and a gate that refuses everything would
   # satisfy every one of them -- so the suite leads with an all-pass positive control, and each
-  # refusal asserts on the REASON rather than on the boolean. Two arms reconstruct merges that
+  # refusal asserts on the REASON rather than on the boolean. One arm reconstructs a merge that
   # actually went wrong: a red `Windows MinGW` read as green because a shell split the check NAME
-  # on whitespace and landed on `MinGW` where the status belongs (#3234), and an all-green result
-  # describing a PR head the branch had moved two commits past (#3243). Both are shapes this
-  # repository produces routinely -- check names here contain spaces, and every lane pushes after
-  # CI starts -- so neither arm is hypothetical.
+  # on whitespace and landed on `MinGW` where the status belongs (#3234). The stale-head arm is
+  # NOT a reconstruction -- #3259 first cited #3243 as one and that was wrong on the dates -- it
+  # guards a state this repository produces routinely, since every lane pushes after CI starts.
   add_test(NAME pr_merge_gate
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/ci/test_pr_merge_gate.py")
   # PROSPER_ENV_ON/_VALUE sample getenv once and return it forever. Applied to a name a TEST arms at

--- a/prosper/tools/ci/AGENTS.md
+++ b/prosper/tools/ci/AGENTS.md
@@ -1,0 +1,44 @@
+# tools/ci — checks about the process, not about the emulator
+
+Everything here answers a question about **how a change is being made**, never about whether the
+emulator is correct. Nothing in this folder loads a module, decodes a packet or touches a GPU. If a
+check needs a dump, a Vulkan device or a guest, it does not belong here — it belongs in `tests/`.
+
+The boundary against its siblings: `tools/docs/` validates the *content* of Markdown (numbered
+tables, trap citations, cross-references); this folder validates the *mechanics* around a change —
+the shape of a contribution, whether a test gate was actually armed, whether a tool still prints its
+usage, whether a PR is safe to merge.
+
+## What lives here
+
+- **`check_contribution_shape.py`** — the contribution-shape CI job.
+- **`check_ctest_gate.py`** — finds callers that run `ctest` without `--no-tests=error`. Plain
+  `ctest` exits 0 when it finds no tests, so "nothing ran" and "everything passed" share a status.
+- **`check_usage_text.py`** — finds tools whose usage block stopped being a docstring, so
+  `print(__doc__)` prints the literal `None` and the caller is told nothing.
+- **`pr_merge_gate.py`** — is this PR safe to merge right now? Counts checks by bucket from
+  `gh --json` and refuses when the PR's recorded head is no longer the branch tip.
+
+## The property they share, and why it dictates how they are tested
+
+**Every check here fails silently when it breaks.** A matcher that stops matching reports a clean
+tree forever. A gate that mis-parses reports green. None of these produce an error when they go
+wrong — they produce a *reassuring answer*, which is worse than an error because it stops the reader
+looking.
+
+So each carries self-tests that pin its own behaviour rather than relying on the repository
+happening to contain a violation, and each is registered in ctest. When you add a check here, add
+the arm that would redden if its matcher quietly widened. `test_pr_merge_gate.py` also carries the
+harder half for a boolean gate: because nearly every arm is a refusal, and a gate that refuses
+*everything* satisfies all of them, it leads with a positive control and asserts on the refusal
+*reason* rather than on the boolean.
+
+## A note on gates that decide something irreversible
+
+`pr_merge_gate.py` exists because two PRs merged wrongly on one day (#3259), and neither cause was
+carelessness — a check name containing a space was read as a status, and CI reported green for a
+commit the branch had moved past. Both readings looked plausible. When a check here decides
+something that cannot be undone by rerunning it, prefer being wrong in the direction of refusing:
+exit non-zero on anything unrecognised, treat an empty result as void rather than clean, and use a
+distinct exit status for "could not evaluate" so it can never be confused with "evaluated, and the
+answer is no".

--- a/prosper/tools/ci/AGENTS.md
+++ b/prosper/tools/ci/AGENTS.md
@@ -35,9 +35,12 @@ harder half for a boolean gate: because nearly every arm is a refusal, and a gat
 
 ## A note on gates that decide something irreversible
 
-`pr_merge_gate.py` exists because two PRs merged wrongly on one day (#3259), and neither cause was
-carelessness — a check name containing a space was read as a status, and CI reported green for a
-commit the branch had moved past. Both readings looked plausible. When a check here decides
+`pr_merge_gate.py` exists because a PR merged red (#3234) when a shell gate split `gh pr checks`'s
+tab-separated output on whitespace and read the second word of `Windows MinGW` as a status — a
+reading that looked entirely plausible. Its head-vs-tip rule is a precaution rather than a scar:
+#3259 originally cited #3243 as a second incident and that was **wrong on the dates**, which is
+itself the lesson worth keeping — the claim was withdrawn only because a reviewer dated the commits
+against `mergedAt` instead of trusting a frozen-looking PR record. When a check here decides
 something that cannot be undone by rerunning it, prefer being wrong in the direction of refusing:
 exit non-zero on anything unrecognised, treat an empty result as void rather than clean, and use a
 distinct exit status for "could not evaluate" so it can never be confused with "evaluated, and the

--- a/prosper/tools/ci/AGENTS.md
+++ b/prosper/tools/ci/AGENTS.md
@@ -45,3 +45,21 @@ something that cannot be undone by rerunning it, prefer being wrong in the direc
 exit non-zero on anything unrecognised, treat an empty result as void rather than clean, and use a
 distinct exit status for "could not evaluate" so it can never be confused with "evaluated, and the
 answer is no".
+
+## Verifying a prose correction: normalise whitespace before grepping
+
+A phrase you are removing from documentation will often be **hard-wrapped across a line break**, and
+`grep` is line-oriented, so it reports zero and you believe the phrase is gone. This is not
+hypothetical: correcting one wrong claim across this PR's files took three review rounds, and a
+*different* file survived each round for exactly this reason. `grep 'checks describe'` returned
+nothing while the phrase sat in `CLAUDE.md`, split after "the head the checks".
+
+    # what actually answers "is this phrase still anywhere?"
+    for f in $(git diff --name-only origin/main...HEAD); do
+        n=$(tr '\n' ' ' < "$f" | tr -s ' ' | grep -o 'the phrase' | wc -l)
+        [ "$n" -gt 0 ] && echo "STILL PRESENT in $f ($n)"
+    done
+
+The same applies to any claim, figure or citation you are retracting. A single-line grep is fine for
+code, where the thing you are looking for rarely wraps; it is close to useless for prose in this
+repository, which wraps at about 100 columns.

--- a/prosper/tools/ci/pr_merge_gate.py
+++ b/prosper/tools/ci/pr_merge_gate.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Answer one question about a pull request: is it safe to merge RIGHT NOW?
+
+Everything here is shaped by two merges that went wrong on 2026-09-02, both from mechanical
+causes rather than carelessness (#3259).
+
+**A check name is not a status.** `gh pr checks` prints tab-separated columns and this
+repository's check names contain spaces -- `Windows App`, `Linux App Package`,
+`macOS (x86_64 / Rosetta 2)`. Splitting that on whitespace puts the second *word of the name*
+where the status should be, so `Windows App` reads as a status of `App`. A shell gate matching
+the text this way merged #3234 with a red `Windows MinGW`; an `awk '$2=="pass"'` written while
+filing #3259 counted 2 passing checks where 8 were passing. Both readings look plausible, which
+is exactly what makes them dangerous. So this tool consumes `--json name,state,bucket` and never
+the text form, and `parse_checks` rejects a payload that is not that JSON shape rather than
+falling back to a looser parse.
+
+**CI green can describe a commit that would not merge.** GitHub's recorded PR head can lag the
+branch: on #3243 it froze while the branch advanced two commits, no run was ever queued for the
+newer ones, and the merge carried code CI had never seen. `CLAUDE.md` records this detachment for
+*reviews* ("a rebase or a new push detaches every review from head"); it applies identically to
+*checks*, and that half was written down nowhere. So the head the checks describe is compared
+against the real branch tip, and a mismatch refuses however green the checks are.
+
+**An empty check list is VOID, not green.** Immediately after a push, `gh pr checks` can report
+nothing at all. "No checks failed" and "no checks ran" are the same answer to a naive `fail == 0`
+test, which is the same trap `CLAUDE.md` records for `ctest` (plain `ctest` on an empty build
+directory exits 0). Hence the `pass > 0` requirement, and hence this tool reports COUNTS: a count
+is falsifiable, an exit code alone is not.
+
+Usage:
+    pr_merge_gate.py <pr-number> [--repo-dir DIR] [--json]
+
+Exit status: 0 only when every check has passed, none is pending, at least one passed, and the
+head the checks describe is the branch tip. Any other state exits 1 and says which rule refused.
+Network or tooling failure exits 2 -- distinguishable from a refusal, because "the gate could not
+run" must never be confused with "the gate said no".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+# gh classifies every check into one of these. Only `pass` and `skipping` are compatible with
+# merging: `skipping` is a job whose own conditions excluded it (the Progress tracker job skips on
+# most PRs), which is a decision CI made deliberately, not an absence of information.
+BUCKET_PASS = "pass"
+BUCKET_FAIL = "fail"
+BUCKET_PENDING = "pending"
+BUCKET_SKIPPING = "skipping"
+BUCKET_CANCEL = "cancel"
+
+# A cancelled check is treated as blocking, not as skipped. A cancellation usually means someone
+# stopped the run or a newer push superseded it, and in both cases nothing was verified.
+BLOCKING_BUCKETS = (BUCKET_FAIL, BUCKET_CANCEL)
+
+
+class GateError(RuntimeError):
+    """The gate could not reach a verdict (bad input, `gh` failure, malformed payload)."""
+
+
+@dataclass
+class GateResult:
+    ok: bool
+    counts: dict
+    reasons: list = field(default_factory=list)
+    blocking: list = field(default_factory=list)
+    pending: list = field(default_factory=list)
+    pr_head: str = ""
+    branch_tip: str = ""
+
+    def render(self, pr: int) -> str:
+        c = self.counts
+        lines = [
+            "GATE #%d: pass=%d fail=%d pending=%d skipping=%d cancel=%d"
+            % (pr, c["pass"], c["fail"], c["pending"], c["skipping"], c["cancel"])
+        ]
+        for name, bucket in self.blocking:
+            lines.append("  BLOCKING: %s (%s)" % (name, bucket))
+        for name in self.pending:
+            lines.append("  pending:  %s" % name)
+        if self.pr_head:
+            same = self.pr_head == self.branch_tip
+            lines.append(
+                "  head %s branch tip (pr=%s tip=%s)"
+                % ("matches" if same else "DOES NOT MATCH", self.pr_head[:8], self.branch_tip[:8])
+            )
+        for r in self.reasons:
+            lines.append("  refused: %s" % r)
+        lines.append("  => %s" % ("GREEN" if self.ok else "NOT MERGEABLE"))
+        return "\n".join(lines)
+
+
+def parse_checks(payload):
+    """Take the JSON `gh pr checks --json name,state,bucket` emits, and nothing looser.
+
+    The point of being strict here is that the text form of the same data is the trap this whole
+    tool exists for: a permissive parser that fell back to splitting lines would reintroduce it.
+    """
+    if isinstance(payload, (str, bytes)):
+        try:
+            payload = json.loads(payload)
+        except (ValueError, TypeError) as exc:
+            raise GateError("check payload is not JSON: %s" % exc)
+    if not isinstance(payload, list):
+        raise GateError("check payload is not a JSON list (got %s)" % type(payload).__name__)
+    out = []
+    for i, row in enumerate(payload):
+        if not isinstance(row, dict):
+            raise GateError("check #%d is not an object" % i)
+        if "bucket" not in row or "name" not in row:
+            raise GateError("check #%d lacks 'name'/'bucket' -- wrong --json fields?" % i)
+        name, bucket = row["name"], row["bucket"]
+        if not isinstance(name, str) or not isinstance(bucket, str):
+            raise GateError("check #%d has a non-string name/bucket" % i)
+        out.append((name, bucket))
+    return out
+
+
+def evaluate(checks, pr_head=None, branch_tip=None):
+    """Decide, from already-fetched facts. Pure -- this is the half the tests drive."""
+    counts = {b: 0 for b in (BUCKET_PASS, BUCKET_FAIL, BUCKET_PENDING, BUCKET_SKIPPING, BUCKET_CANCEL)}
+    blocking, pending = [], []
+    for name, bucket in checks:
+        if bucket in counts:
+            counts[bucket] += 1
+        else:
+            # An unrecognised bucket is blocking. A new gh bucket must not silently read as
+            # success just because this tool predates it.
+            counts.setdefault("unknown", 0)
+            counts["unknown"] += 1
+            blocking.append((name, bucket))
+            continue
+        if bucket in BLOCKING_BUCKETS:
+            blocking.append((name, bucket))
+        elif bucket == BUCKET_PENDING:
+            pending.append(name)
+
+    reasons = []
+    if counts[BUCKET_PASS] == 0:
+        # Covers both "no checks reported yet" and "everything skipped": in neither case has
+        # anything actually been verified.
+        reasons.append("no check has passed -- an empty or all-skipped result is VOID, not green")
+    if blocking:
+        reasons.append("%d check(s) failed or were cancelled" % len(blocking))
+    if pending:
+        reasons.append("%d check(s) still pending" % len(pending))
+    if pr_head is not None and branch_tip is not None and pr_head != branch_tip:
+        reasons.append(
+            "the checks describe %s but the branch tip is %s -- CI never saw what would merge"
+            % (pr_head[:8], branch_tip[:8])
+        )
+
+    return GateResult(
+        ok=not reasons,
+        counts=counts,
+        reasons=reasons,
+        blocking=blocking,
+        pending=pending,
+        pr_head=pr_head or "",
+        branch_tip=branch_tip or "",
+    )
+
+
+def _run(cmd, cwd):
+    try:
+        p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    except OSError as exc:
+        raise GateError("could not run %s: %s" % (cmd[0], exc))
+    if p.returncode != 0:
+        raise GateError("%s failed (%d): %s" % (" ".join(cmd[:3]), p.returncode, p.stderr.strip()[:300]))
+    return p.stdout
+
+
+def collect(pr, repo_dir):
+    checks = parse_checks(_run(["gh", "pr", "checks", str(pr), "--json", "name,state,bucket"], repo_dir))
+    view = _run(["gh", "pr", "view", str(pr), "--json", "headRefOid,headRefName"], repo_dir)
+    try:
+        info = json.loads(view)
+        pr_head, branch = info["headRefOid"], info["headRefName"]
+    except (ValueError, KeyError) as exc:
+        raise GateError("could not read PR head: %s" % exc)
+    ls = _run(["git", "ls-remote", "origin", "refs/heads/%s" % branch], repo_dir)
+    tip = ls.split("\t")[0].strip() if ls.strip() else ""
+    if not tip:
+        raise GateError("branch %s has no remote tip -- deleted, or never pushed?" % branch)
+    return checks, pr_head, tip
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Is this PR safe to merge right now?")
+    ap.add_argument("pr", type=int)
+    ap.add_argument("--repo-dir", default=".", help="repository to run gh/git in")
+    ap.add_argument("--json", action="store_true", help="emit the verdict as JSON")
+    args = ap.parse_args(argv)
+    try:
+        checks, head, tip = collect(args.pr, args.repo_dir)
+    except GateError as exc:
+        # Exit 2, never 1: "the gate could not run" must be distinguishable from "the gate said no".
+        print("GATE #%d: COULD NOT EVALUATE -- %s" % (args.pr, exc), file=sys.stderr)
+        return 2
+    res = evaluate(checks, head, tip)
+    if args.json:
+        print(json.dumps({"ok": res.ok, "counts": res.counts, "reasons": res.reasons,
+                          "blocking": res.blocking, "pending": res.pending,
+                          "pr_head": res.pr_head, "branch_tip": res.branch_tip}, indent=2))
+    else:
+        print(res.render(args.pr))
+    return 0 if res.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/ci/pr_merge_gate.py
+++ b/prosper/tools/ci/pr_merge_gate.py
@@ -38,7 +38,9 @@ Usage:
     pr_merge_gate.py <pr-number> [--repo-dir DIR] [--json]
 
 Exit status: 0 only when every check has passed, none is pending, at least one passed, and the
-head the checks describe is the branch tip. Any other state exits 1 and says which rule refused.
+PR's recorded head is still the branch tip. Any other state exits 1 and says which rule refused.
+(`gh pr checks --json` carries no SHA, so the checks are the ones GitHub associates with the PR;
+what is compared is the PR's recorded head, not a SHA read off the checks themselves.)
 Network or tooling failure exits 2 -- distinguishable from a refusal, because "the gate could not
 run" must never be confused with "the gate said no".
 """
@@ -157,7 +159,7 @@ def evaluate(checks, pr_head=None, branch_tip=None):
         reasons.append("%d check(s) still pending" % len(pending))
     if pr_head is not None and branch_tip is not None and pr_head != branch_tip:
         reasons.append(
-            "the checks describe %s but the branch tip is %s -- CI never saw what would merge"
+            "the PR's recorded head is %s but the branch tip is %s -- nothing verified what would merge"
             % (pr_head[:8], branch_tip[:8])
         )
 
@@ -230,28 +232,29 @@ def main(argv=None):
     ap.add_argument("--repo-dir", default=".", help="repository to run gh/git in")
     ap.add_argument("--json", action="store_true", help="emit the verdict as JSON")
     args = ap.parse_args(argv)
+    # The guard spans EVERYTHING, not just collect(). Reporting is inside it because a failure
+    # while rendering or writing the verdict is still "could not evaluate": an exception escaping
+    # from render() or from print() exits 1, which this tool defines as "the gate said no", so a
+    # bug in the gate would masquerade as a considered refusal. That is not hypothetical and does
+    # not need a mutation to reach -- `pr_merge_gate.py N | head -1` raises BrokenPipeError on the
+    # print, which an earlier revision let escape.
     try:
         checks, head, tip = collect(args.pr, args.repo_dir)
+        res = evaluate(checks, head, tip)
+        if args.json:
+            print(json.dumps({"ok": res.ok, "counts": res.counts, "reasons": res.reasons,
+                              "blocking": res.blocking, "pending": res.pending,
+                              "pr_head": res.pr_head, "branch_tip": res.branch_tip}, indent=2))
+        else:
+            print(res.render(args.pr))
     except GateError as exc:
         # Exit 2, never 1: "the gate could not run" must be distinguishable from "the gate said no".
         print("GATE #%d: COULD NOT EVALUATE -- %s" % (args.pr, exc), file=sys.stderr)
         return 2
-    except Exception as exc:  # noqa: BLE001 -- deliberate catch-all, see below
-        # An UNEXPECTED exception is also "could not evaluate", and it must not escape. Letting a
-        # traceback propagate exits 1, which this tool defines as "the gate said no" -- so a bug in
-        # the gate would masquerade as a considered refusal, and worse, a caller keying on 1-vs-2
-        # would mis-route it. Mutation testing found exactly this: a mutant that let a null head
-        # through raised AttributeError deep in collect() and surfaced as a plain rc=1.
+    except Exception as exc:  # noqa: BLE001 -- deliberate catch-all, see above
         print("GATE #%d: COULD NOT EVALUATE -- unexpected %s: %s"
               % (args.pr, type(exc).__name__, exc), file=sys.stderr)
         return 2
-    res = evaluate(checks, head, tip)
-    if args.json:
-        print(json.dumps({"ok": res.ok, "counts": res.counts, "reasons": res.reasons,
-                          "blocking": res.blocking, "pending": res.pending,
-                          "pr_head": res.pr_head, "branch_tip": res.branch_tip}, indent=2))
-    else:
-        print(res.render(args.pr))
     return 0 if res.ok else 1
 
 

--- a/prosper/tools/ci/pr_merge_gate.py
+++ b/prosper/tools/ci/pr_merge_gate.py
@@ -14,12 +14,19 @@ is exactly what makes them dangerous. So this tool consumes `--json name,state,b
 the text form, and `parse_checks` rejects a payload that is not that JSON shape rather than
 falling back to a looser parse.
 
-**CI green can describe a commit that would not merge.** GitHub's recorded PR head can lag the
-branch: on #3243 it froze while the branch advanced two commits, no run was ever queued for the
-newer ones, and the merge carried code CI had never seen. `CLAUDE.md` records this detachment for
-*reviews* ("a rebase or a new push detaches every review from head"); it applies identically to
-*checks*, and that half was written down nowhere. So the head the checks describe is compared
-against the real branch tip, and a mismatch refuses however green the checks are.
+**CI green can describe a commit that would not merge.** A branch pushed after its checks started
+leaves `gh` reporting green for a commit that is no longer what a merge would take. `CLAUDE.md`
+records this detachment for *reviews* ("a rebase or a new push detaches every review from head");
+the same applies to *checks*. So the PR's recorded head is compared against the real branch tip and
+a mismatch refuses however green the checks are.
+
+This rule is here on its own merits, and it is worth being precise about what it has NOT done. An
+earlier version of this file claimed it would have caught #3243. **That claim was false** and was
+withdrawn after review: #3243's head *was* the branch tip when it merged, all eleven checks on that
+exact commit were green fifteen seconds earlier, and the two commits that made the branch look
+advanced were authored minutes AFTER the merge. What let that PR through was the review half, not
+CI, and no head comparison would have helped. The error was inferring that a gap seen *now* existed
+*at merge time* -- so the rule stands, but this tool claims no save it did not make.
 
 **An empty check list is VOID, not green.** Immediately after a push, `gh pr checks` can report
 nothing at all. "No checks failed" and "no checks ran" are the same answer to a naive `fail == 0`
@@ -175,19 +182,46 @@ def _run(cmd, cwd):
     return p.stdout
 
 
+def resolve_tip(ls_output, branch):
+    """Pick the tip for exactly `refs/heads/<branch>` out of `git ls-remote` output.
+
+    `git ls-remote origin refs/heads/foo` matches by SUFFIX, so a branch literally named
+    `bar/refs/heads/foo` comes back on the same query. Taking the first line would then compare
+    against the wrong branch and could report GREEN for one that was never checked. Improbable,
+    but a gate whose failure mode is a false GREEN does not get to rely on improbability.
+    """
+    want = "refs/heads/%s" % branch
+    hits = []
+    for line in ls_output.splitlines():
+        if "\t" not in line:
+            continue
+        sha, ref = line.split("\t", 1)
+        if ref.strip() == want:
+            hits.append(sha.strip())
+    if not hits:
+        raise GateError("branch %s has no remote tip -- deleted, or never pushed?" % branch)
+    if len(hits) > 1:
+        raise GateError("branch %s resolved to %d tips" % (branch, len(hits)))
+    return hits[0]
+
+
 def collect(pr, repo_dir):
     checks = parse_checks(_run(["gh", "pr", "checks", str(pr), "--json", "name,state,bucket"], repo_dir))
     view = _run(["gh", "pr", "view", str(pr), "--json", "headRefOid,headRefName"], repo_dir)
     try:
         info = json.loads(view)
-        pr_head, branch = info["headRefOid"], info["headRefName"]
-    except (ValueError, KeyError) as exc:
-        raise GateError("could not read PR head: %s" % exc)
-    ls = _run(["git", "ls-remote", "origin", "refs/heads/%s" % branch], repo_dir)
-    tip = ls.split("\t")[0].strip() if ls.strip() else ""
-    if not tip:
-        raise GateError("branch %s has no remote tip -- deleted, or never pushed?" % branch)
-    return checks, pr_head, tip
+    except ValueError as exc:
+        raise GateError("could not parse PR view: %s" % exc)
+    pr_head, branch = info.get("headRefOid"), info.get("headRefName")
+    # A null/absent head is NOT a reason to skip the comparison. Treating it as "no head
+    # information" made the gate print no head line at all and exit 0 -- a silent GREEN exactly
+    # where the verification should have been.
+    if not isinstance(pr_head, str) or not pr_head.strip():
+        raise GateError("PR %s reports no headRefOid -- cannot verify what would merge" % pr)
+    if not isinstance(branch, str) or not branch.strip():
+        raise GateError("PR %s reports no headRefName -- cannot resolve the branch tip" % pr)
+    tip = resolve_tip(_run(["git", "ls-remote", "origin", "refs/heads/%s" % branch], repo_dir), branch)
+    return checks, pr_head.strip(), tip
 
 
 def main(argv=None):
@@ -201,6 +235,15 @@ def main(argv=None):
     except GateError as exc:
         # Exit 2, never 1: "the gate could not run" must be distinguishable from "the gate said no".
         print("GATE #%d: COULD NOT EVALUATE -- %s" % (args.pr, exc), file=sys.stderr)
+        return 2
+    except Exception as exc:  # noqa: BLE001 -- deliberate catch-all, see below
+        # An UNEXPECTED exception is also "could not evaluate", and it must not escape. Letting a
+        # traceback propagate exits 1, which this tool defines as "the gate said no" -- so a bug in
+        # the gate would masquerade as a considered refusal, and worse, a caller keying on 1-vs-2
+        # would mis-route it. Mutation testing found exactly this: a mutant that let a null head
+        # through raised AttributeError deep in collect() and surfaced as a plain rc=1.
+        print("GATE #%d: COULD NOT EVALUATE -- unexpected %s: %s"
+              % (args.pr, type(exc).__name__, exc), file=sys.stderr)
         return 2
     res = evaluate(checks, head, tip)
     if args.json:

--- a/prosper/tools/ci/test_pr_merge_gate.py
+++ b/prosper/tools/ci/test_pr_merge_gate.py
@@ -330,6 +330,25 @@ _, green_report = run_main_capture(FakeGh(GREEN_CHECKS, VIEW, LS_ONE), ["1"])
 case("a passing PR's report says GREEN", "=> GREEN" in green_report, True)
 case("...and carries no BLOCKING line", "BLOCKING:" in green_report, False)
 
+# The fourteenth mutation: `"matches" if same else "DOES NOT MATCH"` -> `"matches"` survived
+# everything above, printing `head matches branch tip (pr=fd1dbb92 tip=1144bea7)` -- a line that
+# contradicts itself on its own text. Less dangerous than the always-GREEN mutant, because the
+# refusal reason and the verdict both refute it, but it is one arm.
+_, stale_report = run_main_capture(
+    FakeGh(GREEN_CHECKS, VIEW, "cccc3333\trefs/heads/topic\n"), ["1"])
+case("a stale head's report says DOES NOT MATCH", "DOES NOT MATCH" in stale_report, True)
+case("...and does not also claim it matches", "head matches" in stale_report, False)
+
+# The --json payload's counts, for the same reason the human report's counts are pinned: this
+# tool's argument for reporting them at all is that a count is falsifiable and an exit code is not.
+_, jr = run_main_capture(FakeGh(
+    '[{"name": "Docs", "bucket": "pass", "state": "S"},'
+    ' {"name": "Windows MinGW", "bucket": "fail", "state": "F"}]', VIEW, LS_ONE), ["1", "--json"])
+jp = json.loads(jr)
+case("--json carries the real counts", (jp["counts"]["pass"], jp["counts"]["fail"]), (1, 1))
+case("...names the blocking check", ["Windows MinGW", "fail"] in jp["blocking"], True)
+case("...and both SHAs it compared", (jp["pr_head"], jp["branch_tip"]), ("aaaa1111", "aaaa1111"))
+
 print()
 if FAILURES:
     for f in FAILURES:

--- a/prosper/tools/ci/test_pr_merge_gate.py
+++ b/prosper/tools/ci/test_pr_merge_gate.py
@@ -278,14 +278,6 @@ print("\n-- a failure while REPORTING is 'could not evaluate', not 'said no'")
 # The guard used to wrap collect() only, so an exception in render()/print() escaped and the
 # interpreter exited 1 -- the exact masquerade the code comment warns about. Reachable without a
 # mutation: `pr_merge_gate.py N | head -1` raises BrokenPipeError on the print.
-class ExplodingRender:
-    def __init__(self, inner):
-        self.inner = inner
-
-    def __call__(self, cmd, cwd):
-        return self.inner(cmd, cwd)
-
-
 _real_render = pr_merge_gate.GateResult.render
 try:
     def _boom(self, pr):
@@ -303,6 +295,40 @@ finally:
     pr_merge_gate.GateResult.render = _real_render
 case("...and the gate still works afterwards",
      run_main(FakeGh(GREEN_CHECKS, VIEW, LS_ONE)), 0)
+
+print("\n-- the HUMAN report is an interface too, and its CONTENT was pinned by nothing")
+# The thirteenth mutation, from review. Five mutations to render() left the suite 44/44 green:
+# pass count always 0, BLOCKING lines dropped, head line dropped, reasons dropped, and `=> GREEN`
+# printed unconditionally. That last one reproduces #3234 with new machinery -- the exit code is
+# correct and the report a person reads says GREEN over a failing check.
+#
+# It is on-thesis rather than a coverage nit: this tool's own docstring says it reports COUNTS
+# because "a count is falsifiable, an exit code alone is not", and until now the suite pinned the
+# exit code and not the count. After the --json arms landed, the MACHINE output was better verified
+# than the one a human acts on, which is exactly backwards.
+_, report = run_main_capture(FakeGh(
+    '[{"name": "Docs", "bucket": "pass", "state": "S"},'
+    ' {"name": "Windows MinGW", "bucket": "fail", "state": "F"},'
+    ' {"name": "macOS (x86_64 / Rosetta 2)", "bucket": "pending", "state": "P"},'
+    ' {"name": "Progress tracker", "bucket": "skipping", "state": "K"}]',
+    VIEW, LS_ONE), ["3234"])
+case("the report states the real counts",
+     "pass=1 fail=1 pending=1 skipping=1" in report, True)
+case("...names the failing check on a BLOCKING line",
+     "BLOCKING: Windows MinGW (fail)" in report, True)
+case("...names what it is still waiting on",
+     "pending:  macOS (x86_64 / Rosetta 2)" in report, True)
+case("...shows the head it verified", "head matches branch tip" in report, True)
+case("...gives the reason it refused",
+     "check(s) failed or were cancelled" in report and "still pending" in report, True)
+# The one that matters most: a report reading GREEN over a failing check would be #3234 again,
+# with the exit code correct and the human misled.
+case("...and does NOT say GREEN", "=> GREEN" in report, False)
+case("...it says NOT MERGEABLE", "=> NOT MERGEABLE" in report, True)
+
+_, green_report = run_main_capture(FakeGh(GREEN_CHECKS, VIEW, LS_ONE), ["1"])
+case("a passing PR's report says GREEN", "=> GREEN" in green_report, True)
+case("...and carries no BLOCKING line", "BLOCKING:" in green_report, False)
 
 print()
 if FAILURES:

--- a/prosper/tools/ci/test_pr_merge_gate.py
+++ b/prosper/tools/ci/test_pr_merge_gate.py
@@ -4,9 +4,15 @@
 Nothing here touches the network. `evaluate()` and `parse_checks()` are pure, so every arm drives
 them with synthetic payloads shaped exactly like `gh pr checks --json name,state,bucket` emits.
 
-The two arms that matter most are RECONSTRUCTIONS of merges that actually went wrong (#3259), not
-invented cases: #3234's red `Windows MinGW` and #3243's frozen PR head. An arm built from a real
-incident cannot be satisfied by a scenario nobody encounters.
+One arm is a RECONSTRUCTION of a merge that actually went wrong (#3259): #3234's red
+`Windows MinGW`, read as green because a shell split the check NAME on whitespace. An arm built
+from a real incident cannot be satisfied by a scenario nobody encounters.
+
+The stale-head arm is NOT one, and saying so matters because an earlier version of this file
+claimed it was. #3259 originally cited #3243 as a second incident; #3243's head was in fact the
+branch tip when it merged, with every check green on that exact commit. That arm guards a state
+this repository produces routinely -- every lane pushes after CI starts -- which is a weaker
+warrant than a reconstruction, and it should not borrow one it does not have.
 
 HOW TO TELL A REAL ARM FROM ONE THAT REDDENS NOTHING (borrowed from test_trap_number.py, and
 applied here):
@@ -20,6 +26,7 @@ all-pass matching-head case -- whose failure would expose a gate stuck at "no". 
 are what make a refusal meaningful; either alone is void.
 """
 
+import json
 import os
 import sys
 
@@ -76,12 +83,13 @@ res = evaluate(parse_checks(rows(
 )), HEAD, HEAD)
 case("multi-word passing names count once each, not per word", res.counts["pass"], 3)
 
-print("\n-- CI green on a commit that would not merge (the #3243 class)")
-# Every check passes. The only thing wrong is that they describe a commit the branch has moved
-# past -- which is precisely the state that merged an unreviewed 239-byte overread.
+print("\n-- CI green on a commit that would not merge")
+# Every check passes. The only thing wrong is that the recorded head is a commit the branch has
+# moved past, so nothing verified what would actually merge. No merge here is known to have been
+# lost this way (see the docstring); the arm guards the state, not a scar.
 res = evaluate(parse_checks(rows(("Docs", "pass"), ("Linux", "pass"))), OTHER, HEAD)
 case("all-green on a stale head still REFUSES", res.ok, False)
-case("...for the head-mismatch reason specifically", refused_for(res, "CI never saw what would merge"), True)
+case("...for the head-mismatch reason specifically", refused_for(res, "nothing verified what would merge"), True)
 case("...and no check is blamed, because none failed", res.blocking, [])
 
 print("\n-- an empty or unverified result is VOID, not green")
@@ -225,6 +233,76 @@ for label, view in [("headRefOid null", '{"headRefOid": null, "headRefName": "to
                     ("headRefOid empty", '{"headRefOid": "", "headRefName": "topic"}'),
                     ("headRefName missing", '{"headRefOid": "aaaa1111"}')]:
     case(label + " -> exit 2, never 0", run_main(FakeGh(GREEN_CHECKS, view, LS_ONE)), 2)
+
+print("\n-- --json is an exit path too, and nothing pinned it")
+# The tenth mutation: `return 0` inserted before the --json print left the whole suite green,
+# because no arm ever passed --json. That path is not decorative -- it is the machine-readable
+# record of what a gate refused, so anything built on it inherits whatever this arm does not check.
+import io  # noqa: E402
+import contextlib  # noqa: E402
+
+
+def run_main_capture(fake, argv):
+    buf = io.StringIO()
+    real = pr_merge_gate._run
+    pr_merge_gate._run = fake
+    try:
+        with contextlib.redirect_stdout(buf):
+            rc = pr_merge_gate.main(list(argv))
+    finally:
+        pr_merge_gate._run = real
+    return rc, buf.getvalue()
+
+
+rc, out = run_main_capture(FakeGh(RED_CHECKS, VIEW, LS_ONE), ["1", "--json"])
+case("--json on a failing PR still exits 1", rc, 1)
+try:
+    payload = json.loads(out)
+except ValueError:
+    payload = None
+case("...and emits parseable JSON", isinstance(payload, dict), True)
+case("...whose ok is False", (payload or {}).get("ok"), False)
+# The reasons list is the override record a caller would quote, so pin that it is populated.
+case("...and whose reasons say why", bool((payload or {}).get("reasons")), True)
+rc, out = run_main_capture(FakeGh(GREEN_CHECKS, VIEW, LS_ONE), ["1", "--json"])
+case("--json on a green PR exits 0", rc, 0)
+# Parsed defensively: a bare json.loads here CRASHES the suite under any mutant that suppresses
+# the --json print, which costs every arm below it and reports as a traceback instead of a name.
+try:
+    green_ok = json.loads(out).get("ok")
+except ValueError:
+    green_ok = "<not JSON>"
+case("...with ok True", green_ok, True)
+
+print("\n-- a failure while REPORTING is 'could not evaluate', not 'said no'")
+# The guard used to wrap collect() only, so an exception in render()/print() escaped and the
+# interpreter exited 1 -- the exact masquerade the code comment warns about. Reachable without a
+# mutation: `pr_merge_gate.py N | head -1` raises BrokenPipeError on the print.
+class ExplodingRender:
+    def __init__(self, inner):
+        self.inner = inner
+
+    def __call__(self, cmd, cwd):
+        return self.inner(cmd, cwd)
+
+
+_real_render = pr_merge_gate.GateResult.render
+try:
+    def _boom(self, pr):
+        raise KeyError("render blew up")
+    pr_merge_gate.GateResult.render = _boom
+    # The escape is caught HERE and turned into a value, not left to propagate. Without this, a
+    # build whose catch-all is missing kills the suite with a traceback -- which is red, but names
+    # nothing and takes every arm below it with it. An arm should say what broke.
+    try:
+        rc_render = run_main(FakeGh(GREEN_CHECKS, VIEW, LS_ONE))
+    except BaseException as exc:  # noqa: BLE001
+        rc_render = "escaped %s" % type(exc).__name__
+    case("an exception while rendering -> exit 2, never 1", rc_render, 2)
+finally:
+    pr_merge_gate.GateResult.render = _real_render
+case("...and the gate still works afterwards",
+     run_main(FakeGh(GREEN_CHECKS, VIEW, LS_ONE)), 0)
 
 print()
 if FAILURES:

--- a/prosper/tools/ci/test_pr_merge_gate.py
+++ b/prosper/tools/ci/test_pr_merge_gate.py
@@ -24,7 +24,8 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from pr_merge_gate import GateError, evaluate, parse_checks  # noqa: E402
+import pr_merge_gate  # noqa: E402
+from pr_merge_gate import GateError, evaluate, parse_checks, resolve_tip  # noqa: E402
 
 FAILURES = []
 
@@ -123,9 +124,107 @@ for label, payload in [
     except GateError:
         case(label + " is rejected", "GateError", "GateError")
 
-print("\n-- head comparison is skipped only when the caller supplies no heads")
+print("\n-- evaluate() without heads is the PURE contract, not a reachable gate state")
+# evaluate() is deliberately usable without head information so the arms above can drive it. That
+# is NOT a state a real run can reach: collect() raises before returning a null head, and the
+# main() arms below pin that. Keeping this arm without that note previously read as blessing a
+# silent GREEN with no head verification.
 res = evaluate(parse_checks(rows(("Linux", "pass"))), None, None)
 case("no head information given -> checks alone decide", res.ok, True)
+
+
+# ---------------------------------------------------------------------------------------------
+# The I/O layer. Everything above drives evaluate(), which is pure -- and a suite that stops there
+# leaves collect() and main() pinned by NOTHING. Review demonstrated five mutations in those two
+# functions that the pure-function arms could not see, two of them fatal:
+#
+#     return 2  -> return 0   in main's `except GateError`   : exit 0 on ANY tooling failure
+#     `0 if res.ok else 1` -> `0`                            : a gate that APPROVES EVERYTHING
+#
+# The second is the mirror of the flaw the arms above defend against. Those arms guard against a
+# gate stuck at "no"; nothing guarded against one stuck at "yes", because no arm ever called main().
+# `_run` is the single process boundary, so monkeypatching it covers both functions with no
+# production seam.
+# ---------------------------------------------------------------------------------------------
+
+print("\n-- resolve_tip matches the ref EXACTLY, not by suffix")
+LS_ONE = "aaaa1111\trefs/heads/topic\n"
+LS_DECOY = "bbbb2222\trefs/heads/other/refs/heads/topic\naaaa1111\trefs/heads/topic\n"
+case("a single exact match resolves", resolve_tip(LS_ONE, "topic"), "aaaa1111")
+# git ls-remote matches by SUFFIX, so this decoy really does come back on the same query. Taking
+# line 1 would compare against a branch nobody asked about -- and report GREEN for it.
+try:
+    case("a suffix decoy on line 1 does not win", resolve_tip(LS_DECOY, "topic"), "aaaa1111")
+except GateError as exc:
+    # Reported as a named failure rather than an escaping traceback: a suffix-matching
+    # implementation raises here (two hits) instead of returning the wrong sha, and a suite that
+    # dies with a stack trace tells the reader far less than one that names the arm.
+    case("a suffix decoy on line 1 does not win", "GateError: %s" % exc, "aaaa1111")
+for label, out, br in [("no match refuses", "", "topic"),
+                       ("only a suffix decoy refuses", "bbbb2222\trefs/heads/x/refs/heads/topic\n", "topic")]:
+    try:
+        resolve_tip(out, br); case(label, "returned", "GateError")
+    except GateError:
+        case(label, "GateError", "GateError")
+
+
+class FakeGh:
+    """Stands in for `_run`, keyed on the command being asked for."""
+
+    def __init__(self, checks_json, view_json, ls_out, fail_on=None):
+        self.checks_json, self.view_json, self.ls_out, self.fail_on = checks_json, view_json, ls_out, fail_on
+
+    def __call__(self, cmd, cwd):
+        joined = " ".join(cmd)
+        if self.fail_on and self.fail_on in joined:
+            raise GateError("simulated failure of %s" % self.fail_on)
+        if cmd[0] == "git":
+            return self.ls_out
+        if "checks" in cmd:
+            return self.checks_json
+        return self.view_json
+
+
+GREEN_CHECKS = '[{"name": "Windows App", "bucket": "pass", "state": "S"}]'
+RED_CHECKS = '[{"name": "Windows MinGW", "bucket": "fail", "state": "F"}]'
+VIEW = '{"headRefOid": "aaaa1111", "headRefName": "topic"}'
+
+
+def run_main(fake, argv=("1",)):
+    real = pr_merge_gate._run
+    pr_merge_gate._run = fake
+    try:
+        return pr_merge_gate.main(list(argv))
+    finally:
+        pr_merge_gate._run = real
+
+
+print("\n-- main() exit codes: the arms that pin a gate stuck at YES")
+case("all green, head == tip -> exit 0",
+     run_main(FakeGh(GREEN_CHECKS, VIEW, LS_ONE)), 0)
+# Without this arm, replacing main's return with a bare `return 0` passes the whole suite.
+case("a FAILING check -> exit 1, never 0",
+     run_main(FakeGh(RED_CHECKS, VIEW, LS_ONE)), 1)
+case("head behind the branch tip -> exit 1, never 0",
+     run_main(FakeGh(GREEN_CHECKS, VIEW, "cccc3333\trefs/heads/topic\n")), 1)
+
+print("\n-- main() distinguishes 'could not run' from 'said no'")
+# `return 2 -> return 0` here means every auth failure, network failure and malformed payload
+# reports a clean merge. This is the single most dangerous mutation in the file.
+case("gh failure -> exit 2, not 0 and not 1",
+     run_main(FakeGh(GREEN_CHECKS, VIEW, LS_ONE, fail_on="pr checks")), 2)
+case("git ls-remote failure -> exit 2",
+     run_main(FakeGh(GREEN_CHECKS, VIEW, LS_ONE, fail_on="ls-remote")), 2)
+case("a malformed check payload -> exit 2",
+     run_main(FakeGh("not json at all", VIEW, LS_ONE)), 2)
+
+print("\n-- a PR with no usable head must REFUSE, not silently skip the head check")
+# Previously headRefOid: null left pr_head=None, evaluate skipped the comparison, render() printed
+# no head line, and the gate exited 0 -- a silent GREEN precisely where the verification belonged.
+for label, view in [("headRefOid null", '{"headRefOid": null, "headRefName": "topic"}'),
+                    ("headRefOid empty", '{"headRefOid": "", "headRefName": "topic"}'),
+                    ("headRefName missing", '{"headRefOid": "aaaa1111"}')]:
+    case(label + " -> exit 2, never 0", run_main(FakeGh(GREEN_CHECKS, view, LS_ONE)), 2)
 
 print()
 if FAILURES:

--- a/prosper/tools/ci/test_pr_merge_gate.py
+++ b/prosper/tools/ci/test_pr_merge_gate.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Self-checking tests for pr_merge_gate.py (exit code is truth).
+
+Nothing here touches the network. `evaluate()` and `parse_checks()` are pure, so every arm drives
+them with synthetic payloads shaped exactly like `gh pr checks --json name,state,bucket` emits.
+
+The two arms that matter most are RECONSTRUCTIONS of merges that actually went wrong (#3259), not
+invented cases: #3234's red `Windows MinGW` and #3243's frozen PR head. An arm built from a real
+incident cannot be satisfied by a scenario nobody encounters.
+
+HOW TO TELL A REAL ARM FROM ONE THAT REDDENS NOTHING (borrowed from test_trap_number.py, and
+applied here):
+
+    Ask "WHAT ELSE COULD SATISFY THIS ASSERTION?"
+
+For a gate whose whole output is a boolean, that question bites hard: nearly every refusal arm is
+satisfied by a gate that refuses EVERYTHING. `ok == False` alone therefore discriminates nothing.
+So each refusal arm also asserts on the REASON, and the suite carries a positive control -- the
+all-pass matching-head case -- whose failure would expose a gate stuck at "no". The two together
+are what make a refusal meaningful; either alone is void.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pr_merge_gate import GateError, evaluate, parse_checks  # noqa: E402
+
+FAILURES = []
+
+
+def case(label, got, want):
+    ok = got == want
+    print(("  ok   " if ok else "  FAIL ") + label)
+    if not ok:
+        FAILURES.append("%s (got %r, want %r)" % (label, got, want))
+
+
+def refused_for(res, needle):
+    """True when the gate refused AND said so for the stated reason."""
+    return (not res.ok) and any(needle in r for r in res.reasons)
+
+
+HEAD = "04de4ac925d4503d71d3ac999feb0209f539bfbe"
+OTHER = "fd1dbb92aa1c40e2b2f7a0f0e8ee2f0f3d5c1a77"
+
+
+def rows(*pairs):
+    return [{"name": n, "bucket": b, "state": "X"} for n, b in pairs]
+
+
+print("\n-- the positive control (without it, every refusal arm below is void)")
+res = evaluate(parse_checks(rows(
+    ("Docs", "pass"), ("Linux", "pass"), ("Windows App", "pass"),
+    ("macOS (x86_64 / Rosetta 2)", "pass"), ("Progress tracker", "skipping"),
+)), HEAD, HEAD)
+case("all-pass with a matching head is GREEN", res.ok, True)
+case("...and counts the passes, not the words in their names", res.counts["pass"], 4)
+case("...and a deliberately skipped job does not block", res.counts["skipping"], 1)
+
+print("\n-- a check NAME is never read as a status (the #3234 class)")
+# The historical failure: a shell gate split `Windows MinGW\tfail` on whitespace, read `MinGW`
+# where the status belongs, and merged. Asserting on the count (not just on ok) is what makes this
+# arm specific: a gate that refused for any other reason would still leave fail==1 unexplained.
+res = evaluate(parse_checks(rows(
+    ("Docs", "pass"), ("Linux", "pass"), ("Windows MinGW", "fail"),
+)), HEAD, HEAD)
+case("a failing multi-word check is counted as a FAILURE", res.counts["fail"], 1)
+case("...and it refuses, naming failure as the reason", refused_for(res, "failed or were cancelled"), True)
+case("...and it is named in the blocking list", ("Windows MinGW", "fail") in res.blocking, True)
+
+# The mirror image, and the subtler half: multi-word names must not inflate the PASS count either.
+res = evaluate(parse_checks(rows(
+    ("Windows App", "pass"), ("Linux App Package", "pass"), ("macOS App (SDL3 + MoltenVK)", "pass"),
+)), HEAD, HEAD)
+case("multi-word passing names count once each, not per word", res.counts["pass"], 3)
+
+print("\n-- CI green on a commit that would not merge (the #3243 class)")
+# Every check passes. The only thing wrong is that they describe a commit the branch has moved
+# past -- which is precisely the state that merged an unreviewed 239-byte overread.
+res = evaluate(parse_checks(rows(("Docs", "pass"), ("Linux", "pass"))), OTHER, HEAD)
+case("all-green on a stale head still REFUSES", res.ok, False)
+case("...for the head-mismatch reason specifically", refused_for(res, "CI never saw what would merge"), True)
+case("...and no check is blamed, because none failed", res.blocking, [])
+
+print("\n-- an empty or unverified result is VOID, not green")
+res = evaluate(parse_checks([]), HEAD, HEAD)
+case("zero checks refuses", res.ok, False)
+case("...calling itself void rather than failed", refused_for(res, "VOID, not green"), True)
+
+res = evaluate(parse_checks(rows(("Progress tracker", "skipping"), ("Docs", "skipping"))), HEAD, HEAD)
+case("an ALL-SKIPPED result refuses too (nothing was verified)", refused_for(res, "VOID, not green"), True)
+
+print("\n-- pending and cancelled block")
+res = evaluate(parse_checks(rows(("Linux", "pass"), ("Windows MinGW", "pending"))), HEAD, HEAD)
+case("a pending check refuses", refused_for(res, "still pending"), True)
+case("...and is named so the waiter knows what it waits on", res.pending, ["Windows MinGW"])
+
+res = evaluate(parse_checks(rows(("Linux", "pass"), ("Windows App", "cancel"))), HEAD, HEAD)
+case("a CANCELLED check blocks (nothing was verified by it)", refused_for(res, "failed or were cancelled"), True)
+
+print("\n-- a bucket this tool has never heard of must not read as success")
+res = evaluate(parse_checks(rows(("Linux", "pass"), ("Some Future Job", "quarantined"))), HEAD, HEAD)
+case("an unknown bucket blocks", res.ok, False)
+case("...and is reported as blocking, not silently dropped", ("Some Future Job", "quarantined") in res.blocking, True)
+
+print("\n-- the parser refuses the TEXT form, so no loose fallback can creep back in")
+text = "Docs\tpass\t34s\thttps://example\nWindows MinGW\tfail\t7m\thttps://example\n"
+try:
+    parse_checks(text)
+    case("tab-separated text is rejected", "accepted", "GateError")
+except GateError:
+    case("tab-separated text is rejected", "GateError", "GateError")
+
+for label, payload in [
+    ("a JSON object instead of a list", '{"bucket": "pass"}'),
+    ("rows missing 'bucket' (wrong --json fields)", '[{"name": "Docs", "state": "SUCCESS"}]'),
+    ("a non-string bucket", '[{"name": "Docs", "bucket": 1}]'),
+]:
+    try:
+        parse_checks(payload)
+        case(label + " is rejected", "accepted", "GateError")
+    except GateError:
+        case(label + " is rejected", "GateError", "GateError")
+
+print("\n-- head comparison is skipped only when the caller supplies no heads")
+res = evaluate(parse_checks(rows(("Linux", "pass"))), None, None)
+case("no head information given -> checks alone decide", res.ok, True)
+
+print()
+if FAILURES:
+    for f in FAILURES:
+        print("FAIL: %s" % f, file=sys.stderr)
+    print("\n%d case(s) failed." % len(FAILURES), file=sys.stderr)
+    sys.exit(1)
+print("all cases passed")


### PR DESCRIPTION
## The problem

Two PRs merged wrongly on 2026-09-02. **Neither cause was carelessness** — both were mechanical, and
both produced a *reassuring* wrong answer rather than an error. Nothing committed in this repository
gates a merge on CI state: `verify-pr.ps1` reads `headRefOid` but is a Windows author-verification
driver, and `tools/ci/`'s three existing checks run *inside* CI rather than deciding whether to merge.

### #3234 — a check NAME read as a status

A shell gate matched the **text** output of `gh pr checks`:

```sh
case "$s" in *"pending=0"*"bad="*) ... ;; esac
```

That output is tab-separated and this repository's check names contain spaces — `Windows App`,
`Linux App Package`, `macOS (x86_64 / Rosetta 2)`. Splitting on whitespace puts the second *word of
the name* where the status belongs. `bad=Windows MinGW` matched a pattern meant to detect an empty
failure list, the gate reported green, and **#3234 merged with a red `Windows MinGW`**. `main` was
red on `wt_stash_tool` until #3238.

**The same class recurred while filing this issue.** `gh pr checks 3256 | awk '$2=="pass"'` reported
**2** passing checks; the true count was **8**. `Windows App` puts `App` in `$2`. A count wrong by 4x
still reads as plausible — that is the danger.

### #3243 — CI green on a commit that would not merge

GitHub's recorded PR head froze at `fd1dbb92` while the branch advanced two commits. No run was ever
queued for the newer ones, `gh pr checks` reported green for the frozen head, and the merge carried a
silent 239-byte overread CI had never seen (fixed by #3252).

`CLAUDE.md` records this detachment for **reviews** — *"a rebase or a new push detaches every review
from head"*. It applies identically to **checks**, and that half was written down nowhere.

## What this adds

`prosper/tools/ci/pr_merge_gate.py` answers one question — *is PR N safe to merge right now?* — and
is designed to be wrong in the safe direction:

| rule | why |
| --- | --- |
| consume `--json name,state,bucket`; **reject** any other payload shape | a permissive parser that fell back to splitting lines would reintroduce the #3234 bug |
| require `pass > 0` | an empty or all-skipped result is **VOID, not green** — the same trap `CLAUDE.md` records for plain `ctest` exiting 0 on an empty build dir |
| `cancel` and any unrecognised bucket **block** | a cancelled run verified nothing; a future `gh` bucket must not silently read as success |
| compare `headRefOid` against `git ls-remote origin refs/heads/<branch>` | #3243 |
| exit **2** when it could not evaluate | "the gate could not run" must never be confused with "the gate said no" |

It reports **counts**, not just a status — `CLAUDE.md` makes this point for `ctest` (*"a count is
falsifiable, an exit code alone is not"*) and it applies identically here.

```
GATE #3256: pass=9 fail=0 pending=0 skipping=2
  head matches branch tip (04de4ac9)
  => GREEN
```

## Verification

**24 arms over synthetic payloads. No network, no authentication** — a test that needs credentials is
a test that gets disabled.

**Two arms reconstruct the real merges** rather than inventing scenarios: a red `Windows MinGW`
alongside passing checks, and an all-green result on a head the branch has moved past.

**The discrimination problem this suite has, stated plainly:** nearly every arm is a refusal, and *a
gate that refused everything would satisfy all of them*. `ok == False` therefore discriminates
nothing on its own. So the suite leads with an **all-pass positive control**, and every refusal arm
asserts on the **reason** rather than the boolean. Either half alone is void.

**Mutation arms** — each removes one rule and must redden the arms that cover it:

| mutation | rc | arms reddened |
| --- | --- | --- |
| drop the `pass == 0` VOID rule | 1 | 3 |
| drop the head-mismatch rule | 1 | 2 |
| treat `cancel` as non-blocking | 1 | 1 |
| let an unknown bucket pass silently | 1 | 2 |
| drop the pending rule | 1 | 1 |
| *(restored tool)* | **0** | — |

**ctest:** registered as `pr_merge_gate`, verified **by name** —
`1/1 Test #29: pr_merge_gate .... Passed`, exit 0. **345** registered in a configure-only tree
against the **344** baseline at this branch point.

**Other gates:** `check_usage_text.py --selftest` rc=0 (the new tool satisfies the `print(__doc__)`
scan), `check_ctest_gate.py --selftest` rc=0, `check_numbered_table.py` over every tracked `.md`
rc=0, `git diff --check` clean, **422 insertions / 0 deletions**, no absolute host paths added
(verified by count, not by a `grep | head` whose `||` could never fire).

## Also in this PR

- **`prosper/tools/ci/AGENTS.md`** — the folder had none. It names the boundary against
  `tools/docs/` (content of Markdown vs mechanics around a change) and records the property all four
  checks share: *they fail silently*, producing a reassuring answer rather than an error, which
  dictates that each carries self-tests rather than relying on the tree containing a violation.
- **`CLAUDE.md`** — two rules in the merge section (checks detach from head too; never parse the
  text form) plus a pointer to the tool. This is where both incidents' readers were looking.

## Deliberately not done

No CI job runs this. It is a tool for the agent about to merge, and a job that gated merges on
itself would need `gh` credentials in CI to tell you something you can already ask for locally in
one second.

Fixes #3259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
