### PR TITLE
windows: a variadic HLE handler gets the guest's own frame, not a signature (#3246)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2193,6 +2193,16 @@ if(TARGET prosper_core)
   target_link_libraries(test_sysv_ms_bridge PRIVATE prosper_core)
   add_test(NAME sysv_ms_bridge COMMAND test_sysv_ms_bridge)
 
+  # #3246: the one argument list #2955's CallSignature cannot describe — a real C variadic, whose
+  # shape the format string decides at run time. CROSS-PLATFORM for the same reason as the bridge
+  # above, and then some: reading a guest System V va_list and writing a Microsoft one are pure
+  # functions, and BOTH conventions' va_arg are available on any x86-64 host through
+  # __builtin_sysv_va_list / __builtin_ms_va_list — so the round trip is executed against the
+  # compiler's own readers here, and against the real CRT on Windows.
+  add_executable(test_guest_varargs tests/host/abi/test_guest_varargs.cpp)
+  target_link_libraries(test_guest_varargs PRIVATE prosper_core)
+  add_test(NAME guest_varargs COMMAND test_guest_varargs)
+
   # sceImeUpdate must invoke the guest key handler on the CALLER's guest %fs, not the host %fs the
   # import stub swapped in (#1286: Evergate SIGSEGV at eboot+0xaf8431 on a key press). Drives the real
   # import path on an activated guest TCB; a no-op pass off Linux.

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -605,11 +605,18 @@ edge cases are tracked separately in #697.
 3. ~~**Validate/repair the guest→HLE ABI trampoline for XMM/float args.**~~ Done (#2955). The bridge
    is signature-driven: `src/host/abi/` carries the two placement tables and emits the trampoline
    from the handler's own C++ declaration, which `Hle::register_typed` preserves. A handler with no
-   float still gets the historical fixed integer shuffle, byte for byte. `printf`-family handlers are
-   deliberately NOT converted — they are real host variadics, reached by the same fixed path as
-   before, and a variadic Microsoft x64 call additionally wants each FP argument duplicated into the
-   integer register. That is #3246, open and unmeasured; a `CallSignature` cannot describe it at all,
-   because the argument list is whatever the format string says at run time.
+   float still gets the historical fixed integer shuffle, byte for byte.
+   ~~The `printf` family is deliberately NOT converted.~~ Done too (#3246), by a different route,
+   because a `CallSignature` genuinely cannot describe a list the format string decides at run time.
+   Those handlers are now tagged `PROSPER_GUEST_ABI` — really `__attribute__((sysv_abi))` on Windows
+   — and their import stub is the same bare tail-jump Linux uses, so the compiler's own System V
+   variadic prologue captures the guest's frame. `src/host/abi/guest_varargs.cpp` then reads that
+   list by the System V rules and writes the flat 8-byte-slot array that IS a Microsoft `va_list`,
+   which sidesteps the FP-duplication rule rather than trying to satisfy it in registers.
+   The attribute route being "abandoned" (above) still holds for the 537 STL-using handlers: MinGW
+   cannot emit SEH unwind data for a `sysv_abi` frame, so it only works where the frame can be kept
+   free of unwind cleanups. Three tiny capture-and-delegate shims can be; a library of handlers
+   cannot.
 4. **VEH recovery hardening for genuine stack-overflow faults.** #633 added a tested assembly recovery
    entry with valid Microsoft-x64 shadow space/alignment, but a truly exhausted guest stack still needs
    a guard-page/dedicated-stack story (Linux uses `sigaltstack`).
@@ -618,12 +625,46 @@ edge cases are tracked separately in #697.
    NIDs — the `libSceFont` scale/slant/weight/render group and the whole libm bank plus
    `strtod`/`strtof` in `hle_libc.cpp` — and those now register through `Hle::register_typed`. The
    remaining cast targets pass and return integers and pointers, which both conventions place
-   identically. What is still unaudited is the *other* half of the original question: whether a cast
-   target's argument COUNT exceeds ten, which the fixed path silently truncates. #3246 carries it.
+   identically.
+   ~~What is still unaudited is the *other* half of the original question: whether a cast target's
+   argument COUNT exceeds ten, which the fixed path silently truncates.~~ Audited for #3246, and the
+   answer is negative: no registered handler declares more than ten arguments. Handlers are written
+   through per-file `HLE`/`HLE7`/`HLE8`/`HLE9`/`HLE10` macros whose widest member is exactly ten (12
+   uses of `HLE10`; there is no `HLE11`), and the only hand-written wide declarations reach nine.
+   `abi::kLegacyForwardedArgs` records the prologue's capacity beside the emitter that implements it.
+   The audit is a source census, so it goes stale the day someone writes an `HLE11` — the surviving
+   truncation risk is that edit, not anything in the tree today.
 
 ### Ruled out — the Windows import trampoline's floating-point arguments
 
-One line per falsified hypothesis, per `CLAUDE.md`. The mechanism and the fix are #2955.
+One line per falsified hypothesis, per `CLAUDE.md`. The mechanism and the fix are #2955, with the
+variadic half in #3246.
+
+- **"The `v*` forms take a `va_list` POINTER and are not affected — they copy the guest's list
+  wholesale."** False on Windows, and it was #3246's own opening claim. A Windows `va_list` is a bare
+  `char*`, so `memcpy(&ap, guest_ptr, sizeof(va_list))` copies **eight** bytes of a **twenty-four**
+  byte System V structure and then reads its `{gp_offset, fp_offset}` pair as a pointer. That is not
+  a wholesale copy, it is a type confusion, and it applied to `vsnprintf`, `vsprintf` and `vsscanf`
+  on every Windows boot. Fixed by the same repacking path as the real variadics; the Linux arms are
+  untouched, where the copy really is wholesale and correct.
+- **"`sscanf` is affected."** False, and it is the one row of #3246's affected table that does not
+  hold. Every variadic argument a scanf-family call passes is a POINTER, so the list is all-integer,
+  no floating-point duplication is required, and System V's integer registers map one-for-one onto
+  Microsoft's first ten argument positions — which is exactly what the historical shuffle already
+  delivers. `h_sscanf` is deliberately left on that path rather than converted for symmetry. The cap
+  that remains is the shuffle's ten arguments, recorded rather than fixed.
+- **"A variadic Microsoft x64 call needs each FP argument duplicated into the integer register, so
+  the fix must emit that duplication."** True of the rule and false of the fix. The duplication only
+  matters to code that FORWARDS a variadic call in registers; prosper does not have to. Reading the
+  guest's System V list and writing a Microsoft `va_list` image directly means no register ever
+  carries a variadic floating-point argument on the host side, and the rule never applies.
+- **"`__attribute__((sysv_abi))` cannot be used on a Windows handler at all."** Too strong, though
+  the shape it came from is real. Measured on MinGW GCC 16.1.1 (2026-09-02): a `sysv_abi` variadic
+  function assembles and runs correctly under wine — *unless* its frame needs an unwind cleanup, in
+  which case the assembler rejects `.seh_handlerdata used outside of .seh_proc block`. And that is an
+  **inlining** decision, so the same source compiled at `-O0` and `-O2` and failed at `-O1`, where a
+  throwing callee was inlined into the tagged frame. So the attribute is usable exactly where the
+  frame can be kept cleanup-free, which is why the variadic shims capture and delegate immediately.
 
 - **"Only four handlers are affected, all in `src/hle/util/hle_font.cpp`; nothing else in 700+
   registered NIDs declares a float parameter."** False — that was #2955's own opening census, and it

--- a/prosper/src/hle/audio/hle_audio.cpp
+++ b/prosper/src/hle/audio/hle_audio.cpp
@@ -5,6 +5,7 @@
 // prosper_core stays dependency-free; a concrete output frontend (SDL3, ...) installs itself via
 // audio_set_sink() from outside the core.
 #include "hle/dispatch/dispatch.hpp"
+#include "host/abi/sysv_ms_bridge.hpp"   // #3246: kLegacyForwardedArgs, the fixed prologue's capacity
 #include "host/image/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "hle/dispatch/nid.hpp"
 #include "hle/audio/audio.hpp"
@@ -50,6 +51,13 @@ namespace prosper {
 #define HLE10(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6, \
                                        uint64_t a7, uint64_t a8, uint64_t a9)
+// HLE10 is the WIDEST handler shape in the tree, and that is a fact the Windows import stub depends
+// on: its fixed integer prologue forwards exactly `kLegacyForwardedArgs` guest arguments and would
+// silently drop anything beyond them (#3246, where the census was taken). Widening this macro — or
+// adding an HLE11 anywhere — needs the prologue widened first, so the coupling is asserted here
+// rather than left to be rediscovered on a platform nobody develops on.
+static_assert(10 <= prosper::abi::kLegacyForwardedArgs,
+              "HLE10 declares more arguments than the Windows import stub forwards");
 #define P(x) ((void*)(uintptr_t)(x))
 
 namespace {

--- a/prosper/src/hle/dispatch/dispatch.cpp
+++ b/prosper/src/hle/dispatch/dispatch.cpp
@@ -20,6 +20,7 @@ namespace {
         bool placeholder = false;
         HleReturnHook return_hook = nullptr;
         abi::CallSignature signature{};   // #2955: only ever set for a float/double-bearing handler
+        bool guest_abi = false;           // #3246: handler compiled in the guest's own convention
     };
     std::unordered_map<std::string, Reg>& registry() {
         static std::unordered_map<std::string, Reg> r; return r;
@@ -105,7 +106,7 @@ void Hle::register_fn(const std::string& nid, HleFn fn, const char* name,
     // A re-registration with the SAME fn (harmless dedup) is not recorded.
     if (it != reg.end() && it->second.fn != fn && !it->second.placeholder)
         shadow_list().push_back({ nid, it->second.name, name ? name : "" });
-    reg[nid] = { fn, name ? name : "", false, return_hook, {} };
+    reg[nid] = { fn, name ? name : "", false, return_hook, {}, false };
 }
 void Hle::register_fn_with_signature(const std::string& nid, HleFn fn, const char* name,
                                      const abi::CallSignature& signature,
@@ -121,6 +122,18 @@ void Hle::register_fn_with_signature(const std::string& nid, HleFn fn, const cha
     // an overwrite is already the #330 shadow class and is recorded above.
     if (signature.needs_conversion()) registry()[nid].signature = signature;
 }
+void Hle::register_guest_abi_fn(const std::string& nid, HleFn fn, const char* name) {
+    register_fn(nid, fn, name);
+    // Set AFTER register_fn, which rewrites the whole entry. As with a declared signature, a later
+    // plain register_fn on the same NID drops the flag along with the handler it described — the safe
+    // direction, since an unknown handler is then reached through the converting bridge rather than
+    // through a tail-jump that would hand it the guest's frame raw.
+    registry()[nid].guest_abi = true;
+}
+bool Hle::guest_abi_nid(const std::string& nid) {
+    auto it = registry().find(nid);
+    return it != registry().end() && it->second.guest_abi;
+}
 abi::CallSignature Hle::signature_of_nid(const std::string& nid) {
     auto it = registry().find(nid);
     return it == registry().end() ? abi::CallSignature{} : it->second.signature;
@@ -133,7 +146,7 @@ void Hle::register_placeholder(const std::string& nid, HleFn fn, const char* nam
     auto it = reg.find(nid);
     if (it != reg.end() && it->second.fn != fn && !it->second.placeholder)
         shadow_list().push_back({ nid, it->second.name, name ? name : "" });
-    reg[nid] = { fn, name ? name : "", true, nullptr, {} };
+    reg[nid] = { fn, name ? name : "", true, nullptr, {}, false };
 }
 const std::vector<ShadowedReg>& Hle::shadowed_registrations() { return shadow_list(); }
 std::vector<RegisteredFn> Hle::registrations() {
@@ -141,7 +154,7 @@ std::vector<RegisteredFn> Hle::registrations() {
     out.reserve(registry().size());
     for (const auto& kv : registry())
         out.push_back({ kv.first, kv.second.name, (const void*)kv.second.fn, kv.second.placeholder,
-                        kv.second.signature });
+                        kv.second.signature, kv.second.guest_abi });
     return out;
 }
 HleFn Hle::lookup(const std::string& nid) {

--- a/prosper/src/hle/dispatch/dispatch.hpp
+++ b/prosper/src/hle/dispatch/dispatch.hpp
@@ -120,6 +120,13 @@ public:
     // parameter type carries PROSPER_GUEST_ABI, so on Windows an untagged handler is a compile
     // error rather than a stub that silently reads the wrong registers — the tag and the
     // registration cannot drift apart. `A...` is the fixed prefix; the `...` is the real ellipsis.
+    //
+    // ANY DIRECT CALLER MUST USE A PROSPER_GUEST_ABI POINTER TYPE. `Hle::lookup` hands back a bare
+    // address, and calling one of these through an ordinary host-ABI function pointer places the
+    // arguments by the wrong convention — on Windows the first `%s` then dereferences whatever
+    // landed in rdi. Not hypothetical: `test_printf` and `test_guest_log_capture` did exactly that
+    // and SEGFAULTed on the Windows MinGW job the moment these handlers were tagged, and passed
+    // everywhere else. `HleFn` is the wrong type for one of these too.
     template <class R, class... A>
     static void register_guest_abi(const std::string& nid, PROSPER_GUEST_ABI R (*fn)(A..., ...),
                                    const char* name) {

--- a/prosper/src/hle/dispatch/dispatch.hpp
+++ b/prosper/src/hle/dispatch/dispatch.hpp
@@ -35,6 +35,33 @@ namespace prosper {
 // marker of the boundary in case a future toolchain makes the attribute viable.
 #define PROSPER_SYSV_ABI
 
+// A handler compiled in the GUEST's convention rather than the host's. On Windows that really is
+// `__attribute__((sysv_abi))`; everywhere else the host ABI already is the guest's and it expands to
+// nothing. The import stub for such a handler is the same bare tail-jump Linux uses, so the guest's
+// frame arrives intact.
+//
+// This is NOT a reversal of the note above. Tagging the ~537 STL-using handlers was tried and
+// abandoned, and the reason is a hard constraint that still applies: **MinGW cannot emit SEH unwind
+// data for a sysv_abi function**, so a frame that needs an unwind cleanup fails to assemble with
+// `.seh_handlerdata used outside of .seh_proc block`. Reproduced 2026-09-02 on MinGW GCC 16.1.1, and
+// it is optimization-dependent — the same source assembles at `-O0`/`-O2` and fails at `-O1`, where
+// a throwing callee gets inlined into the tagged frame.
+//
+// So the tag is for handlers that can be kept trivially cleanup-free, and the rule is mechanical:
+// **a PROSPER_GUEST_ABI function must own no object with a destructor and must call nothing that can
+// be inlined into it carrying one.** Capture what the guest passed, hand it to an ordinary
+// `noinline` host function, return. Everything interesting happens in that callee, in the host ABI,
+// where the compiler is free again.
+//
+// What it buys, and why the escape hatch exists at all: a REAL C VARIADIC cannot be described by a
+// `CallSignature`, because its argument list is whatever the format string says at run time (#3246).
+// The only thing that can capture it is the compiler's own System V variadic prologue.
+#if defined(_WIN32) && (defined(__x86_64__) || defined(_M_X64))
+#define PROSPER_GUEST_ABI __attribute__((sysv_abi))
+#else
+#define PROSPER_GUEST_ABI
+#endif
+
 // Cached diagnostic-flag reads for HOT paths (PROSPER_ENV_ON / PROSPER_ENV_VALUE) moved to
 // diagnostics/env_cache.hpp: the renderer backend and the draw executor need them too, and
 // should not have to include the HLE dispatch registry to ask whether a switch is on. Included
@@ -66,6 +93,7 @@ struct RegisteredFn {
     const void* fn = nullptr; // handler address; equal addresses = Sony entry points that collapse
     bool placeholder = false; // registered as a deliberately-overridable tracing thunk
     abi::CallSignature signature{};  // #2955: declared only where a float/double is involved
+    bool guest_abi = false;   // #3246: PROSPER_GUEST_ABI handler; the Windows stub converts nothing
 };
 
 // Registry of implemented functions, keyed by NID.
@@ -88,6 +116,19 @@ public:
     static void  register_fn_with_signature(const std::string& nid, HleFn fn, const char* name,
                                             const abi::CallSignature& signature,
                                             HleReturnHook return_hook = nullptr);
+    // Register a REAL C VARIADIC (or any other handler compiled in the guest's own convention). The
+    // parameter type carries PROSPER_GUEST_ABI, so on Windows an untagged handler is a compile
+    // error rather than a stub that silently reads the wrong registers — the tag and the
+    // registration cannot drift apart. `A...` is the fixed prefix; the `...` is the real ellipsis.
+    template <class R, class... A>
+    static void register_guest_abi(const std::string& nid, PROSPER_GUEST_ABI R (*fn)(A..., ...),
+                                   const char* name) {
+        register_guest_abi_fn(nid, reinterpret_cast<HleFn>(fn), name);
+    }
+    static void  register_guest_abi_fn(const std::string& nid, HleFn fn, const char* name);
+    // Whether the handler for a NID is compiled in the guest's convention. The Windows import stub
+    // consults this and emits a bare tail-jump; every other platform emits one regardless.
+    static bool  guest_abi_nid(const std::string& nid);
     // The declared signature for a NID, or a default-constructed (undeclared) one. The Windows
     // import stub consults this; every other platform's host ABI already matches the guest's.
     static abi::CallSignature signature_of_nid(const std::string& nid);

--- a/prosper/src/hle/libc/hle_libc.cpp
+++ b/prosper/src/hle/libc/hle_libc.cpp
@@ -3,6 +3,7 @@
 // host C library. Registered by NID so the loader binds imports directly to them.
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/dispatch/nid.hpp"
+#include "host/abi/guest_varargs.hpp"   // #3246: the guest's variadic list, re-expressed for the host
 #include "gpu/timeline/gpu_timeline.hpp"
 #include <cstring>
 #include <cstdlib>
@@ -457,7 +458,86 @@ HLE(h_strspn)   { return (uint64_t)strspn(CS(a0), CS(a1)); }
 HLE(h_strcspn)  { return (uint64_t)strcspn(CS(a0), CS(a1)); }
 HLE(h_strpbrk)  { return (uint64_t)(uintptr_t)strpbrk(CS(a0), CS(a1)); }
 HLE(h_wcslen)   { return (uint64_t)wcslen((const wchar_t*)P(a0)); }   // host wchar_t is 32-bit == PS5/FreeBSD ABI
-HLE(h_vsscanf)  { va_list ap; if (a2) memcpy(&ap, P(a2), sizeof(va_list)); return (uint64_t)(int64_t)vsscanf(CS(a0), CS(a1), ap); }
+// --- variadic calls across the guest/host ABI boundary (#3246) ---------------------------------
+//
+// On Linux and macOS the host convention IS the guest's: the import stub tail-jumps with the guest's
+// System V frame intact, the compiler's own variadic prologue captures it, and a guest `va_list`
+// pointer can be copied straight into a host one. Nothing in this block runs there.
+//
+// On Windows neither half holds, and both failures are silent:
+//   * `va_list` is a bare `char*` walking a flat array of 8-byte slots, so copying `sizeof(va_list)`
+//     bytes out of a guest list copies EIGHT bytes of a TWENTY-FOUR byte System V structure and then
+//     reads its {gp_offset, fp_offset} pair as a pointer. That is what the v* handlers below did.
+//   * a Microsoft variadic call additionally wants every floating-point argument duplicated into the
+//     corresponding INTEGER register, which the fixed import shuffle never did — so `%f` arrived as
+//     whatever happened to be in that register, and, because System V counts integer and SSE
+//     arguments separately, every argument BEHIND the float was displaced as well.
+//
+// One answer serves both: read the guest's System V list by the System V rules, learn each
+// argument's class from the format string, and write the flat slot array that IS a Microsoft
+// `va_list`. host/abi/guest_varargs.cpp owns that; this is the wiring.
+namespace {
+int capture_aware_vprintf(const char* format, va_list args);   // defined below, with the log capture
+
+#if defined(_WIN32)
+using prosper::abi::FormatGrammar;
+using prosper::abi::MsVarargCall;
+using prosper::abi::SysvVaList;
+
+// A format the model cannot fully express formats only the prefix it can (MsVarargCall). Say so, a
+// bounded number of times: it is silence that made the defect this replaces invisible for so long.
+void warn_unmodelled_format(const char* fmt, const char* why) {
+    static std::atomic<unsigned> warned{0};
+    if (warned.fetch_add(1, std::memory_order_relaxed) >= 8) return;
+    fprintf(stderr, "[libc] variadic format not fully modelled (%s); formatted its leading part "
+                    "only: \"%s\"\n", why ? why : "?", fmt ? fmt : "(null)");
+}
+
+enum class WinVariadicSink { Printf, Sprintf, Snprintf, Sscanf };
+
+// Everything the PROSPER_GUEST_ABI shims must not do in their own frames. `noinline` and `noexcept`
+// are load-bearing rather than decorative: a guest-ABI frame cannot carry SEH unwind data, so an
+// inlined callee owning a destructor — or a call that may throw — makes the function fail to
+// assemble (`.seh_handlerdata used outside of .seh_proc block`). See PROSPER_GUEST_ABI in
+// dispatch.hpp. Keeping every C++ object on this side of the call is the whole discipline.
+__attribute__((noinline))
+uint64_t win_variadic_call(WinVariadicSink sink, void* buf, size_t n, const char* src,
+                           const char* fmt, const SysvVaList& ap, bool run_checkpoint) noexcept {
+    const bool scanf_like = sink == WinVariadicSink::Sscanf;
+    MsVarargCall call(fmt, ap, scanf_like ? FormatGrammar::Scanf : FormatGrammar::Printf);
+    if (!call.complete()) warn_unmodelled_format(fmt, call.reject());
+    va_list host_ap = (va_list)(char*)call.va_list_image();
+    int r = 0;
+    switch (sink) {
+    case WinVariadicSink::Printf:   r = capture_aware_vprintf(call.format(), host_ap); break;
+    case WinVariadicSink::Sprintf:  r = vsprintf((char*)buf, call.format(), host_ap); break;
+    case WinVariadicSink::Snprintf: r = vsnprintf((char*)buf, n, call.format(), host_ap); break;
+    case WinVariadicSink::Sscanf:   r = vsscanf(src, call.format(), host_ap); break;
+    }
+    // A guest-ABI handler is reached by a bare tail-jump, so the import stub's pending-guest-exception
+    // checkpoint never runs for it. Make the poll here instead, keeping the contract every other
+    // import return has. The v* handlers keep the converting stub and its checkpoint, and pass false.
+    if (run_checkpoint) dispatch_pending_guest_exception();
+    return (uint64_t)(int64_t)r;
+}
+
+// A guest `va_list*`, read as the System V structure it actually is.
+SysvVaList guest_va_list_at(uint64_t guest_ptr) {
+    SysvVaList ap{};
+    if (guest_ptr) memcpy(&ap, (const void*)(uintptr_t)guest_ptr, sizeof ap);
+    return ap;
+}
+#endif  // _WIN32
+} // namespace
+
+HLE(h_vsscanf)  {
+#if defined(_WIN32)
+    return win_variadic_call(WinVariadicSink::Sscanf, nullptr, 0, CS(a0), CS(a1),
+                             guest_va_list_at(a2), /*run_checkpoint=*/false);
+#else
+    va_list ap; if (a2) memcpy(&ap, P(a2), sizeof(va_list)); return (uint64_t)(int64_t)vsscanf(CS(a0), CS(a1), ap);
+#endif
+}
 // _init_env / malloc_stats_fast: legitimately no-ops here (no PS5 process env vars; no malloc stats
 // sink). Registered so they resolve as real, intentional no-ops rather than logged "unimplemented".
 HLE(h_init_env)         { return 0; }
@@ -514,28 +594,22 @@ static double m_expm1(double x){return expm1(x);} static float m_expm1f(float x)
 static double m_strtod(const char* s, char** e){ return strtod(s, e); }
 static float  m_strtof(const char* s, char** e){ return strtof(s, e); }
 
-HLE(h_vsnprintf) { va_list ap; if (a3) memcpy(&ap, P(a3), sizeof(va_list)); return (uint64_t)(int64_t)vsnprintf((char*)P(a0), (size_t)a1, (const char*)P(a2), ap); }
-HLE(h_vsprintf)  { va_list ap; if (a2) memcpy(&ap, P(a2), sizeof(va_list)); return (uint64_t)(int64_t)vsprintf((char*)P(a0), (const char*)P(a1), ap); }
-// Variadic forms: REAL C variadic functions, not the old 3-int-register forward (which dropped
-// %f/XMM args, all stack args, and %s past the 4th argument -> garbage output or a SIGSEGV on a
-// bogus %s pointer). The import stub TAIL-JUMPS into these with the guest's SysV call frame intact
-// (GP regs + XMM + AL + overflow stack), so the compiler-generated variadic prologue captures the
-// full argument set and va_start/v*printf format it correctly. Guest pointers are identity-mapped
-// (guest VA == host VA), so the buffer, format string, and any %s arguments are usable host
-// pointers directly — no P() translation needed (the tail-jump passes the raw guest values).
-// CONFIDENCE: HIGH for register + XMM args (the overwhelmingly common case, correct on both the
-// tail-jmp and GUEST_FS swap-stub paths). MED only for args that spill to the STACK (>6 GP or
-// >8 FP) under the GUEST_FS swap stub, whose reframing shifts the overflow area — rare for a
-// format call, and still strictly better than the old register-only truncation.
-static uint64_t h_snprintf(void* buf, size_t n, const char* fmt, ...) {
-    va_list ap; va_start(ap, fmt); int r = vsnprintf((char*)buf, n, fmt, ap); va_end(ap);
-    return (uint64_t)(int64_t)r;
+HLE(h_vsnprintf) {
+#if defined(_WIN32)
+    return win_variadic_call(WinVariadicSink::Snprintf, P(a0), (size_t)a1, nullptr,
+                             (const char*)P(a2), guest_va_list_at(a3), /*run_checkpoint=*/false);
+#else
+    va_list ap; if (a3) memcpy(&ap, P(a3), sizeof(va_list)); return (uint64_t)(int64_t)vsnprintf((char*)P(a0), (size_t)a1, (const char*)P(a2), ap);
+#endif
 }
-static uint64_t h_sprintf(void* buf, const char* fmt, ...) {
-    va_list ap; va_start(ap, fmt); int r = vsprintf((char*)buf, fmt, ap); va_end(ap);
-    return (uint64_t)(int64_t)r;
+HLE(h_vsprintf)  {
+#if defined(_WIN32)
+    return win_variadic_call(WinVariadicSink::Sprintf, P(a0), 0, nullptr,
+                             (const char*)P(a1), guest_va_list_at(a2), /*run_checkpoint=*/false);
+#else
+    va_list ap; if (a2) memcpy(&ap, P(a2), sizeof(va_list)); return (uint64_t)(int64_t)vsprintf((char*)P(a0), (const char*)P(a1), ap);
+#endif
 }
-
 namespace {
 // A %n conversion writes through a guest pointer while formatting. The capture adapter must never
 // evaluate it speculatively, so conservatively leave such calls on the original one-pass vprintf path.
@@ -603,14 +677,75 @@ void observe_guest_c_string(const char* text, bool known_newline,
 }
 } // namespace
 
-static uint64_t h_printf(const char* fmt, ...) {
+// The printf family: REAL C variadic functions, and PROSPER_GUEST_ABI so the import stub is the same
+// bare tail-jump on EVERY platform. That is what puts the guest's own System V frame — integer
+// registers, xmm registers, AL and the overflow area alike — in front of the compiler's variadic
+// prologue, which is the only thing that can capture an argument list the format string decides at
+// run time. On Linux and macOS this is exactly what already happened and the tag expands to nothing;
+// on Windows it replaces a fixed integer shuffle that could not deliver a floating-point argument at
+// all and displaced every argument behind one (#3246).
+//
+// Guest pointers are identity-mapped (guest VA == host VA), so the buffer, the format string and any
+// %s argument are usable host pointers directly — no P() translation, because nothing re-places the
+// guest's values on the way in.
+//
+// Each body is deliberately trivial, and that is a REQUIREMENT rather than a style: a guest-ABI frame
+// cannot carry SEH unwind data on Windows, so it may own no object with a destructor and must call
+// nothing that could be inlined into it carrying one (PROSPER_GUEST_ABI in dispatch.hpp). Capture,
+// delegate, return.
+//
+// CONFIDENCE: HIGH on Linux/macOS, where this is the long-standing behaviour and the tag is empty.
+// HIGH on the Windows mechanism as well — the shape below was assembled by MinGW GCC 16.1.1 at every
+// optimization level and executed under wine, delivering a twelve-argument mixed call including
+// System V overflow-area integers and five xmm doubles (#3246). What is NOT verified is a live guest
+// calling it on a Windows host; nobody here has one.
+static PROSPER_GUEST_ABI uint64_t h_snprintf(void* buf, size_t n, const char* fmt, ...) {
+#if defined(_WIN32)
+    __builtin_sysv_va_list ap; __builtin_sysv_va_start(ap, fmt);
+    prosper::abi::SysvVaList captured; memcpy(&captured, &ap, sizeof captured);
+    __builtin_sysv_va_end(ap);
+    return win_variadic_call(WinVariadicSink::Snprintf, buf, n, nullptr, fmt, captured,
+                             /*run_checkpoint=*/true);
+#else
+    va_list ap; va_start(ap, fmt); int r = vsnprintf((char*)buf, n, fmt, ap); va_end(ap);
+    return (uint64_t)(int64_t)r;
+#endif
+}
+static PROSPER_GUEST_ABI uint64_t h_sprintf(void* buf, const char* fmt, ...) {
+#if defined(_WIN32)
+    __builtin_sysv_va_list ap; __builtin_sysv_va_start(ap, fmt);
+    prosper::abi::SysvVaList captured; memcpy(&captured, &ap, sizeof captured);
+    __builtin_sysv_va_end(ap);
+    return win_variadic_call(WinVariadicSink::Sprintf, buf, 0, nullptr, fmt, captured,
+                             /*run_checkpoint=*/true);
+#else
+    va_list ap; va_start(ap, fmt); int r = vsprintf((char*)buf, fmt, ap); va_end(ap);
+    return (uint64_t)(int64_t)r;
+#endif
+}
+static PROSPER_GUEST_ABI uint64_t h_printf(const char* fmt, ...) {
+#if defined(_WIN32)
+    __builtin_sysv_va_list ap; __builtin_sysv_va_start(ap, fmt);
+    prosper::abi::SysvVaList captured; memcpy(&captured, &ap, sizeof captured);
+    __builtin_sysv_va_end(ap);
+    return win_variadic_call(WinVariadicSink::Printf, nullptr, 0, nullptr, fmt, captured,
+                             /*run_checkpoint=*/true);
+#else
     va_list ap; va_start(ap, fmt); int r = capture_aware_vprintf(fmt, ap); va_end(ap);
     return (uint64_t)(int64_t)r;
+#endif
 }
-// sscanf: a REAL variadic host thunk (like the *printf family) — the import stub tail-jumps with the
-// guest's full SysV frame so va_start captures every arg. Output pointer args are guest pointers
-// (identity-mapped), so vsscanf writes through them directly. MISSING before -> returned 0 leaving ALL
-// output args uninitialized (the guest consumed uninit memory as parsed values).
+// sscanf: a REAL variadic host thunk, and deliberately NOT guest-ABI — the one member of the family
+// #3246's affected table lists that turns out not to be affected. Every variadic argument a
+// scanf-family call passes is a POINTER, so the list is all-integer, no floating-point duplication is
+// required, and System V's integer registers map one-for-one onto Microsoft's first ten argument
+// positions — which is precisely what the historical shuffle already delivers. Leaving it there keeps
+// a correct path unchanged rather than routing it through a new one for symmetry.
+//
+// The cap that remains is the shuffle's: it forwards ten arguments, so an eleventh assignment would
+// be dropped on Windows. Recorded rather than fixed, because fixing it would change a working path.
+// MISSING before -> returned 0 leaving ALL output args uninitialized (the guest consumed uninit
+// memory as parsed values).
 static uint64_t h_sscanf(const char* s, const char* fmt, ...) {
     va_list ap; va_start(ap, fmt); int r = vsscanf(s, fmt, ap); va_end(ap);
     return (uint64_t)(int64_t)r;
@@ -826,6 +961,10 @@ void register_builtin_hle() {
     // whose signature mentions float or double; R is correct for everything else, and for an
     // integer-only signature the two are equivalent by construction.
     #define RT(str, fn) Hle::register_typed(nid_hash(str), fn, str)
+    // RV registers a REAL C VARIADIC. Its parameter type carries PROSPER_GUEST_ABI, so on Windows a
+    // handler that forgot the tag is a compile error rather than a stub reading the wrong registers;
+    // the emitted stub then converts nothing and the guest's own variadic frame arrives intact (#3246).
+    #define RV(str, fn) Hle::register_guest_abi(nid_hash(str), fn, str)
     // libSceLibcInternalExt heap-trace hookup (raw NID — guaranteed match; see handler comment).
     Hle::register_fn("NWtTN10cJzE", (HleFn)h_heap_get_trace_info, "sceLibcHeapGetTraceInfo");
     R("memcpy", h_memcpy);   R("memmove", h_memmove); R("memset", h_memset);
@@ -858,9 +997,9 @@ void register_builtin_hle() {
     R("_ZdlPvRKSt9nothrow_t", h_delete); R("_ZdaPvRKSt9nothrow_t", h_delete);
     // stdio
     R("vsnprintf", h_vsnprintf); R("vsprintf", h_vsprintf);
-    R("snprintf", h_snprintf);   R("sprintf", h_sprintf);   R("snprintf_s", h_snprintf);
-    R("sprintf_s", h_snprintf);   // Annex-K sprintf_s(s, n, fmt, ...) has a size arg -> bounded snprintf, NOT sprintf
-    R("printf", h_printf);       R("puts", h_puts);
+    RV("snprintf", h_snprintf);  RV("sprintf", h_sprintf);  RV("snprintf_s", h_snprintf);
+    RV("sprintf_s", h_snprintf);  // Annex-K sprintf_s(s, n, fmt, ...) has a size arg -> bounded snprintf, NOT sprintf
+    RV("printf", h_printf);      R("puts", h_puts);
     R("putchar", h_putchar);     R("fputs", h_fputs);
     // locale / ctype
     R("_Getpctype", h_getpctype); R("_Getptolower", h_getptolow); R("_Getptoupper", h_getptoup);
@@ -908,6 +1047,7 @@ void register_builtin_hle() {
     RT("sinh", m_sinh); RT("sinhf", m_sinhf); RT("cosh", m_cosh); RT("coshf", m_coshf);
     RT("tanh", m_tanh); RT("tanhf", m_tanhf); RT("log1p", m_log1p); RT("log1pf", m_log1pf);
     RT("expm1", m_expm1); RT("expm1f", m_expm1f);
+    #undef RV
     #undef RT
     #undef R
     register_file_hle();     // file I/O (stdio + POSIX, /app0 translation)

--- a/prosper/src/hle/libc/hle_libc.cpp
+++ b/prosper/src/hle/libc/hle_libc.cpp
@@ -694,11 +694,28 @@ void observe_guest_c_string(const char* text, bool known_newline,
 // nothing that could be inlined into it carrying one (PROSPER_GUEST_ABI in dispatch.hpp). Capture,
 // delegate, return.
 //
-// CONFIDENCE: HIGH on Linux/macOS, where this is the long-standing behaviour and the tag is empty.
-// HIGH on the Windows mechanism as well — the shape below was assembled by MinGW GCC 16.1.1 at every
-// optimization level and executed under wine, delivering a twelve-argument mixed call including
-// System V overflow-area integers and five xmm doubles (#3246). What is NOT verified is a live guest
-// calling it on a Windows host; nobody here has one.
+// THE ONE CAVEAT, and it is on LINUX rather than on the new path. When guest %fs TLS is on — which is
+// the DEFAULT (`guest_tls.cpp` opts out only through PROSPER_NO_GUEST_FS) — the import stub is not a
+// tail-jump at all but the swap stub, which interposes a CALL so it can restore the guest's %fs
+// afterwards. To keep the callee's stack arguments where SysV puts them it re-pushes the guest's
+// spilled words... and it re-pushes exactly FOUR of them (`emit_swap_stub`, exec_image_linux.cpp:
+// "push original arg10/9/8/7"). Immediately behind those sits the stub's saved r11, then the guest's
+// return address, then a shifted duplicate of the same four words.
+//
+// So a variadic call whose overflow area holds a FIFTH word reads the stub's saved r11 as that
+// argument, and everything after it is wrong too. Reaching it needs more than six integer-class or
+// more than eight floating-point variadic arguments — rare for a format call, and unchanged by this
+// commit, which is why it is recorded rather than fixed here (#3271). It is NOT a Windows problem: there the
+// guest-ABI stub really is a bare tail-jump with no interposed frame, so the overflow area arrives
+// whole. macOS never emits the swap stub either (`stub_swap_mode()` returns false there).
+//
+// CONFIDENCE: HIGH on Linux/macOS for register and xmm arguments, which is the overwhelmingly common
+// case and the long-standing behaviour with the tag empty; MED for Linux stack-spilled arguments past
+// the fourth, per the paragraph above. HIGH on the Windows mechanism — the shape below was assembled
+// by MinGW GCC 16.1.1 at every optimization level and executed under wine, delivering a
+// twelve-argument mixed call including System V overflow-area integers and five xmm doubles, and the
+// whole suite runs on the Windows MinGW CI host (#3246). What is NOT verified is a live guest calling
+// it on a Windows host; nobody here has one.
 static PROSPER_GUEST_ABI uint64_t h_snprintf(void* buf, size_t n, const char* fmt, ...) {
 #if defined(_WIN32)
     __builtin_sysv_va_list ap; __builtin_sysv_va_start(ap, fmt);

--- a/prosper/src/host/abi/AGENTS.md
+++ b/prosper/src/host/abi/AGENTS.md
@@ -5,7 +5,7 @@ macOS it is SysV too, so a guest call lands on an HLE handler with nothing in be
 Windows it is **Microsoft x64**, and every argument has to be moved before the handler can read it.
 This folder owns that translation, and only that translation.
 
-Two files, one for each half of the problem:
+Three files. Two are the fixed-signature half of the problem:
 
 - `call_signature.hpp` — *what a handler's arguments are*. A `CallSignature` records which argument
   positions are floating-point and whether the return is, deduced from the handler's own C++
@@ -16,6 +16,27 @@ Two files, one for each half of the problem:
 - `sysv_ms_bridge.hpp/.cpp` — *where those arguments go*. The two placement tables, and the machine
   code that moves a guest SysV call frame into a Microsoft x64 one. Compiled everywhere, installed
   only by `host/image/exec_image_win.cpp`.
+
+The third is the shape a signature cannot reach:
+
+- `guest_varargs.hpp/.cpp` — *a variadic call*. A real C variadic's argument list is whatever the
+  format string says at run time, so no compile-time `CallSignature` describes it (#3246). This
+  reads the guest's System V `va_list` by the System V rules, learns each argument's class from the
+  format string, and writes the flat array of 8-byte slots that IS a Microsoft `va_list`. The
+  handler is then tagged `PROSPER_GUEST_ABI` (`hle/dispatch/dispatch.hpp`) and reached by a bare
+  tail-jump, so the compiler's own variadic prologue captures the frame — including the overflow
+  area, which nothing else here can see. `emit_guest_abi_tailjump` is those stub bytes.
+
+  Two constraints govern any work in this file, and both are cheap to violate:
+  - **A `PROSPER_GUEST_ABI` frame may own no object with a destructor**, and must call nothing that
+    could be inlined into it carrying one. MinGW cannot emit SEH unwind data for a `sysv_abi`
+    function, so a cleanup landing pad makes the file fail to assemble — and whether one appears is
+    an *inlining* decision, so the same source can build at `-O0` and `-O2` and fail at `-O1`.
+    Capture, delegate to a `noinline`/`noexcept` host function, return.
+  - **A System V `va_list` dies with the frame it came from.** It points into the caller's outgoing
+    argument area and into the callee's own register save area, so everything must be read while the
+    variadic function is still on the stack. Deferring the read to "just after" is the failure this
+    file's test found in its own first draft.
 
 **The boundary against its siblings.** `host/x86` is instruction encoding and decoding for the
 fault handlers and the SSE4a patcher — bytes, with no opinion about arguments. `host/image` maps
@@ -30,4 +51,14 @@ file from its type. So a single float in the middle of a signature displaces eve
 as well, and a translation that handles "float arguments" by adding xmm moves to a positional
 integer shuffle is still wrong (#2955). Any change here should be checked against
 `tests/host/abi/test_sysv_ms_bridge.cpp`, which asserts the placement tables directly and then
-*executes* the emitted trampoline across a matrix of signatures on any x86-64 host.
+*executes* the emitted trampoline across a matrix of signatures on any x86-64 host, and against
+`tests/host/abi/test_guest_varargs.cpp`, which does the same for the variadic path — both
+conventions' `va_arg` are reachable from any x86-64 host through `__builtin_sysv_va_list` and
+`__builtin_ms_va_list`, so the round trip is checked against the *compiler's* readers rather than
+against this folder's belief about the layouts.
+
+**What no test here can reach is a live guest on a Windows host.** The next best thing is committed
+as `tools/probe_win_varargs.cpp`, which is not part of the build: it cross-compiles these production
+sources with MinGW and runs them under wine, so the CRT, the ABI and the stub bytes are real. Its
+header carries the command. Run it at several `-O` levels — the SEH constraint above is
+optimization-dependent, so one level passing says little about the others.

--- a/prosper/src/host/abi/guest_varargs.cpp
+++ b/prosper/src/host/abi/guest_varargs.cpp
@@ -6,9 +6,9 @@ namespace prosper::abi {
 namespace {
 
 bool is_digit(char c) { return c >= '0' && c <= '9'; }
-// ' is the SUSv2 thousands-grouping flag; the rest are C's.
+// C's five. NOT the SUSv2 thousands-grouping `'` -- see the subset rule below.
 bool is_printf_flag(char c) {
-    return c == '-' || c == '+' || c == ' ' || c == '#' || c == '0' || c == '\'';
+    return c == '-' || c == '+' || c == ' ' || c == '#' || c == '0';
 }
 bool is_float_conversion(char c) {
     return c == 'e' || c == 'E' || c == 'f' || c == 'F' ||
@@ -26,21 +26,36 @@ bool is_integer_conversion(char c) {
 // would get on hardware, and that is its business — but if THIS walker and the CRT disagree about
 // the same string, the CRT reads a slot the walker never wrote or skips one it did, and every
 // argument behind that point is wrong. That is precisely the failure this file exists to remove,
-// reintroduced one level up. So an extension is accepted only once it has been MEASURED, and
-// anything unmeasured falls through to the refusal path, which truncates rather than desynchronises.
+// reintroduced one level up.
 //
-// Measured 2026-09-03 against the MinGW CRT under wine (tools/probe_win_varargs.cpp's toolchain), by
-// asking whether a trailing sentinel argument still lands where the caller put it:
+// Measured 2026-09-03 against the REAL ucrtbase.dll — loaded directly and called through its
+// exported `__stdio_common_vsprintf`, since UCRT keeps `snprintf` inline in its headers — by asking
+// whether a trailing sentinel argument still lands where the caller put it:
 //
-//   %zu %jd %td %hhd %a %S %C   consume one argument  -> safe to accept
-//   %'d                         consumes one argument -> accepted, but it is the one entry resting
-//                                                        on MinGW's ANSI stdio rather than on
-//                                                        standard C; re-measure if the CRT changes
-//   %qd                         prints "%qd" LITERALLY and consumes NOTHING -> must be refused
+//   %zu %jd %td %hhd %lld %a %.2f    consume one argument   -> accepted
+//   %'d                              prints "'d" and consumes NOTHING  -> REFUSED
+//   %qd                              prints "qd" and consumes NOTHING  -> REFUSED
 //
-// `q` is therefore absent from the switch below on purpose: a BSD long-long modifier the guest may
-// well emit (332 occurrences across 50 dumps) that the host CRT does not implement. Refusing it
-// costs the tail of one line; accepting it would shift every argument behind it.
+// `q` is a BSD long-long modifier and `'` the SUSv2 thousands-grouping flag; the guest may well emit
+// either (332 and 971 occurrences across the dump corpus). Refusing them costs the tail of one line.
+// Accepting them shifts every argument behind, and a `%s` behind one dereferences a non-pointer.
+//
+// HOW THIS WAS GOT WRONG THE FIRST TIME, because the trap is subtler than the character:
+// `'` was originally KEPT, on a measurement that ran a MinGW probe under wine and saw the argument
+// consumed. That measurement was real and its conclusion was false, because the probe and the
+// shipped build do not resolve `printf` to the same implementation:
+//
+//                        toolchain                __USE_MINGW_ANSI_STDIO   vsnprintf is
+//   the probe            Fedora cross, msvcrt     1                        __mingw_vsnprintf  ('  ok)
+//   CI and shipping      MSYS2 UCRT64             0                        UCRT's own         ('  NOT ok)
+//
+// `_mingw.h:442-454` auto-enables ANSI stdio only while `__MSVCRT_VERSION__ < 0xE00`, and `:229-236`
+// sets exactly 0xE00 on the UCRT branch — so the C++11 clause that rescues the msvcrt build cannot
+// fire on the shipped one, and nothing in CMakeLists.txt or ci.yml defines the escape hatches.
+// THE LESSON IS ABOUT EVIDENCE, NOT ABOUT `'`: "executed on a real Microsoft x64 host" is a strong
+// claim that silently says nothing about anything the two CRTs disagree on. A specifier is accepted
+// here only against the CRT THAT SHIPS, and `test_guest_varargs.cpp` now asks whichever CRT it was
+// built against and fails if this list is not a subset of it.
 
 // Skip a length modifier, reporting whether it was the x87 `L`. `L` matters because a System V
 // `long double` is an 80-bit x87 value passed in MEMORY with 16-byte alignment — neither an integer

--- a/prosper/src/host/abi/guest_varargs.cpp
+++ b/prosper/src/host/abi/guest_varargs.cpp
@@ -21,6 +21,27 @@ bool is_integer_conversion(char c) {
            c == 'c' || c == 'C' || c == 's' || c == 'S' || c == 'p' || c == 'n';
 }
 
+// THE RULE THIS WHOLE FILE OBEYS: what is accepted here must be a SUBSET of what the host CRT
+// consumes an argument for. A guest that lies about its own format string gets the same garbage it
+// would get on hardware, and that is its business — but if THIS walker and the CRT disagree about
+// the same string, the CRT reads a slot the walker never wrote or skips one it did, and every
+// argument behind that point is wrong. That is precisely the failure this file exists to remove,
+// reintroduced one level up. So an extension is accepted only once it has been MEASURED, and
+// anything unmeasured falls through to the refusal path, which truncates rather than desynchronises.
+//
+// Measured 2026-09-03 against the MinGW CRT under wine (tools/probe_win_varargs.cpp's toolchain), by
+// asking whether a trailing sentinel argument still lands where the caller put it:
+//
+//   %zu %jd %td %hhd %a %S %C   consume one argument  -> safe to accept
+//   %'d                         consumes one argument -> accepted, but it is the one entry resting
+//                                                        on MinGW's ANSI stdio rather than on
+//                                                        standard C; re-measure if the CRT changes
+//   %qd                         prints "%qd" LITERALLY and consumes NOTHING -> must be refused
+//
+// `q` is therefore absent from the switch below on purpose: a BSD long-long modifier the guest may
+// well emit (332 occurrences across 50 dumps) that the host CRT does not implement. Refusing it
+// costs the tail of one line; accepting it would shift every argument behind it.
+
 // Skip a length modifier, reporting whether it was the x87 `L`. `L` matters because a System V
 // `long double` is an 80-bit x87 value passed in MEMORY with 16-byte alignment — neither an integer
 // slot nor an SSE one — so a format carrying it is refused rather than mis-read as a double.
@@ -30,7 +51,7 @@ const char* skip_length(const char* p, bool* long_double) {
     case 'h': ++p; if (*p == 'h') ++p; break;
     case 'l': ++p; if (*p == 'l') ++p; break;
     case 'L': *long_double = true; ++p; break;
-    case 'q': case 'j': case 'z': case 't': ++p; break;
+    case 'j': case 'z': case 't': ++p; break;   // NOT 'q' — see the subset rule above
     default: break;
     }
     return p;
@@ -176,12 +197,30 @@ void pack_ms_va_slots(const FormatPlan& plan, SysvVaList ap, uint64_t* slots) {
 
 MsVarargCall::MsVarargCall(const char* fmt, const SysvVaList& ap, FormatGrammar grammar)
     : plan_(plan_format(fmt, grammar)) {
-    pack_ms_va_slots(plan_, ap, slots_);
-    if (plan_.complete) { format_ = fmt; return; }
+    complete_ = plan_.complete;
+    reject_   = plan_.reject;
+    if (plan_.complete) {
+        pack_ms_va_slots(plan_, ap, slots_);
+        format_ = fmt;
+        return;
+    }
+
     size_t keep = plan_.modelled_bytes;
     if (keep >= kMaxPrefixBytes) keep = kMaxPrefixBytes - 1;
     if (keep && fmt) std::memcpy(prefix_, fmt, keep);
     prefix_[keep] = '\0';
+
+    // Re-plan the PREFIX rather than trusting the cap. `modelled_bytes` is always a conversion
+    // boundary, but kMaxPrefixBytes is not, so a long format can be cut in the middle of a `%...`
+    // spec — and the slot count planned for the whole format would then no longer describe the
+    // string actually handed to the CRT. Planning what will really be formatted keeps the two
+    // definitionally in step, and shortens the prefix again when the cut landed inside a conversion.
+    // The prefix's own plan may come back `complete`, since the cut can have removed the very thing
+    // that was refused; the CALLER's verdict stays the original one, which is why it is captured
+    // above rather than read back from here.
+    plan_ = plan_format(prefix_, grammar);
+    prefix_[plan_.modelled_bytes] = '\0';
+    pack_ms_va_slots(plan_, ap, slots_);
     format_ = prefix_;
 }
 

--- a/prosper/src/host/abi/guest_varargs.cpp
+++ b/prosper/src/host/abi/guest_varargs.cpp
@@ -1,0 +1,188 @@
+#include "host/abi/guest_varargs.hpp"
+#include <cstring>
+
+namespace prosper::abi {
+
+namespace {
+
+bool is_digit(char c) { return c >= '0' && c <= '9'; }
+// ' is the SUSv2 thousands-grouping flag; the rest are C's.
+bool is_printf_flag(char c) {
+    return c == '-' || c == '+' || c == ' ' || c == '#' || c == '0' || c == '\'';
+}
+bool is_float_conversion(char c) {
+    return c == 'e' || c == 'E' || c == 'f' || c == 'F' ||
+           c == 'g' || c == 'G' || c == 'a' || c == 'A';
+}
+// Conversions that consume exactly one integer-file slot: an int of some width, a pointer, or a
+// character promoted to int. `S` and `C` are the BSD wide forms, which are still one pointer/int.
+bool is_integer_conversion(char c) {
+    return c == 'd' || c == 'i' || c == 'o' || c == 'u' || c == 'x' || c == 'X' ||
+           c == 'c' || c == 'C' || c == 's' || c == 'S' || c == 'p' || c == 'n';
+}
+
+// Skip a length modifier, reporting whether it was the x87 `L`. `L` matters because a System V
+// `long double` is an 80-bit x87 value passed in MEMORY with 16-byte alignment — neither an integer
+// slot nor an SSE one — so a format carrying it is refused rather than mis-read as a double.
+const char* skip_length(const char* p, bool* long_double) {
+    *long_double = false;
+    switch (*p) {
+    case 'h': ++p; if (*p == 'h') ++p; break;
+    case 'l': ++p; if (*p == 'l') ++p; break;
+    case 'L': *long_double = true; ++p; break;
+    case 'q': case 'j': case 'z': case 't': ++p; break;
+    default: break;
+    }
+    return p;
+}
+
+// A conversion beginning at `p` (just past the '%'): is it a POSIX positional `%2$d`? Those name
+// their argument rather than consuming the next one, so a sequential model would read the wrong
+// slots for every conversion in the string.
+bool is_positional(const char* p) {
+    const char* q = p;
+    while (is_digit(*q)) ++q;
+    return q != p && *q == '$';
+}
+
+} // namespace
+
+uint64_t sysv_va_arg(SysvVaList& ap, VarargClass cls) {
+    uint64_t value = 0;
+    if (cls == VarargClass::Sse) {
+        // An SSE argument occupies a 16-byte slot in the save area but only ever eight meaningful
+        // bytes: a double is the whole slot, and a float was promoted to double by the caller.
+        if (ap.fp_offset + 8 <= kSysvRegSaveEnd) {
+            std::memcpy(&value, (const void*)(uintptr_t)(ap.reg_save_area + ap.fp_offset), 8);
+            ap.fp_offset += 16;
+            return value;
+        }
+    } else if (ap.gp_offset + 8 <= kSysvGpSaveEnd) {
+        std::memcpy(&value, (const void*)(uintptr_t)(ap.reg_save_area + ap.gp_offset), 8);
+        ap.gp_offset += 8;
+        return value;
+    }
+    // Both files spill to the same overflow area, in declaration order, eight bytes each.
+    std::memcpy(&value, (const void*)(uintptr_t)ap.overflow_arg_area, 8);
+    ap.overflow_arg_area += 8;
+    return value;
+}
+
+FormatPlan plan_format(const char* fmt, FormatGrammar grammar) {
+    FormatPlan plan{};
+    if (!fmt) {
+        plan.complete = false;
+        plan.reject = "null format string";
+        return plan;
+    }
+
+    const char* p = fmt;
+    // Refuse everything from `spec` onward, rewinding to the argument count the accepted prefix
+    // consumed: a `*` width pushes its argument before the conversion character is known, so a
+    // half-parsed conversion must not leave that push behind.
+    auto refuse = [&](const char* spec, unsigned accepted_args, const char* why) {
+        plan.count = accepted_args;
+        plan.complete = false;
+        plan.reject = why;
+        plan.modelled_bytes = (size_t)(spec - fmt);
+        return plan;
+    };
+    auto push = [&](VarargClass cls) {
+        if (plan.count >= kMaxFormatArgs) return false;
+        plan.cls[plan.count++] = cls;
+        return true;
+    };
+
+    while (*p) {
+        if (*p != '%') { ++p; continue; }
+        const char* const spec = p;
+        const unsigned before = plan.count;
+        ++p;
+        if (*p == '%') { ++p; continue; }        // a literal percent consumes nothing
+        if (!*p) return refuse(spec, before, "format string ends inside a conversion");
+        if (is_positional(p)) return refuse(spec, before, "POSIX positional conversion (%n$)");
+
+        if (grammar == FormatGrammar::Scanf) {
+            // %[*][width][length]conv, and a scanset. Every conversion that assigns takes a POINTER,
+            // so the class is never in doubt — only whether an argument is consumed at all.
+            const bool suppressed = (*p == '*');
+            if (suppressed) ++p;
+            while (is_digit(*p)) ++p;
+            bool long_double = false;
+            p = skip_length(p, &long_double);
+            if (!*p) return refuse(spec, before, "format string ends inside a conversion");
+            if (*p == '[') {
+                // A scanset: ']' loses its meaning immediately after '[' or "[^".
+                ++p;
+                if (*p == '^') ++p;
+                if (*p == ']') ++p;
+                while (*p && *p != ']') ++p;
+                if (!*p) return refuse(spec, before, "unterminated scanset");
+                ++p;
+            } else if (is_integer_conversion(*p) || is_float_conversion(*p)) {
+                ++p;
+            } else {
+                return refuse(spec, before, "unrecognised scanf conversion");
+            }
+            if (!suppressed && !push(VarargClass::Integer))
+                return refuse(spec, before, "more arguments than the model holds");
+            plan.modelled_bytes = (size_t)(p - fmt);
+            continue;
+        }
+
+        while (is_printf_flag(*p)) ++p;
+        if (*p == '*') {
+            if (!push(VarargClass::Integer)) return refuse(spec, before, "more arguments than the model holds");
+            ++p;
+        } else {
+            while (is_digit(*p)) ++p;
+        }
+        if (*p == '.') {
+            ++p;
+            if (*p == '*') {
+                if (!push(VarargClass::Integer))
+                    return refuse(spec, before, "more arguments than the model holds");
+                ++p;
+            } else {
+                while (is_digit(*p)) ++p;
+            }
+        }
+        bool long_double = false;
+        p = skip_length(p, &long_double);
+        const char conv = *p;
+        if (!conv) return refuse(spec, before, "format string ends inside a conversion");
+        if (is_float_conversion(conv)) {
+            if (long_double) return refuse(spec, before, "x87 long double conversion (%L)");
+            if (!push(VarargClass::Sse)) return refuse(spec, before, "more arguments than the model holds");
+        } else if (is_integer_conversion(conv)) {
+            if (!push(VarargClass::Integer))
+                return refuse(spec, before, "more arguments than the model holds");
+        } else {
+            // Deliberately conservative. An unknown conversion may or may not consume an argument,
+            // and guessing wrong shifts every argument behind it.
+            return refuse(spec, before, "unrecognised printf conversion");
+        }
+        ++p;
+        plan.modelled_bytes = (size_t)(p - fmt);
+    }
+
+    plan.modelled_bytes = (size_t)(p - fmt);
+    return plan;
+}
+
+void pack_ms_va_slots(const FormatPlan& plan, SysvVaList ap, uint64_t* slots) {
+    for (unsigned i = 0; i < plan.count; ++i) slots[i] = sysv_va_arg(ap, plan.cls[i]);
+}
+
+MsVarargCall::MsVarargCall(const char* fmt, const SysvVaList& ap, FormatGrammar grammar)
+    : plan_(plan_format(fmt, grammar)) {
+    pack_ms_va_slots(plan_, ap, slots_);
+    if (plan_.complete) { format_ = fmt; return; }
+    size_t keep = plan_.modelled_bytes;
+    if (keep >= kMaxPrefixBytes) keep = kMaxPrefixBytes - 1;
+    if (keep && fmt) std::memcpy(prefix_, fmt, keep);
+    prefix_[keep] = '\0';
+    format_ = prefix_;
+}
+
+} // namespace prosper::abi

--- a/prosper/src/host/abi/guest_varargs.hpp
+++ b/prosper/src/host/abi/guest_varargs.hpp
@@ -98,19 +98,24 @@ public:
     const char* format() const { return format_; }
     // The Microsoft x64 va_list image. On Windows this is castable to `va_list` directly.
     void*       va_list_image() { return slots_; }
+    // Slots actually packed, which always describes `format()` rather than the original string.
     unsigned    count() const { return plan_.count; }
-    bool        complete() const { return plan_.complete; }
-    const char* reject() const { return plan_.reject; }
+    // The verdict on the ORIGINAL format. Deliberately not read back from `plan_`, which after a
+    // refusal describes the truncated prefix and can itself be complete.
+    bool        complete() const { return complete_; }
+    const char* reject() const { return reject_; }
 
 private:
     // Longest format prefix retained when the tail cannot be modelled. A format longer than this that
     // also carries an unmodellable conversion loses more of its tail, which is the safe direction.
     static constexpr size_t kMaxPrefixBytes = 512;
 
-    FormatPlan plan_{};
+    FormatPlan plan_{};                  // the plan for `format_`, i.e. what was actually packed
     uint64_t   slots_[kMaxFormatArgs]{};
     char       prefix_[kMaxPrefixBytes]{};
     const char* format_ = nullptr;
+    bool        complete_ = true;        // the verdict on the format as GIVEN
+    const char* reject_ = nullptr;
 };
 
 } // namespace prosper::abi

--- a/prosper/src/host/abi/guest_varargs.hpp
+++ b/prosper/src/host/abi/guest_varargs.hpp
@@ -1,0 +1,116 @@
+// guest_varargs.hpp — a guest System V variadic argument list, and its Microsoft x64 re-expression.
+//
+// `call_signature.hpp` describes an argument list the TYPE SYSTEM knows. This file exists for the
+// one shape it cannot: a real C variadic, whose argument list is whatever the format string says at
+// run time (#3246). Two conventions disagree about that list in a way no compile-time signature can
+// bridge:
+//
+//   System V:  the callee's va_start writes a REGISTER SAVE AREA (rdi,rsi,rdx,rcx,r8,r9 then
+//              xmm0..xmm7) plus a pointer to the caller's overflow words, and va_arg walks the two
+//              files with two independent cursors.
+//   Microsoft: there is one file. A variadic callee spills rcx,rdx,r8,r9 into its home area and
+//              va_list is a bare `char*` walking 8-byte slots from there into the caller's stack —
+//              which is why the convention ALSO requires a floating-point variadic argument to be
+//              duplicated into the corresponding integer register: `va_arg(ap, double)` reads the
+//              memory slot the integer register was spilled to, and never looks at xmm.
+//
+// So the conversion is not a register shuffle at all. It is: read the guest's SysV list by the SysV
+// rules, learn each argument's class from the format string, and write a flat array of 8-byte slots
+// — which IS a Microsoft va_list, and can be handed straight to the host CRT's `v*` function.
+//
+// Everything here is a pure function of (format string, argument list) and is compiled and tested on
+// every platform; only the final `(va_list)MsVarargCall::va_list_image()` cast is Windows-specific,
+// because only there is `va_list` the flat array this builds.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+namespace prosper::abi {
+
+// The System V AMD64 va_list, exactly as a guest's own `va_start` builds it. The guest is always
+// SysV, so this layout is fixed regardless of what the host's `va_list` happens to be — reading it
+// as the host's type is the defect this replaces, and on Windows that is an 8-byte `char*` read of a
+// 24-byte structure.
+struct SysvVaList {
+    uint32_t gp_offset;          // next integer argument, as a byte offset into reg_save_area
+    uint32_t fp_offset;          // next SSE argument, likewise
+    uint64_t overflow_arg_area;  // the caller's spilled words
+    uint64_t reg_save_area;      // 6 integer registers then 8 xmm registers
+};
+static_assert(sizeof(SysvVaList) == 24, "the guest's va_list is 24 bytes on System V AMD64");
+
+// The register save area: 6 integer registers of 8 bytes, then 8 SSE registers of 16. `gp_offset`
+// having reached the first and `fp_offset` the second means that file is exhausted and the argument
+// comes from the overflow area instead.
+inline constexpr uint32_t kSysvGpSaveEnd  = 6 * 8;
+inline constexpr uint32_t kSysvRegSaveEnd = kSysvGpSaveEnd + 8 * 16;
+
+enum class VarargClass : uint8_t { Integer = 0, Sse = 1 };
+
+// One argument, advancing `ap` exactly as `va_arg` would. Every scalar a printf-family conversion can
+// consume occupies one 8-byte slot under both conventions (Microsoft's `long double` is a double),
+// so a class is all the caller needs to know.
+uint64_t sysv_va_arg(SysvVaList& ap, VarargClass cls);
+
+// The grammar a format string is read against. They differ in what consumes an argument, not in the
+// register files: every scanf conversion takes a POINTER, so a scanf argument list is all-integer and
+// places identically under both conventions — which is why `sscanf` is not part of #3246's defect.
+enum class FormatGrammar : uint8_t { Printf = 0, Scanf = 1 };
+
+// A format string's argument list, as far as this model can express it. `complete == false` means the
+// format contains a conversion the model refuses to guess at (a POSIX positional `%2$d`, an x87
+// `long double`, an unknown conversion character): `count` and `cls` then describe only the prefix
+// `modelled_bytes` long, and a caller must not format past it — consuming an argument by the wrong
+// class desynchronizes every argument after it, which is exactly the silent corruption this file
+// exists to remove.
+inline constexpr unsigned kMaxFormatArgs = 64;
+
+struct FormatPlan {
+    unsigned    count = 0;
+    VarargClass cls[kMaxFormatArgs]{};
+    size_t      modelled_bytes = 0;
+    bool        complete = true;
+    const char* reject = nullptr;   // why, when !complete
+};
+
+FormatPlan plan_format(const char* fmt, FormatGrammar grammar);
+
+// Fill `slots` (at least `plan.count` entries) with the Microsoft x64 va_list image of the arguments
+// `plan` describes, drawn from `ap`. Takes the list BY VALUE: the caller's cursor is left alone, so a
+// fallback path can re-read the same arguments.
+void pack_ms_va_slots(const FormatPlan& plan, SysvVaList ap, uint64_t* slots);
+
+// One printf- or scanf-family call, re-expressed for a host whose variadic convention is Microsoft
+// x64. Holds its own storage and has no destructor, no allocation and no failure mode: a format the
+// model cannot express yields a TRUNCATED format string covering only the part it can, which formats
+// less than the guest asked for but never formats it from the wrong argument.
+//
+// The no-destructor property is load-bearing on Windows and not merely tidy — see PROSPER_GUEST_ABI
+// in hle/dispatch/dispatch.hpp: a guest-ABI shim cannot carry SEH unwind data, so an object needing
+// cleanup must not live in one. Constructing this in an ordinary host frame keeps that decision in
+// one place.
+class MsVarargCall {
+public:
+    MsVarargCall(const char* fmt, const SysvVaList& ap, FormatGrammar grammar);
+
+    // The format string to actually pass to the host CRT: `fmt` itself, or the prefix of it this
+    // call's arguments are known to match.
+    const char* format() const { return format_; }
+    // The Microsoft x64 va_list image. On Windows this is castable to `va_list` directly.
+    void*       va_list_image() { return slots_; }
+    unsigned    count() const { return plan_.count; }
+    bool        complete() const { return plan_.complete; }
+    const char* reject() const { return plan_.reject; }
+
+private:
+    // Longest format prefix retained when the tail cannot be modelled. A format longer than this that
+    // also carries an unmodellable conversion loses more of its tail, which is the safe direction.
+    static constexpr size_t kMaxPrefixBytes = 512;
+
+    FormatPlan plan_{};
+    uint64_t   slots_[kMaxFormatArgs]{};
+    char       prefix_[kMaxPrefixBytes]{};
+    const char* format_ = nullptr;
+};
+
+} // namespace prosper::abi

--- a/prosper/src/host/abi/sysv_ms_bridge.cpp
+++ b/prosper/src/host/abi/sysv_ms_bridge.cpp
@@ -129,9 +129,22 @@ size_t emit_legacy_integer_prologue(uint8_t* out) {
     return sizeof seq;
 }
 
+size_t emit_guest_abi_tailjump(uint8_t* out, uint64_t handler) {
+    Buf b{ out };
+    movabs_rax(b, handler);
+    b.b(0xFF); b.b(0xE0);          // jmp rax
+    return b.n;
+}
+
 size_t emit_sysv_to_ms_bridge(uint8_t* out, const BridgeParams& params) {
     Buf b{ out };
     const CallSignature& sig = params.signature;
+
+    // A handler compiled in the guest's own convention needs no conversion at all — the guest's frame
+    // is already the one it reads, including a variadic frame no CallSignature could have described
+    // (#3246). Checked before the signature, because the two are mutually exclusive: a guest-ABI
+    // handler's arguments are not the bridge's business, and a declared signature would only mislead.
+    if (params.guest_abi) return emit_guest_abi_tailjump(out, params.handler);
 
     if (!sig.needs_conversion()) {
         // Historical path, byte for byte. The pad + four copied guest stack words + the 0x30 outgoing

--- a/prosper/src/host/abi/sysv_ms_bridge.cpp
+++ b/prosper/src/host/abi/sysv_ms_bridge.cpp
@@ -144,7 +144,17 @@ size_t emit_sysv_to_ms_bridge(uint8_t* out, const BridgeParams& params) {
     // is already the one it reads, including a variadic frame no CallSignature could have described
     // (#3246). Checked before the signature, because the two are mutually exclusive: a guest-ABI
     // handler's arguments are not the bridge's business, and a declared signature would only mislead.
-    if (params.guest_abi) return emit_guest_abi_tailjump(out, params.handler);
+    if (params.guest_abi) {
+        // ...but a tail-jump returns straight to the guest, so there is NOWHERE to run a return hook
+        // afterwards. The combination is unreachable today by construction — register_guest_abi_fn
+        // takes no hook, and a later register_fn that supplied one would drop the guest_abi flag
+        // along with the handler it described — so this is a guard against a future edit, not a live
+        // case. Refuse it the way an over-wide signature is refused: an impossible length, which
+        // install_stubs reports before writing anything. Silently dropping the hook is the one
+        // outcome that must not happen, because nothing downstream would ever notice.
+        if (params.return_hook) return kMaxBridgeBytes + 1;
+        return emit_guest_abi_tailjump(out, params.handler);
+    }
 
     if (!sig.needs_conversion()) {
         // Historical path, byte for byte. The pad + four copied guest stack words + the 0x30 outgoing

--- a/prosper/src/host/abi/sysv_ms_bridge.hpp
+++ b/prosper/src/host/abi/sysv_ms_bridge.hpp
@@ -50,10 +50,18 @@ ArgLocation ms_arg_location(const CallSignature& sig, unsigned arg);
 
 // Everything one import stub needs. `checkpoint` and `return_hook` are host-ABI functions taking no
 // arguments; `return_hook` is optional.
+//
+// `guest_abi` says the handler is compiled in the GUEST's own convention (PROSPER_GUEST_ABI in
+// hle/dispatch/dispatch.hpp), so there is nothing to convert and the stub is the same bare tail-jump
+// Linux uses. It is how a REAL C VARIADIC is reached (#3246): a `CallSignature` describes a list the
+// type system knows, and a variadic handler's list is whatever its format string says at run time —
+// so the only way to hand it an intact System V frame is to let the compiler's own System V variadic
+// prologue capture it. See emit_guest_abi_tailjump for what it costs.
 struct BridgeParams {
     uint64_t      handler     = 0;
     uint64_t      checkpoint  = 0;
     uint64_t      return_hook = 0;
+    bool          guest_abi   = false;
     CallSignature signature{};
 };
 
@@ -82,5 +90,19 @@ size_t emit_sysv_to_ms_bridge(uint8_t* out, const BridgeParams& params);
 // stack into the Microsoft integer registers and outgoing stack. Exposed so a test can pin the
 // no-op property by byte comparison rather than by inspection.
 size_t emit_legacy_integer_prologue(uint8_t* out);
+
+// The number of guest arguments the fixed integer prologue forwards. A handler declaring more than
+// this and registered by `(HleFn)` cast would silently lose the rest on Windows — audited for #3246
+// and clear today: the widest HLE macro in the tree is `HLE10`, which is exactly this many.
+inline constexpr unsigned kLegacyForwardedArgs = 10;
+
+// `movabs rax, handler ; jmp rax` — the bare tail-jump, byte-identical to the LINUX import stub
+// (host/image/exec_image_linux.cpp's emit_impl). Emitted on Windows only for a handler compiled in
+// the guest's own convention, where there is nothing to convert.
+//
+// The cost is the return checkpoint: a tail-jump returns straight to the guest, so a guest-ABI
+// handler that wants the pending-guest-exception poll must call
+// `dispatch_pending_guest_exception()` itself before returning. That is what the libc variadics do.
+size_t emit_guest_abi_tailjump(uint8_t* out, uint64_t handler);
 
 } // namespace prosper::abi

--- a/prosper/src/host/image/exec_image_win.cpp
+++ b/prosper/src/host/image/exec_image_win.cpp
@@ -323,11 +323,12 @@ namespace {
     // registry supplies the handler's declared signature, without which a floating-point argument —
     // and every argument after it — cannot be placed at all.
     size_t emit_impl(uint8_t* p, uint64_t fn, uint64_t return_hook,
-                     const abi::CallSignature& signature) {
+                     const abi::CallSignature& signature, bool guest_abi) {
         abi::BridgeParams params;
         params.handler     = fn;
         params.checkpoint  = (uint64_t)(uintptr_t)&dispatch_pending_guest_exception;
         params.return_hook = return_hook;
+        params.guest_abi   = guest_abi;
         params.signature   = signature;
         return abi::emit_sysv_to_ms_bridge(p, params);
     }
@@ -1200,7 +1201,8 @@ static size_t emit_one_stub(uint8_t* slot, const ImportSlot& s, uint32_t idx, si
     // table would already have overrun the next slot by the time the caller compared the length.
     uint8_t staged[abi::kMaxBridgeBytes];
     const size_t emitted =
-        fn ? emit_impl(staged, (uint64_t)fn, return_hook, Hle::signature_of_nid(s.nid))
+        fn ? emit_impl(staged, (uint64_t)fn, return_hook, Hle::signature_of_nid(s.nid),
+                       Hle::guest_abi_nid(s.nid))
            : emit_unimpl(staged, idx, (uint64_t)&prosper_on_unimpl);
     if (emitted <= capacity) memcpy(slot, staged, emitted);
     return emitted;

--- a/prosper/tests/gpu/test_guest_log_capture.cpp
+++ b/prosper/tests/gpu/test_guest_log_capture.cpp
@@ -64,7 +64,11 @@ int main() {
     CHECK(guest_log_capture_bundle_enabled(), "exact-line gate enables only with marker and bundle path");
 
     prosper::register_builtin_hle();
-    using PrintfFn = int (*)(const char*, ...);
+    // `printf` is a real C variadic compiled in the GUEST's convention (#3246), so its pointer type
+    // must carry PROSPER_GUEST_ABI -- on Windows that is `sysv_abi`, and calling it through an
+    // untagged type places the arguments by the wrong convention. The integer handlers below are
+    // ordinary host functions and need no tag.
+    using PrintfFn = PROSPER_GUEST_ABI int (*)(const char*, ...);
     using HleFn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
     auto guest_printf = reinterpret_cast<PrintfFn>(
         reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("printf"))));

--- a/prosper/tests/hle/test_printf.cpp
+++ b/prosper/tests/hle/test_printf.cpp
@@ -15,8 +15,13 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
-using SnprintfFn = int (*)(char*, size_t, const char*, ...);
-using SprintfFn  = int (*)(char*, const char*, ...);
+// PROSPER_GUEST_ABI is what makes the comment above TRUE rather than aspirational. These handlers
+// are compiled in the GUEST's convention (#3246), which on Windows is not the host's -- so an
+// untagged pointer type here would place the arguments by Microsoft x64 rules for a callee reading
+// them by System V, and the first `%s` would dereference whatever landed in `rdi`. It did: this test
+// SEGFAULTed on the Windows MinGW job the moment the handlers were tagged. Empty on Linux/macOS.
+using SnprintfFn = PROSPER_GUEST_ABI int (*)(char*, size_t, const char*, ...);
+using SprintfFn  = PROSPER_GUEST_ABI int (*)(char*, const char*, ...);
 
 int main() {
     printf("== test_printf ==\n");

--- a/prosper/tests/host/abi/test_guest_varargs.cpp
+++ b/prosper/tests/host/abi/test_guest_varargs.cpp
@@ -28,6 +28,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <type_traits>
 
 using namespace prosper;
 using namespace prosper::abi;
@@ -57,6 +58,23 @@ using namespace prosper::abi;
 #endif
 
 namespace {
+// PROSPER_GUEST_ABI's whole value is that it is part of the FUNCTION TYPE: that is what makes
+// `Hle::register_guest_abi` reject an untagged handler at compile time on Windows, and what makes
+// the tag a no-op everywhere else. Both halves are checked by the compiler, here, rather than
+// asserted in a PR body — and the Windows half is only ever evaluated by the Windows MinGW job,
+// which is the point. If the tag ever silently stopped changing the type, the registration guard
+// would still compile and would be closing nothing.
+using GuestAbiVariadic = PROSPER_GUEST_ABI int (*)(const char*, ...);
+using HostAbiVariadic  = int (*)(const char*, ...);
+#if defined(_WIN32) && (defined(__x86_64__) || defined(_M_X64))
+static_assert(!std::is_same_v<GuestAbiVariadic, HostAbiVariadic>,
+              "PROSPER_GUEST_ABI does not change the function type on Windows, so "
+              "register_guest_abi's compile-time guard cannot refuse an untagged handler");
+#else
+static_assert(std::is_same_v<GuestAbiVariadic, HostAbiVariadic>,
+              "PROSPER_GUEST_ABI is not empty off Windows, so the change is not the no-op it claims");
+#endif
+
 int g_fail = 0;
 void fail(const char* what, const std::string& detail) {
     fprintf(stderr, "FAIL %-44s: %s\n", what, detail.c_str());
@@ -100,6 +118,16 @@ void check_plans() {
     // conventions, and Microsoft's `long double` is a double.
     check_plan("%lld %zu %ju %td %hhd %hd %ld %p %c %s", "iiiiiiiiii");
     check_plan("%lf %le %Lg", "ff!");             // ...except x87 long double, which is refused
+    // The accepted set is a SUBSET of what the host CRT consumes an argument for (guest_varargs.cpp,
+    // "THE RULE THIS WHOLE FILE OBEYS"). `q` is the BSD long-long modifier: measured under wine, the
+    // MinGW CRT prints "%qd" literally and consumes NOTHING, so accepting it would shift every
+    // argument behind it. It must refuse, not classify.
+    check_plan("%d %qd", "i!");
+    check_plan("%qu", "!");
+    // `'` is on the other side of the same measurement -- the CRT does consume an argument for it --
+    // so it stays accepted. Pinned so that dropping it is a deliberate act with a measurement behind
+    // it, not a tidy-up.
+    check_plan("%'d %'f", "if");
     check_plan("%.2f %10.4e %+g %#a", "ffff");
     // A `*` width or precision consumes an int of its own, ahead of the conversion's own argument.
     check_plan("%*d", "ii");
@@ -154,8 +182,25 @@ void check_stub_and_registry() {
     expect("guest-abi flag moves the emitter", emit_sysv_to_ms_bridge(bytes, converting) != n,
            "the converting bridge emitted the same length as the tail-jump");
 
+    // A tail-jump returns straight to the guest, so it cannot run a return hook afterwards. The
+    // combination is unreachable through the registry today, and the emitter must REFUSE it rather
+    // than emit a stub that silently drops the hook -- the one outcome nothing downstream notices.
+    BridgeParams hooked = params;
+    hooked.return_hook = 0x0102030405060708ull;
+    expect("guest-abi + return hook is refused",
+           emit_sysv_to_ms_bridge(bytes, hooked) > kMaxBridgeBytes,
+           "a guest-ABI stub with a return hook was emitted, dropping the hook");
+
     // The registry really carries the flag for the printf family, and only where it is meant to.
     register_builtin_hle();
+    // ...and the registry keeps the flag and a return hook apart, which is what makes the emitter
+    // case above a guard against a future edit rather than a live path. NOTE THE PLACEMENT: read
+    // before register_builtin_hle() this loop passes vacuously against an empty registry, which is
+    // exactly how it was first written here.
+    for (const char* name : { "printf", "sprintf", "snprintf", "sprintf_s", "snprintf_s" })
+        expect("guest-abi NIDs carry no return hook",
+               Hle::return_hook_of(nid_hash(name)) == nullptr,
+               std::string(name) + " has a return hook a tail-jump stub could not run");
     unsigned marked = 0;
     for (const char* name : { "printf", "sprintf", "snprintf", "sprintf_s", "snprintf_s" }) {
         if (Hle::guest_abi_nid(nid_hash(name))) { ++marked; continue; }
@@ -190,6 +235,7 @@ FormatPlan  g_plan{};
 uint64_t    g_slots[kMaxFormatArgs]{};
 uint64_t    g_blind_slots[kMaxFormatArgs]{};
 bool        g_fallback_complete = true;
+const char* g_fallback_reject = nullptr;
 char        g_fallback_format[512]{};
 
 // Everything the capture is used for happens HERE, while the guest frame is still live — which is
@@ -210,6 +256,7 @@ void capture_and_pack(const char* fmt, const SysvVaList& ap) {
     // ...and the truncating fallback, from the same frame.
     MsVarargCall call(fmt, ap, FormatGrammar::Printf);
     g_fallback_complete = call.complete();
+    g_fallback_reject = call.reject();
     snprintf(g_fallback_format, sizeof g_fallback_format, "%s", call.format());
 }
 
@@ -346,11 +393,51 @@ void check_executed() {
         prepare(fmt);
         guest_call(fmt, (uint64_t)7, 6.5, s1);
         expect("truncating fallback refuses", !g_fallback_complete, "a positional format was accepted");
+        expect("truncating fallback names a reason", g_fallback_reject != nullptr,
+               "a refusal carried no reason");
         // The prefix must be exactly the conversions the packed slots match — two of them here, so
         // the guest sees less than it asked for and never sees a value read from the wrong file.
         expect("truncating fallback keeps a safe prefix",
                strcmp(g_fallback_format, "a=%d b=%f c=") == 0,
                std::string("kept \"") + g_fallback_format + "\"");
+    }
+
+    // --- the prefix cap must not slice a conversion in half -----------------------------------------
+    // MsVarargCall retains at most 511 bytes of a refused format, and that limit is NOT a conversion
+    // boundary. Build one where the cut lands inside a `%...` spec and require the retained string to
+    // end on a boundary anyway -- otherwise the CRT is handed a dangling conversion and the packed
+    // slot count no longer describes what is being formatted.
+    {
+        // Getting the cap to bite at all took two tries, and both failures were the arm proving
+        // nothing rather than the code being wrong:
+        //   * 504 bytes of "ab%d" never reached the 511-byte limit, and the arm passed against a
+        //     build with the fix REMOVED;
+        //   * 600 bytes of "ab%d" reached the ARGUMENT limit first (kMaxFormatArgs = 64 conversions,
+        //     i.e. 258 bytes in), so the byte cap was still never exercised.
+        // Hence mostly literal filler with ONE conversion, positioned so the 511-byte cut falls
+        // inside it: 510 bytes of 'x', then "%d" occupying offsets 510-511. Cutting at 511 leaves a
+        // dangling '%', which is exactly the slice this fix exists to prevent.
+        std::string long_fmt(510, 'x');
+        long_fmt += "%d";        // straddles the cut
+        long_fmt += "z";
+        long_fmt += "%1$s";      // ...and something the model must refuse, so the prefix path runs
+        prepare(long_fmt.c_str());
+        guest_call(long_fmt.c_str(), (uint64_t)1);
+        const size_t kept = strlen(g_fallback_format);
+        expect("the prefix cap actually bit", kept == 510,
+               "kept " + std::to_string(kept) + " bytes; 510 means the cut landed inside the `%d` and "
+               "was walked back, anything else means this arm is vacuous");
+        expect("prefix cap stays under the limit", kept < 512,
+               "kept " + std::to_string(kept) + " bytes");
+        expect("prefix cap does not end inside a conversion",
+               kept == 0 || g_fallback_format[kept - 1] != '%',
+               std::string("prefix ends with a dangling '%'"));
+        // The decisive check: re-planning what was kept must agree with it exactly, which is what
+        // "the packed count describes the formatted string" means.
+        const FormatPlan of_kept = plan_format(g_fallback_format, FormatGrammar::Printf);
+        expect("prefix is fully modelled by its own plan",
+               of_kept.complete && of_kept.modelled_bytes == kept,
+               "the retained prefix does not re-plan cleanly");
     }
 
 #if defined(_WIN32)

--- a/prosper/tests/host/abi/test_guest_varargs.cpp
+++ b/prosper/tests/host/abi/test_guest_varargs.cpp
@@ -1,0 +1,388 @@
+// test_guest_varargs — a guest System V variadic call, re-expressed for a Microsoft x64 host (#3246).
+//
+// #2955 made the import bridge signature-driven, and #3246 is the one shape a signature cannot
+// describe: a real C variadic, whose argument list is whatever the format string says at run time.
+// Three independent things have to hold, and only the last needs a Windows host:
+//
+//   (1) READING the guest's list. `sysv_va_arg` walks the System V register save area and overflow
+//       area. Checked against a REAL `va_start` frame produced by the compiler — a positive instance
+//       built outside the machinery under test, including arguments that spill past both files.
+//   (2) CLASSIFYING the arguments. `plan_format` decides, per conversion, which System V file the
+//       argument came from. A table, asserted directly, on any platform.
+//   (3) WRITING the Microsoft list. The packed slots are consumed by the COMPILER's own Microsoft
+//       va_arg (`__builtin_ms_va_list`), which is available on Linux too — so the layout claim is
+//       checked against the toolchain rather than against this file's own belief about it. On
+//       Windows the real CRT reads the same bytes, and the formatted string is asserted as well.
+//
+// Plus the two structural facts the wiring depends on: a guest-ABI handler's stub is a bare
+// tail-jump, and the printf family really is registered that way.
+//
+// What NONE of this checks is a live guest calling printf on a Windows host. Nothing here pretends to.
+#include "host/abi/guest_varargs.hpp"
+#include "host/abi/sysv_ms_bridge.hpp"
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+using namespace prosper;
+using namespace prosper::abi;
+
+#if defined(__x86_64__) || defined(_M_X64)
+#define PROSPER_TEST_X86_64 1
+#else
+#define PROSPER_TEST_X86_64 0
+#endif
+
+#if PROSPER_TEST_X86_64
+// The producer side must build a SYSTEM V frame. On Linux that is what an ordinary variadic function
+// already does; on Windows it needs the same tag the real handlers carry.
+#if defined(_WIN32)
+#define TEST_GUEST_ABI      __attribute__((sysv_abi))
+#define TEST_GUEST_VA_LIST  __builtin_sysv_va_list
+#define TEST_GUEST_VA_START __builtin_sysv_va_start
+#define TEST_GUEST_VA_END   __builtin_sysv_va_end
+#define TEST_MS_VA_LIST     va_list
+#else
+#define TEST_GUEST_ABI
+#define TEST_GUEST_VA_LIST  va_list
+#define TEST_GUEST_VA_START va_start
+#define TEST_GUEST_VA_END   va_end
+#define TEST_MS_VA_LIST     __builtin_ms_va_list
+#endif
+#endif
+
+namespace {
+int g_fail = 0;
+void fail(const char* what, const std::string& detail) {
+    fprintf(stderr, "FAIL %-44s: %s\n", what, detail.c_str());
+    ++g_fail;
+}
+void expect(const char* what, bool ok, const std::string& detail) {
+    if (!ok) fail(what, detail);
+}
+
+// ---------------------------------------------------------------------------------------------
+// (2) The format plan.
+// ---------------------------------------------------------------------------------------------
+
+std::string show(const FormatPlan& p) {
+    std::string s;
+    for (unsigned i = 0; i < p.count; ++i) s += (p.cls[i] == VarargClass::Sse) ? 'f' : 'i';
+    if (!p.complete) s += "!";
+    return s;
+}
+
+void check_plan(const char* fmt, const char* want, FormatGrammar grammar = FormatGrammar::Printf) {
+    const FormatPlan plan = plan_format(fmt, grammar);
+    const std::string got = show(plan);
+    if (got == want) return;
+    char d[400];
+    snprintf(d, sizeof d, "\"%s\" planned as \"%s\", expected \"%s\"", fmt, got.c_str(), want);
+    fail("format plan", d);
+}
+
+void check_plans() {
+    // The shape #3246 names: one float in the middle, an integer behind it. Under System V the float
+    // is in xmm0 and the two strings in rsi/rdx — different FILES, so a bridge that shuffled integer
+    // registers positionally delivered the float's slot to the second string.
+    check_plan("%s %d %f %s", "iifi");
+    check_plan("%d", "i");
+    check_plan("%f", "f");
+    check_plan("no conversions at all", "");
+    check_plan("100%% done", "");
+    check_plan("%%%d%%", "i");
+    // Length modifiers never change the SLOT count: every one of these is eight bytes under both
+    // conventions, and Microsoft's `long double` is a double.
+    check_plan("%lld %zu %ju %td %hhd %hd %ld %p %c %s", "iiiiiiiiii");
+    check_plan("%lf %le %Lg", "ff!");             // ...except x87 long double, which is refused
+    check_plan("%.2f %10.4e %+g %#a", "ffff");
+    // A `*` width or precision consumes an int of its own, ahead of the conversion's own argument.
+    check_plan("%*d", "ii");
+    check_plan("%.*f", "if");
+    check_plan("%*.*f", "iif");
+    // Refusals. Each keeps the arguments of the prefix it accepted and drops the rest, so a caller
+    // formats less than the guest asked rather than formatting it from the wrong slot.
+    check_plan("%d %1$s", "i!");                  // POSIX positional
+    check_plan("%d %y", "i!");                    // unknown conversion
+    check_plan("%d %", "i!");                     // truncated conversion
+    check_plan("%d %*", "i!");                    // ...and one that already consumed a `*` argument
+    // scanf: assignment suppression consumes nothing, and every assignment is a pointer.
+    check_plan("read %d", "i", FormatGrammar::Scanf);
+    check_plan("%d %d", "ii", FormatGrammar::Scanf);
+    check_plan("%*d %d", "i", FormatGrammar::Scanf);
+    check_plan("%f %s", "ii", FormatGrammar::Scanf);   // a %f target is a float*, an INTEGER slot
+    check_plan("%10s %[^\n] %[]] %[^]]", "iiii", FormatGrammar::Scanf);
+    check_plan("%d %[abc", "i!", FormatGrammar::Scanf);
+
+    const FormatPlan nul = plan_format(nullptr, FormatGrammar::Printf);
+    expect("null format", !nul.complete && nul.count == 0, "a null format was not refused");
+
+    // The prefix a refusal keeps must be the bytes BEFORE the offending conversion, since that is
+    // what a caller formats.
+    const FormatPlan cut = plan_format("a=%d b=%1$s", FormatGrammar::Printf);
+    expect("refusal prefix", cut.modelled_bytes == 7,
+           "kept " + std::to_string(cut.modelled_bytes) + " bytes, expected 7 (\"a=%d b=\")");
+}
+
+// ---------------------------------------------------------------------------------------------
+// (5) The stub a guest-ABI handler gets, and the registry that asks for one.
+// ---------------------------------------------------------------------------------------------
+
+void check_stub_and_registry() {
+    uint8_t bytes[kMaxBridgeBytes];
+    BridgeParams params;
+    params.handler = 0x1122334455667788ull;
+    params.checkpoint = 0x99aabbccddeeff00ull;
+    params.guest_abi = true;
+    const size_t n = emit_sysv_to_ms_bridge(bytes, params);
+    static const uint8_t kTailJump[] = { 0x48, 0xB8, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
+                                         0xFF, 0xE0 };
+    expect("guest-abi stub length", n == sizeof kTailJump,
+           "emitted " + std::to_string(n) + " bytes, expected 12");
+    expect("guest-abi stub bytes", n == sizeof kTailJump && memcmp(bytes, kTailJump, n) == 0,
+           "the tail-jump is not `movabs rax, handler ; jmp rax`");
+
+    // DISCRIMINATOR. Without the flag the same params emit the converting bridge, which is many times
+    // longer. If they agreed, the arm above would be asserting nothing about the flag.
+    BridgeParams converting = params;
+    converting.guest_abi = false;
+    expect("guest-abi flag moves the emitter", emit_sysv_to_ms_bridge(bytes, converting) != n,
+           "the converting bridge emitted the same length as the tail-jump");
+
+    // The registry really carries the flag for the printf family, and only where it is meant to.
+    register_builtin_hle();
+    unsigned marked = 0;
+    for (const char* name : { "printf", "sprintf", "snprintf", "sprintf_s", "snprintf_s" }) {
+        if (Hle::guest_abi_nid(nid_hash(name))) { ++marked; continue; }
+        fail("guest-abi registration", std::string(name) + " is not registered as a guest-ABI handler");
+    }
+    expect("guest-abi registry is not vacuous", marked > 0,
+           "no printf-family NID is marked, so this arm measured nothing");
+    // An ordinary handler must NOT be marked: the flag suppresses argument conversion entirely, so a
+    // stray one would hand a Microsoft-ABI handler the guest's raw System V frame.
+    expect("memcpy is not guest-abi", !Hle::guest_abi_nid(nid_hash("memcpy")),
+           "an ordinary integer handler is marked guest-ABI");
+    // sscanf stays on the converting path deliberately (its variadic arguments are all pointers).
+    expect("sscanf is not guest-abi", !Hle::guest_abi_nid(nid_hash("sscanf")),
+           "sscanf was routed through the guest-ABI path; #3246 records why it should not be");
+}
+
+#if PROSPER_TEST_X86_64
+// ---------------------------------------------------------------------------------------------
+// (1) + (3) Executed: a real System V variadic frame, read, packed, and consumed as Microsoft x64.
+// ---------------------------------------------------------------------------------------------
+//
+// The two TEST_GUEST_ABI functions below hold no C++ object and call nothing that owns one. That is
+// not tidiness: on Windows they carry `sysv_abi`, and MinGW cannot emit SEH unwind data for such a
+// frame, so a `std::string` temporary anywhere inside would make the file fail to ASSEMBLE. They
+// record; every comparison happens afterwards, in ordinary host frames.
+
+VarargClass g_cls[kMaxFormatArgs]{};      // classes the reference reader should use
+unsigned    g_ref_n = 0;
+uint64_t    g_ref_u[kMaxFormatArgs]{};
+double      g_ref_d[kMaxFormatArgs]{};
+FormatPlan  g_plan{};
+uint64_t    g_slots[kMaxFormatArgs]{};
+uint64_t    g_blind_slots[kMaxFormatArgs]{};
+bool        g_fallback_complete = true;
+char        g_fallback_format[512]{};
+
+// Everything the capture is used for happens HERE, while the guest frame is still live — which is
+// also why this mirrors production rather than being a convenience. A System V va_list points into
+// the caller's outgoing argument area and into the callee's own register save area, so BOTH die when
+// the variadic function returns. Deferring the pack until after `guest_call` returned read a frame
+// the next ordinary call had already overwritten, and the first version of this test did exactly
+// that: arguments 14 and 16-19, the ones that came from the overflow area, arrived as stack litter.
+// A PROSPER_GUEST_ABI handler has the same obligation and meets it the same way (hle_libc.cpp).
+__attribute__((noinline))
+void capture_and_pack(const char* fmt, const SysvVaList& ap) {
+    g_plan = plan_format(fmt, FormatGrammar::Printf);
+    pack_ms_va_slots(g_plan, ap, g_slots);
+    // What the pre-#3246 Windows path effectively did: every argument read from the integer file.
+    FormatPlan blind = g_plan;
+    for (unsigned i = 0; i < blind.count; ++i) blind.cls[i] = VarargClass::Integer;
+    pack_ms_va_slots(blind, ap, g_blind_slots);
+    // ...and the truncating fallback, from the same frame.
+    MsVarargCall call(fmt, ap, FormatGrammar::Printf);
+    g_fallback_complete = call.complete();
+    snprintf(g_fallback_format, sizeof g_fallback_format, "%s", call.format());
+}
+
+// The guest side: an ordinary C variadic call, placed by System V. What it captures is exactly what
+// h_printf captures.
+TEST_GUEST_ABI void guest_call(const char* fmt, ...) {
+    TEST_GUEST_VA_LIST ap;
+    TEST_GUEST_VA_START(ap, fmt);
+    SysvVaList captured;
+    memcpy(&captured, &ap, sizeof captured);
+    TEST_GUEST_VA_END(ap);
+    capture_and_pack(fmt, captured);
+}
+
+// The same frame, read by the COMPILER's own System V va_arg instead of by sysv_va_arg — the
+// independently produced positive instance that stops arm (1) being checked against itself.
+TEST_GUEST_ABI void guest_call_reference(const char* fmt, ...) {
+    TEST_GUEST_VA_LIST ap;
+    TEST_GUEST_VA_START(ap, fmt);
+    for (unsigned i = 0; i < g_ref_n; ++i) {
+        if (g_cls[i] == VarargClass::Sse) g_ref_d[i] = __builtin_va_arg(ap, double);
+        else                              g_ref_u[i] = __builtin_va_arg(ap, uint64_t);
+    }
+    TEST_GUEST_VA_END(ap);
+}
+
+// Consume a packed Microsoft va_list image with the COMPILER's own Microsoft va_arg. This is what
+// makes the layout claim — "a Microsoft va_list is a flat array of 8-byte slots" — checkable without
+// a Windows host: were it wrong, GCC's own reader would disagree with this file's writer.
+__attribute__((noinline))
+void consume_ms(TEST_MS_VA_LIST ap, unsigned n, const char* name) {
+    for (unsigned i = 0; i < n; ++i) {
+        if (g_cls[i] == VarargClass::Sse) {
+            const double got = __builtin_va_arg(ap, double);
+            if (got == g_ref_d[i]) continue;
+            char d[160];
+            snprintf(d, sizeof d, "argument %u arrived as %g, expected %g", i, got, g_ref_d[i]);
+            fail(name, d);
+        } else {
+            const uint64_t got = __builtin_va_arg(ap, uint64_t);
+            if (got == g_ref_u[i]) continue;
+            char d[160];
+            snprintf(d, sizeof d, "argument %u arrived as 0x%llx, expected 0x%llx", i,
+                     (unsigned long long)got, (unsigned long long)g_ref_u[i]);
+            fail(name, d);
+        }
+    }
+}
+
+// Plan `fmt`, publish its classes for the reference reader, and clear the recorded values.
+FormatPlan prepare(const char* fmt) {
+    const FormatPlan plan = plan_format(fmt, FormatGrammar::Printf);
+    g_ref_n = plan.count;
+    for (unsigned i = 0; i < plan.count; ++i) {
+        g_cls[i] = plan.cls[i];
+        g_ref_u[i] = 0;
+        g_ref_d[i] = 0;
+    }
+    return plan;
+}
+
+void check_executed() {
+    // --- the shape #3246 names -------------------------------------------------------------------
+    // "%s %d %f %s": System V puts the two strings and the int in rsi/rdx/rcx and the double in xmm0
+    // — different FILES — so an integer-register shuffle delivers the second string where the double
+    // belongs and displaces everything behind it. Distinctive values, so a shifted read cannot match.
+    const char* const s1 = "alpha";
+    const char* const s2 = "omega";
+    {
+        const char* fmt = "%s %d %f %s";
+        const FormatPlan plan = prepare(fmt);
+        expect("plan of %s %d %f %s", plan.count == 4 && plan.complete, "plan is wrong");
+        guest_call_reference(fmt, s1, (uint64_t)0x0BADC0DEull, -2.5, s2);
+        guest_call(fmt, s1, (uint64_t)0x0BADC0DEull, -2.5, s2);
+        expect("reference read %s %d %f %s",
+               g_ref_u[0] == (uint64_t)(uintptr_t)s1 && g_ref_u[1] == 0x0BADC0DEull &&
+               g_ref_d[2] == -2.5 && g_ref_u[3] == (uint64_t)(uintptr_t)s2,
+               "the compiler's own va_arg did not read the values that were passed");
+        consume_ms((TEST_MS_VA_LIST)(char*)g_slots, g_plan.count, "executed %s %d %f %s");
+
+        // DISCRIMINATOR. Reading the double's slot as an integer argument is exactly what the
+        // pre-#3246 Windows path did, and it must NOT produce the double. Without this arm the one
+        // above could pass on a host where the two files happened to coincide. `capture_and_pack`
+        // built it from the same frame in the same call, for the lifetime reason recorded there.
+        double as_double = 0;
+        memcpy(&as_double, &g_blind_slots[2], 8);
+        if (as_double == -2.5)
+            fail("class-blind plan",
+                 "an all-integer plan still delivered the double, so this test cannot see the defect");
+    }
+
+    // --- past BOTH System V register files --------------------------------------------------------
+    // Ten integer-class arguments (rdi holds the format, so rsi..r9 take five and four spill) and ten
+    // doubles (xmm0..xmm7 take eight, two spill). The overflow area then interleaves the two files in
+    // declaration order, which no register-only model can express at all.
+    {
+        const char* fmt = "%d%f%d%f%d%f%d%f%d%f%d%f%d%f%d%f%d%f%d%f";
+        const FormatPlan plan = prepare(fmt);
+        expect("plan of the 20-argument call", plan.count == 20 && plan.complete, "plan is wrong");
+        guest_call_reference(fmt,
+            (uint64_t)0x5000, 1.5, (uint64_t)0x5002, 3.5, (uint64_t)0x5004, 5.5,
+            (uint64_t)0x5006, 7.5, (uint64_t)0x5008, 9.5, (uint64_t)0x500A, 11.5,
+            (uint64_t)0x500C, 13.5, (uint64_t)0x500E, 15.5, (uint64_t)0x5010, 17.5,
+            (uint64_t)0x5012, 19.5);
+        guest_call(fmt,
+            (uint64_t)0x5000, 1.5, (uint64_t)0x5002, 3.5, (uint64_t)0x5004, 5.5,
+            (uint64_t)0x5006, 7.5, (uint64_t)0x5008, 9.5, (uint64_t)0x500A, 11.5,
+            (uint64_t)0x500C, 13.5, (uint64_t)0x500E, 15.5, (uint64_t)0x5010, 17.5,
+            (uint64_t)0x5012, 19.5);
+        bool reference_ok = true;
+        for (unsigned i = 0; i < 20; ++i)
+            reference_ok &= (i % 2) ? (g_ref_d[i] == 0.5 + (double)i)
+                                    : (g_ref_u[i] == 0x5000ull + i);
+        expect("reference read of the 20-argument call", reference_ok,
+               "the compiler's own va_arg did not read the values that were passed");
+        consume_ms((TEST_MS_VA_LIST)(char*)g_slots, g_plan.count, "executed 10 ints + 10 doubles");
+    }
+
+    // --- a `*` width, which consumes arguments the conversion character does not name --------------
+    {
+        const char* fmt = "%*.*f|%s";
+        const FormatPlan plan = prepare(fmt);
+        expect("plan of %*.*f|%s", plan.count == 4 && plan.complete, "plan is wrong");
+        guest_call_reference(fmt, (uint64_t)12, (uint64_t)3, 1.25, s2);
+        guest_call(fmt, (uint64_t)12, (uint64_t)3, 1.25, s2);
+        consume_ms((TEST_MS_VA_LIST)(char*)g_slots, g_plan.count, "executed %*.*f|%s");
+    }
+
+    // --- the truncating fallback, executed ---------------------------------------------------------
+    // A format carrying something the model refuses still has to be SAFE: MsVarargCall must hand back
+    // a prefix whose conversions match the slots it packed.
+    {
+        const char* fmt = "a=%d b=%f c=%1$s";
+        prepare(fmt);
+        guest_call(fmt, (uint64_t)7, 6.5, s1);
+        expect("truncating fallback refuses", !g_fallback_complete, "a positional format was accepted");
+        // The prefix must be exactly the conversions the packed slots match — two of them here, so
+        // the guest sees less than it asked for and never sees a value read from the wrong file.
+        expect("truncating fallback keeps a safe prefix",
+               strcmp(g_fallback_format, "a=%d b=%f c=") == 0,
+               std::string("kept \"") + g_fallback_format + "\"");
+    }
+
+#if defined(_WIN32)
+    // --- the host CRT, on the platform this exists for ---------------------------------------------
+    // The layout is checked above against the compiler's own reader; here the real vsnprintf reads
+    // the same bytes and the formatted text itself is asserted.
+    {
+        const char* fmt = "%s|%d|%.2f|%s|%.2f|%lld";
+        prepare(fmt);
+        guest_call(fmt, "A", (uint64_t)1, 1.5, "B", 2.5, (uint64_t)7);
+        char buf[128];
+        const int n = vsnprintf(buf, sizeof buf, fmt, (va_list)(char*)g_slots);
+        const char* want = "A|1|1.50|B|2.50|7";
+        if (n < 0 || strcmp(buf, want) != 0)
+            fail("Windows CRT round trip",
+                 std::string("formatted \"") + buf + "\", expected \"" + want + "\"");
+    }
+#endif
+}
+#endif  // PROSPER_TEST_X86_64
+
+} // namespace
+
+int main() {
+    check_plans();
+    check_stub_and_registry();
+#if PROSPER_TEST_X86_64
+    check_executed();
+#else
+    printf("test_guest_varargs: not x86-64; the plan and the stub were checked but not executed\n");
+#endif
+    if (g_fail) { fprintf(stderr, "test_guest_varargs: %d failure(s)\n", g_fail); return 1; }
+    printf("test_guest_varargs: all cases passed\n");
+    return 0;
+}

--- a/prosper/tests/host/abi/test_guest_varargs.cpp
+++ b/prosper/tests/host/abi/test_guest_varargs.cpp
@@ -124,10 +124,11 @@ void check_plans() {
     // argument behind it. It must refuse, not classify.
     check_plan("%d %qd", "i!");
     check_plan("%qu", "!");
-    // `'` is on the other side of the same measurement -- the CRT does consume an argument for it --
-    // so it stays accepted. Pinned so that dropping it is a deliberate act with a measurement behind
-    // it, not a tidy-up.
-    check_plan("%'d %'f", "if");
+    // `'` is the SUSv2 thousands-grouping flag, and it goes the same way for the same reason: real
+    // ucrtbase.dll prints "'d" and consumes nothing. It was KEPT at first on a measurement taken
+    // against a DIFFERENT CRT than the one that ships -- see guest_varargs.cpp's subset rule.
+    check_plan("%d %'d", "i!");
+    check_plan("%'f", "!");
     check_plan("%.2f %10.4e %+g %#a", "ffff");
     // A `*` width or precision consumes an int of its own, ahead of the conversion's own argument.
     check_plan("%*d", "ii");
@@ -441,6 +442,74 @@ void check_executed() {
     }
 
 #if defined(_WIN32)
+    // --- the subset rule, asked of the CRT THIS BUILD ACTUALLY LINKS -------------------------------
+    // The rule guest_varargs.cpp obeys is that plan_format must never consume an argument the CRT
+    // does not. That was a judgment call backed by a measurement on one toolchain, and the toolchain
+    // was the wrong one: the first version of this change accepted `%'d` because a Fedora cross-mingw
+    // probe (ANSI stdio, __mingw_vsnprintf) consumed it, while CI and the shipped build are MSYS2
+    // UCRT64 (no ANSI stdio, UCRT's own vsnprintf) where it consumes nothing.
+    //
+    // So stop asserting it and ASK. For each specifier, hand the CRT a call with a trailing sentinel:
+    // if the spec consumed its own argument the sentinel prints, and if it consumed nothing the spec
+    // ate the sentinel instead. Then require the implication that actually matters —
+    //
+    //     we consume  =>  the CRT consumes
+    //
+    // — rather than equality, because refusing something the CRT does support is merely a truncated
+    // line, while accepting something it does not is the argument-shifting corruption this file
+    // exists to prevent. Whichever CRT a future build resolves to, this arm answers for it.
+    {
+        static const struct { const char* spec; const char* fmt; bool fp; } kSpecs[] = {
+            { "%'d",  "%'d|%d",  false },   // the one that was got wrong
+            { "%qd",  "%qd|%d",  false },
+            { "%zu",  "%zu|%d",  false },
+            { "%jd",  "%jd|%d",  false },
+            { "%td",  "%td|%d",  false },
+            { "%hhd", "%hhd|%d", false },
+            { "%lld", "%lld|%d", false },
+            { "%d",   "%d|%d",   false },
+            { "%a",   "%a|%d",   true  },
+            { "%.2f", "%.2f|%d", true  },
+            { "%s",   "%s|%d",   false },
+        };
+        unsigned probed = 0, crt_rejects = 0;
+        for (const auto& c : kSpecs) {
+            // Ask the CRT. The sentinel is 77; the leading argument is distinctive either way.
+            char rendered[160];
+            if (c.fp)                       snprintf(rendered, sizeof rendered, c.fmt, 1.5, 77);
+            else if (strcmp(c.spec, "%s") == 0)
+                                            snprintf(rendered, sizeof rendered, c.fmt, "str", 77);
+            else                            snprintf(rendered, sizeof rendered, c.fmt,
+                                                     (long long)1234, 77);
+            const bool crt_consumes = strstr(rendered, "|77") != nullptr;
+
+            // Ask the walker.
+            char just_spec[16];
+            snprintf(just_spec, sizeof just_spec, "%s", c.spec);
+            const FormatPlan plan = plan_format(just_spec, FormatGrammar::Printf);
+            const bool we_consume = plan.complete && plan.count == 1;
+
+            ++probed;
+            if (!crt_consumes) ++crt_rejects;
+            char d[220];
+            snprintf(d, sizeof d,
+                     "%s: the walker consumes an argument but this CRT does not (it rendered "
+                     "\"%s\"), so every argument behind it would shift", c.spec, rendered);
+            expect("accepted set is a subset of the CRT's", !we_consume || crt_consumes, d);
+        }
+        // Vacuity guards, and the second one is the load-bearing half. The implication passes trivially
+        // for any specifier the CRT consumes, so if the sentinel technique could not DETECT a
+        // non-consuming specifier -- if it silently reported "consumes" for everything -- the whole
+        // loop would be green and would be measuring nothing. The table therefore has to contain at
+        // least one specifier this CRT rejects, and `%qd` is rejected by both the UCRT and the ANSI
+        // stdio implementations, so the guard holds whichever one a build resolves to.
+        expect("CRT subset probe ran", probed == sizeof kSpecs / sizeof *kSpecs,
+               "the specifier table changed but the count did not");
+        expect("CRT subset probe can see a refusal", crt_rejects > 0,
+               "this CRT reports that it consumes an argument for EVERY specifier probed, including "
+               "%qd -- the sentinel detector is broken, so the subset rule was never tested");
+    }
+
     // --- the host CRT, on the platform this exists for ---------------------------------------------
     // The layout is checked above against the compiler's own reader; here the real vsnprintf reads
     // the same bytes and the formatted text itself is asserted.
@@ -454,6 +523,24 @@ void check_executed() {
         if (n < 0 || strcmp(buf, want) != 0)
             fail("Windows CRT round trip",
                  std::string("formatted \"") + buf + "\", expected \"" + want + "\"");
+    }
+
+    // ...and the same round trip for a format carrying `%'d`, driven through the REAL CRT. This is
+    // the case the first version of this change got wrong, so it is pinned end to end rather than
+    // only in the plan table: the walker must refuse at the `%'d`, and what the CRT is then handed
+    // must be the safe prefix with its own arguments intact — never the full format against a slot
+    // array the CRT will read differently.
+    {
+        const char* fmt = "n=%d t=%'d";
+        prepare(fmt);
+        guest_call(fmt, (uint64_t)42, (uint64_t)1234567);
+        char buf[128];
+        const int n = vsnprintf(buf, sizeof buf, g_fallback_format, (va_list)(char*)g_slots);
+        if (n < 0 || strcmp(buf, "n=42 t=") != 0)
+            fail("Windows CRT round trip with %'d",
+                 std::string("formatted \"") + buf + "\", expected \"n=42 t=\"");
+        if (g_fallback_complete)
+            fail("Windows CRT round trip with %'d", "the walker accepted %'d");
     }
 #endif
 }

--- a/prosper/tools/probe_win_varargs.cpp
+++ b/prosper/tools/probe_win_varargs.cpp
@@ -2,9 +2,15 @@
 //
 // NOT part of the build and NOT a ctest case: it is the reproduction recipe for the one claim the
 // Linux suite cannot make, kept beside the change so the next person does not have to rebuild it.
-// `tests/host/abi/test_guest_varargs.cpp` checks the same logic on any x86-64 host; this compiles the
-// PRODUCTION sources for Windows and executes them, so the CRT, the ABI and the emitted stub bytes
-// are the real ones rather than modelled ones.
+//
+// BE PRECISE ABOUT WHAT THIS SHARES WITH PRODUCTION, because "it runs the production code" would be
+// an overclaim. It compiles the production TRANSLATION sources — `guest_varargs.cpp` and
+// `sysv_ms_bridge.cpp`, the two files that decide argument classes, read the guest's System V list,
+// write the Microsoft one and emit the stub bytes — and it exercises them through the real MinGW CRT
+// on a real Microsoft x64 ABI. What it does NOT link is `hle_libc.cpp`: `guest_snprintf` below
+// RE-SPELLS the guest-ABI shim's shape rather than being it, because linking the HLE would drag in
+// the whole emulator. So the ABI, the CRT and the translation are the real ones; the four-line shim
+// around them is a copy, and a change to the real shim's shape has to be mirrored here by hand.
 //
 //   distrobox enter ps5ys -- bash -lc '
 //     x86_64-w64-mingw32-g++ -std=c++20 -O2 -static -I prosper/src \
@@ -100,8 +106,13 @@ int main() {
     // defect, and it is also why the control here avoids reproducing it: a probe that crashes cannot
     // report its own result.
     ((LegacyGuest)code)(g_legacy_buf, sizeof g_legacy_buf, "%d|%.2f|%d", 1, 1.5, 2);
+    // Assert the SHAPE of the corruption, not merely that it differs. `!=` would also be satisfied by
+    // a truncated buffer or an empty one, i.e. by the probe being broken. What actually happens is
+    // deterministic for the first two fields: the first integer still arrives (both conventions place
+    // it identically), and the float is read from the integer register holding the NEXT argument, a
+    // tiny denormal that prints as 0.00. Only the third field is stack-dependent.
     check("signature-blind stub does NOT deliver the float",
-          strcmp(g_legacy_buf, "1|1.50|2") != 0, g_legacy_buf);
+          strncmp(g_legacy_buf, "1|0.00|", 7) == 0, g_legacy_buf);
 
     printf(g_fail ? "\nprobe_win_varargs: %d failure(s)\n" : "\nprobe_win_varargs: all cases passed\n",
            g_fail);

--- a/prosper/tools/probe_win_varargs.cpp
+++ b/prosper/tools/probe_win_varargs.cpp
@@ -1,0 +1,109 @@
+// probe_win_varargs — run #3246's real code on a real Microsoft x64 host.
+//
+// NOT part of the build and NOT a ctest case: it is the reproduction recipe for the one claim the
+// Linux suite cannot make, kept beside the change so the next person does not have to rebuild it.
+// `tests/host/abi/test_guest_varargs.cpp` checks the same logic on any x86-64 host; this compiles the
+// PRODUCTION sources for Windows and executes them, so the CRT, the ABI and the emitted stub bytes
+// are the real ones rather than modelled ones.
+//
+//   distrobox enter ps5ys -- bash -lc '
+//     x86_64-w64-mingw32-g++ -std=c++20 -O2 -static -I prosper/src \
+//         -o /tmp/probe.exe prosper/tools/probe_win_varargs.cpp \
+//         prosper/src/host/abi/guest_varargs.cpp prosper/src/host/abi/sysv_ms_bridge.cpp
+//     WINEDEBUG=-all wine /tmp/probe.exe'
+//
+// Vary -O0/-O1/-O2/-O3/-Og/-Os: the guest-ABI shim shape has to ASSEMBLE at all of them, because
+// MinGW cannot emit SEH unwind data for a sysv_abi frame and inlining decides whether one is needed.
+#include "host/abi/guest_varargs.hpp"
+#include "host/abi/sysv_ms_bridge.hpp"
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <windows.h>
+
+using namespace prosper::abi;
+
+static int g_fail = 0;
+static void check(const char* what, bool ok, const char* detail) {
+    printf("%-52s %s%s%s\n", what, ok ? "PASS" : "FAIL", detail && *detail ? " -- " : "",
+           detail ? detail : "");
+    if (!ok) ++g_fail;
+}
+
+// --- the fix, exactly as hle_libc.cpp spells it ------------------------------------------------
+__attribute__((noinline))
+static int host_snprintf(char* buf, size_t n, const char* fmt, const SysvVaList& ap) noexcept {
+    MsVarargCall call(fmt, ap, FormatGrammar::Printf);
+    return vsnprintf(buf, n, call.format(), (va_list)(char*)call.va_list_image());
+}
+
+static __attribute__((sysv_abi)) int guest_snprintf(char* buf, size_t n, const char* fmt, ...) {
+    __builtin_sysv_va_list ap;
+    __builtin_sysv_va_start(ap, fmt);
+    SysvVaList captured;
+    memcpy(&captured, &ap, sizeof captured);
+    __builtin_sysv_va_end(ap);
+    return host_snprintf(buf, n, fmt, captured);
+}
+
+// --- the defect: an MS-ABI variadic reached through the signature-blind bridge -------------------
+// This is what a Windows build did before #3246, byte for byte: the fixed integer shuffle, then a
+// host variadic that reads its arguments by the Microsoft rules.
+static char g_legacy_buf[256];
+static uint64_t legacy_target(void* buf, uint64_t n, const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    const int r = vsnprintf((char*)buf, (size_t)n, fmt, ap);
+    va_end(ap);
+    return (uint64_t)r;
+}
+static void legacy_checkpoint() {}
+
+int main() {
+    char buf[256];
+
+    // 1. A mixed list, including arguments past both System V register files.
+    guest_snprintf(buf, sizeof buf, "%s|%d|%.2f|%s|%.2f|%d|%.2f|%s|%.2f|%lld|%.2f|%s",
+                   "A", 1, 1.5, "B", 2.5, 2, 3.5, "C", 4.5, (long long)7, 5.5, "D");
+    check("mixed 12-argument call", strcmp(buf, "A|1|1.50|B|2.50|2|3.50|C|4.50|7|5.50|D") == 0, buf);
+
+    // 2. Ten doubles: two of them past xmm0..xmm7, in the System V overflow area.
+    guest_snprintf(buf, sizeof buf, "%.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f",
+                   0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5);
+    check("ten doubles (two past the SSE file)",
+          strcmp(buf, "0.5 1.5 2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5") == 0, buf);
+
+    // 3. A format the model refuses formats its safe prefix and stops.
+    guest_snprintf(buf, sizeof buf, "a=%d b=%f c=%1$s", 7, 6.5, "x");
+    check("unmodellable format truncates safely", strcmp(buf, "a=7 b=6.500000 c=") == 0, buf);
+
+    // 4. THE DEFECT, executed. Same call through the pre-#3246 stub: the bridge with no declared
+    //    signature, which is what a variadic handler got. If this reproduced the correct string the
+    //    probe would be proving nothing.
+    uint8_t staged[kMaxBridgeBytes];
+    BridgeParams params;
+    params.handler = (uint64_t)(uintptr_t)&legacy_target;
+    params.checkpoint = (uint64_t)(uintptr_t)&legacy_checkpoint;
+    const size_t n = emit_sysv_to_ms_bridge(staged, params);
+    auto* code = (uint8_t*)VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE,
+                                        PAGE_EXECUTE_READWRITE);
+    if (!code) { printf("VirtualAlloc failed\n"); return 2; }
+    memcpy(code, staged, n);
+    using LegacyGuest = __attribute__((sysv_abi)) uint64_t (*)(void*, uint64_t, const char*, ...);
+    memset(g_legacy_buf, 0, sizeof g_legacy_buf);
+    // Deliberately all-numeric. With a `%s` behind the float this call does not merely print the
+    // wrong text — the displaced argument is read as a POINTER and the CRT dereferences it, which
+    // faulted outright under wine at -O2 (`Unhandled page fault on read access to FFFFFFFFFFFFFFFF`)
+    // and printed the stub's own machine code as a string at -O0. That is the real severity of the
+    // defect, and it is also why the control here avoids reproducing it: a probe that crashes cannot
+    // report its own result.
+    ((LegacyGuest)code)(g_legacy_buf, sizeof g_legacy_buf, "%d|%.2f|%d", 1, 1.5, 2);
+    check("signature-blind stub does NOT deliver the float",
+          strcmp(g_legacy_buf, "1|1.50|2") != 0, g_legacy_buf);
+
+    printf(g_fail ? "\nprobe_win_varargs: %d failure(s)\n" : "\nprobe_win_varargs: all cases passed\n",
+           g_fail);
+    return g_fail != 0;
+}

--- a/prosper/tools/probe_win_varargs.cpp
+++ b/prosper/tools/probe_win_varargs.cpp
@@ -20,6 +20,23 @@
 //
 // Vary -O0/-O1/-O2/-O3/-Og/-Os: the guest-ABI shim shape has to ASSEMBLE at all of them, because
 // MinGW cannot emit SEH unwind data for a sysv_abi frame and inlining decides whether one is needed.
+//
+// READ THIS BEFORE TRUSTING A RESULT FROM HERE. This probe's CRT is NOT the shipped CRT, and the
+// difference is invisible in its output:
+//
+//                     toolchain                 __USE_MINGW_ANSI_STDIO   vsnprintf resolves to
+//   this probe        a cross mingw, msvcrt     1                        __mingw_vsnprintf
+//   CI and shipping   MSYS2 UCRT64 (ci.yml)     0                        UCRT's own
+//
+// `_mingw.h:442-454` auto-enables ANSI stdio only while `__MSVCRT_VERSION__ < 0xE00`, and `:229-236`
+// pins exactly 0xE00 on the UCRT branch, so the clause that enables it here cannot fire there.
+// The two implementations agree about the ABI, the register files, the overflow area and the va_list
+// layout — everything this probe exists to check — and DISAGREE about format-string extensions:
+// __mingw_vsnprintf consumes an argument for `%'d`, UCRT does not. A green "4/4 at six optimisation
+// levels" from here is therefore strong evidence about ABI and translation and NO evidence at all
+// about which specifiers may be accepted. That question belongs to the CRT that ships, and
+// `tests/host/abi/test_guest_varargs.cpp` asks it there, in the Windows job, on every run.
+// A `%'d` here would pass and ship a defect; that is not hypothetical, it happened (#3266 review).
 #include "host/abi/guest_varargs.hpp"
 #include "host/abi/sysv_ms_bridge.hpp"
 


### PR DESCRIPTION
Fixes #3246.

## The defect

#2955 made the Windows import bridge signature-driven, and explicitly deferred the one argument list
a `CallSignature` cannot describe: a **real C variadic**, whose shape the format string decides at run
time. Those handlers kept the historical fixed integer shuffle, which never touches xmm.

The consequence is larger than "the float is missing", for the same reason as #2955: System V counts
integer and SSE arguments with **two independent counters** and Microsoft x64 with **one positional**
one, so a single float desynchronizes them and displaces every argument behind it too.

For `printf("%d %f %s", i, f, s)`:

| arg | guest sets (SysV) | handler reads (MS) | old stub delivered |
| --- | --- | --- | --- |
| 0 `fmt` | `rdi` | `rcx` | `rcx` ✓ |
| 1 `%d` | `rsi` | `rdx` | `rdx` ✓ |
| 2 `%f` | `xmm0` | home slot 2, from `r8` | **`s`'s pointer bits, read as a double** |
| 3 `%s` | `rdx` | home slot 3, from `r9` | **whatever `r9` held** |

Executed on a real Microsoft x64 host (MinGW + wine), the pre-fix path prints `1|0.00|9437184` where
`1|1.50|2` was asked for. With a `%s` behind the float it is worse than wrong output: the displaced
argument is read as a **pointer and dereferenced**, which printed the stub's own machine code as a
string at `-O0` and **faulted outright** at `-O2` (`Unhandled page fault on read access to
FFFFFFFFFFFFFFFF`).

## The census

Every dump in the local corpus (56 titles) imports `printf`, `sprintf`, `snprintf`, `sprintf_s`,
`snprintf_s`, `sscanf`, `vsnprintf` and `vsprintf`, and every one carries thousands of format strings
with a floating-point conversion (median ~3,500, max 33,761). So the class is universal rather than
exotic — what is unknown is which of those call sites a given boot reaches, which needs a Windows host.

## Two things the issue did not have

**The `v*` forms are NOT unaffected**, and the issue says they are. On Windows `va_list` is a bare
`char*`, so

```cpp
va_list ap; if (a3) memcpy(&ap, P(a3), sizeof(va_list));   // sizeof(va_list) == 8 on Windows
```

copies **eight** bytes of a **twenty-four** byte System V structure and then reads its
`{gp_offset, fp_offset}` pair as a pointer. That is not a wholesale copy, it is a type confusion, and
it applied to `vsnprintf`, `vsprintf` and `vsscanf` on every Windows boot.

**`sscanf` IS unaffected**, and the issue lists it as affected. Every variadic argument a scanf-family
call passes is a **pointer**, so the list is all-integer, no floating-point duplication is required,
and System V's integer registers map one-for-one onto Microsoft's first ten argument positions —
exactly what the historical shuffle already delivers. It is deliberately left on that path.

## The fix

Not to satisfy the Microsoft varargs FP-duplication rule but to **sidestep** it. That rule only binds
on code that *forwards* a variadic call in registers; prosper does not have to.

- **`PROSPER_GUEST_ABI`** (`hle/dispatch/dispatch.hpp`) — `__attribute__((sysv_abi))` on Windows, empty
  elsewhere. `printf`/`sprintf`/`snprintf` carry it, so their import stub becomes the same **bare
  tail-jump Linux uses** and the compiler's own System V variadic prologue captures the guest's frame:
  registers, xmm, AL and the overflow area alike. No width cap, no new emitted machine code.
- **`src/host/abi/guest_varargs.hpp/.cpp`** — reads that list by the System V rules, learns each
  argument's class from the format string, and writes the flat array of 8-byte slots that **is** a
  Microsoft `va_list`, handed straight to the host CRT's `v*` function. Pure functions, compiled and
  tested on every platform.
- **`Hle::register_guest_abi`** — a template whose parameter type carries the attribute, so on Windows
  a handler that forgot the tag is a **compile error**, not a stub reading the wrong registers.
- `emit_guest_abi_tailjump` in the bridge, so those stub bytes stay in `host/abi` and stay testable.

A format the model will not guess at (a POSIX `%1$s`, an x87 `%Lf`, an unknown conversion) formats only
the **prefix it can account for** and says so on stderr — less than the guest asked for, never a value
read from the wrong file.

### The constraint that shapes the code

**MinGW cannot emit SEH unwind data for a `sysv_abi` function.** A frame needing an unwind cleanup
fails to assemble with `.seh_handlerdata used outside of .seh_proc block` — and whether one appears is
an **inlining** decision, so the same source assembles at `-O0` and `-O2` and fails at `-O1` when a
throwing callee gets inlined in. Reproduced on MinGW GCC 16.1.1. So each shim captures and immediately
delegates to a `noinline`/`noexcept` host function that owns every C++ object. That is why
`docs/PORTING.md`'s "the attribute route was abandoned" still stands for the 537 STL-using handlers:
three capture-and-delegate shims can be kept cleanup-free; a library of handlers cannot.

## The ">10 arguments" audit riding on the issue

Answered, negative. No registered handler declares more than ten arguments: handlers are written
through per-file `HLE`/`HLE7`/`HLE8`/`HLE9`/`HLE10` macros whose widest member is exactly ten (12 uses
of `HLE10`, no `HLE11`), and the widest hand-written declarations reach nine. `abi::kLegacyForwardedArgs`
now records the prologue's capacity, and a `static_assert` at the `HLE10` definition couples the two —
the surviving risk is a future `HLE11`, not anything in the tree today. Not split into its own issue
because the answer is one paragraph and one assert.

## Linux and macOS: a no-op by construction

`PROSPER_GUEST_ABI` is empty there, the stub was already a bare tail-jump, and every
`#if defined(_WIN32)` arm leaves the existing code character for character. The guest-ABI registry flag
is set on all platforms because it is *true* on all platforms ("no conversion needed"); only the
Windows emitter reads it.

## Verification

**On this Linux box** — `cmake -S prosper -B prosper/build-linux && cmake --build prosper/build-linux -j6`:

| | result |
| --- | --- |
| build | exit **0** |
| `ctest --no-tests=error` | exit **0**, **347/347 passed** |

Baseline measured on the branch point (`30c4270b6`) in a separate worktree: exit **0**, **346/346** —
so the change adds exactly the one new case and moves nothing else. The first pass of this branch was
verified the same way on its original base `e13fd40af` (345/345 against a 344/344 baseline).

**And on a real Windows host, in CI.** `Windows MinGW` builds the whole tree and runs the whole suite
with `--no-tests=error`: **266/266**, including `guest_varargs`, `sysv_ms_bridge`, `printf_varargs` and
`guest_log_capture`. That job is also what caught the second commit's defect — see below — which is the
single best argument for it being a required check on ABI work.

The new `guest_varargs` case is cross-platform on purpose. Both conventions' `va_arg` are reachable
from any x86-64 host through `__builtin_sysv_va_list` and `__builtin_ms_va_list`, so:

- the System V **read** is checked against a real `va_start` frame read by the **compiler's own**
  `va_arg` — an independently produced positive instance, not the machinery checking itself;
- the Microsoft **write** is consumed by the **compiler's own** ms_abi `va_arg`, so the layout claim is
  checked against the toolchain rather than against the test's belief about it;
- a 20-argument call drives arguments past **both** register files and through the interleaved overflow
  area.

**On a real Microsoft x64 host.** `tools/probe_win_varargs.cpp` (not part of the build; its header
carries the command) cross-compiles the **production sources** with MinGW and runs them under wine:

```
x86_64-w64-mingw32-g++ -std=c++20 -O$O -static -I prosper/src -o probe.exe \
    prosper/tools/probe_win_varargs.cpp prosper/src/host/abi/guest_varargs.cpp \
    prosper/src/host/abi/sysv_ms_bridge.cpp
WINEDEBUG=-all wine probe.exe
```

**4/4 at `-O0`, `-O1`, `-O2`, `-O3`, `-Og`, `-Os`** — a mixed 12-argument call, ten doubles including
two past `xmm7`, the truncating fallback, and the negative control above.

**Not verified:** a live guest calling `printf` on a Windows host. Nobody here has one. The command that
would settle it is the ordinary Windows run — build under MSYS2 UCRT64 with
`cmake -S prosper -B prosper/build-windows -G Ninja -DPROSPER_APP=ON`, launch any title, and confirm the
guest's own log output is intact and a run reaches the same point it does on Linux.

## Verification the tests carry themselves

- the **class-blind** plan must NOT deliver the double (if it did, the test could not see the defect);
- the **guest-ABI flag** must move the emitter (if the two agreed, the stub arm would assert nothing);
- the registry sweep fails if **zero** printf-family NIDs are marked, which would mean the registration
  is not reaching the registry;
- an ordinary handler (`memcpy`) and `sscanf` must NOT be marked.

## Mutation arms

Each was built and run, so the failure is the test's rather than the compiler's.

| mutation | build | ctest | what failed |
| --- | --- | --- | --- |
| `sysv_va_arg` advances the SSE cursor by 8 instead of 16 | `0` | `8` | 10 failures, all in the 20-argument call (`argument 3 arrived as 0, expected 3.5`) |
| the format plan classifies float conversions as Integer (the pre-fix behaviour) | `0` | `8` | 10 failures across the plan table and both executed calls |
| the emitter ignores `guest_abi` | `0` | `8` | 3 failures — `emitted 83 bytes, expected 12` |
| the registration drops the `guest_abi` flag | `0` | `8` | 6 failures — every printf-family NID unmarked, plus the vacuity guard |

Reverted; rebuild `0`, ctest `0`, 345/345.

## The second commit, and why it is here

The first push of this branch **failed `Windows MinGW`**: `printf_varargs` and `guest_log_capture`
SEGFAULTed. Neither could fail on Linux, and the cause is the change working as intended.

Both tests take a printf handler's address out of the registry and call it through an ordinary
host-ABI variadic function-pointer type. That was correct while the handlers were Microsoft x64. Now
they are compiled in the guest's convention, so the arguments were placed by one convention and read
by the other, and the first `%s` dereferenced whatever landed in `rdi`.

Both pointer types now carry `PROSPER_GUEST_ABI` — empty everywhere but Windows. `test_printf`'s own
header already claimed it called "through its TRUE variadic signature (same SysV ABI the guest uses
via the tail-jump stub)"; the type simply could not express that before, so this makes the file honest
as well as green. The obligation is recorded at `register_guest_abi`, because `Hle::lookup` hands back
a bare address and nothing in the type system stops the next caller repeating it. A sweep for other
direct callers (`nid_hash("printf")` and friends, plus every `Hle::lookup` user) finds none — every
other one takes an ordinary integer handler, for which `HleFn` remains right.

## Review findings, and what changed

Independent review approved this and asked for one fix. All six actionable findings are addressed in
the third commit.

- **F1 (blocking, and a deletion).** The rewritten comment dropped the caveat that Linux's guest-`%fs`
  swap stub re-pushes only **four** of the guest's spilled words. Re-verified against `emit_swap_stub`
  rather than taken on trust — the four pushes are there, the saved `r11` sits immediately behind them,
  and `guest_tls_enabled()` defaults **on** — so it is live on the primary platform. Restored and
  **updated**, because the new architecture makes it Linux-only: the Windows guest-ABI stub is a bare
  tail-jump with no interposed frame, and macOS never emits the swap stub. Now also **#3271**, since a
  code comment being its only record is precisely what nearly lost it.
- **F5.** `plan_format`'s accepted set must be a subset of what the CRT consumes. **Measured** under
  wine rather than assumed: `%zu %jd %td %hhd %a %S %C` and `%'d` each consume one argument, but `%qd`
  prints `%qd` **literally and consumes nothing**. `q` is refused (332 occurrences across 50 dumps);
  `'` stays, with the measurement recorded beside it because it rests on MinGW's ANSI stdio.
- **F2.** A guest-ABI stub cannot run a return hook. Unreachable through the registry today; the
  emitter now refuses it visibly rather than emitting a stub that drops the hook.
- **F4.** The 511-byte retained prefix could be cut mid-conversion. It is now re-planned, walking the
  cut back to a conversion boundary and keeping the slot count and the formatted string in step.
- **F3 (half).** The registration guard is now checked **by the compiler**: a `static_assert` requires
  `PROSPER_GUEST_ABI` to change the function type on Windows and to leave it alone elsewhere. If the
  tag ever stopped changing the type, the guard would compile and close nothing. The other half — the
  guard closes registration, not calls, which is exactly what the CI catch was — is **#3272**.
- **F6/F7.** The probe no longer claims to compile "the production sources": it compiles the production
  *translation* sources and **re-spells** the shim shape, and says so. Its negative control asserts the
  shape of the corruption (`1|0.00|`) rather than mere inequality.

**Two of the new arms were vacuous when first written**, and both are recorded as such in the test so
the next person does not repeat them: the prefix-cap arm **passed against a build with its own fix
removed** (504 bytes never reached the cap; 600 bytes then hit the 64-argument limit first, at 258
bytes), and the return-hook registry arm read the registry before `register_builtin_hle()` populated
it.

## Second review round: `%'d`, and the method behind it

The reviewer found that `'` was kept on a measurement taken against **the wrong C runtime**. Verified
here rather than accepted, then measured on the real thing.

**The confound.** My probe and the shipping build do not resolve `printf` to the same implementation:

| | toolchain | `__USE_MINGW_ANSI_STDIO` | `vsnprintf` resolves to |
| --- | --- | --- | --- |
| the probe, under wine | Fedora cross mingw, msvcrt (`0x600`) | **1** | `__mingw_vsnprintf` — supports `'` |
| CI + shipped | MSYS2 **UCRT64** (`ci.yml:643`, `:685`) | **0** | UCRT's own — does not |

`_mingw.h:442-454` auto-enables ANSI stdio only while `__MSVCRT_VERSION__ < 0xE00`; `:229-236` pins
exactly `0xE00` on the UCRT branch, so the C++11 clause that rescues the msvcrt build cannot fire on
the shipped one. Confirmed in the local header and in `ci.yml`.

**Then measured, not inferred.** I loaded the real `ucrtbase.dll` and drove its exported
`__stdio_common_vsprintf` (UCRT keeps `snprintf` inline in headers), asking each specifier whether a
trailing sentinel survives:

```
  UCRT %'d   ['d|1234              ] consumes NOTHING
  UCRT %qd   [qd|1234              ] consumes NOTHING
  UCRT %zu %jd %td %hhd %lld %a %.2f  all CONSUME an argument
```

So `'` is `%qd` again — the exact defect this PR fixes, reintroduced by the one specifier I kept.
**Dropped.**

**The method is fixed too, which is the larger half.** A new Windows-only arm stops asserting the
subset rule and **asks whichever CRT the build actually links**, requiring `we consume ⟹ the CRT
consumes` — an implication rather than equality, because refusing something the CRT supports costs a
truncated line while accepting something it does not is argument-shifting corruption. Its vacuity
guard is load-bearing: the table must contain at least one specifier *this* CRT rejects, or the
sentinel detector could be reporting "consumes" for everything and the loop would be green while
measuring nothing.

Because that arm only ever executes on the Windows job, I validated its logic standalone under wine
against **both** runtimes first:

| | `'` refused (shipped) | `'` re-accepted (mutation) |
| --- | --- | --- |
| ANSI stdio — my probe's CRT | ARM PASSES | **ARM PASSES** |
| real UCRT — CI's CRT | ARM PASSES | **ARM FAILS** — `VIOLATION %'d ['d|1234]` |

That bottom-left/bottom-right pair *is* the trap, reproduced: the original measurement was green
because it asked the CRT that does not ship.

`tools/probe_win_varargs.cpp`'s header now carries that table, because its "4/4 at six optimisation
levels" is strong evidence about ABI, register files, overflow area and va_list layout — and **no**
evidence about which specifiers may be accepted.

**The asymmetry the reviewer named, recorded because it is the transferable lesson:** `q` was refused
on a quantified basis (332 occurrences across 50 dumps); `'` was kept on an unquantified "output that
demonstrably works" — even though the 971-occurrence count for `'` was already in hand. Same decision,
two standards of evidence, and the weaker one is the one that survived.

## Is this safe to merge with nobody having booted a guest on Windows?

The reviewer's answer is yes, and the reasoning is worth having here rather than in a thread:

- non-Windows is untouched by construction — `PROSPER_GUEST_ABI` is empty, the stub was already a
  tail-jump, and every `#if defined(_WIN32)` arm leaves the existing code character for character;
- the Windows path being replaced **was not a working path** — it could not deliver a floating-point
  variadic argument at all, and the `v*` handlers were reading a 24-byte structure as an 8-byte one;
- the mechanism is executed on a real Microsoft x64 host at six optimization levels, and the whole
  suite runs there in CI (266/266);
- the blast radius is 8 NIDs, all in the formatting path;
- the residual risks fail toward **truncated output plus a stderr line**, not corruption.

**Please grep the first Windows boot after this lands for `[libc] variadic format not fully
modelled`.** "Unreachable in practice" is currently a *static* census over the dumps — the refusable
shapes look like noise inside the guests' own libc format tables rather than call sites — and one boot
converts that into an observation. The same request is on #3246.

## Risks

- **The riskiest part is the part that cannot be run here**: this changes the machine code installed for
  five imports and the argument handling of three more, on a platform this box cannot boot. Mitigated by
  executing the production sources on a genuine Microsoft x64 host at six optimization levels, and by
  every non-Windows path being untouched.
- **The SEH constraint is optimization-dependent**, so it is a build-breaking hazard rather than a
  silent one — but only if someone edits a `PROSPER_GUEST_ABI` body. The rule is stated at the macro, in
  `src/host/abi/AGENTS.md`, and beside each shim.
- **A System V `va_list` dies with the frame it came from.** The production shims read it while the guest
  frame is live; the first draft of the test did not, and its overflow arguments came back as stack
  litter. That is recorded where it can be re-learned cheaply.
- **The truncating fallback loses output** for a format the model refuses. Measured over the corpus, the
  refusable shapes are essentially all noise inside the guests' own libc format tables (a contiguous
  `%Lf %LF %Le %LE %Lg %LG %La %LA` block) rather than call sites — but it is a real behaviour change on
  Windows if one is ever reached, and it is loud.

## Docs

`docs/PORTING.md` items 3 and 5 updated, four new `## Ruled out` rows (the `v*` claim, the `sscanf`
claim, the FP-duplication framing, and "sysv_abi cannot be used at all"); `src/host/abi/AGENTS.md`
extended for the third file and the two constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
