### PR TITLE
env: the write-watch knobs refuse a typo instead of quietly picking another setting (#3253)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1273,7 +1273,9 @@ if(TARGET prosper_core)
   add_test(NAME capture_compute_policy COMMAND test_capture_compute_policy)
 
   add_executable(test_write_watch_policy frontends/shared/tests/test_write_watch_policy.cpp)
-  target_include_directories(test_write_watch_policy PRIVATE frontends)
+  # `src` as well as `frontends`: the knobs' strict parsing lives in diagnostics/env_numeric.hpp,
+  # and it is asserted here beside the policy whose sentinels make a typo dangerous (#3253).
+  target_include_directories(test_write_watch_policy PRIVATE frontends src)
   add_test(NAME write_watch_policy COMMAND test_write_watch_policy)
 
   add_executable(test_texture_decode_diagnostic

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -451,17 +451,25 @@ page-protection write watch: texture sources below 1 MiB stay on exact compariso
 immediately, and larger
 sources arm after three exact unchanged validations. Promotions are limited to 8 MiB per ordered submit,
 with at most one source larger than that limit, and adjacent pages are protected in coalesced runs. Set
-`PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB`, `PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS`, or
-`PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB` for controlled A/B runs.
+`PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB`, `PROSPER_TEXTURE_WRITE_WATCH_MIN_KB`,
+`PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS`, or `PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB` for controlled
+A/B runs.
+
+**Every one of these takes a plain decimal integer and nothing else, and a malformed value is refused
+on stderr while the default stands (#3253).** That is not pedantry about input: on each of them **0 is
+a meaningful and maximally aggressive setting** — defer nothing, no size floor, promote on first sight,
+unbounded arming — and a bare `strtoull` answers 0 for anything it cannot parse. So `=8mb`, `=8 KB` or
+a stray quote used to select the *opposite* arm from the one you asked for, with nothing in the run's
+output saying so. No sign, no `0x`, no units, no surrounding whitespace; unset takes the default in
+silence.
 
 Compute buffer/image residency uses the same exact-first rule with `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS`
 and `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB` — **but it does not have the "1-8 MiB arm immediately" half**,
 and this paragraph claimed it did until #3155. That path has always passed a defer minimum of **one byte**,
 which makes the size exemption unreachable, so every compute source must climb the stability ladder however
 small it is. `PROSPER_COMPUTE_WATCH_DEFER_MIN_KB` exposes that minimum for A/B (unset = 1 byte, i.e. today's
-behaviour; `=8192` gives renderer parity; `=0` defers nothing). A malformed value is refused loudly and keeps
-the default — unlike the four older variables beside it, where a typo silently selects the most
-aggressive setting (#3253). Whether the asymmetry is right is open —
+behaviour; `=8192` gives renderer parity; `=0` defers nothing). Like the rest of the family since #3253, a
+malformed value is refused loudly and keeps the default. Whether the asymmetry is right is open —
 see `RENDERER_PERFORMANCE_2026_07.md` § *Compute write-watch promotion census*.
 
 `PROSPER_WATCH_PROMOTE_CENSUS=1` reports what any of those settings actually bought, every 256 submits and
@@ -478,7 +486,9 @@ if another architectural writer invalidates it, the next invocation takes ordina
 establishes the exact baseline needed for later identical-result skips. A failed attempt to replace a
 host result fallback with a GPU baseline invalidates that obsolete fallback before returning. Partial,
 readable, and replay-owned targets retain their original exact contract. Set
-`PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` to retune the crossover. The broader
+`PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` to retune the crossover — it validated its input before #3253 but
+fell back in silence, which fails the other way: a typo left you measuring the default while believing
+you had moved it. The broader
 `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` control restores immediate storage-result snapshots.
 
 A sampled image that successfully imports an authoritative renderer-owned Vulkan image does not validate,

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -10,6 +10,7 @@
 #include "shared/device/vulkan_device_select.hpp"
 #include "shared/texture/write_watch_census.hpp"
 #include "shared/texture/write_watch_policy.hpp"
+#include "diagnostics/env_numeric.hpp"   // #3253: a typo must not select a different setting
 #include "shared/perf/performance_capture.hpp"      // bounded F8 post-trigger compute timing
 #include "shared/perf/performance_timing_policy.hpp" // F8 measures without enabling verbose timing logs
 
@@ -1105,9 +1106,13 @@ VkDeviceSize persistent_compute_image_limit(
 
 uint32_t compute_write_watch_promotion_validations() {
     static const uint32_t value = [] {
+        // 0 here is not "off": `stable >= 0` is always true, so every source arms on first
+        // acquisition. A malformed value must therefore keep the default rather than becoming it
+        // (#3253).
         const char* text = std::getenv("PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS");
-        const uint64_t parsed = text ? std::strtoull(text, nullptr, 10) : 3ull;
-        return static_cast<uint32_t>(std::min<uint64_t>(parsed, UINT32_MAX));
+        return static_cast<uint32_t>(prosper::diag::env_u64_or_default_capped(
+            "PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS", text, 3ull, UINT32_MAX,
+            "unchanged validations"));
     }();
     return value;
 }
@@ -1133,20 +1138,20 @@ uint32_t compute_write_watch_promotion_validations() {
 // Pair it with PROSPER_WATCH_PROMOTE_CENSUS, which reports what each setting actually bought.
 size_t compute_write_watch_defer_min_bytes() {
     static const size_t value = [] {
+        // The historical default is 1 BYTE, not 1 KiB, so it cannot be expressed in this knob's own
+        // units -- hence the explicit unset case rather than a KiB default handed to the helper.
         constexpr size_t historical_default = 1;
         const char* text = std::getenv("PROSPER_COMPUTE_WATCH_DEFER_MIN_KB");
         if (!text || !*text) return historical_default;
-        // Refuse a malformed value LOUDLY and keep the default. A bare `strtoull` answers 0 for
-        // anything non-numeric, and 0 here means "defer nothing" -- the most aggressive setting on
-        // the knob. A typo must cost you the experiment, never hand you a different one you did not
-        // ask for and cannot see in the run's own output.
-        char* end = nullptr;
-        const uint64_t kib = std::strtoull(text, &end, 10);
-        if (end == text || (end && *end)) {
+        // #3251 gave this knob a strict parse; #3253 moved that parse into diagnostics/env_numeric
+        // so the whole write-watch family shares one, rather than this one being the exception. The
+        // sentinel it protects: 0 means "defer nothing", i.e. arm every source on first acquisition.
+        uint64_t kib = 0;
+        if (!prosper::diag::parse_u64_strict(text, &kib)) {
             std::fprintf(stderr,
-                         "[watch-policy] PROSPER_COMPUTE_WATCH_DEFER_MIN_KB='%s' is not a number "
-                         "-- the compute defer minimum stays at its default and NOTHING is being "
-                         "A/B'd\n",
+                         "[env] PROSPER_COMPUTE_WATCH_DEFER_MIN_KB='%s' is not a plain "
+                         "non-negative integer of KiB -- keeping the default (1 byte) and NOTHING "
+                         "is being A/B'd\n",
                          text);
             return historical_default;
         }
@@ -1158,11 +1163,13 @@ size_t compute_write_watch_defer_min_bytes() {
 
 size_t compute_write_watch_promotion_budget_bytes() {
     static const size_t value = [] {
+        // 0 here is not "off" either: WriteWatchPromotionBudget::try_consume returns true
+        // unconditionally when the byte limit is 0, i.e. UNBOUNDED arming per submit (#3253).
         const char* text = std::getenv("PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB");
-        const uint64_t mib = text ? std::strtoull(text, nullptr, 10) : 8ull;
-        return static_cast<size_t>(
-            std::min<uint64_t>(mib, SIZE_MAX / (1024ull * 1024ull)) *
-            (1024ull * 1024ull));
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB", text, 8ull,
+            SIZE_MAX / (1024ull * 1024ull), "MiB");
+        return static_cast<size_t>(mib * (1024ull * 1024ull));
     }();
     return value;
 }
@@ -1190,13 +1197,14 @@ size_t cold_storage_result_snapshot_defer_min_bytes() {
             false, std::memory_order_acq_rel))
         return 0;
     static const size_t bytes = [] {
+        // This one already validated its end pointer but fell back in SILENCE, which fails the
+        // other way from the rest of the family: a typo left you measuring the default while
+        // believing you had moved it (#3253). Same helper, so the refusal is now audible.
         const char* value = std::getenv("PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB");
-        char* end = nullptr;
-        const uint64_t parsed = value ? std::strtoull(value, &end, 10) : 16ull;
-        const uint64_t mib = value && (!end || *end) ? 16ull : parsed;
-        return static_cast<size_t>(
-            std::min<uint64_t>(mib, SIZE_MAX / (1024ull * 1024ull)) *
-            (1024ull * 1024ull));
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB", value, 16ull,
+            SIZE_MAX / (1024ull * 1024ull), "MiB");
+        return static_cast<size_t>(mib * (1024ull * 1024ull));
     }();
     return bytes;
 }

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -2,6 +2,7 @@
 // (behavior-preserving); Vulkan-backed, so this unit links Vulkan::Vulkan.
 #include "shared/live/live_renderer.hpp"
 #include "diagnostics/env_cache.hpp"   // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
+#include "diagnostics/env_numeric.hpp" // #3253: a typo must not select a different setting
 #include "gpu/resources/metadata_kind_correlation.hpp"  // positive metadata-kind correlation (pure, tested)
 #include "gpu/diagnostics/watch_list.hpp"                 // strict 0x-only watch parsing
 #include "gpu/diagnostics/draw_program_skip.hpp"          // PROSPER_SKIP_DRAW_PROGRAM / census
@@ -1709,11 +1710,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             drain_guest_gpu_writes(g_rtt, invalidate_ds);
             const prosper::gpu::LiveRenderPhase phase = prosper::gpu::live_render_phase();
             static const size_t write_watch_promotion_budget_bytes = [] {
+                // 0 is not "off": an empty budget makes WriteWatchPromotionBudget::try_consume
+                // return true unconditionally, i.e. unbounded arming per submit. A typo must keep
+                // the default rather than select that (#3253).
                 const char* value = PROSPER_ENV_VALUE("PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB");
-                const uint64_t mib = value ? strtoull(value, nullptr, 10) : 8ull;
-                return static_cast<size_t>(
-                    std::min<uint64_t>(mib, SIZE_MAX / (1024ull * 1024ull)) *
-                    (1024ull * 1024ull));
+                const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+                    "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", value, 8ull,
+                    SIZE_MAX / (1024ull * 1024ull), "MiB");
+                return static_cast<size_t>(mib * (1024ull * 1024ull));
             }();
             static thread_local prosper::frontend::WriteWatchPromotionBudget
                 write_watch_promotion_budget;
@@ -3844,23 +3848,35 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // sources large enough for it to amortize.  Keep the cutoff tunable for
                         // host/platform profiling without changing the cache's correctness policy.
                         static const size_t cross_submit_watch_min_bytes = [] {
+                            // Same family, same sentinel: 0 makes every source large enough, so a
+                            // typo would widen eligibility rather than disable the knob (#3253).
                             const char* value = PROSPER_ENV_VALUE("PROSPER_TEXTURE_WRITE_WATCH_MIN_KB");
-                            const uint64_t kib = value ? strtoull(value, nullptr, 10) : 1024ull;
-                            return static_cast<size_t>(
-                                std::min<uint64_t>(kib, SIZE_MAX / 1024ull) * 1024ull);
+                            const uint64_t kib = prosper::diag::env_u64_or_default_capped(
+                                "PROSPER_TEXTURE_WRITE_WATCH_MIN_KB", value, 1024ull,
+                                SIZE_MAX / 1024ull, "KiB");
+                            return static_cast<size_t>(kib * 1024ull);
                         }();
                         const bool cross_submit_watch_eligible = cross_submit_watch_enabled &&
                             persistent_source_size >= cross_submit_watch_min_bytes;
                         static const size_t cross_submit_watch_defer_min_bytes = [] {
+                            // 0 means "defer nothing": should_promote_write_watch returns true
+                            // immediately, arming every source on first sight. This is the knob
+                            // #3253 names first, because it is the one an A/B is most likely to
+                            // mistype (`=8mb`, `=8 KB`, a stray quote) -- and a bare strtoull would
+                            // hand back the MOST aggressive arm instead of the one asked for.
                             const char* value = PROSPER_ENV_VALUE("PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB");
-                            const uint64_t kib = value ? strtoull(value, nullptr, 10) : 8192ull;
-                            return static_cast<size_t>(
-                                std::min<uint64_t>(kib, SIZE_MAX / 1024ull) * 1024ull);
+                            const uint64_t kib = prosper::diag::env_u64_or_default_capped(
+                                "PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB", value, 8192ull,
+                                SIZE_MAX / 1024ull, "KiB");
+                            return static_cast<size_t>(kib * 1024ull);
                         }();
                         static const uint32_t cross_submit_watch_promotion_validations = [] {
+                            // 0 makes `stable >= 0` always true, so every deferred source promotes
+                            // on its first acquisition -- the aggressive end, not the off end.
                             const char* value = PROSPER_ENV_VALUE("PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS");
-                            const uint64_t hits = value ? strtoull(value, nullptr, 10) : 3ull;
-                            return static_cast<uint32_t>(std::min<uint64_t>(hits, UINT32_MAX));
+                            return static_cast<uint32_t>(prosper::diag::env_u64_or_default_capped(
+                                "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS", value, 3ull, UINT32_MAX,
+                                "unchanged validations"));
                         }();
                         static const bool audit_cross_submit_watch =
                             PROSPER_ENV_VALUE("PROSPER_AUDIT_CROSS_SUBMIT_TEXTURE_WRITE_WATCH") != nullptr;

--- a/prosper/frontends/shared/tests/test_write_watch_policy.cpp
+++ b/prosper/frontends/shared/tests/test_write_watch_policy.cpp
@@ -1,7 +1,9 @@
 #include "shared/texture/write_watch_census.hpp"
 #include "shared/texture/write_watch_policy.hpp"
+#include "diagnostics/env_numeric.hpp"
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 
@@ -118,6 +120,104 @@ int main() {
         CHECK(tiny[tiny_capacity] == 0x7f && tiny[sizeof tiny - 1] == 0x7f);
         CHECK(format_write_watch_census(snapshot, nullptr, sizeof tiny) == 0);
         CHECK(format_write_watch_census(snapshot, tiny, 0) == 0);
+    }
+
+    // ---- the knobs' own parsing (#3253) ----------------------------------------------------
+    //
+    // These five variables tune the policy above, and on every one of them ZERO is a meaningful and
+    // maximally aggressive setting rather than "off". A bare `strtoull(value, nullptr, 10)` reaches
+    // that zero for anything it cannot start parsing -- and, measured on glibc rather than assumed,
+    // reaches TWO other silent wrong answers as well:
+    //
+    //   "eight", "yes", "\"8192\""  -> 0                    the most aggressive arm
+    //   "8mb", "8 KB", "8,192"      -> 8                    a value 1024x smaller than intended
+    //   "-1", "18446744073709551616"-> UINT64_MAX           saturates to the cap, i.e. unbounded
+    //
+    // #3253 names only the first. The middle one is arguably the nastiest, because 8 is a plausible
+    // number that no reader would question. All three are asserted below, because a fix that keeps
+    // the default is only interesting next to what the old spelling actually produced.
+    {
+        using prosper::diag::env_u64_or_default;
+        using prosper::diag::parse_u64_strict;
+
+        uint64_t parsed = 0;
+        CHECK(parse_u64_strict("0", &parsed) && parsed == 0);
+        CHECK(parse_u64_strict("8192", &parsed) && parsed == 8192);
+        CHECK(parse_u64_strict("18446744073709551615", &parsed) && parsed == UINT64_MAX);
+
+        // Everything a mistyped A/B actually looks like.
+        CHECK(!parse_u64_strict(nullptr, &parsed));
+        CHECK(!parse_u64_strict("", &parsed));
+        CHECK(!parse_u64_strict("8mb", &parsed));       // a unit suffix
+        CHECK(!parse_u64_strict("8 KB", &parsed));      // a unit, spaced
+        CHECK(!parse_u64_strict("8,192", &parsed));     // a thousands separator
+        CHECK(!parse_u64_strict(" 8", &parsed));        // leading whitespace
+        CHECK(!parse_u64_strict("8 ", &parsed));        // trailing whitespace
+        CHECK(!parse_u64_strict("\"8\"", &parsed));     // a quote that survived the shell
+        CHECK(!parse_u64_strict("eight", &parsed));
+        CHECK(!parse_u64_strict("-1", &parsed));        // strtoull WRAPS this to UINT64_MAX
+        CHECK(!parse_u64_strict("+8", &parsed));
+        CHECK(!parse_u64_strict("0x2000", &parsed));
+        CHECK(!parse_u64_strict("8.5", &parsed));
+        CHECK(!parse_u64_strict("18446744073709551616", &parsed));   // one past the top
+        CHECK(!parse_u64_strict("99999999999999999999999", &parsed));
+
+        // A refused parse must leave the caller's value ALONE -- a helper that half-wrote its
+        // output would reintroduce the defect one level up.
+        uint64_t untouched = 1234;
+        CHECK(!parse_u64_strict("8mb", &untouched) && untouched == 1234);
+
+        // What the old spelling really answered. Measured, not assumed: the third of these is the
+        // one that makes "a typo yields 0" an incomplete description of the hazard.
+        CHECK(std::strtoull("eight", nullptr, 10) == 0);
+        CHECK(std::strtoull("\"8192\"", nullptr, 10) == 0);
+        CHECK(std::strtoull("8mb", nullptr, 10) == 8);
+        CHECK(std::strtoull("-1", nullptr, 10) == UINT64_MAX);
+
+        // THE LOAD-BEARING ARM. Each of those keeps the DEFAULT instead.
+        CHECK(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB", "eight", 8192) == 8192);
+        CHECK(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB", "8mb", 8192) == 8192);
+        CHECK(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS", "-1", 3) == 3);
+        // Unset and empty are not typos and take the default in silence.
+        CHECK(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS", nullptr, 3) == 3);
+        CHECK(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS", "", 3) == 3);
+        // A well-formed 0 is still honoured: this refuses TYPOS, not the aggressive setting itself.
+        CHECK(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB", "0", 8192) == 0);
+        CHECK(prosper::diag::env_u64_or_default_capped(
+                  "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", "99999", 8, 1024) == 1024);
+        CHECK(prosper::diag::env_u64_or_default_capped(
+                  "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", "12", 8, 1024) == 12);
+
+        // ...and WHY it matters, in the policy's own terms. The value the old parse handed back for
+        // a non-numeric typo is not a no-op, it is the OPPOSITE arm: a 32 MiB source the default
+        // defers arms immediately under it.
+        const size_t typo_zero =
+            static_cast<size_t>(std::strtoull("eight", nullptr, 10)) * 1024;
+        const size_t kept =
+            static_cast<size_t>(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB",
+                                                   "eight", 8192)) * 1024;
+        CHECK(should_promote_write_watch(32u << 20, 0, typo_zero, promote_after));
+        CHECK(!should_promote_write_watch(32u << 20, 0, kept, promote_after));
+
+        // The 1024x arm, which breaks no test and every experiment. `=8mb` used to mean 8 KiB, and
+        // a SMALLER defer minimum exempts FEWER sources -- so this lands on the opposite arm from
+        // the zero above: a 1 MiB source that the intended 8 MiB minimum arms on first sight has to
+        // climb the stability ladder instead. Which direction a typo moves the policy depends on the
+        // typo, which is the whole problem: it is unpredictable and it is silent.
+        const size_t typo_scaled = static_cast<size_t>(std::strtoull("8mb", nullptr, 10)) * 1024;
+        CHECK(!should_promote_write_watch(1u << 20, 0, typo_scaled, promote_after));
+        CHECK(should_promote_write_watch(1u << 20, 0, kept, promote_after));
+
+        // The promotion budget's sentinel: 0 is unbounded, the default is not.
+        WriteWatchPromotionBudget typo_budget;
+        typo_budget.reset(static_cast<size_t>(std::strtoull("eight", nullptr, 10)) * (1u << 20));
+        CHECK(typo_budget.try_consume(64u << 20));
+        CHECK(typo_budget.try_consume(64u << 20));   // unbounded: a second large watch also arms
+        WriteWatchPromotionBudget kept_budget;
+        kept_budget.reset(static_cast<size_t>(env_u64_or_default(
+            "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", "eight", 8)) * (1u << 20));
+        CHECK(kept_budget.try_consume(64u << 20));
+        CHECK(!kept_budget.try_consume(64u << 20));  // bounded, which is what was asked for
     }
 
     if (!failures) std::printf("write_watch_policy: OK\n");

--- a/prosper/frontends/shared/tests/test_write_watch_policy.cpp
+++ b/prosper/frontends/shared/tests/test_write_watch_policy.cpp
@@ -173,6 +173,15 @@ int main() {
         CHECK(std::strtoull("\"8192\"", nullptr, 10) == 0);
         CHECK(std::strtoull("8mb", nullptr, 10) == 8);
         CHECK(std::strtoull("-1", nullptr, 10) == UINT64_MAX);
+        // Two more the reviewer of #3253 added, both worth keeping. A hex-looking value is the
+        // sharpest of the lot: someone reaching for `0x2000` on a byte-valued knob is thinking in
+        // hex, and base 10 stops at the '0' -- landing on the aggressive sentinel, not on 8192.
+        CHECK(std::strtoull("0x10", nullptr, 10) == 0);
+        CHECK(!parse_u64_strict("0x10", &parsed));
+        // And a trailing newline, which a heredoc or a `$(cat file)` puts there without anyone
+        // typing it. strtoull takes it; this does not.
+        CHECK(std::strtoull("8192\n", nullptr, 10) == 8192);
+        CHECK(!parse_u64_strict("8192\n", &parsed));
 
         // THE LOAD-BEARING ARM. Each of those keeps the DEFAULT instead.
         CHECK(env_u64_or_default("PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB", "eight", 8192) == 8192);

--- a/prosper/src/diagnostics/AGENTS.md
+++ b/prosper/src/diagnostics/AGENTS.md
@@ -45,8 +45,8 @@ is process-wide, so independently taken values in unrelated translation units co
 no anchor or registry. Anything that needs to be time-ordered against a diagnostic in another
 subsystem should stamp it rather than grow a private clock.
 
-`env_cache.hpp` is the third always-reachable file, and it is here for the same reason as
-`diag_clock.hpp`: it is shared, and it belongs to no one subsystem. It holds `PROSPER_ENV_ON` /
+`env_cache.hpp` and `env_numeric.hpp` are the remaining always-reachable files, and they are here for
+the same reason as `diag_clock.hpp`: it is shared, and it belongs to no one subsystem. It holds `PROSPER_ENV_ON` /
 `PROSPER_ENV_VALUE`, the one-shot reads of a `PROSPER_*` switch. They lived in
 `hle/dispatch/dispatch.hpp` until #3094, which is where they were first needed and not where they
 belong — the renderer backend, the draw executor and the live frontend all evaluate diagnostic
@@ -63,3 +63,18 @@ runtime, and separately pins the hot sites #3094 converted so they cannot regrow
 Run it before caching a new name. Note it can only see arming through a *literal* name —
 `tools/gpu_replay` re-applies `render_env[]` (`gpu/capture/gpu_capture.cpp`) per bundle submit
 through a variable, which is invisible to it; that comment lives in `env_cache.hpp` itself.
+
+`env_numeric.hpp` answers the neighbouring question — not "was this set?" but "what NUMBER is that
+text?" — and exists because the obvious spelling is quietly wrong. `strtoull(value, nullptr, 10)`
+discards the end pointer, so the parse cannot fail; it just answers something, and measured on glibc
+it answers **three** different wrong things: `0` for text it cannot start on, the leading digits for
+`8mb`, and `UINT64_MAX` for `-1`. On a knob where 0 means "off" that is a lost experiment. On the
+write-watch family it is worse, because 0 there is a *meaningful and maximally aggressive* setting, so
+a typo silently ran a different experiment than the one asked for (#3253, after #3155's retracted
+measurement). `env_u64_or_default*` refuses loudly and keeps the default; the accepted grammar is
+exactly `[0-9]+`.
+
+Both headers take the variable's NAME as a literal argument, and `check_cached_env.py` treats any
+callee containing `env` as an environment WRITE — so a new reader here has to be added to that
+script's `ENV_READERS` set or it reads as an arming. That coupling is the one non-obvious thing about
+adding a function to this pair.

--- a/prosper/src/diagnostics/env_numeric.hpp
+++ b/prosper/src/diagnostics/env_numeric.hpp
@@ -1,0 +1,77 @@
+// env_numeric.hpp — reading a PROSPER_* variable as a NUMBER, and refusing a typo out loud.
+//
+// `env_cache.hpp` answers "was this set, and to what text?". This answers "what number is that
+// text?", and exists because the obvious spelling is quietly wrong:
+//
+//     const uint64_t kib = value ? std::strtoull(value, nullptr, 10) : 8192ull;
+//
+// `strtoull` returns **0** for anything it cannot parse, and reports that only through an end
+// pointer nobody passed. So `FOO=8mb`, `FOO=8 KB`, `FOO="8"` and `FOO=eight` all select **0**.
+//
+// On a knob where 0 means "off" that is merely a lost experiment. On several of prosper's it is
+// worse than that, because **0 is a meaningful and MAXIMALLY AGGRESSIVE setting** — the write-watch
+// family's `defer_min_bytes == 0` means "defer nothing, arm every source on first sight", and a
+// promotion budget of 0 means "unbounded". A typo there does not disable the experiment; it silently
+// selects a different, more aggressive one, and nothing in the run's output says so. An agent then
+// attributes what it measured to the value it believed it set. That is `GAME_COMPAT_ORCHESTRATION.md`'s
+// instrument-trap shape exactly, and this family has already produced one retracted measurement
+// (#3155, #3253).
+//
+// The rule these implement is the one `PROSPER_LAZY_COMMIT_STRICT` already follows: **a malformed
+// value refuses LOUDLY and keeps the default**, rather than firing at an unintended setting.
+//
+// Deliberately strict. The accepted grammar is exactly `[0-9]+` — no sign, no leading or trailing
+// whitespace, no `0x`, no suffix. `strtoull` would take a leading space and a leading `-` (wrapping
+// it to a huge unsigned), and both are far likelier to be a typo than an intention. An UNSET or
+// EMPTY variable is not a typo and takes the default in silence.
+#pragma once
+#include <cstdint>
+#include <cstdio>
+
+namespace prosper::diag {
+
+// Parse `text` as a plain non-negative decimal integer. Returns false — leaving `*out` untouched —
+// for null, empty, any non-digit character anywhere, or a value that would exceed uint64_t.
+inline bool parse_u64_strict(const char* text, uint64_t* out) {
+    if (!text || !*text || !out) return false;
+    uint64_t value = 0;
+    for (const char* p = text; *p; ++p) {
+        if (*p < '0' || *p > '9') return false;
+        const uint64_t digit = static_cast<uint64_t>(*p - '0');
+        if (value > (UINT64_MAX - digit) / 10u) return false;   // would overflow
+        value = value * 10u + digit;
+    }
+    *out = value;
+    return true;
+}
+
+// `text` as a number, or `fallback` — reporting the refusal on stderr, once per call, naming the
+// variable, the text it was given and the default it is keeping. Pass the text rather than the name
+// alone so the caller keeps its own choice of cached (`PROSPER_ENV_VALUE`) or live (`std::getenv`)
+// read; `name` is for the message.
+//
+// `unit` is an optional trailing note for the message ("KiB", "MiB", ...), because a knob's units
+// live at its call site and a reader who mistyped one wants to be told which was expected.
+inline uint64_t env_u64_or_default(const char* name, const char* text, uint64_t fallback,
+                                   const char* unit = nullptr) {
+    uint64_t value = 0;
+    if (parse_u64_strict(text, &value)) return value;
+    if (!text || !*text) return fallback;   // unset or empty: not a typo, and not worth a line
+    std::fprintf(stderr,
+                 "[env] %s='%s' is not a plain non-negative integer%s%s -- keeping the default "
+                 "(%llu) and changing NOTHING\n",
+                 name, text, unit ? " of " : "", unit ? unit : "",
+                 static_cast<unsigned long long>(fallback));
+    return fallback;
+}
+
+// The same, saturating at `cap` instead of overflowing a later multiply. Every byte-valued knob in
+// the tree scales its number by 1024 or 1024*1024, and a value near UINT64_MAX would wrap that
+// product to something small — the same class of silent wrong setting this header exists to remove.
+inline uint64_t env_u64_or_default_capped(const char* name, const char* text, uint64_t fallback,
+                                          uint64_t cap, const char* unit = nullptr) {
+    const uint64_t value = env_u64_or_default(name, text, fallback, unit);
+    return value < cap ? value : cap;
+}
+
+} // namespace prosper::diag

--- a/prosper/src/diagnostics/env_numeric.hpp
+++ b/prosper/src/diagnostics/env_numeric.hpp
@@ -50,22 +50,26 @@ inline bool parse_u64_strict(const char* text, uint64_t* out) {
 // alone so the caller keeps its own choice of cached (`PROSPER_ENV_VALUE`) or live (`std::getenv`)
 // read; `name` is for the message.
 //
-// `unit` is an optional trailing note for the message ("KiB", "MiB", ...), because a knob's units
-// live at its call site and a reader who mistyped one wants to be told which was expected.
+// `unit` is an optional trailing note for the message ("KiB", "MiB", "validations", ...), because a
+// knob's units live at its call site and a reader who mistyped one wants to be told which was
+// expected. It is rendered as "... is not a plain non-negative count of KiB", so pass a bare noun.
 inline uint64_t env_u64_or_default(const char* name, const char* text, uint64_t fallback,
                                    const char* unit = nullptr) {
     uint64_t value = 0;
     if (parse_u64_strict(text, &value)) return value;
     if (!text || !*text) return fallback;   // unset or empty: not a typo, and not worth a line
     std::fprintf(stderr,
-                 "[env] %s='%s' is not a plain non-negative integer%s%s -- keeping the default "
-                 "(%llu) and changing NOTHING\n",
-                 name, text, unit ? " of " : "", unit ? unit : "",
+                 "[env] %s='%s' is not a plain non-negative %s%s -- keeping the default (%llu) and "
+                 "changing NOTHING\n",
+                 name, text, unit ? "count of " : "integer", unit ? unit : "",
                  static_cast<unsigned long long>(fallback));
     return fallback;
 }
 
-// The same, saturating at `cap` instead of overflowing a later multiply. Every byte-valued knob in
+// The same, saturating at `cap` instead of overflowing a later multiply. NOTE that the saturation
+// itself is SILENT -- only a malformed value is reported. A well-formed but absurd number is a
+// deliberate act ("as large as possible"), where clamping is the expected answer rather than a
+// surprise; a typo cannot reach here, because it was already refused above. Every byte-valued knob in
 // the tree scales its number by 1024 or 1024*1024, and a value near UINT64_MAX would wrap that
 // product to something small — the same class of silent wrong setting this header exists to remove.
 inline uint64_t env_u64_or_default_capped(const char* name, const char* text, uint64_t fallback,

--- a/prosper/tools/env/check_cached_env.py
+++ b/prosper/tools/env/check_cached_env.py
@@ -55,11 +55,25 @@ def armed_callee(name: str) -> bool:
     low = name.lower()
     if "env" not in low:
         return False
-    if low in ("getenv", "std_getenv"):          # a READ is the fix, not the defect
+    if low in ENV_READERS:                       # a READ is the fix, not the defect
         return False
     if name.startswith("PROSPER_ENV_"):          # the caching macros themselves
         return False
     return True
+
+
+# Callees that contain "env" and READ rather than write. Deliberately an explicit list rather than a
+# looser pattern: the heuristic above is conservative on purpose, and the cost of widening it wrongly
+# is a silently vacuous test, which is the entire defect class this gate exists for.
+#
+# `env_u64_or_default` (diagnostics/env_numeric.hpp) takes the variable's NAME as a literal first
+# argument purely so a refusal can name it, and the value as the second -- so a caller passing a
+# literal name is reading, not arming, and `test_write_watch_policy.cpp` does exactly that with three
+# names production caches (#3253).
+ENV_READERS = frozenset((
+    "getenv", "std_getenv",
+    "env_u64_or_default", "env_u64_or_default_capped",
+))
 
 SCAN_DIRS = ("src", "frontends", "tools", "tests")
 SCAN_EXT = (".c", ".cc", ".cpp", ".h", ".hpp")
@@ -186,6 +200,9 @@ SELF_TESTS = [
     ('const char* v = PROSPER_ENV_VALUE("PROSPER_BAR");', ["PROSPER_BAR"], []),
     ('PROSPER_ENV_VALUE( "PROSPER_SPACED" )', ["PROSPER_SPACED"], []),
     ('setenv("PROSPER_BAZ", "1", 1);', [], ["PROSPER_BAZ"]),
+    # A reader that names the variable so it can report a refusal is NOT an arming (#3253).
+    ('env_u64_or_default("PROSPER_READ_ONLY", text, 8192);', [], []),
+    ('prosper::diag::env_u64_or_default_capped("PROSPER_READ_ONLY2", v, 8, 99);', [], []),
     ('_putenv_s("PROSPER_QUX", "1");', [], ["PROSPER_QUX"]),
     ('unsetenv("PROSPER_QUUX");', [], ["PROSPER_QUUX"]),
     # The WRAPPER forms. These are the cases the first version of this checker missed, which let it


### PR DESCRIPTION
Fixes #3253.

## The defect

Six write-watch tuning variables parsed with a bare `strtoull(value, nullptr, 10)`. That discards the
end pointer, so the parse cannot fail — it just answers something.

**And "a typo becomes 0" understates it.** Measured against glibc rather than assumed, the old
spelling reaches **three** different wrong answers:

| input | old answer | what it selected |
| --- | --- | --- |
| `eight`, `yes`, `"8192"` (a quote survived the shell) | **0** | the **most aggressive** setting on every one of these knobs |
| `8mb`, `8 KB`, `8,192`, `8.5` | **8** | a plausible number **1024x** from the one intended |
| `-1`, `18446744073709551616` | **UINT64_MAX** | saturates to the following cap, i.e. unbounded |

On this family `0` is not "off":

| variable | default | what 0 means |
| --- | --- | --- |
| `PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB` | 8192 | `should_promote_write_watch` returns true immediately — **defer nothing** |
| `PROSPER_TEXTURE_WRITE_WATCH_MIN_KB` | 1024 | no size floor — **every** source is watch-eligible |
| `PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS` | 3 | `stable >= 0` is always true — arm on first acquisition |
| `PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB` | 8 | `try_consume` returns true unconditionally — **unbounded** arming per submit |
| `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS` | 3 | as above |
| `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB` | 8 | as above |

So a mistyped A/B did not lose the experiment — it **silently ran a different one**, and nothing in
the run's output said so. That is `GAME_COMPAT_ORCHESTRATION.md`'s instrument-trap shape exactly, and
this family has already produced one retracted measurement (#3155).

**The middle row is the nastiest**, and the issue does not mention it: `=8mb` gave 8 KiB, a plausible
number no reader would question. It also moves the policy the *other* way — a smaller defer minimum
exempts fewer sources, so a 1 MiB texture the intended 8 MiB minimum arms on first sight has to climb
the stability ladder instead. Which direction a typo moves the policy depends on the typo. Both
directions are asserted in the test.

`PROSPER_TEXTURE_WRITE_WATCH_MIN_KB` is not in the issue's table and has the same sentinel; it is
included. `cold_storage_result_snapshot_defer_min_bytes` is — it validated its end pointer but fell
back in **silence**, failing the other way: a typo left you measuring the default while believing you
had moved it.

## The fix

One strict parser, `src/diagnostics/env_numeric.hpp`:

```cpp
prosper::diag::parse_u64_strict(text, &out);                         // exactly [0-9]+, overflow-checked
prosper::diag::env_u64_or_default(name, text, fallback, unit);       // refuses LOUDLY, keeps the default
prosper::diag::env_u64_or_default_capped(name, text, fallback, cap); // ...and saturates before a later multiply
```

No sign, no `0x`, no units, no surrounding whitespace — `strtoull` accepts a leading space and wraps a
leading `-` to `UINT64_MAX`, and both are far likelier to be a typo than an intention. Unset or empty
is **not** a typo and takes the default in silence. It sits in `diagnostics/` beside `env_cache.hpp`,
which answers the neighbouring question ("was this set, and to what text?"), rather than in the
policy header — the parsing is not a write-watch concept and three of the six call sites are in a
different subsystem.

All six sites use it, **and so does #3251's own site**, which had grown its own strict parse a day
earlier — so the family ends with one pattern rather than two. Its historical default is 1 *byte*,
which cannot be expressed in that knob's own KiB units, so it keeps an explicit unset case and calls
`parse_u64_strict` directly.

## The one non-obvious change

`tools/env/check_cached_env.py` learns that a **reader** naming its variable is not an arming. Its
heuristic treats any callee containing `env` as an environment *write* — deliberately conservative,
and correct until now — and `env_u64_or_default` takes the variable's name as a literal first argument
purely so a refusal can report it. Without this, the gate reads the new test as arming three names
that production caches and fails. Two self-test cases pin the carve-out.

## Verification

Base `a4d49cb41`, `cmake -S prosper -B prosper/build-linux && cmake --build prosper/build-linux -j6`:

| | build | ctest `--no-tests=error` |
| --- | --- | --- |
| baseline (`origin/main`, detached, same worktree and build dir) | **0** | **0**, **347/347** |
| this branch | **0** | **0**, **347/347** |

Also green on every CI platform, `Windows MinGW` and `macOS (x86_64 / Rosetta 2)` included — this
change is platform-independent, but `check_cached_env.py` runs everywhere and is the part most likely
to surprise a different tree.

No new test target — the arms live in `write_watch_policy`, beside the policy whose sentinels make a
typo dangerous, which is where #3253 asked for them.

The arms cover empty, null, a unit suffix, a spaced unit, a thousands separator, leading and trailing
whitespace, a surviving quote, a word, a sign, hex, a decimal point, and both overflow shapes — and
each asserts **what the old spelling produced** beside what the new one keeps, because "keeps the
default" means nothing without it. Then the consequence, in the policy's own terms: the value the old
parse handed back is not a no-op but the opposite arm, for both the defer minimum and the promotion
budget.

## Mutation arms

Both were built and run, so the failure is the test's rather than the compiler's.

| mutation | build | ctest | what failed |
| --- | --- | --- | --- |
| `parse_u64_strict` stops at the first non-digit, i.e. behaves like a bare `strtoull` | `0` | `8` | **17** failures — every typo shape, plus both policy consequences |
| a refused value returns `0` instead of the default (the defect itself) | `0` | `8` | **5** failures — the three load-bearing arms and both policy consequences |

Reverted; the tree is clean and the run above is on it.

## Risks

- **A previously-accepted value is now refused.** `=8mb` used to mean 8, `=-1` used to mean unbounded.
  Anything relying on that was relying on an accident, and the refusal is loud — but it is a real
  behaviour change for a hand-typed A/B. Nothing in the tree sets these: `grep` over `*.py`, `*.sh`,
  `*.json`, `*.ps1`, `*.yml` finds only prose in `docs/`.
- **A well-formed `0` is still honoured.** This refuses typos, not the aggressive setting itself.
- The `check_cached_env.py` carve-out widens a deliberately conservative heuristic by exactly two
  names. A future `env_`-prefixed function that *writes* would need adding to the list, not removing
  from it.
- **An empty value now takes the default silently on `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` too.**
  Its old parse treated `FOO=` as text and fell back on the end-pointer check; the shared helper treats
  unset and empty alike and says nothing. That is the right call — `FOO=` is not a typo anyone makes by
  mistyping a *number* — but it is a behaviour change on that one knob and belongs in this list.
- **`env_u64_or_default_capped` saturates silently.** Only a malformed value is reported. A well-formed
  but absurd number is someone asking for "as large as possible", where clamping is the expected answer
  rather than a surprise, and a typo cannot reach the clamp because it was refused a line earlier.

## Review response

Approved with nothing to fix. The reviewer compiled a standalone probe rather than taking the
`strtoull` table from this body, and all three rows verified. Four suggestions, all taken in the second
commit:

- **Two more rows worth having**, now in the test. `0x10` reaches **0** under base 10 — the sharpest
  case in the set, because someone reaching for hex on a byte-valued knob lands on the aggressive
  sentinel rather than on a large number — and a trailing newline, which a heredoc or `$(cat file)`
  supplies without anyone typing it, parses today and is refused now.
- The refusal message read *"not a plain non-negative integer of unchanged validations"* for a
  countable knob; it now reads *"not a plain non-negative count of &lt;unit&gt;"*, with the no-unit form
  unchanged.
- The silent saturation and the empty-value change are in the risk list above.
- **`src/diagnostics/AGENTS.md` enumerated the folder's shared headers positionally** ("`env_cache.hpp`
  is the third always-reachable file"), so this change did not leave that map incomplete — it made it
  **wrong**. Rewritten, including the coupling that is genuinely non-obvious: both headers take the
  variable name as a literal argument, so a new reader here has to join `check_cached_env.py`'s
  `ENV_READERS` set or it registers as an arming.

## Not fixed here

The same lax spelling appears at **169** other env-derived numeric parses in the tree, against 71 that
check an end pointer. Most are knobs where 0 means "off", so the same spelling is far less dangerous,
and each needs the question "what does 0 mean here?" answered before conversion. Filed as #3267 with
the census, the per-file distribution and a suggested triage order rather than swept blind inside this
PR.

## Docs

`docs/FRONTEND_APP.md` states the accepted grammar where the knobs are documented, and records why the
old spelling was dangerous rather than merely sloppy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
