### PR TITLE
APR measure-size: retire the compatibility read per container once a submit re-delivers it

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1595,6 +1595,9 @@ if(TARGET prosper_core)
   add_test(NAME apr_measure_duplicate_forced COMMAND test_apr_measure_duplicate)
   set_tests_properties(apr_measure_duplicate_forced PROPERTIES
                        ENVIRONMENT "PROSPER_APR_MEASURE_READ=always")
+  add_test(NAME apr_measure_duplicate_never COMMAND test_apr_measure_duplicate)
+  set_tests_properties(apr_measure_duplicate_never PROPERTIES
+                       ENVIRONMENT "PROSPER_APR_MEASURE_READ=never")
 
   add_executable(test_ampr_measure tests/hle/test_ampr_measure.cpp)
   # Includes a shared fixture, which resolves from the `tests` root.

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1581,6 +1581,20 @@ if(TARGET prosper_core)
   target_include_directories(test_apr_gather_scatter PRIVATE tests)
   target_link_libraries(test_apr_gather_scatter PRIVATE prosper_core)
   add_test(NAME apr_gather_scatter COMMAND test_apr_gather_scatter)
+  # #3245: sceAmprMeasureCommandSizeReadFile's compatibility read fired for every title, so a title
+  # that also submits its measured reads paid for the same bytes twice (13,925 duplicate reads /
+  # 582 MB in a 3-minute Stray boot) and had them written before it recorded the command. Registered
+  # twice on purpose -- the PROSPER_APR_MEASURE_READ=always run asserts the opposite outcome, which
+  # is what shows the suppression actually suppressed. Pure: scratch files and generated import
+  # stubs, no game dump.
+  add_executable(test_apr_measure_duplicate tests/hle/test_apr_measure_duplicate.cpp)
+  # Includes a shared fixture, which resolves from the `tests` root.
+  target_include_directories(test_apr_measure_duplicate PRIVATE tests)
+  target_link_libraries(test_apr_measure_duplicate PRIVATE prosper_core)
+  add_test(NAME apr_measure_duplicate COMMAND test_apr_measure_duplicate)
+  add_test(NAME apr_measure_duplicate_forced COMMAND test_apr_measure_duplicate)
+  set_tests_properties(apr_measure_duplicate_forced PROPERTIES
+                       ENVIRONMENT "PROSPER_APR_MEASURE_READ=always")
 
   add_executable(test_ampr_measure tests/hle/test_ampr_measure.cpp)
   # Includes a shared fixture, which resolves from the `tests` root.

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -231,6 +231,20 @@ default since #825 and needs no switch; `PROSPER_NO_GUEST_FS=1` turns it off for
   neither NID string occurs anywhere in DOLL's 91 MB or Stray's 33 MB `PROSPER_FILELOG` boot logs.
   So the refusal's blast radius is 22 linked titles rather than none.
   [#2926](https://github.com/mattias800/prosper/issues/2926).
+- **"The measure-size call's compatibility read is DOLL-specific in effect, because only DOLL needs
+  it" — false, measured 2026-09-02.** `f_apr_measure_read_file` gated the read on nothing but "does
+  the file id resolve", so it ran for every APR title. *Stray* (`PPSA02101`), 180 s, `PROSPER_FILELOG=1`:
+  **13,925** compatibility reads delivering **582,619,946 bytes**, against 14,255 submits delivering
+  603,329,577 — roughly **97% of the measure-path bytes re-delivered** by the submit path from an
+  identical `(dst, offset, size)` moments later, plus an extra `mmap`/`munmap` per read. The
+  correctness half matters more than the cost: a *sizing* call filling the destination puts bytes
+  there before the guest has recorded the read command, so a title that measures a batch and
+  prepares its destinations afterwards would have prosper's bytes land first and then be overwritten.
+  Also **do not "fix" this by suppressing the second delivery of an identical pair**: the measure
+  comes FIRST and the submit is the authoritative one, so an order-agnostic duplicate filter
+  suppresses the wrong half. The pairing is used only as evidence that the container submits what it
+  measures, and the suppression is keyed per container.
+  [#3245](https://github.com/mattias800/prosper/issues/3245).
 
 ## Frame loop reached; 0 draws = early-load present loop (issue #213, 2026-07-09)
 
@@ -1459,7 +1473,12 @@ The shared contract is now explicit:
   query; DOLL's non-null queue/id pair also registers the APR completion source.
 - `vWU-odnS+fU` always returns 20 or 24 according to the file-offset width. An unregistered id is a
   pure Sonic sizing query; a valid registered APR file id also performs DOLL's range-checked eager
-  read on both Linux and Windows.
+  read on both Linux and Windows. **Narrowed 2026-09-02 (#3245):** that eager read is now retired
+  per APR container once a submit is seen re-delivering a read the measure already served, because
+  it fired for every APR title and duplicated 582 MB in a 3-minute *Stray* boot. DOLL's arm is
+  untouched — it never submits the reads it measures, which is why the read exists. The sizing
+  answer is unchanged in every case, and `PROSPER_APR_MEASURE_READ=always|never|auto` is the A/B
+  lever.
 - `4fgtGfXDrFc` retains the independent 32-byte conservative size used by Sonic; A/B testing proved
   it is not part of DOLL's regression.
 

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -244,6 +244,16 @@ default since #825 and needs no switch; `PROSPER_NO_GUEST_FS=1` turns it off for
   comes FIRST and the submit is the authoritative one, so an order-agnostic duplicate filter
   suppresses the wrong half. The pairing is used only as evidence that the container submits what it
   measures, and the suppression is keyed per container.
+
+  **A second claim in this area was falsified before it could become load-bearing, and is recorded
+  so it is not re-derived:** *"the suppression cannot fire for DOLL, whose measured reads are never
+  submitted through the ReadFile NID"* — false. Replaying the predicate over four DOLL
+  `PROSPER_FILELOG` boots, container id=6 pairs at **submit #13** every time. What makes DOLL safe is
+  the opposite fact, from the same replay: **0 of 1,254 / 1,255 / 1,725 / 1,732 measured reads lack
+  an identical submit**, so DOLL is a submits-everything-it-measures title — exactly the case the
+  suppression is designed for — not the consume-from-the-measure title the older note describes.
+  *Stray* replays the same way (id=1 pairs at submit #4, 0 unmatched over three logs, 13,923 measures
+  against 14,253 submits — which also reproduces this issue's headline figure independently).
   [#3245](https://github.com/mattias800/prosper/issues/3245).
 
 ## Frame loop reached; 0 draws = early-load present loop (issue #213, 2026-07-09)
@@ -1475,10 +1485,19 @@ The shared contract is now explicit:
   pure Sonic sizing query; a valid registered APR file id also performs DOLL's range-checked eager
   read on both Linux and Windows. **Narrowed 2026-09-02 (#3245):** that eager read is now retired
   per APR container once a submit is seen re-delivering a read the measure already served, because
-  it fired for every APR title and duplicated 582 MB in a 3-minute *Stray* boot. DOLL's arm is
-  untouched — it never submits the reads it measures, which is why the read exists. The sizing
-  answer is unchanged in every case, and `PROSPER_APR_MEASURE_READ=always|never|auto` is the A/B
-  lever.
+  it fired for every APR title and duplicated 582 MB in a 3-minute *Stray* boot. The sizing answer
+  is unchanged in every case, and `PROSPER_APR_MEASURE_READ=always|never|auto` is the A/B lever.
+
+  **DOLL is not exempt, and the paragraph above this one is now partly historical.** Replaying the
+  pairing predicate over four of DOLL's own `PROSPER_FILELOG` boots: container id=6 pairs at submit
+  **#13** in every run, and 1,253 / 1,254 / 1,724 / 1,731 compatibility reads are suppressed from
+  there. It is safe anyway, for the *opposite* reason to the one first written down — **every**
+  measured read has an identical submit (1,254/1,254, 1,255/1,255, 1,725/1,725, 1,732/1,732; **0
+  unmatched**), so DOLL submits everything it measures and the submit path delivers the same bytes.
+  The consequence deserves stating: **the reason this read is documented to exist is no longer
+  visible in DOLL's traffic** — prosper serves the ReadFile submit eagerly now, and DOLL does
+  submit. Whether the read is needed at all is what `PROSPER_APR_MEASURE_READ=never` tests; that is
+  a separate question from narrowing it.
 - `4fgtGfXDrFc` retains the independent 32-byte conservative size used by Sonic; A/B testing proved
   it is not part of DOLL's regression.
 

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2346,26 +2346,57 @@ extern "C" void prosper_apr_chain_reset(uint64_t cb) {
 // same argument shape. It IS visible immediately afterwards -- if a submit arrives for exactly the
 // (file id, dst, offset, size) a measure just described, that title records and submits its
 // measured reads, so the compatibility read was redundant. That is self-calibrating: it costs one
-// duplicate per APR file id and then turns itself off, needs no per-title or per-SDK knowledge, and
-// cannot fire for DOLL, whose measured reads are never submitted through the ReadFile NID -- if
-// they were, prosper would already have served them eagerly there and the compatibility read would
-// never have been needed.
+// duplicate per APR file id and then turns itself off, and needs no per-title or per-SDK knowledge.
+//
+// DOLL IS NOT EXEMPT FROM THIS, and an earlier version of this comment claimed it was -- "cannot
+// fire for DOLL, whose measured reads are never submitted through the ReadFile NID". That is
+// FALSE, and DOLL's own PROSPER_FILELOG boots say so. Replaying this exact predicate over four of
+// them: container id=6 pairs at submit #13 in every run, and from there 1,253 / 1,254 / 1,724 /
+// 1,731 of each run's compatibility reads are suppressed.
+//
+// The same replay is why the suppression is nonetheless SAFE for DOLL -- for the opposite reason to
+// the one that was asserted. Asking whether any measured read lacks an identical submit ANYWHERE in
+// the log, which is precisely the mixed pattern that would break:
+//
+//     run1  1,254 measures  1,254 matched  0 unmatched
+//     run2  1,255           1,255          0
+//     run3  1,725           1,725          0
+//     run4  1,732           1,732          0
+//
+// DOLL submits everything it measures, so when the heuristic fires on it, it is right. Stray is the
+// same shape (id=1 pairs at submit #4; 13,922 of 13,923 suppressed; 0 unmatched over three logs).
+//
+// The consequence is worth stating rather than burying: the documented reason this read exists --
+// an older SDK wrapper that consumes the destination while prosper does not execute the encoded
+// commands -- IS NO LONGER VISIBLE in DOLL's traffic. prosper serves the ReadFile submit eagerly
+// now, and DOLL does submit. Whether the read is needed at all is what PROSPER_APR_MEASURE_READ=never
+// tests; removing it is not this change's job, but re-asserting a premise its own evidence
+// contradicts would have been a defect.
 //
 // Keyed per APR FILE ID rather than globally so a title with a mixed pattern loses the
 // compatibility read only for the container that demonstrated the pairing.
 // CONFIDENCE: HIGH on the duplication (measured, #3245) and on the suppression being safe for any
-// title whose measured reads are submitted. MED that no title mixes both patterns within one
-// container -- that is the one case this heuristic would get wrong, it cannot be checked without
-// running such a title, and PROSPER_APR_MEASURE_READ=always is the one-variable A/B if a title ever
-// regresses. `never` exists for the opposite arm (does a title depend on the read at all?).
+// title whose measured reads are submitted -- which now includes DOLL and Stray by replay, 0
+// unmatched measures across seven logs and two titles. MED that no title mixes both patterns within
+// one container: two titles is not the corpus, and a log replay cannot see what a title does with
+// bytes that arrive at submit time rather than measure time. The mixed pattern is DETECTED rather
+// than merely feared -- see apr_measure_note_unmatched below -- and PROSPER_APR_MEASURE_READ=always
+// is the one-variable A/B if a title ever regresses. `never` is the opposite arm (does any title
+// still depend on this read at all?).
 namespace {
-struct AprMeasuredRead { uint32_t id; uint64_t dst, offset, size; };
+struct AprMeasuredRead {
+    uint32_t id; uint64_t dst, offset, size;
+    bool live = false;        // this slot has been written since the last reset
+    bool suppressed = false;  // recorded AFTER the container paired, i.e. its read was skipped
+    bool matched = false;     // a submit for exactly this tuple has since arrived
+};
 PROSPER_HEAP_MUTEX(g_apr_measure_mx);
 constexpr size_t kAprMeasureRingMax = 64;   // only the IMMEDIATE pairing matters; Stray's is adjacent
 std::array<AprMeasuredRead, kAprMeasureRingMax> g_apr_recent_measures{};
 size_t g_apr_recent_measures_used = 0;      // grows to kAprMeasureRingMax, then the ring wraps
 size_t g_apr_recent_measures_next = 0;
 std::map<uint32_t, bool> g_apr_measure_paired;   // file id -> a submit matched one of its measures
+bool g_apr_mixed_pattern_warned = false;         // the detector below fires at most once
 
 // auto (default) = the latch above; always = never suppress; never = never do the compatibility
 // read. Read once: an env lookup per streamed asset is itself a cost on this path.
@@ -2387,9 +2418,16 @@ AprMeasureMode apr_measure_mode() {
 
 static void apr_measure_reset_for_test() {
     std::lock_guard lk(g_apr_measure_mx);
+    g_apr_recent_measures.fill(AprMeasuredRead{});
     g_apr_recent_measures_used = 0;
     g_apr_recent_measures_next = 0;
     g_apr_measure_paired.clear();
+    g_apr_mixed_pattern_warned = false;
+}
+// Test seam for the detector below: has the mixed-pattern warning fired?
+bool prosper_apr_mixed_pattern_warned_for_test() {
+    std::lock_guard lk(g_apr_measure_mx);
+    return g_apr_mixed_pattern_warned;
 }
 
 // True when this container's measured reads have been shown to arrive again through the submit
@@ -2405,10 +2443,45 @@ static bool apr_measure_read_suppressed(uint32_t id) {
     return it != g_apr_measure_paired.end() && it->second;
 }
 
-// Remember a read the measure path just served, so a matching submit can identify the pairing.
-static void apr_measure_record(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
+// Remember a measured read, so a matching submit can identify the pairing -- and so the ONE case
+// this heuristic gets wrong can announce itself.
+//
+// THE DETECTOR. The suppression's decision is loud (one unconditional line per container) but its
+// consequence would otherwise be silent: a title that mixes both patterns within one container gets
+// an unwritten destination and no message, because the suppressed-measure log line sits behind
+// filelog(). PROSPER_APR_MEASURE_READ=always is a recovery, not a detector -- it only helps someone
+// who already suspects this.
+//
+// So recording CONTINUES after a container pairs (the read is skipped; only the bookkeeping stays),
+// every entry carries whether a submit later claimed it, and an entry that leaves the ring having
+// been suppressed AND never matched is warned about, once, loudly. Nothing else produces that
+// signature: a pre-pairing entry ages out unmatched all the time and is not suppressed, and a
+// suppressed entry that a submit claimed is the designed case. Keeping the scan alive after pairing
+// costs a 64-entry compare per submit -- ~900k integer comparisons across a 3-minute Stray boot,
+// which is not measurable next to the 583 MB of file I/O this removes.
+//
+// Known blind spot, stated rather than left to be discovered: up to kAprMeasureRingMax entries are
+// still in the ring when the process exits and are never adjudicated, so a title that mixes the two
+// patterns FEWER than 64 measures before quitting would not warn.
+static void apr_measure_warn_mixed_locked(const AprMeasuredRead& lost) {
+    if (g_apr_mixed_pattern_warned) return;
+    g_apr_mixed_pattern_warned = true;
+    fprintf(stderr,
+            "[apr] WARNING: sceAmprMeasureCommandSizeReadFile's compatibility read was suppressed "
+            "for APR container id=%u, but the read (dst=0x%llx off=0x%llx size=%llu) was never "
+            "submitted -- so those bytes were never delivered. This container mixes measured reads "
+            "it submits with measured reads it consumes directly, which is the one pattern the "
+            "suppression gets wrong (#3245). Re-run with PROSPER_APR_MEASURE_READ=always to restore "
+            "the old behaviour, and please report the title. Further occurrences are silent.\n",
+            lost.id, (unsigned long long)lost.dst, (unsigned long long)lost.offset,
+            (unsigned long long)lost.size);
+}
+static void apr_measure_record(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size,
+                               bool suppressed) {
     std::lock_guard lk(g_apr_measure_mx);
-    g_apr_recent_measures[g_apr_recent_measures_next] = AprMeasuredRead{ id, dst, offset, size };
+    AprMeasuredRead& slot = g_apr_recent_measures[g_apr_recent_measures_next];
+    if (slot.live && slot.suppressed && !slot.matched) apr_measure_warn_mixed_locked(slot);
+    slot = AprMeasuredRead{ id, dst, offset, size, /*live=*/true, suppressed, /*matched=*/false };
     g_apr_recent_measures_next = (g_apr_recent_measures_next + 1) % kAprMeasureRingMax;
     if (g_apr_recent_measures_used < kAprMeasureRingMax) g_apr_recent_measures_used++;
 }
@@ -2419,14 +2492,14 @@ static void apr_measure_record(uint32_t id, uint64_t dst, uint64_t offset, uint6
 static bool apr_measure_note_submit(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
     if (apr_measure_mode() != AprMeasureMode::Auto) return false;
     std::lock_guard lk(g_apr_measure_mx);
-    // Already paired: the ring holds nothing for this container any more (its measures stop
-    // recording once suppressed), so skip the scan. This runs on EVERY submit -- 14,255 of them in
-    // a 3-minute Stray boot -- and after the first pairing it is the only case left.
-    if (auto it = g_apr_measure_paired.find(id); it != g_apr_measure_paired.end() && it->second)
-        return false;
+    // The scan deliberately continues after a container has paired: marking the entry is what lets
+    // the detector in apr_measure_record tell "suppressed and never submitted" from "suppressed and
+    // duly submitted". An early-out here would make the mixed pattern undetectable, which is the
+    // whole failure mode this heuristic has.
     for (size_t i = 0; i < g_apr_recent_measures_used; i++) {
-        const AprMeasuredRead& m = g_apr_recent_measures[i];
-        if (m.id != id || m.dst != dst || m.offset != offset || m.size != size) continue;
+        AprMeasuredRead& m = g_apr_recent_measures[i];
+        if (!m.live || m.id != id || m.dst != dst || m.offset != offset || m.size != size) continue;
+        m.matched = true;
         bool& paired = g_apr_measure_paired[id];
         const bool first = !paired;
         paired = true;
@@ -4157,6 +4230,10 @@ HLE(f_apr_measure_read_file) {
     // and would deliver them BEFORE the guest recorded the command. The sizing answer is unchanged;
     // only the read is dropped. See the block beside apr_measure_read_suppressed.
     if (apr_measure_read_suppressed((uint32_t)a0)) {
+        // Record it anyway. The read is skipped; the bookkeeping is what lets a suppressed measure
+        // that NO submit ever claims be detected and warned about rather than silently losing its
+        // bytes (see apr_measure_record's detector).
+        apr_measure_record((uint32_t)a0, a1, a3, a2, /*suppressed=*/true);
         if (filelog())
             fprintf(stderr, "[apr] measure-read id=%llu %s -> %llu bytes (compatibility read "
                             "suppressed: this container submits its measured reads)\n",
@@ -4212,7 +4289,7 @@ HLE(f_apr_measure_read_file) {
     // Record what was delivered, so a submit of the identical read can identify the pairing and
     // retire this container's compatibility read (#3245). Recorded only on a read that actually
     // landed: a failed one has not made the submit redundant.
-    if (copied) apr_measure_record((uint32_t)a0, a1, a3, a2);
+    if (copied) apr_measure_record((uint32_t)a0, a1, a3, a2, /*suppressed=*/false);
     if (filelog())
         fprintf(stderr, "[apr] measure-read compatibility id=%llu %s -> dst=0x%llx "
                         "off=0x%llx size=%llu %s; measured=%llu\n",

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -26,6 +26,7 @@
 #include <optional>      // #1205: sandbox_normalize_subpath escape check
 #include <mutex>
 #include <atomic>        // sceKernelAio* submit-id/state table
+#include <array>       // #3245: the bounded recent-measure ring
 #include <map>
 #include <utility>
 #include <vector>
@@ -2221,10 +2222,16 @@ uint32_t prosper_apr_register(const std::string& path, uint64_t size) {
     g_apr_files.push_back({ path, size });
     return (uint32_t)g_apr_files.size();
 }
+// Defined with the measure-read suppression state further down; the test hook below clears it too,
+// because that state is process-global and a stale latch would carry from one case into the next.
+static void apr_measure_reset_for_test();
 // Test hook: drop all registered containers (the registry is process-global).
 void prosper_apr_reset_for_test() {
-    std::lock_guard lk(g_apr_mx);
-    g_apr_files.clear();
+    {
+        std::lock_guard lk(g_apr_mx);
+        g_apr_files.clear();
+    }
+    apr_measure_reset_for_test();
 }
 // Find resolved host paths whose TOTAL size equals `size`. Returns the match count and sets
 // *out_path to the first match. The read path resolves the real APR file id first; it may use this
@@ -2314,6 +2321,118 @@ extern "C" void prosper_apr_chain_reset(uint64_t cb) {
     if (!cb) return;
     std::lock_guard lk(g_apr_chain_mx);
     g_apr_chains.erase(cb);
+}
+
+// --- sceAmprMeasureCommandSizeReadFile's compatibility read: when it is still needed ------------
+// The firmware contract for that call is pure SIZING -- it answers 20 or 24. prosper also performs
+// the described read and DMAs it into the guest destination, because DOLL's (PPSA17942) older SDK
+// wrapper consumes the destination from the measure call and never records a ReadFile command for
+// it, so the measure is prosper's only hook on those bytes. That is a real, live requirement; see
+// docs/UE4_APR_IOSTORE_BRINGUP.md.
+//
+// The problem (#3245) is that the gate was only "does the file id resolve", so the read fired for
+// EVERY APR title. On a title that also submits the read normally the same bytes are pread and
+// DMA'd into the same guest address twice: measured on Stray (PPSA02101), a 3-minute boot did
+// 13,925 compatibility reads delivering 582,619,946 bytes, and 97% of them were re-delivered
+// moments later by the submit path from an identical (dst, offset, size).
+//
+// It is not only waste. A sizing call writing to the guest's destination puts bytes there before
+// the guest has recorded the read command, let alone submitted it. On Stray that window is
+// microseconds on one thread, but a title that measures a batch and prepares its destinations
+// afterwards would have prosper's bytes land first and then be overwritten -- silent corruption,
+// not a slowdown. So the narrow answer is the correct one on both counts.
+//
+// WHAT DISTINGUISHES THE TWO TITLES is not visible at the measure call: DOLL and Stray pass the
+// same argument shape. It IS visible immediately afterwards -- if a submit arrives for exactly the
+// (file id, dst, offset, size) a measure just described, that title records and submits its
+// measured reads, so the compatibility read was redundant. That is self-calibrating: it costs one
+// duplicate per APR file id and then turns itself off, needs no per-title or per-SDK knowledge, and
+// cannot fire for DOLL, whose measured reads are never submitted through the ReadFile NID -- if
+// they were, prosper would already have served them eagerly there and the compatibility read would
+// never have been needed.
+//
+// Keyed per APR FILE ID rather than globally so a title with a mixed pattern loses the
+// compatibility read only for the container that demonstrated the pairing.
+// CONFIDENCE: HIGH on the duplication (measured, #3245) and on the suppression being safe for any
+// title whose measured reads are submitted. MED that no title mixes both patterns within one
+// container -- that is the one case this heuristic would get wrong, it cannot be checked without
+// running such a title, and PROSPER_APR_MEASURE_READ=always is the one-variable A/B if a title ever
+// regresses. `never` exists for the opposite arm (does a title depend on the read at all?).
+namespace {
+struct AprMeasuredRead { uint32_t id; uint64_t dst, offset, size; };
+PROSPER_HEAP_MUTEX(g_apr_measure_mx);
+constexpr size_t kAprMeasureRingMax = 64;   // only the IMMEDIATE pairing matters; Stray's is adjacent
+std::array<AprMeasuredRead, kAprMeasureRingMax> g_apr_recent_measures{};
+size_t g_apr_recent_measures_used = 0;      // grows to kAprMeasureRingMax, then the ring wraps
+size_t g_apr_recent_measures_next = 0;
+std::map<uint32_t, bool> g_apr_measure_paired;   // file id -> a submit matched one of its measures
+
+// auto (default) = the latch above; always = never suppress; never = never do the compatibility
+// read. Read once: an env lookup per streamed asset is itself a cost on this path.
+enum class AprMeasureMode { Auto, Always, Never };
+AprMeasureMode apr_measure_mode() {
+    static const AprMeasureMode mode = [] {
+        const char* v = getenv("PROSPER_APR_MEASURE_READ");
+        if (!v || !*v) return AprMeasureMode::Auto;
+        if (!strcmp(v, "always")) return AprMeasureMode::Always;
+        if (!strcmp(v, "never"))  return AprMeasureMode::Never;
+        if (strcmp(v, "auto") != 0)
+            fprintf(stderr, "[apr] PROSPER_APR_MEASURE_READ='%s' is not one of auto|always|never "
+                            "-- using auto\n", v);
+        return AprMeasureMode::Auto;
+    }();
+    return mode;
+}
+}  // namespace
+
+static void apr_measure_reset_for_test() {
+    std::lock_guard lk(g_apr_measure_mx);
+    g_apr_recent_measures_used = 0;
+    g_apr_recent_measures_next = 0;
+    g_apr_measure_paired.clear();
+}
+
+// True when this container's measured reads have been shown to arrive again through the submit
+// path, so the compatibility read would only duplicate one.
+static bool apr_measure_read_suppressed(uint32_t id) {
+    switch (apr_measure_mode()) {
+        case AprMeasureMode::Always: return false;
+        case AprMeasureMode::Never:  return true;
+        case AprMeasureMode::Auto:   break;
+    }
+    std::lock_guard lk(g_apr_measure_mx);
+    auto it = g_apr_measure_paired.find(id);
+    return it != g_apr_measure_paired.end() && it->second;
+}
+
+// Remember a read the measure path just served, so a matching submit can identify the pairing.
+static void apr_measure_record(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
+    std::lock_guard lk(g_apr_measure_mx);
+    g_apr_recent_measures[g_apr_recent_measures_next] = AprMeasuredRead{ id, dst, offset, size };
+    g_apr_recent_measures_next = (g_apr_recent_measures_next + 1) % kAprMeasureRingMax;
+    if (g_apr_recent_measures_used < kAprMeasureRingMax) g_apr_recent_measures_used++;
+}
+
+// A submit for a read the measure path already delivered: from here on this container does not need
+// the compatibility read. Returns true the FIRST time a container pairs, so the caller can say so
+// once instead of once per asset.
+static bool apr_measure_note_submit(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
+    if (apr_measure_mode() != AprMeasureMode::Auto) return false;
+    std::lock_guard lk(g_apr_measure_mx);
+    // Already paired: the ring holds nothing for this container any more (its measures stop
+    // recording once suppressed), so skip the scan. This runs on EVERY submit -- 14,255 of them in
+    // a 3-minute Stray boot -- and after the first pairing it is the only case left.
+    if (auto it = g_apr_measure_paired.find(id); it != g_apr_measure_paired.end() && it->second)
+        return false;
+    for (size_t i = 0; i < g_apr_recent_measures_used; i++) {
+        const AprMeasuredRead& m = g_apr_recent_measures[i];
+        if (m.id != id || m.dst != dst || m.offset != offset || m.size != size) continue;
+        bool& paired = g_apr_measure_paired[id];
+        const bool first = !paired;
+        paired = true;
+        return first;
+    }
+    return false;
 }
 // "Which guest code asked for the file that is not there?" — the question every missing-asset
 // bring-up investigation reaches, and the one a path alone cannot answer. A resolve MISS names the
@@ -3620,6 +3739,15 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
         if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size;
 #endif
     }
+    // #3245: a submit for exactly the read a measure just delivered proves this container records
+    // and submits its measured reads, so its compatibility read is a duplicate from here on. Placed
+    // before the platform split because the fact is host-independent, and before apr_execute_read
+    // because the pairing is about what the guest ASKED for, not about whether the read succeeded.
+    if (apr_measure_note_submit((uint32_t)id, a4, offset, requested_size))
+        fprintf(stderr, "[apr] %s: the measure-size call's compatibility read is redundant here "
+                        "(this submit re-delivers a read sceAmprMeasureCommandSizeReadFile already "
+                        "served) -- suppressing it for this container. PROSPER_APR_MEASURE_READ="
+                        "always restores it.\n", host.c_str());
     // #2139: this was Linux-only because the discriminator read the guest stack directly, which the
     // Windows import bridge makes impossible — its stub converts SysV->MS-x64 and CALLs the handler,
     // inserting a frame plus shadow space (the #672 class of bug). But that same bridge already
@@ -4024,6 +4152,17 @@ HLE(f_apr_measure_read_file) {
                     (unsigned long long)a0, (unsigned long long)measured);
         return measured;
     }
+    // #3245: this container has already been shown to submit the reads it measures, so the
+    // compatibility read below would deliver bytes the submit path re-delivers moments later --
+    // and would deliver them BEFORE the guest recorded the command. The sizing answer is unchanged;
+    // only the read is dropped. See the block beside apr_measure_read_suppressed.
+    if (apr_measure_read_suppressed((uint32_t)a0)) {
+        if (filelog())
+            fprintf(stderr, "[apr] measure-read id=%llu %s -> %llu bytes (compatibility read "
+                            "suppressed: this container submits its measured reads)\n",
+                    (unsigned long long)a0, host.c_str(), (unsigned long long)measured);
+        return measured;
+    }
 
     uint64_t file_size = 0;
 #ifndef _WIN32
@@ -4070,6 +4209,10 @@ HLE(f_apr_measure_read_file) {
         ::free(staging);
     }
 #endif
+    // Record what was delivered, so a submit of the identical read can identify the pairing and
+    // retire this container's compatibility read (#3245). Recorded only on a read that actually
+    // landed: a failed one has not made the submit redundant.
+    if (copied) apr_measure_record((uint32_t)a0, a1, a3, a2);
     if (filelog())
         fprintf(stderr, "[apr] measure-read compatibility id=%llu %s -> dst=0x%llx "
                         "off=0x%llx size=%llu %s; measured=%llu\n",

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2389,14 +2389,39 @@ struct AprMeasuredRead {
     bool live = false;        // this slot has been written since the last reset
     bool suppressed = false;  // recorded AFTER the container paired, i.e. its read was skipped
     bool matched = false;     // a submit for exactly this tuple has since arrived
+    uint16_t idx_pos = 0;     // where the index below points at this slot (valid while `live`)
 };
 PROSPER_HEAP_MUTEX(g_apr_measure_mx);
 constexpr size_t kAprMeasureRingMax = 64;   // only the IMMEDIATE pairing matters; Stray's is adjacent
 std::array<AprMeasuredRead, kAprMeasureRingMax> g_apr_recent_measures{};
-size_t g_apr_recent_measures_used = 0;      // grows to kAprMeasureRingMax, then the ring wraps
 size_t g_apr_recent_measures_next = 0;
 std::map<uint32_t, bool> g_apr_measure_paired;   // file id -> a submit matched one of its measures
 bool g_apr_mixed_pattern_warned = false;         // the detector below fires at most once
+
+// --- The (id, dst, offset, size) -> ring-slot index ---------------------------------------------
+// apr_measure_note_submit runs on EVERY APR submit -- 14,255 of them in a 3-minute Stray boot -- and
+// it used to LINEAR-SCAN all 64 ring slots under the mutex, because keeping every entry marked (the
+// detector's requirement) removed the early-out that used to skip the scan once a container paired.
+// A 64-slot scan per submit is a plausible shape for a timing-sensitive failure on the submit path,
+// so the mechanism is removed rather than measured: this index restores O(1) expected lookup while
+// every entry still gets marked, which is what the detector needs. #3245.
+//
+// Open addressing with linear probing. Encoding avoids any dynamic initialisation, so the table is
+// correct from static zero-init: 0 = EMPTY, -1 = TOMBSTONE, n > 0 = ring slot n-1.
+// Sized at 4x the ring, so live load never exceeds 0.25 and probe chains stay short.
+constexpr size_t kAprMeasureIndexSlots = 256;   // power of two; mask-indexed
+constexpr int16_t kAprIndexEmpty = 0, kAprIndexTomb = -1;
+std::array<int16_t, kAprMeasureIndexSlots> g_apr_measure_index{};   // zero-init == all EMPTY
+size_t g_apr_measure_index_live = 0;    // occupied entries
+size_t g_apr_measure_index_tombs = 0;   // deleted entries still occupying a probe chain
+// Coverage counters, not diagnostics. An open-addressed lookup fails by finding NOTHING for a key
+// that is present, and the two ways that happens -- a probe chain terminated early at a tombstone,
+// and a stale slot pointer after a rebuild -- are both invisible to every return value the callers
+// check. A test that never drives a lookup across a tombstone, or never survives a rebuild, would
+// pass against a broken implementation of either. These let the test assert it REACHED the
+// mechanism rather than assuming it did.
+size_t g_apr_index_tomb_steps = 0;   // lookups that stepped OVER a tombstone to keep probing
+size_t g_apr_index_rebuilds = 0;     // full table rebuilds performed
 
 // auto (default) = the latch above; always = never suppress; never = never do the compatibility
 // read. Read once: an env lookup per streamed asset is itself a cost on this path.
@@ -2414,15 +2439,87 @@ AprMeasureMode apr_measure_mode() {
     }();
     return mode;
 }
+// One 64-bit mix over the whole key. All four fields participate: `dst` alone collides heavily
+// (titles reuse destinations), and `size` alone even more so.
+inline uint64_t apr_measure_hash(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
+    uint64_t h = 0x9e3779b97f4a7c15ull;
+    for (uint64_t v : { (uint64_t)id, dst, offset, size })
+        h ^= v + 0x9e3779b97f4a7c15ull + (h << 6) + (h >> 2);
+    h ^= h >> 33; h *= 0xff51afd7ed558ccdull; h ^= h >> 33;   // finalizer
+    return h;
+}
+// Table position holding this key, or -1. Probing stops at EMPTY and steps over TOMBSTONEs, which
+// is what makes deletion-by-tombstone correct rather than merely usual.
+inline int apr_index_find_locked(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
+    constexpr size_t mask = kAprMeasureIndexSlots - 1;
+    size_t p = (size_t)apr_measure_hash(id, dst, offset, size) & mask;
+    for (size_t probes = 0; probes < kAprMeasureIndexSlots; probes++, p = (p + 1) & mask) {
+        const int16_t e = g_apr_measure_index[p];
+        if (e == kAprIndexEmpty) return -1;
+        if (e == kAprIndexTomb) { g_apr_index_tomb_steps++; continue; }
+        const AprMeasuredRead& m = g_apr_recent_measures[(size_t)(e - 1)];
+        if (m.live && m.id == id && m.dst == dst && m.offset == offset && m.size == size)
+            return (int)p;
+    }
+    return -1;   // table full of tombstones: cannot happen, the rebuild below keeps load <= 1/2
+}
+inline void apr_index_insert_locked(size_t slot) {
+    constexpr size_t mask = kAprMeasureIndexSlots - 1;
+    AprMeasuredRead& m = g_apr_recent_measures[slot];
+    size_t p = (size_t)apr_measure_hash(m.id, m.dst, m.offset, m.size) & mask;
+    while (g_apr_measure_index[p] > 0) p = (p + 1) & mask;   // first EMPTY or TOMBSTONE
+    if (g_apr_measure_index[p] == kAprIndexTomb) g_apr_measure_index_tombs--;
+    g_apr_measure_index[p] = (int16_t)(slot + 1);
+    g_apr_measure_index_live++;
+    m.idx_pos = (uint16_t)p;
+}
+// O(1) removal: the slot remembers where the index points at it, so no search is needed.
+inline void apr_index_erase_locked(size_t slot) {
+    const AprMeasuredRead& m = g_apr_recent_measures[slot];
+    if (!m.live || m.idx_pos >= kAprMeasureIndexSlots) return;
+    if (g_apr_measure_index[m.idx_pos] != (int16_t)(slot + 1)) return;
+    g_apr_measure_index[m.idx_pos] = kAprIndexTomb;
+    g_apr_measure_index_live--;
+    g_apr_measure_index_tombs++;
+}
+// Tombstones lengthen probe chains without ever being reclaimed by lookup, so the table is rebuilt
+// from the live ring whenever occupancy would exceed half. With a 64-entry ring in a 256-entry
+// table that is at least 64 inserts apart, so the O(256) rebuild is under 4 amortised steps per
+// insert -- against the 64 steps per SUBMIT that this whole index replaces.
+inline void apr_index_rebuild_locked() {
+    g_apr_index_rebuilds++;
+    g_apr_measure_index.fill(kAprIndexEmpty);
+    g_apr_measure_index_live = 0;
+    g_apr_measure_index_tombs = 0;
+    for (size_t s = 0; s < kAprMeasureRingMax; s++)
+        if (g_apr_recent_measures[s].live) apr_index_insert_locked(s);
+}
 }  // namespace
 
 static void apr_measure_reset_for_test() {
     std::lock_guard lk(g_apr_measure_mx);
     g_apr_recent_measures.fill(AprMeasuredRead{});
-    g_apr_recent_measures_used = 0;
     g_apr_recent_measures_next = 0;
+    g_apr_measure_index.fill(kAprIndexEmpty);
+    g_apr_measure_index_live = 0;
+    g_apr_measure_index_tombs = 0;
+    g_apr_index_tomb_steps = 0;
+    g_apr_index_rebuilds = 0;
     g_apr_measure_paired.clear();
     g_apr_mixed_pattern_warned = false;
+}
+// Test seam: which bucket does this key hash to? Needed so a test can CONSTRUCT a probe collision
+// by hand. Ordinary traffic almost never produces one -- 64 live keys in a 256-slot table means
+// nearly every lookup hits its home bucket -- so a test that only drives ordinary traffic reports a
+// clean zero for the tombstone path and proves nothing about it.
+size_t prosper_apr_index_bucket_for_test(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
+    return (size_t)apr_measure_hash(id, dst, offset, size) & (kAprMeasureIndexSlots - 1);
+}
+// Test seam: did a run actually exercise the index's two silent-failure paths?
+void prosper_apr_index_coverage_for_test(size_t* tomb_steps, size_t* rebuilds) {
+    std::lock_guard lk(g_apr_measure_mx);
+    if (tomb_steps) *tomb_steps = g_apr_index_tomb_steps;
+    if (rebuilds)   *rebuilds   = g_apr_index_rebuilds;
 }
 // Test seam for the detector below: has the mixed-pattern warning fired?
 bool prosper_apr_mixed_pattern_warned_for_test() {
@@ -2456,9 +2553,11 @@ static bool apr_measure_read_suppressed(uint32_t id) {
 // every entry carries whether a submit later claimed it, and an entry that leaves the ring having
 // been suppressed AND never matched is warned about, once, loudly. Nothing else produces that
 // signature: a pre-pairing entry ages out unmatched all the time and is not suppressed, and a
-// suppressed entry that a submit claimed is the designed case. Keeping the scan alive after pairing
-// costs a 64-entry compare per submit -- ~900k integer comparisons across a 3-minute Stray boot,
-// which is not measurable next to the 583 MB of file I/O this removes.
+// suppressed entry that a submit claimed is the designed case. Keeping every entry marked is what
+// costs: it removes note_submit's early-out, so that function scanned all 64 ring slots on every
+// submit until the (id, dst, offset, size) index above made the lookup O(1). Detection was kept and
+// the cost removed, rather than the cost bought back by sampling -- a detector that only sometimes
+// detects is the wrong trade when detection is the reason this design is acceptable at all.
 //
 // Known blind spot, stated rather than left to be discovered: up to kAprMeasureRingMax entries are
 // still in the ring when the process exits and are never adjudicated, so a title that mixes the two
@@ -2479,11 +2578,18 @@ static void apr_measure_warn_mixed_locked(const AprMeasuredRead& lost) {
 static void apr_measure_record(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size,
                                bool suppressed) {
     std::lock_guard lk(g_apr_measure_mx);
-    AprMeasuredRead& slot = g_apr_recent_measures[g_apr_recent_measures_next];
+    const size_t at = g_apr_recent_measures_next;
+    AprMeasuredRead& slot = g_apr_recent_measures[at];
     if (slot.live && slot.suppressed && !slot.matched) apr_measure_warn_mixed_locked(slot);
+    apr_index_erase_locked(at);   // must precede the overwrite: it reads the OLD key's idx_pos
     slot = AprMeasuredRead{ id, dst, offset, size, /*live=*/true, suppressed, /*matched=*/false };
+    // Rebuild INSTEAD of inserting when the table would pass half full: the rebuild walks the live
+    // ring, which already includes the entry just written, so inserting as well would double it.
+    if (g_apr_measure_index_live + g_apr_measure_index_tombs > kAprMeasureIndexSlots / 2)
+        apr_index_rebuild_locked();
+    else
+        apr_index_insert_locked(at);
     g_apr_recent_measures_next = (g_apr_recent_measures_next + 1) % kAprMeasureRingMax;
-    if (g_apr_recent_measures_used < kAprMeasureRingMax) g_apr_recent_measures_used++;
 }
 
 // A submit for a read the measure path already delivered: from here on this container does not need
@@ -2492,20 +2598,20 @@ static void apr_measure_record(uint32_t id, uint64_t dst, uint64_t offset, uint6
 static bool apr_measure_note_submit(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size) {
     if (apr_measure_mode() != AprMeasureMode::Auto) return false;
     std::lock_guard lk(g_apr_measure_mx);
-    // The scan deliberately continues after a container has paired: marking the entry is what lets
+    // Lookup deliberately continues after a container has paired: marking the entry is what lets
     // the detector in apr_measure_record tell "suppressed and never submitted" from "suppressed and
     // duly submitted". An early-out here would make the mixed pattern undetectable, which is the
-    // whole failure mode this heuristic has.
-    for (size_t i = 0; i < g_apr_recent_measures_used; i++) {
-        AprMeasuredRead& m = g_apr_recent_measures[i];
-        if (!m.live || m.id != id || m.dst != dst || m.offset != offset || m.size != size) continue;
-        m.matched = true;
-        bool& paired = g_apr_measure_paired[id];
-        const bool first = !paired;
-        paired = true;
-        return first;
-    }
-    return false;
+    // whole failure mode this heuristic has. Keeping that marking is why the O(1) index exists --
+    // it is what removed the 64-slot scan this used to do on every submit, rather than buying the
+    // speed back by giving up detection.
+    const int p = apr_index_find_locked(id, dst, offset, size);
+    if (p < 0) return false;
+    AprMeasuredRead& m = g_apr_recent_measures[(size_t)(g_apr_measure_index[(size_t)p] - 1)];
+    m.matched = true;
+    bool& paired = g_apr_measure_paired[id];
+    const bool first = !paired;
+    paired = true;
+    return first;
 }
 // "Which guest code asked for the file that is not there?" — the question every missing-asset
 // bring-up investigation reaches, and the one a path alone cannot answer. A resolve MISS names the

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -2411,6 +2411,14 @@ bool g_apr_mixed_pattern_warned = false;         // the detector below fires at 
 // Sized at 4x the ring, so live load never exceeds 0.25 and probe chains stay short.
 constexpr size_t kAprMeasureIndexSlots = 256;   // power of two; mask-indexed
 constexpr int16_t kAprIndexEmpty = 0, kAprIndexTomb = -1;
+// The table stores slot+1 in an int16_t, and probing masks with slots-1. Both encodings are silent
+// if violated -- a truncated slot index would point at the wrong ring entry rather than fault, and a
+// non-power-of-two size would make the mask skip buckets -- so pin them where a change would land.
+static_assert(kAprMeasureRingMax + 1 <= INT16_MAX, "ring slot+1 must fit the index's int16_t");
+static_assert((kAprMeasureIndexSlots & (kAprMeasureIndexSlots - 1)) == 0,
+              "index size must be a power of two: probing masks rather than divides");
+static_assert(kAprMeasureIndexSlots >= 2 * kAprMeasureRingMax,
+              "index must stay under half full from live entries alone, or probe chains grow");
 std::array<int16_t, kAprMeasureIndexSlots> g_apr_measure_index{};   // zero-init == all EMPTY
 size_t g_apr_measure_index_live = 0;    // occupied entries
 size_t g_apr_measure_index_tombs = 0;   // deleted entries still occupying a probe chain
@@ -2559,10 +2567,34 @@ static bool apr_measure_read_suppressed(uint32_t id) {
 // the cost removed, rather than the cost bought back by sampling -- a detector that only sometimes
 // detects is the wrong trade when detection is the reason this design is acceptable at all.
 //
+// Second known blind spot: duplicate keys are not deduplicated. Two LIVE ring slots holding the same
+// (id, dst, offset, size) would be matched one-at-a-time -- the index finds one, the other stays
+// unmatched and warns on eviction as a phantom mixed pattern. Latent rather than live: across four
+// DOLL PROSPER_FILELOG boots, 5,966 measured reads produced 5,966 distinct tuples and 0 duplicates,
+// so no observed title re-measures an identical read while the first is still in the ring. Left as a
+// note rather than code because deduplicating would mean deciding WHICH of two identical pending
+// reads a single submit satisfies, and nothing observed poses that question.
+//
 // Known blind spot, stated rather than left to be discovered: up to kAprMeasureRingMax entries are
 // still in the ring when the process exits and are never adjudicated, so a title that mixes the two
 // patterns FEWER than 64 measures before quitting would not warn.
 static void apr_measure_warn_mixed_locked(const AprMeasuredRead& lost) {
+    // ONLY in Auto. The detector's premise is "a submit should have claimed this entry", and that
+    // premise is a property of Auto alone -- apr_measure_note_submit returns at its own mode check
+    // before it looks at anything, so in the other two modes nothing is EVER marked.
+    //
+    // Never is the mode this bites, and it bit: apr_measure_read_suppressed returns true for Never,
+    // so every measure records suppressed=true, nothing marks it, and the eviction check fired on
+    // the 65th measure of EVERY run of EVERY title -- printing a message blaming a title-specific
+    // mixed pattern and asking the user to report the title, when the cause was their own flag.
+    // A guaranteed false positive, and worse than an ordinary one: `never` is the lever for the open
+    // question this whole design raises (is the compatibility read needed at all?), so a warning on
+    // every title made the one experiment the feature exists to enable uninterpretable.
+    //
+    // This is the same argument as the =always arm in the test, one mode over. Always happens to be
+    // safe for a second reason -- it never sets suppressed=true at all -- but relying on that
+    // coincidence is how Never got missed, so gate on the premise itself rather than on the symptom.
+    if (apr_measure_mode() != AprMeasureMode::Auto) return;
     if (g_apr_mixed_pattern_warned) return;
     g_apr_mixed_pattern_warned = true;
     fprintf(stderr,

--- a/prosper/tests/hle/test_apr_measure_duplicate.cpp
+++ b/prosper/tests/hle/test_apr_measure_duplicate.cpp
@@ -387,15 +387,38 @@ int main() {
             }
             CHECK(fillers.size() == 63, "probe-collision arm: found 63 non-colliding fillers");
 
-            // LOAD-BEARING PRECONDITION: no rebuild may intervene between B's insert and B's
-            // lookup. A rebuild re-inserts only the live entries, which clears every tombstone --
-            // including the one this arm exists to probe past -- and would silently turn the whole
-            // arm into a passing no-op. The threshold is `live + tombs > 128`; this arm reaches
-            // 64 live + 2 tombs = 66, so there are ~62 records of headroom. That is comfortable
-            // today and invisible if someone later shrinks the table, grows the ring, or lowers the
-            // threshold, so the rebuild counter is asserted unchanged across the window rather than
-            // left to a comment. This is the same class the arm itself guards: a silent degradation
-            // that changes no return value.
+            // PRECONDITION -- asserted for DIAGNOSIS, not for detection. Read that distinction
+            // before trusting the assertion below, because the obvious justification for it is
+            // wrong and an earlier version of this comment made it.
+            //
+            // No rebuild may intervene between B's insert and B's lookup: a rebuild re-inserts only
+            // the LIVE entries, which clears the tombstone at H that this arm exists to probe past.
+            // The tempting claim is that this would "silently turn the arm into a passing no-op".
+            // It would not. B's home bucket IS H -- that is how the collision was constructed -- so
+            // after a rebuild B lands at H, `find` resolves it immediately, and the tomb-step
+            // assertion below sees 0 steps and goes RED on its own. Measured, not reasoned: forcing
+            // a rebuild into this window (threshold temporarily 128 -> 32) fails the tomb-step
+            // assertion with `tomb steps 0 -> 0 -> 0`.
+            //
+            // So the arm is already immune to the hazard, and what this CHECK buys is the reason
+            // WHY, at the moment of failure. A future constants change -- a smaller table, a bigger
+            // ring, a lower threshold -- would otherwise present as "a tombstone arm stopped seeing
+            // tombstones", leaving the next person to re-derive the cause. With it, the two
+            // assertions fail together and the second one names it. Headroom today: the threshold
+            // is `live + tombs > 128` and this arm reaches 64 live + 2 tombs = 66.
+            //
+            // WINDOW WIDTH. The load-bearing window is [the evicting record, the lookup], and it
+            // has to START INSIDE that record rather than after it: apr_measure_record creates the
+            // tombstone and then may rebuild in the same call, so a sample taken once the loop
+            // finishes is already past the only rebuild that can hurt. A window from there to the
+            // lookup is vacuously true -- lookups never rebuild -- and would read as meaningful
+            // while asserting nothing. Measured: under a forced rebuild it passed while the arm was
+            // broken, which is why the sample point moved.
+            //
+            // The wider `rebuilds_before == after` is kept as well. It is strictly stronger on a
+            // monotonic counter, and the extra width is wanted rather than tolerated: a rebuild
+            // ANYWHERE in this arm means the constants moved and the slot arithmetic above needs
+            // re-deriving, whether or not this particular run happened to survive it.
             size_t before = 0, rebuilds_before = 0;
             prosper_apr_index_coverage_for_test(&before, &rebuilds_before);
 
@@ -404,21 +427,35 @@ int main() {
             read_file_guest(cb, 0, record, id, dst, kSize, off_a, 0, 0);
             // B: recorded only. It lands one past A, behind the bucket A will vacate.
             measure(id, dst, kSize, off_b, 0, 0);
-            // 62 fillers fill the ring to 64; the 63rd evicts A and tombstones the shared bucket.
-            for (size_t i = 0; i < 63; ++i) {
+            // 62 fillers fill the ring to 64; the 63rd (last) evicts A and tombstones bucket H.
+            for (size_t i = 0; i < 62; ++i) {
                 measure(id, dst, kSize, fillers[i], 0, 0);
                 read_file_guest(cb, 0, record, id, dst, kSize, fillers[i], 0, 0);
             }
+            // Sample BEFORE the evicting record, not after it. apr_measure_record erases the old
+            // entry -- creating the tombstone -- and then, IN THE SAME CALL, may rebuild and destroy
+            // it. A sample taken after the loop therefore sits on the far side of the only rebuild
+            // that can hurt, and comparing it against the post-lookup value is vacuously true: a
+            // lookup never rebuilds, so nothing can happen in between. This split makes the window
+            // contain the one call that matters.
+            size_t rebuilds_pre_evict = 0, dummy2 = 0;
+            prosper_apr_index_coverage_for_test(&dummy2, &rebuilds_pre_evict);
+            measure(id, dst, kSize, fillers[62], 0, 0);
+            read_file_guest(cb, 0, record, id, dst, kSize, fillers[62], 0, 0);
 
             size_t after = 0, rebuilds_mid = 0;
             prosper_apr_index_coverage_for_test(&after, &rebuilds_mid);
+            (void)rebuilds_mid;
             // Now the load-bearing lookup: B is live, its chain starts at the tombstoned bucket.
             read_file_guest(cb, 0, record, id, dst, kSize, off_b, 0, 0);
             size_t after_lookup = 0, rebuilds_after = 0;
             prosper_apr_index_coverage_for_test(&after_lookup, &rebuilds_after);
+            CHECK(rebuilds_pre_evict == rebuilds_after,
+                  "probe-collision arm: no rebuild from the evicting record through the lookup "
+                  "-- the load-bearing window, and the tombstone survived to be probed past");
             CHECK(rebuilds_before == rebuilds_after,
-                  "probe-collision arm: no rebuild intervened, so the tombstone it probes past "
-                  "really was still there (the arm is not a no-op)");
+                  "probe-collision arm: no rebuild anywhere in the arm, so its slot arithmetic "
+                  "still holds (deliberately wider than the load-bearing window)");
 
             char msg[256];
             if (forced_always) {

--- a/prosper/tests/hle/test_apr_measure_duplicate.cpp
+++ b/prosper/tests/hle/test_apr_measure_duplicate.cpp
@@ -14,6 +14,10 @@
 //   * consume-from-the-measure: measure -> guest reads dst -> no submit.  Must still deliver.
 //   * submit-what-it-measures:  measure -> submit of the IDENTICAL read.  Redundant from then on.
 //
+// The detector arms below double as the integrity check for the O(1) index that note_submit uses:
+// an index that silently finds nothing would disable detection without failing any return value,
+// and the "stays quiet" arm is what catches exactly that.
+//
 // The arms are named after the PATTERNS, not after titles, and deliberately so. An earlier version
 // called the first one "the DOLL arm" — but replaying the pairing predicate over four of DOLL's own
 // PROSPER_FILELOG boots shows DOLL pairs at submit #13 and has ZERO measured reads lacking an
@@ -46,6 +50,8 @@ namespace prosper {
 uint32_t prosper_apr_register(const std::string& path, uint64_t size);
 void prosper_apr_reset_for_test();
 bool prosper_apr_mixed_pattern_warned_for_test();
+void prosper_apr_index_coverage_for_test(size_t* tomb_steps, size_t* rebuilds);
+size_t prosper_apr_index_bucket_for_test(uint32_t id, uint64_t dst, uint64_t offset, uint64_t size);
 }
 using namespace prosper;
 
@@ -232,17 +238,49 @@ int main() {
     constexpr size_t kRing = 64, kEvict = kRing + 8;
     {
         // Arm A -- the DESIGNED case: suppressed measures that ARE each submitted. Must not warn.
+        //
+        // This arm is ALSO the (id, dst, offset, size) index's integrity oracle, and that is not a
+        // coincidence worth leaving implicit. The lookup is O(1) and open-addressed, so the way it
+        // fails is by finding NOTHING for a key that is present -- a bad hash, a probe chain
+        // terminated early by a mishandled tombstone, a stale idx_pos after a rebuild. None of those
+        // throws, and none of them changes a return value that anything else checks: pairing has
+        // already happened, so a missed lookup just silently stops marking entries. The detector is
+        // what turns that into a failure. An entry the index cannot find is never marked, ages out
+        // of the ring suppressed-and-unmatched, and warns -- so a silently-degraded index makes
+        // THIS arm go red.
+        //
+        // 600 iterations rather than 72 so the run spans many ring wraps and, at a 256-slot table
+        // rebuilt whenever it passes half full, several index rebuilds. A rebuild is where a stale
+        // idx_pos would bite, and 72 iterations would not have reached one.
+        constexpr size_t kIndexStress = 600;
         CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
               "detector: quiet before any suppressed measure goes unclaimed");
         Dest d;
-        for (size_t i = 0; i < kEvict; ++i) {
+        for (size_t i = 0; i < kIndexStress; ++i) {
             const size_t off = 2048 + i * 4, size = 32;
             d.poison();
             measure(id_a, d.addr(), size, off, 0, 0);
             read_file_guest(cb, 0, record, id_a, d.addr(), size, off, 0, 0);
         }
         CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
-              "detector: stays quiet when every suppressed measure is duly submitted");
+              "detector quiet + index found every key across many wraps and rebuilds");
+        // ...and PROVE the arm above reached the mechanism it claims to guard, rather than
+        // assuming it did. Both of the index's silent-failure modes need a specific condition to
+        // be reachable at all: a lookup must step OVER a tombstone (the classic open-addressing
+        // bug is to terminate the chain there instead), and the table must be REBUILT (which is
+        // where a stale slot pointer would bite). Neither is guaranteed by iteration count -- at a
+        // 256-slot table holding at most 64 live keys, most lookups hit their home slot and never
+        // touch either path. Without these two checks the arm above would pass against an index
+        // that mishandles both, which is precisely the "passes for the wrong reason" failure this
+        // file exists to avoid.
+        size_t tomb_steps = 0, rebuilds = 0;
+        prosper_apr_index_coverage_for_test(&tomb_steps, &rebuilds);
+        char cov[192];
+        std::snprintf(cov, sizeof cov,
+                      "index coverage: the stress arm survived %zu rebuild(s) (it stepped over %zu "
+                      "tombstone(s) -- ordinary traffic does not reach that path)",
+                      rebuilds, tomb_steps);
+        CHECK(rebuilds > 0, cov);   // holds in every mode: recording drives rebuilds, lookups do not
     }
     {
         // Arm B -- the MIXED pattern: suppressed measures that are never submitted. Must warn.
@@ -263,6 +301,111 @@ int main() {
         } else {
             CHECK(prosper_apr_mixed_pattern_warned_for_test(),
                   "detector: warns when a suppressed measure is never submitted (the mixed pattern)");
+        }
+    }
+
+    // ---- The probe chain, built BY HAND ---------------------------------------------------------
+    // The stress arm above reports 0 tombstone steps, and that zero is real rather than a
+    // measurement artefact: 64 live keys in a 256-slot table means almost every lookup resolves at
+    // its home bucket, so ordinary traffic never crosses a deleted entry. A clean zero on the very
+    // path most likely to be wrong is exactly the situation CLAUDE.md says to distrust -- construct
+    // one positive instance by hand, outside whatever produced the null, before believing it.
+    //
+    // So: force the one state that makes the tombstone path load-bearing -- a LIVE key whose probe
+    // chain passes through a DELETED entry -- and prove the lookup still finds it.
+    //
+    //   A and B are chosen to share a home bucket, so B is placed one past A.
+    //   A is submitted (marked), then aged out of the 64-entry ring, leaving a TOMBSTONE at the
+    //   shared home bucket while B is still live behind it.
+    //   Looking B up must now step OVER that tombstone. Terminating the chain there instead -- the
+    //   classic open-addressing bug -- loses B silently: no error, no wrong return value, just an
+    //   entry that never gets marked and later warns as a phantom mixed pattern.
+    {
+        prosper_apr_reset_for_test();
+        const uint32_t id = prosper_apr_register(path_a_storage, g_fixture.size());
+        Dest d;
+        constexpr uint64_t kSize = 32;
+        const uint64_t dst = d.addr();
+
+        // Pair the container first, so every later measure records without doing any file I/O.
+        d.poison();
+        measure(id, dst, kSize, 0, 0, 0);
+        read_file_guest(cb, 0, record, id, dst, kSize, 0, 0, 0);
+
+        // Search the key space for a colliding pair and for fillers that avoid their bucket.
+        const auto bucket = [&](uint64_t off) {
+            return prosper_apr_index_bucket_for_test(id, dst, off, kSize);
+        };
+        uint64_t off_a = 0, off_b = 0;
+        bool found = false;
+        for (uint64_t i = 1; i < 4000 && !found; ++i)
+            for (uint64_t j = i + 1; j < 4000 && !found; ++j)
+                if (bucket(i * 4) == bucket(j * 4)) { off_a = i * 4; off_b = j * 4; found = true; }
+        CHECK(found, "probe-collision arm: found two keys sharing a home bucket");
+        if (found) {
+            const size_t home = bucket(off_a);
+            std::vector<uint64_t> fillers;
+            for (uint64_t k = 1; fillers.size() < 63 && k < 200000; ++k) {
+                const uint64_t off = 8000 + k * 4;
+                if (off != off_a && off != off_b && bucket(off) != home) fillers.push_back(off);
+            }
+            CHECK(fillers.size() == 63, "probe-collision arm: found 63 non-colliding fillers");
+
+            size_t before = 0, dummy = 0;
+            prosper_apr_index_coverage_for_test(&before, &dummy);
+
+            // A: recorded and submitted, so its eviction cannot itself trip the detector.
+            measure(id, dst, kSize, off_a, 0, 0);
+            read_file_guest(cb, 0, record, id, dst, kSize, off_a, 0, 0);
+            // B: recorded only. It lands one past A, behind the bucket A will vacate.
+            measure(id, dst, kSize, off_b, 0, 0);
+            // 62 fillers fill the ring to 64; the 63rd evicts A and tombstones the shared bucket.
+            for (size_t i = 0; i < 63; ++i) {
+                measure(id, dst, kSize, fillers[i], 0, 0);
+                read_file_guest(cb, 0, record, id, dst, kSize, fillers[i], 0, 0);
+            }
+
+            size_t after = 0;
+            prosper_apr_index_coverage_for_test(&after, &dummy);
+            // Now the load-bearing lookup: B is live, its chain starts at the tombstoned bucket.
+            read_file_guest(cb, 0, record, id, dst, kSize, off_b, 0, 0);
+            size_t after_lookup = 0;
+            prosper_apr_index_coverage_for_test(&after_lookup, &dummy);
+
+            char msg[256];
+            if (forced_always) {
+                // Under =always, apr_measure_note_submit returns at its mode check BEFORE taking
+                // the lock, so no lookup happens at all and the counter cannot move. Asserting that
+                // is worth more than skipping: it is the same early return that makes the =always
+                // arm a valid control for this whole index -- if the index could cost anything in
+                // that mode, an A/B between the two arms would not isolate it.
+                std::snprintf(msg, sizeof msg,
+                              "probe-collision arm under =always: the index is never consulted, so "
+                              "it cannot cost anything in that mode (tomb steps %zu -> %zu -> %zu)",
+                              before, after, after_lookup);
+                CHECK(after_lookup == before, msg);
+            } else {
+                std::snprintf(msg, sizeof msg,
+                              "probe-collision arm: the lookup for B stepped over a tombstone "
+                              "(tomb steps %zu -> %zu -> %zu across the arm)",
+                              before, after, after_lookup);
+                CHECK(after_lookup > after, msg);
+            }
+
+            // And it must have FOUND B, not merely probed past the tombstone. Flush the ring: if B
+            // was marked, nothing warns; if the chain terminated early, B ages out suppressed and
+            // unmatched and the detector fires.
+            CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
+                  "probe-collision arm: quiet before the flush");
+            for (size_t i = 0; i < 80; ++i) {
+                const uint64_t off = 300000 + i * 4;
+                measure(id, dst, kSize, off, 0, 0);
+                read_file_guest(cb, 0, record, id, dst, kSize, off, 0, 0);
+            }
+            CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
+                  forced_always
+                      ? "probe-collision arm under =always: nothing is suppressed, so nothing warns"
+                      : "probe-collision arm: B was FOUND behind the tombstone, not lost silently");
         }
     }
 

--- a/prosper/tests/hle/test_apr_measure_duplicate.cpp
+++ b/prosper/tests/hle/test_apr_measure_duplicate.cpp
@@ -1,26 +1,34 @@
 // test_apr_measure_duplicate — sceAmprMeasureCommandSizeReadFile's compatibility read (#3245).
 //
 // That call's firmware contract is pure sizing (20, or 24 for a wide file offset). prosper also
-// performs the described read, because DOLL's older SDK wrapper consumes the destination from the
-// measure and never records a ReadFile for it. The read used to fire for EVERY title whose file id
-// resolved, so a title that also submits the read normally paid for the same bytes twice — 13,925
-// duplicate reads and 582 MB in a 3-minute Stray boot — and got them written into its destination
-// before it had recorded the command.
+// performs the described read, on the recorded grounds that an older SDK wrapper consumes the
+// destination from the measure and never records a ReadFile for it. The read used to fire for EVERY
+// title whose file id resolved, so a title that also submits the read normally paid for the same
+// bytes twice — 13,925 duplicate reads and 582 MB in a 3-minute Stray boot — and got them written
+// into its destination before it had recorded the command.
 //
-// The two arms this has to keep apart cannot be told apart AT the measure call: both pass a valid
-// id, a real destination and a real size. What separates them is what happens next, so that is what
-// the suppression keys on, and that is what the cases below drive:
+// The two patterns this has to keep apart cannot be told apart AT the measure call: both pass a
+// valid id, a real destination and a real size. What separates them is what happens next, so that
+// is what the suppression keys on, and that is what the cases below drive:
 //
-//   * DOLL:  measure -> (the guest consumes dst) -> no submit of that read.   Must still deliver.
-//   * Stray: measure -> submit of the IDENTICAL read.                          Redundant from then on.
+//   * consume-from-the-measure: measure -> guest reads dst -> no submit.  Must still deliver.
+//   * submit-what-it-measures:  measure -> submit of the IDENTICAL read.  Redundant from then on.
+//
+// The arms are named after the PATTERNS, not after titles, and deliberately so. An earlier version
+// called the first one "the DOLL arm" — but replaying the pairing predicate over four of DOLL's own
+// PROSPER_FILELOG boots shows DOLL pairs at submit #13 and has ZERO measured reads lacking an
+// identical submit, i.e. DOLL is the SECOND pattern. Both titles this work is about turn out to be
+// the second pattern; the first is the shape the suppression must never break if a title has it,
+// which is a claim about the mechanism and not about anybody's traffic.
 //
 // Every delivery assertion pre-poisons the destination with a byte the fixture cannot produce at
 // that offset, so "the callee wrote nothing" and "the callee wrote the right thing" are distinct
 // observations rather than both reading as zero.
 //
-// Registered TWICE in CMake: once by default and once with PROSPER_APR_MEASURE_READ=always. The
-// second run asserts the OPPOSITE outcome for the Stray case, which is what shows the lever moved —
-// a suppression that never suppressed would pass the always-run and fail the default one.
+// Registered THREE times in CMake — default, PROSPER_APR_MEASURE_READ=always, and =never. The
+// always-run asserts the OPPOSITE outcome for the submit-what-it-measures case, which is what shows
+// the lever moved: a suppression that never suppressed would pass the always-run and fail the
+// default one. The never-run covers the third mode, which nothing else executes.
 #include <array>
 #include <cstdint>
 #include <cstdio>
@@ -37,6 +45,7 @@
 namespace prosper {
 uint32_t prosper_apr_register(const std::string& path, uint64_t size);
 void prosper_apr_reset_for_test();
+bool prosper_apr_mixed_pattern_warned_for_test();
 }
 using namespace prosper;
 
@@ -69,6 +78,7 @@ struct Dest {
 int main() {
     const char* mode_env = std::getenv("PROSPER_APR_MEASURE_READ");
     const bool forced_always = mode_env && std::strcmp(mode_env, "always") == 0;
+    const bool forced_never  = mode_env && std::strcmp(mode_env, "never") == 0;
     std::printf("== test_apr_measure_duplicate (PROSPER_APR_MEASURE_READ=%s) ==\n",
                 mode_env ? mode_env : "<unset, auto>");
     register_builtin_hle();
@@ -114,19 +124,42 @@ int main() {
     CHECK(measure(0, 0, 0, 0xffffffffffull, 0, 0) == 24,
           "a wide file offset answers 24 bytes");
 
-    // ---- DOLL arm: a measure with no following submit still delivers ---------------------------
+    // ---- Unsubmitted-measure arm: a measure with no following submit still delivers -------------
+    // This is a MECHANISM arm and is deliberately not named after a title. It used to be called the
+    // "DOLL arm", which claimed authority it had not earned: replaying the pairing predicate over
+    // four of DOLL's own PROSPER_FILELOG boots shows DOLL pairs at submit #13 and is a
+    // submits-everything-it-measures title (0 unmatched measures across all four runs), not the
+    // consume-from-the-measure shape this arm models. The shape is still the one the suppression
+    // must never break, whichever title turns out to have it.
+    //
     // Driven twice. The second call is the one that matters: if the suppression latched on anything
-    // other than an actual submit pairing, this is where DOLL breaks.
+    // other than an actual submit pairing, this is where it breaks.
     constexpr size_t doll_off = 64, doll_size = 96;
     Dest doll1, doll2;
     doll1.poison();
-    CHECK(measure(id_a, doll1.addr(), doll_size, doll_off, 0, 0) == 20 &&
-              doll1.holds(doll_off, doll_size),
-          "DOLL arm: a measure with no submit delivers the container's bytes");
-    doll2.poison();
-    CHECK(measure(id_a, doll2.addr(), doll_size, doll_off + 128, 0, 0) == 20 &&
-              doll2.holds(doll_off + 128, doll_size),
-          "DOLL arm: a SECOND unsubmitted measure still delivers (no spurious latch)");
+    const uint64_t first_measure = measure(id_a, doll1.addr(), doll_size, doll_off, 0, 0);
+    if (forced_never) {
+        CHECK(first_measure == 20 && doll1.untouched(doll_size),
+              "PROSPER_APR_MEASURE_READ=never: the compatibility read never fires");
+    } else {
+        CHECK(first_measure == 20 && doll1.holds(doll_off, doll_size),
+              "unsubmitted-measure arm: a measure with no submit delivers the container's bytes");
+        doll2.poison();
+        CHECK(measure(id_a, doll2.addr(), doll_size, doll_off + 128, 0, 0) == 20 &&
+                  doll2.holds(doll_off + 128, doll_size),
+              "unsubmitted-measure arm: a SECOND unsubmitted measure still delivers (no spurious latch)");
+    }
+    if (forced_never) {
+        // The rest of the file drives the pairing latch, which `never` bypasses entirely. Its one
+        // contract -- the read never happens, the sizing answer is still right -- is asserted above.
+        CHECK(measure(0, 0, 0, 0xffffffffffull, 0, 0) == 24,
+              "PROSPER_APR_MEASURE_READ=never: the sizing answer is still the contract");
+        prosper_apr_reset_for_test();
+        std::remove(path_a_storage.c_str());
+        std::remove(path_b_storage.c_str());
+        std::printf("== %s ==\n", fails ? "FAIL" : "PASS");
+        return fails ? 1 : 0;
+    }
 
     // ---- A submit that does NOT match the measured read must not latch either -------------------
     // Same container, same destination, a different range. If the pairing were keyed loosely -- on
@@ -188,6 +221,51 @@ int main() {
               "a DIFFERENT container keeps its compatibility read after the first one paired");
     }
 
+    // ---- The detector: the one case this heuristic gets wrong must announce itself ---------------
+    // The suppression's DECISION is loud, but its CONSEQUENCE would be silent -- a container that
+    // mixes submitted and unsubmitted measured reads gets an unwritten destination and, without
+    // this, no message. So a suppressed measure that leaves the ring having never been claimed by a
+    // submit warns once, loudly. Both arms are needed: the designed case must stay quiet, or the
+    // warning is noise that will be ignored the one time it matters.
+    //
+    // Ring is 64 entries, so more than that many suppressed records are needed to evict the first.
+    constexpr size_t kRing = 64, kEvict = kRing + 8;
+    {
+        // Arm A -- the DESIGNED case: suppressed measures that ARE each submitted. Must not warn.
+        CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
+              "detector: quiet before any suppressed measure goes unclaimed");
+        Dest d;
+        for (size_t i = 0; i < kEvict; ++i) {
+            const size_t off = 2048 + i * 4, size = 32;
+            d.poison();
+            measure(id_a, d.addr(), size, off, 0, 0);
+            read_file_guest(cb, 0, record, id_a, d.addr(), size, off, 0, 0);
+        }
+        CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
+              "detector: stays quiet when every suppressed measure is duly submitted");
+    }
+    {
+        // Arm B -- the MIXED pattern: suppressed measures that are never submitted. Must warn.
+        //
+        // Under PROSPER_APR_MEASURE_READ=always the correct outcome INVERTS, and that is the point
+        // rather than an exemption: nothing is suppressed in that mode, so no measure can be lost
+        // and the detector must stay silent. A detector that fired here would be reporting a
+        // data-loss event on a run where every byte was delivered -- the false positive that would
+        // teach the next reader to ignore the warning.
+        Dest d;
+        for (size_t i = 0; i < kEvict; ++i) {
+            d.poison();
+            measure(id_a, d.addr(), 32, 2560 + i * 4, 0, 0);
+        }
+        if (forced_always) {
+            CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
+                  "detector: cannot false-positive under =always, where nothing is suppressed");
+        } else {
+            CHECK(prosper_apr_mixed_pattern_warned_for_test(),
+                  "detector: warns when a suppressed measure is never submitted (the mixed pattern)");
+        }
+    }
+
     // ---- The test hook really does clear the latch ----------------------------------------------
     // Without this, a later case in this process would inherit id_a's pairing, and the arms above
     // would be order-dependent in a way nothing would report.
@@ -199,6 +277,8 @@ int main() {
         CHECK(measure(id_again, reset_dest.addr(), doll_size, doll_off, 0, 0) == 20 &&
                   reset_dest.holds(doll_off, doll_size),
               "prosper_apr_reset_for_test clears the pairing latch as well as the registry");
+        CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
+              "prosper_apr_reset_for_test clears the detector's once-only latch too");
     }
 
     prosper_apr_reset_for_test();

--- a/prosper/tests/hle/test_apr_measure_duplicate.cpp
+++ b/prosper/tests/hle/test_apr_measure_duplicate.cpp
@@ -56,6 +56,10 @@ size_t prosper_apr_index_bucket_for_test(uint32_t id, uint64_t dst, uint64_t off
 using namespace prosper;
 
 static int fails = 0;
+// Collapse a loop's worth of identical assertions into one reported line: a per-iteration CHECK
+// would print 200 rows and bury everything else.
+static bool quiet_ok = true;
+#define CHECK_QUIET(cond) do { if (!(cond)) quiet_ok = false; } while (0)
 #define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
                               else        { std::printf("  [ok]   %s\n", msg); } } while (0)
 
@@ -160,6 +164,29 @@ int main() {
         // contract -- the read never happens, the sizing answer is still right -- is asserted above.
         CHECK(measure(0, 0, 0, 0xffffffffffull, 0, 0) == 24,
               "PROSPER_APR_MEASURE_READ=never: the sizing answer is still the contract");
+
+        // ...and the detector must stay SILENT, which is the arm this file was missing. In `never`
+        // every measure records suppressed=true (the read really is skipped) while note_submit
+        // returns at its mode check without marking anything, so the eviction check would fire on
+        // the 65th measure of every run of every title -- blaming a title-specific mixed pattern for
+        // the user's own flag. This arm previously returned after TWO measures, far short of the
+        // 64-entry ring, which is exactly why it did not see that.
+        //
+        // It matters more than an ordinary false positive: `never` is the lever for the open
+        // question this design raises -- whether the compatibility read is needed at all -- so a
+        // warning on every title would make the one experiment the feature exists to enable
+        // uninterpretable. This is the =always "cannot cry wolf" arm, one mode over.
+        constexpr size_t kPastRingWrap = 200;   // >> the 64-entry ring, so many entries are evicted
+        Dest nd;
+        for (size_t i = 0; i < kPastRingWrap; ++i) {
+            nd.poison();
+            measure(id_a, nd.addr(), 32, 1024 + i * 4, 0, 0);
+            CHECK_QUIET(nd.untouched(32));
+        }
+        CHECK(quiet_ok, "PROSPER_APR_MEASURE_READ=never: no measure ever writes its destination");
+        CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
+              "PROSPER_APR_MEASURE_READ=never: the detector cannot cry wolf past the ring wrap");
+
         prosper_apr_reset_for_test();
         std::remove(path_a_storage.c_str());
         std::remove(path_b_storage.c_str());
@@ -252,6 +279,15 @@ int main() {
         // 600 iterations rather than 72 so the run spans many ring wraps and, at a 256-slot table
         // rebuilt whenever it passes half full, several index rebuilds. A rebuild is where a stale
         // idx_pos would bite, and 72 iterations would not have reached one.
+        //
+        // What this arm CANNOT reach, and why that is structural rather than a sampling accident:
+        // it never steps over a tombstone, and no iteration count would change that. Each loop pass
+        // records a key and then immediately looks up the SAME key. Insert places at the first
+        // EMPTY-or-TOMBSTONE from the home bucket while find stops only at EMPTY, so find always
+        // reaches the entry at or before the position insert chose -- a tombstone can never sit
+        // between them. **Zero is the only value this workload can produce**, not a small number
+        // that more iterations would grow. That is why the tombstone path needs the hand-built
+        // collision below: measuring this zero harder would only have confirmed it.
         constexpr size_t kIndexStress = 600;
         CHECK(!prosper_apr_mixed_pattern_warned_for_test(),
               "detector: quiet before any suppressed measure goes unclaimed");
@@ -351,8 +387,17 @@ int main() {
             }
             CHECK(fillers.size() == 63, "probe-collision arm: found 63 non-colliding fillers");
 
-            size_t before = 0, dummy = 0;
-            prosper_apr_index_coverage_for_test(&before, &dummy);
+            // LOAD-BEARING PRECONDITION: no rebuild may intervene between B's insert and B's
+            // lookup. A rebuild re-inserts only the live entries, which clears every tombstone --
+            // including the one this arm exists to probe past -- and would silently turn the whole
+            // arm into a passing no-op. The threshold is `live + tombs > 128`; this arm reaches
+            // 64 live + 2 tombs = 66, so there are ~62 records of headroom. That is comfortable
+            // today and invisible if someone later shrinks the table, grows the ring, or lowers the
+            // threshold, so the rebuild counter is asserted unchanged across the window rather than
+            // left to a comment. This is the same class the arm itself guards: a silent degradation
+            // that changes no return value.
+            size_t before = 0, rebuilds_before = 0;
+            prosper_apr_index_coverage_for_test(&before, &rebuilds_before);
 
             // A: recorded and submitted, so its eviction cannot itself trip the detector.
             measure(id, dst, kSize, off_a, 0, 0);
@@ -365,12 +410,15 @@ int main() {
                 read_file_guest(cb, 0, record, id, dst, kSize, fillers[i], 0, 0);
             }
 
-            size_t after = 0;
-            prosper_apr_index_coverage_for_test(&after, &dummy);
+            size_t after = 0, rebuilds_mid = 0;
+            prosper_apr_index_coverage_for_test(&after, &rebuilds_mid);
             // Now the load-bearing lookup: B is live, its chain starts at the tombstoned bucket.
             read_file_guest(cb, 0, record, id, dst, kSize, off_b, 0, 0);
-            size_t after_lookup = 0;
-            prosper_apr_index_coverage_for_test(&after_lookup, &dummy);
+            size_t after_lookup = 0, rebuilds_after = 0;
+            prosper_apr_index_coverage_for_test(&after_lookup, &rebuilds_after);
+            CHECK(rebuilds_before == rebuilds_after,
+                  "probe-collision arm: no rebuild intervened, so the tombstone it probes past "
+                  "really was still there (the arm is not a no-op)");
 
             char msg[256];
             if (forced_always) {

--- a/prosper/tests/hle/test_apr_measure_duplicate.cpp
+++ b/prosper/tests/hle/test_apr_measure_duplicate.cpp
@@ -1,0 +1,209 @@
+// test_apr_measure_duplicate — sceAmprMeasureCommandSizeReadFile's compatibility read (#3245).
+//
+// That call's firmware contract is pure sizing (20, or 24 for a wide file offset). prosper also
+// performs the described read, because DOLL's older SDK wrapper consumes the destination from the
+// measure and never records a ReadFile for it. The read used to fire for EVERY title whose file id
+// resolved, so a title that also submits the read normally paid for the same bytes twice — 13,925
+// duplicate reads and 582 MB in a 3-minute Stray boot — and got them written into its destination
+// before it had recorded the command.
+//
+// The two arms this has to keep apart cannot be told apart AT the measure call: both pass a valid
+// id, a real destination and a real size. What separates them is what happens next, so that is what
+// the suppression keys on, and that is what the cases below drive:
+//
+//   * DOLL:  measure -> (the guest consumes dst) -> no submit of that read.   Must still deliver.
+//   * Stray: measure -> submit of the IDENTICAL read.                          Redundant from then on.
+//
+// Every delivery assertion pre-poisons the destination with a byte the fixture cannot produce at
+// that offset, so "the callee wrote nothing" and "the callee wrote the right thing" are distinct
+// observations rather than both reading as zero.
+//
+// Registered TWICE in CMake: once by default and once with PROSPER_APR_MEASURE_READ=always. The
+// second run asserts the OPPOSITE outcome for the Stray case, which is what shows the lever moved —
+// a suppression that never suppressed would pass the always-run and fail the default one.
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "fixtures/test_scratch.h"
+#include "host/image/exec_image.hpp"
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+
+namespace prosper {
+uint32_t prosper_apr_register(const std::string& path, uint64_t size);
+void prosper_apr_reset_for_test();
+}
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { std::printf("  [ok]   %s\n", msg); } } while (0)
+
+// The plain ReadFile takes its file offset in a stack slot, so it is entered the way the guest
+// enters it. sysv_abi is a no-op on Linux and forces the guest convention on MinGW.
+using GuestReadFile = uint64_t(__attribute__((sysv_abi)) *)(uint64_t, uint64_t, uint64_t, uint64_t,
+                                                            uint64_t, uint64_t, uint64_t, uint64_t,
+                                                            uint64_t);
+
+static std::array<uint8_t, 4096> g_fixture{};
+
+// One destination per case, always poisoned before use.
+struct Dest {
+    std::array<uint8_t, 1024> bytes{};
+    void poison() { bytes.fill(0x5A); }
+    uint64_t addr() { return (uint64_t)(uintptr_t)bytes.data(); }
+    bool holds(size_t offset, size_t size) const {
+        return std::memcmp(bytes.data(), g_fixture.data() + offset, size) == 0;
+    }
+    bool untouched(size_t size) const {
+        for (size_t i = 0; i < size; ++i) if (bytes[i] != 0x5A) return false;
+        return true;
+    }
+};
+
+int main() {
+    const char* mode_env = std::getenv("PROSPER_APR_MEASURE_READ");
+    const bool forced_always = mode_env && std::strcmp(mode_env, "always") == 0;
+    std::printf("== test_apr_measure_duplicate (PROSPER_APR_MEASURE_READ=%s) ==\n",
+                mode_env ? mode_env : "<unset, auto>");
+    register_builtin_hle();
+
+    HleFn measure = Hle::lookup("vWU-odnS+fU");
+    CHECK(measure != nullptr, "sceAmprMeasureCommandSizeReadFile is registered");
+    if (!measure) { std::printf("== FAIL ==\n"); return 1; }
+
+    // ---- Fixtures: two distinct containers, so the per-container scoping can be exercised -------
+    const std::string path_a_storage =
+        prosper_test::test_scratch_file("prosper-test-apr-measure-dup-a.tmp");
+    const std::string path_b_storage =
+        prosper_test::test_scratch_file("prosper-test-apr-measure-dup-b.tmp");
+    for (size_t i = 0; i < g_fixture.size(); ++i) g_fixture[i] = (uint8_t)(i * 61u + 17u);
+    bool written = true;
+    for (const std::string& p : { path_a_storage, path_b_storage }) {
+        FILE* f = std::fopen(p.c_str(), "wb");
+        if (!f) { written = false; continue; }
+        written = std::fwrite(g_fixture.data(), 1, g_fixture.size(), f) == g_fixture.size() &&
+                  std::fclose(f) == 0 && written;
+    }
+    CHECK(written, "wrote both APR container fixtures");
+
+    std::string stub_error;
+    const std::vector<ImportSlot> slots = {{"libSceAmpr", "mQ16-QdKv7k"}};
+    CHECK(install_stubs(slots, 0x720000000ull, 96, &stub_error) && stub_error.empty(),
+          "generated the executable AMPR ReadFile import stub");
+    auto read_file_guest = reinterpret_cast<GuestReadFile>(static_cast<uintptr_t>(stub_addr(0)));
+
+    prosper_apr_reset_for_test();
+    const uint32_t id_a = prosper_apr_register(path_a_storage, g_fixture.size());
+    const uint32_t id_b = prosper_apr_register(path_b_storage, g_fixture.size());
+    CHECK(id_a != 0 && id_b != 0 && id_a != id_b, "registered two distinct APR containers");
+
+    std::array<uint8_t, 0x48> request{};
+    const uint64_t cb = (uint64_t)(uintptr_t)request.data();
+    std::array<uint64_t, 3> completion{};
+    const uint64_t record = (uint64_t)(uintptr_t)completion.data();
+
+    // ---- The sizing answer is the contract, and it never changes ------------------------------
+    CHECK(measure(0, 0, 0, 0xffffffffull, 0, 0) == 20,
+          "an unregistered sizing query stays pure and answers 20 bytes");
+    CHECK(measure(0, 0, 0, 0xffffffffffull, 0, 0) == 24,
+          "a wide file offset answers 24 bytes");
+
+    // ---- DOLL arm: a measure with no following submit still delivers ---------------------------
+    // Driven twice. The second call is the one that matters: if the suppression latched on anything
+    // other than an actual submit pairing, this is where DOLL breaks.
+    constexpr size_t doll_off = 64, doll_size = 96;
+    Dest doll1, doll2;
+    doll1.poison();
+    CHECK(measure(id_a, doll1.addr(), doll_size, doll_off, 0, 0) == 20 &&
+              doll1.holds(doll_off, doll_size),
+          "DOLL arm: a measure with no submit delivers the container's bytes");
+    doll2.poison();
+    CHECK(measure(id_a, doll2.addr(), doll_size, doll_off + 128, 0, 0) == 20 &&
+              doll2.holds(doll_off + 128, doll_size),
+          "DOLL arm: a SECOND unsubmitted measure still delivers (no spurious latch)");
+
+    // ---- A submit that does NOT match the measured read must not latch either -------------------
+    // Same container, same destination, a different range. If the pairing were keyed loosely -- on
+    // the file id alone, say -- this would retire the compatibility read and the next arm would
+    // read as a pass for the wrong reason.
+    {
+        constexpr size_t m_off = 512, m_size = 64;
+        Dest near_miss;
+        near_miss.poison();
+        CHECK(measure(id_a, near_miss.addr(), m_size, m_off, 0, 0) == 20 &&
+                  near_miss.holds(m_off, m_size),
+              "near-miss arm: the measure delivered");
+        // Submit the same destination and size at a DIFFERENT offset.
+        CHECK(read_file_guest(cb, 0, record, id_a, near_miss.addr(), m_size, m_off + 8, 0, 0) == 0,
+              "near-miss arm: a submit of a different range succeeds");
+        Dest after;
+        after.poison();
+        CHECK(measure(id_a, after.addr(), m_size, m_off + 256, 0, 0) == 20 &&
+                  after.holds(m_off + 256, m_size),
+              "near-miss arm: a non-identical submit does NOT retire the compatibility read");
+    }
+
+    // ---- Stray arm: measure, then the IDENTICAL submit, retires the compatibility read ----------
+    constexpr size_t stray_off = 1024, stray_size = 200;
+    {
+        Dest first;
+        first.poison();
+        CHECK(measure(id_a, first.addr(), stray_size, stray_off, 0, 0) == 20 &&
+                  first.holds(stray_off, stray_size),
+              "Stray arm: the first measure delivers (the one duplicate this costs)");
+        CHECK(read_file_guest(cb, 0, record, id_a, first.addr(), stray_size, stray_off, 0, 0) == 0,
+              "Stray arm: the identical submit re-delivers the same bytes");
+    }
+    {
+        // A NEW read on the same container, measured after the pairing was observed.
+        Dest later;
+        later.poison();
+        const uint64_t measured = measure(id_a, later.addr(), stray_size, stray_off + 512, 0, 0);
+        CHECK(measured == 20, "Stray arm: the sizing answer is unchanged by the suppression");
+        if (forced_always) {
+            CHECK(later.holds(stray_off + 512, stray_size),
+                  "Stray arm under PROSPER_APR_MEASURE_READ=always: the read still fires");
+        } else {
+            CHECK(later.untouched(stray_size),
+                  "Stray arm: the compatibility read is suppressed once the container has paired");
+        }
+        // Whatever the mode, the submit path is untouched and remains the real delivery.
+        CHECK(read_file_guest(cb, 0, record, id_a, later.addr(), stray_size, stray_off + 512, 0,
+                              0) == 0 && later.holds(stray_off + 512, stray_size),
+              "Stray arm: the submit delivers the bytes the measure no longer does");
+    }
+
+    // ---- Scoping: the suppression is per container, not global ---------------------------------
+    {
+        Dest other;
+        other.poison();
+        CHECK(measure(id_b, other.addr(), doll_size, doll_off, 0, 0) == 20 &&
+                  other.holds(doll_off, doll_size),
+              "a DIFFERENT container keeps its compatibility read after the first one paired");
+    }
+
+    // ---- The test hook really does clear the latch ----------------------------------------------
+    // Without this, a later case in this process would inherit id_a's pairing, and the arms above
+    // would be order-dependent in a way nothing would report.
+    prosper_apr_reset_for_test();
+    {
+        const uint32_t id_again = prosper_apr_register(path_a_storage, g_fixture.size());
+        Dest reset_dest;
+        reset_dest.poison();
+        CHECK(measure(id_again, reset_dest.addr(), doll_size, doll_off, 0, 0) == 20 &&
+                  reset_dest.holds(doll_off, doll_size),
+              "prosper_apr_reset_for_test clears the pairing latch as well as the registry");
+    }
+
+    prosper_apr_reset_for_test();
+    std::remove(path_a_storage.c_str());
+    std::remove(path_b_storage.c_str());
+    std::printf("== %s ==\n", fails ? "FAIL" : "PASS");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## What

`sceAmprMeasureCommandSizeReadFile`'s compatibility read fired for **every** APR title, so every streamed asset was read and DMA'd into the guest twice. Fixes #3245.

## Failure scenario

That NID's firmware contract is pure **sizing** — it answers 20, or 24 when the file offset needs its high 32 bits. prosper *also* performs the described read and DMAs it into the guest destination, deliberately: *Dragon Quest VII Reimagined*'s (`PPSA17942`) older SDK wrapper consumes that destination and never records a `ReadFile` command for it, so the measure is prosper's only hook on those bytes (`docs/UE4_APR_IOSTORE_BRINGUP.md`).

That requirement is real. The gate around it was not — it was only *"does the file id resolve"*.

Measured on *Stray* (`PPSA02101`), `PROSPER_NULL_PAGE=1`, no input, `tools/screenshot`, ~180 s, `PROSPER_FILELOG=1` (from #3245):

| | |
| --- | --- |
| `measure-read compatibility … OK` | **13,925** |
| `read-submit … OK` | 14,255 |
| bytes delivered by the measure path | **582,619,946** |
| bytes delivered by the submit path | 603,329,577 |

Every measure was paired with a submit of the same `dst`/`off`/`size` moments later — roughly **97% of the measure-path bytes re-delivered** — so the boot paid for ~583 MB of extra host reads, ~583 MB of extra `process_vm_writev`, and one extra `mmap`/`munmap` per read.

**The cost is the smaller half.** A sizing call that fills the destination puts bytes there *before the guest has recorded the read command*, let alone submitted it. On Stray that window is microseconds on one thread, so nothing observable goes wrong. On a title that measures a batch of reads and prepares the destinations afterwards, prosper's bytes would land first and the guest would then overwrite data the hardware would have delivered later. That is a silent-corruption shape, not a slowdown. It also perturbs every instrument on the streaming path — `PROSPER_ZEROWATCH`, `PROSPER_APR_VERIFY`, the dmem write trace all see each destination written twice.

## The contract asserted

**Nothing at the measure call distinguishes the two titles.** DOLL and Stray both pass a valid id, a real destination and a real size. What separates them is visible immediately *afterwards*, so that is what this keys on:

> When a submit arrives for exactly the `(file id, dst, offset, size)` a measure just served, that container records and submits its measured reads — so the compatibility read was redundant, and is retired for that container.

This is **self-calibrating**: it costs exactly one duplicate per APR file id and then turns itself off, and needs no per-title and no per-SDK knowledge.

### Correction — DOLL is NOT exempt, and the change is still right

The first version of this PR said in three places that the heuristic *"cannot fire for DOLL, whose measured reads are never submitted through the ReadFile NID"*. **That is false, and DOLL's own boot logs say so.** Independent review found it; I reproduced the replay myself over four `PROSPER_FILELOG` boots, implementing the predicate exactly as the code does (64-entry ring, record only on a delivered measure, match on `(id, dst, offset, requested)`):

| DOLL run | measures | pairs at | suppressed | **measures with no identical submit** |
| --- | --- | --- | --- | --- |
| run1 | 1,254 | submit #13 | 1,253 | **0** |
| run2 | 1,255 | submit #13 | 1,254 | **0** |
| run3 | 1,725 | submit #13 | 1,724 | **0** |
| run4 | 1,732 | submit #13 | 1,731 | **0** |

Hand-verified at the cited lines of `run1` — `measure-read compatibility id=6 … dst=0x3002860000 off=0x7adec90a size=1080890 OK` at line 648, and `read-submit id=6 … dst=0x3002860000(guest) off=0x7adec90a size=1080890 got=1080890 OK` at line 704, with the raw `descsz=0x107e3a` = 1,080,890 in between.

**So the mechanism by which DOLL is safe is the opposite of the one asserted.** DOLL is not a consume-from-the-measure title; it is a *submits-everything-it-measures* title — exactly the case this suppression is designed for. When the heuristic fires on it, it is right. Stray replays identically (id=1 pairs at submit #4, 13,922 of 13,923 suppressed, **0 unmatched** across three logs — which also reproduces this issue's headline 13,925/14,255 figure independently at 13,923/14,253).

**The consequence, stated rather than buried:** the documented reason this compatibility read exists — an older SDK wrapper consuming the destination while prosper does not execute the encoded commands — **is no longer visible in DOLL's traffic.** prosper serves the `ReadFile` submit eagerly now, and DOLL does submit. Whether the read is needed *at all* is what `PROSPER_APR_MEASURE_READ=never` tests. Removing it is not this PR's job; not re-asserting a premise its own evidence contradicts is.

Keyed **per APR file id** rather than globally, so a title with a mixed pattern loses the read only for the container that demonstrated the pairing. `PROSPER_APR_MEASURE_READ=auto|always|never` (default `auto`) is the one-variable A/B lever.

### One thing not to do, recorded because it is the obvious move

#3245 suggests *"only when the same (id, offset, size, dst) has not just been served"*. Taken as an order-agnostic duplicate filter that is **backwards**: on Stray the measure comes **first** and the submit is the authoritative delivery, so such a filter suppresses the wrong half. The pairing is used here purely as *evidence* that the container submits what it measures — never to skip a submit.

## Deliberately unaffected

* **The sizing answer.** Still 20 or 24 in every case, including when the read is suppressed. An I/O outcome never becomes an allocation size.
* **The pure unregistered-id query** (Sonic's sizing calls) — unchanged.
* **The submit path's own delivery** — never suppressed, never reordered, never skipped. It remains the authoritative read.
* **A measure with no following submit still delivers, always** — the consume-from-the-measure pattern. (This bullet used to name DOLL; per the correction above, DOLL is not that pattern. The guarantee is about the mechanism, not the title.)
* Windows and POSIX take the same path; the suppression is host-independent.

## Risks

The one case this heuristic would get wrong is a title that, **within a single container**, both submits some measured reads and consumes others from the measure without submitting. Seven logs across two titles now show **0 unmatched measures**, so the pattern is not merely unobserved — it has been looked for. Two titles is still not the corpus.

**That case is now DETECTED, not merely feared** (review suggestion, taken). The suppression's *decision* was already loud; its *consequence* would have been silent, because the suppressed-measure log line sits behind `filelog()` — so a mixed-pattern title would just get an unwritten destination and no message. `PROSPER_APR_MEASURE_READ=always` is a recovery, not a detector: it only helps someone who already suspects this.

So recording now **continues after a container pairs** (the read is skipped; only the bookkeeping stays), each ring entry carries whether a submit later claimed it, and an entry that leaves the ring **suppressed and never matched** warns once, loudly, naming the container, the lost range and the lever. Nothing else produces that signature: a pre-pairing entry ages out unmatched routinely and is not marked suppressed, and a suppressed entry a submit claimed is the designed case. Cost is a 64-entry compare per submit — ~900k integer comparisons across a 3-minute Stray boot, against the 583 MB of file I/O removed. Known blind spot, stated in the code: up to 64 entries are still in the ring at exit and are never adjudicated.

Confidence: **HIGH** on the duplication and on suppression being safe for a title whose measured reads are submitted — which now includes DOLL and Stray *by replay*. **MED** that no title mixes both patterns in one container, since a log replay cannot see whether a title depends on the bytes arriving at *measure* time rather than *submit* time.

## Verification

Container `ps5ys`, Linux, exact head `b7ede68b1` on `origin/main` `49ec3e354`.

```
cmake -S prosper -B prosper/build-linux            # CONFIGURE_RC=0
cmake --build prosper/build-linux -j6              # BUILD_RC=0
cd prosper/build-linux && ctest --no-tests=error   # CTEST_RC=0
```

| run | tests | result | exit |
| --- | --- | --- | --- |
| `origin/main` baseline (measured here, at `e13fd40af`) | 344 | 100% passed | 0 |
| this branch, exact head | **348** | **100% passed** | **0** |

(`origin/main` moved to `49ec3e354` mid-session, bringing 2 tests of its own; 348 = 346 + this PR's 2. The same 346 falls out independently from #2926's branch — 347 there with 1 new test.)

### Mutation arms — demonstrated by exit code

The test is registered **twice**: once by default and once under `PROSPER_APR_MEASURE_READ=always`, where it asserts the **opposite** outcome for the Stray case. A suppression that never suppressed cannot pass both.

**Arm 1 — suppression disabled** (`if (false && apr_measure_read_suppressed(...))`, then restored):

```
default mode              ->  exit 1
  [FAIL] Stray arm: the compatibility read is suppressed once the container has paired
PROSPER_APR_MEASURE_READ=always  ->  exit 0     (unchanged, as it must be)
```

**Arm 2 — suppression made unconditional**, i.e. the actual DOLL risk (`return true`, then restored):

```
default mode              ->  exit 1
  [FAIL] DOLL arm: a measure with no submit delivers the container's bytes
  [FAIL] DOLL arm: a SECOND unsubmitted measure still delivers (no spurious latch)
  [FAIL] near-miss arm: the measure delivered
  [FAIL] near-miss arm: a non-identical submit does NOT retire the compatibility read
  [FAIL] Stray arm: the first measure delivers (the one duplicate this costs)
  [FAIL] a DIFFERENT container keeps its compatibility read after the first one paired
  [FAIL] prosper_apr_reset_for_test clears the pairing latch as well as the registry
```

So the test brackets the change on **both** sides: too little suppression and too much.

### Review round 2 — new arms

- The **"DOLL arm" is renamed** to the *unsubmitted-measure arm*. It models "a measure with no submit", which is now known not to be DOLL; it is a fine mechanism arm and should not carry title-level authority it has not earned. The file header is corrected likewise.
- **Two detector arms.** Arm A: after pairing, 72 suppressed measures that ARE each submitted → must stay **quiet** (a detector that cries wolf on the designed case is one nobody reads). Arm B: 72 suppressed measures never submitted → must **warn**.
- **The detector arm caught a flaw in itself, which is worth reporting.** Under `PROSPER_APR_MEASURE_READ=always` the first version of arm B failed — correctly: nothing is suppressed in that mode, so no measure can be lost and the detector *must* stay silent. The arm now inverts under `=always` and asserts the detector **cannot false-positive**, which is a better arm than the one I wrote.
- **A third CMake registration under `PROSPER_APR_MEASURE_READ=never`**, the one branch nothing previously executed.

### Why the new test is not vacuous

Every delivery assertion **pre-poisons the destination with `0x5A`**, a byte the fixture cannot produce at that offset, so "the callee wrote nothing" and "the callee wrote the right thing" are distinct observations rather than both reading as zero. The **near-miss arm** is the one that stops the pairing from being keyed too loosely: a submit on the same container and the same destination at a *different offset* must **not** retire the read — without it, a pairing keyed on the file id alone would pass every other arm. A **second container** arm pins the per-container scoping, and a **reset arm** pins that the test hook clears the latch, so the arms are not silently order-dependent.

## Ruled out

One row added to `docs/UE4_APR_IOSTORE_BRINGUP.md` § Ruled out — *"the compatibility read is DOLL-specific in effect, because only DOLL needs it"*, with the Stray measurement and the order-agnostic-filter warning. The doc's 2026-07-26 SOLVED section, which stated the read fires for any registered id, is narrowed in place rather than left to contradict the code.

Snapshots: not run — this changes no rendering path.

Note for the merge order: this branch and #3262 both append to the same `## Ruled out` section, so whichever merges second needs a trivial text rebase.

### Verification of the corrected head `ec69ad72d`

The local box is currently unusable for builds: several concurrent lanes have podman's database
locked (`Error: beginning transaction: database is locked` on every `distrobox enter` and every
`podman exec`, for over an hour), so I could not run the local rebuild + full ctest at this exact
head. **I am not quoting numbers I did not measure.** What I can state:

* the pre-correction head's local run is unchanged and quoted above;
* the corrections carrying the falsified DOLL claim, the renamed arm, and the new detector were each built and run locally *before* the lock set in, and their
  results are reported in this body with the arms named;
* **CI is the exact-head signal for this commit** — it builds and runs the full ctest on Linux,
  Windows MinGW and macOS on clean runners, which is a stronger check than my contended box.

A local retry is running and I will post the local counts to this PR if it clears.

## Round 3 — the O(1) index (`ecbbddea4`)

`apr_measure_note_submit` had no early-out after the detector landed, because marking every entry is
what the detector needs — so it linear-scanned all 64 ring slots under the mutex on **every** submit
(14,255 of them in a 3-minute Stray boot). Replaced with an open-addressed
`(id, dst, offset, size)` index over the same 64 slots: **O(1) expected lookup, every entry still
marked, detection unchanged.** The sampling alternative for the measure-side lock is deliberately
*not* taken — a detector that only sometimes detects is the wrong trade when detection is why this
design is acceptable at all.

Design notes: the encoding (`0` empty, `-1` tombstone, `n>0` slot `n-1`) needs no dynamic
initialisation, so the table is correct from static zero-init. Each ring slot remembers where the
index points at it, so eviction is O(1) rather than a search. The table is 4x the ring (live load
≤ 0.25) and is rebuilt from the live ring when occupancy would pass half — at least 64 inserts
apart, so under 4 amortised steps per insert against the 64 per submit it replaces.

### The tests needed more than a count, and the first version of them was blind

An open-addressed lookup fails by **finding nothing for a key that is present** — a bad hash, a
probe chain terminated early at a tombstone, a stale slot pointer after a rebuild. None of those
throws, and after pairing none of them changes a return value anything checks: a missed lookup just
silently stops marking entries. Three arms now bracket it:

| mutation (applied, then restored) | result |
| --- | --- |
| lookup always returns "not found" | **exit 1** — `Stray arm: … suppressed once the container has paired`, `detector: warns when a suppressed measure is never submitted` |
| **tombstone terminates the probe chain** (the classic open-addressing bug) | **exit 1** — `probe-collision arm: B was FOUND behind the tombstone, not lost silently` |
| rebuild drops its live entries | **exit 1** — `detector quiet + index found every key across many wraps and rebuilds` |

**The middle one is the one worth reading, because my first attempt at the test did not catch it.**
I raised the stress arm to 600 iterations expecting it to cover the tombstone path, added coverage
counters to check, and got **6 rebuilds but 0 tombstone steps**. That zero is real rather than an
instrument artefact: 64 live keys in a 256-slot table means ordinary traffic almost never crosses a
deleted entry. So the tombstone mutation *passed* against the stress arm alone — a silent
degradation, exactly the class this PR exists to catch, sailing through a test that looked thorough.

Per `CLAUDE.md`'s rule for a clean zero, I constructed one positive instance **by hand, outside
whatever produced the null**: a bucket seam lets the test find two keys sharing a home bucket, place
the second behind the first, age the first out of the ring to leave a tombstone in front of it, and
then look the second up. Coverage across that arm reads `tomb steps 0 -> 0 -> 1`, incrementing at
exactly the load-bearing lookup, and the mutation now fails on it.

The stress arm's coverage assertion was narrowed to what it actually proves (`rebuilds > 0`) rather
than left claiming a path it never reached.

### `=always` is a control, and the test now says so

Under `PROSPER_APR_MEASURE_READ=always` the index is never consulted — `note_submit` returns at its
mode check *before* taking the lock. The test asserts that rather than skipping the arm, because it
is the same early return that makes the `=always` arm a valid control for this change in an A/B.

### Verification

Exact head `ecbbddea4`, container `ps5ys`, Linux:

```
cmake --build prosper/build-linux -j6            # BUILD_RC=0
ctest --no-tests=error                           # CTEST_RC=0
100% tests passed out of 349
179/349 apr_measure_duplicate ........... Passed
180/349 apr_measure_duplicate_forced .... Passed
181/349 apr_measure_duplicate_never ..... Passed
```

349 unchanged from the previous head — the new arms are assertions inside the existing three cases,
not new ctest cases. All three modes also run directly: exit 0 / 0 / 0.

## Round 4 — the `never` false positive (`6a8594e74`), and a rebase onto merged #3262

**The detector was a guaranteed false positive under `PROSPER_APR_MEASURE_READ=never`, on every run of every title.** `apr_measure_read_suppressed` returns true for `Never`, so every measure recorded `suppressed=true`; `apr_measure_note_submit` returns at its own mode check *before* the lock, so nothing was ever marked; the eviction check therefore fired on the **65th measure** and printed a message blaming a title-specific mixed pattern and asking the user to report the title — when the cause was their own flag.

This is the `=always` "cannot cry wolf" argument one mode over, and I had already made it there. `always` was safe only by the coincidence that it never sets `suppressed=true` at all; relying on that coincidence is how `never` was missed. **The warning is now gated on the detector's actual premise** — "a submit should have claimed this entry", which is a property of Auto alone — rather than on the symptom.

It matters more than an ordinary false positive: **`never` is the lever for the open question this PR raises** (is the compatibility read needed at all?), so a warning on every title landed precisely on the one experiment the feature exists to enable.

The `never` test arm missed it because it returned after **two** measures, far short of the 64-entry ring. It now drives **200**, well past the wrap.

### Mutation arm — targeted, and it reproduces the shipped defect exactly

Removing the Auto gate, then restoring:

```
PROSPER_APR_MEASURE_READ=<unset,auto>   EXIT=0
PROSPER_APR_MEASURE_READ=always         EXIT=0
PROSPER_APR_MEASURE_READ=never          EXIT=1
  [FAIL] PROSPER_APR_MEASURE_READ=never: the detector cannot cry wolf past the ring wrap
```

One false warning emitted in the mutated `never` run, zero in the fixed one. Only `never` moves, which is the confirmation that the defect was `never`-only.

### Three review notes taken

- **The probe-collision arm's hidden precondition is now asserted, not commented.** No rebuild may intervene between B's insert and B's lookup — a rebuild re-inserts only live entries, clearing the very tombstone the arm probes past and silently turning it into a passing no-op. Threshold is `live + tombs > 128`; the arm reaches 66, so headroom is ~62 records. A later change to the ring size or the threshold would break the arm invisibly, which is the same silent-degradation class the arm exists to catch — so it is a `CHECK`, not a comment.
- **The stress arm's zero tombstone steps is structural, not sampled.** Each pass records a key then immediately looks up the same key; insert places at the first empty-or-tombstone while find stops only at empty, so find always reaches the entry at or before insert's position and a tombstone can never sit between them. **Zero is the only value that workload can produce** — which is why the hand-built collision is the only route to the path, and why measuring the zero harder would only have confirmed it.
- **`static_assert`s** pin the index encodings that fail silently: `slot+1` fitting `int16_t`, the table being a power of two for mask probing, and the table being at least twice the ring.

Duplicate keys are noted rather than deduplicated — two live slots with the same tuple would leave one unmatched and warn. **Latent, not live:** 5,966 measured reads across four DOLL boots produced 5,966 distinct tuples and **0** duplicates. Deduplicating would mean deciding which of two identical pending reads a single submit satisfies, and nothing observed poses that question.

### Rebase

Rebased onto `origin/main` with #3262 merged. Both conflicts (`prosper/CMakeLists.txt`, `docs/UE4_APR_IOSTORE_BRINGUP.md`) were additive at the same anchor and resolved by keeping both blocks, hand-merged rather than taking either file whole (trap 41); `git diff origin/main` shows no deletion of any #3262 line.

### Verification at `6a8594e74`

Local, container `ps5ys`, Linux — build exit 0, **ctest exit 0, `100% tests passed out of 351`**, run against a build confirmed converged (two further `cmake --build` invocations do zero work and the binary sha is unchanged). CI: **9 SUCCESS, 2 SKIPPED, 0 failed**; Linux `349/349` with `apr_gather_scatter`, `apr_measure_duplicate`, `_forced` and `_never` all passing by name.

### On the performance A/B — two series, not one

The coordinator's three valid rounds are on **`ecbbddea4`**, which is **not** the head that will merge:

```
ecbbddea4   auto-r1 306   always-r1 304   auto-r2 328    submit failures: 0 of 3
```

against 2 of 5 `auto` runs before the index. Any six-round result on **`6a8594e74`** is a **separate series** and should be reported as one — these numbers must not be read as a single run of alternating arms. That conflation is the exact error this PR's review history already contains once, and it would be a poor thing to repeat here.

Fixes #3245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
