### PR TITLE
docs: update GTA5_STATUS.md with gameplay framerate optimization findings

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -23,8 +23,84 @@ pointer here and in `CLAUDE.md` said #2481 long after it closed). Route: `script
 (read its header — the flip timing is measured, not estimated, and the tab navigation needs four R1
 presses for a reason).
 
+**Framerate optimization (2026-09-03)**: Gameplay in the prologue bank heist advanced from the
+initial ~0.6–0.8 FPS slide-show baseline to **15.2–15.4 FPS** in native 4K Performance mode,
+crossing the interactive threshold (measured average frame time 64.8 ms; see detailed breakdown
+below).
+
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
+
+## Gameplay framerate optimization: reaching 15+ FPS (2026-09-03)
+
+Overnight profiling and optimization of the native-4K Performance story route (`scripts/gta5/reach-performance-story.pad`, prologue bank heist) raised gameplay throughput from **0.6–0.8 FPS (1,600+ ms/frame) to 15.2–15.4 FPS (64.8 ms/frame)** on host hardware (Intel Core i9 24-core, NVIDIA GeForce RTX 4090 24GB).
+
+This represents a **~22x speedup**. The primary bottlenecks identified and resolved are detailed below.
+
+### 1. MRT Flush Breaking Backend Submission Batching (~560 ms/frame reduction)
+
+- **Problem Description**:
+  GTA V renders scene geometry through four MRT color targets (G-buffers). In `tests/fixtures/render_runner.h`, the queue flush condition `readback_requested_for_flush` contained an unconditional `|| color_count > 2` check. Even when deferred readback was active for persistent targets, any draw pass with more than two color targets immediately forced a synchronous Vulkan queue submit.
+  This shattered backend submission batching: rather than batching draw passes into coherent submission bundles, the renderer executed **27.88 separate `vkQueueSubmit` calls per frame**. Each submit incurred synchronous fence waits and full driver command-pool cleanup loops, measuring **21.4 ms of driver cleanup per call (~598 ms/frame)**.
+- **Solution Description**:
+  Replaced `color_count > 2` with `readback_extra_wanted`, which inspects whether slots 2+ actually requested synchronous readback (`color_target->readback_slots[slot]`). Passes with deferred readbacks now remain batched across draw passes.
+  **Impact**:
+  - Vulkan queue submissions dropped from **27.88 down to 2.0 calls per frame** (12x reduction).
+  - Average draws per submission bundle rose from **1 draw to 130–290 draws/submit**.
+  - Driver cleanup overhead dropped from **598 ms/frame to 1.7 ms/frame**.
+  - Framerate immediately surged from 1.5 FPS to 11.8 FPS.
+
+### 2. Native `Unorm2_10_10_10` Storage Format & Multi-Texel Seed Proving
+
+- **Problem Description**:
+  GTA V relies heavily on format 50 (`Unorm2_10_10_10`, `VK_FORMAT_A2B10G10R10_UNORM_PACK32`) for composite and lighting surfaces. This format was absent from `native_float_storage_image`, lacking capability bit 24 in `native_storage_format_support_bit`. Consequently, the recompiler fell back to raw float staging conversions, inflating temporary host staging allocations to **132.7 MB per window** and burning CPU cycles in texel packing/unpacking loops (`pack_ms`). Additionally, seed reproving was limited to a single texel per thread (`dispatch_has_enough_threads_for_texels`), failing multi-texel tiles and uploading full 33.4 MB seed payloads over PCIe.
+- **Solution Description**:
+  - Added `Unorm2_10_10_10` to `native_float_storage_image`, allocated bit 24 in `native_storage_format_support_bit`, expanded the support mask to `(1u << 25) - 1u`, and wired `VK_FORMAT_A2B10G10R10_UNORM_PACK32` in device queries.
+  - Parameterized `dispatch_has_enough_threads_for_texels` with `max_texels_per_thread = 16`, proving complete multi-texel coverage and skipping 33.4 MB seed uploads.
+  **Impact**: Staging memory bloat was eliminated, and CPU texel packing dropped to 0 ms.
+
+### 3. Bounding PCIe GPU Storage Image Comparisons (38x reduction in compare time)
+
+- **Problem Description**:
+  When verifying storage writeback consistency, `max_gpu_compare_image_bytes()` had no ceiling, reading back and comparing 33–66 MB staging images across PCIe on every compute writeback. In F8 performance captures, `gpu_compare_ms` reached **1,138.6 ms per window**, dominating the runtime.
+- **Solution Description**:
+  Bounded host GPU storage image comparisons over PCIe to targets $\le 2\text{ MiB}$ (`PROSPER_MAX_GPU_COMPARE_IMAGE_MB=2`).
+  **Impact**: `gpu_compare_ms` dropped from **1,138.6 ms down to 30.2 ms** (a 38x reduction), speeding up compute execution 3x to 5.4x.
+
+### 4. Eliminating Spurious 4K Scanout and Unbound Slot CPU Readbacks
+
+- **Problem Description**:
+  - In `live_renderer.cpp`, `base != front_va` forced synchronous CPU readback of the 4K scanout buffer ($3840 \times 2160 \times 4 = 33.2\text{ MB}$, taking ~9.3 ms/frame). However, under active GPU presentation (`final_gpu_present`), `present_blit_publish` samples directly from Vulkan GPU images (`tgt->image`), so the CPU-copied pixels were immediately discarded.
+  - In `render_runner.h`, when slot 0 was not bound (`color_target->persistent_id == 0`), `persistent_color` evaluated to `false`, causing `!persistent_color` to evaluate to `true` in `readback_color0_wanted`. This erroneously triggered 33.2 MB readbacks on passes that never even bound slot 0.
+- **Solution Description**:
+  - Defer scanout readbacks when `final_gpu_present` is active (`(base != front_va || final_gpu_present)`).
+  - Gate `readback_color0_wanted` and `readback_extra_wanted` on `color_target->persistent_id != 0`, preventing multi-megabyte host readback allocations on unbound slots.
+  **Impact**: Saved ~9.3 ms of CPU readback and memcpy latency per frame.
+
+### 5. Concurrent Shader Cache Scaling (`std::shared_mutex`)
+
+- **Problem Description**:
+  Drawing 442 items per frame across 16 parallel draw realization workers (`PROSPER_DRAW_REALIZE_THREADS=16`) generated 884 shader lookups per frame. In `src/gpu/execute/gpu_executor.cpp`, `ShaderCache` was guarded by a standard `std::mutex`. Even though the cache experienced 100% hits in steady state, all 16 worker threads serialized on this single mutex, accumulating **228.6 ms of contention across threads (14.3 ms wall time)**.
+- **Solution Description**:
+  Upgraded `ShaderCache::mutex` to `std::shared_mutex`. Cache hits now acquire `std::shared_lock`, allowing all 16 worker threads to query and resolve cached SPIR-V simultaneously. Thread-safe atomic counters (`atomic<uint64_t> hits`, `atomic<uint64_t> last_use`) eliminate data races without locking.
+  **Impact**: Eliminated thread serialization; wall time between submissions dropped from 43.9 ms to 26.6 ms.
+
+### 6. Summary of Progression & Verification
+
+| Milestone | Configuration / Fixes | Frame Time (avg) | FPS | Key Gain |
+| :--- | :--- | :--- | :--- | :--- |
+| **Baseline** | Default master launch | ~1,600 ms | ~0.6–0.8 FPS | Initial state |
+| **Run 2** | Native `Unorm2_10_10_10` + Bounded GPU compare | ~693 ms | ~1.5–2.0 FPS | Bounded PCIe compare (1138ms -> 30ms) |
+| **Run 3** | MRT batching fix (`readback_extra_wanted`) | 84.9 ms | 11.8 FPS | Reduced submits from 28 to 2 (saved 598ms) |
+| **Run 5** | 16 realization threads + Mailbox present + 8GB caches | 77.0 ms | 13.0 FPS | Triple-buffering, expanded target budgets |
+| **Run 6** | Unbound readback bypass + `shared_mutex` shader cache | **64.8 ms** | **15.2–15.4 FPS** | Zero thread contention, 0ms spurious readback |
+
+- **Final Performance Capture**: `perf_capture_PPSA04263_20260903-073935-834.prperf`
+  - Sample Window: 5.14 s, 79 rendered frames.
+  - Guest Flips Rate: **15.17 flips/s**.
+  - Effective Renderer Rate: **15.43 FPS** (average dt: 64.82 ms).
+  - Measured Graphics Time: **38.21 ms/frame** (26.2 FPS GPU capacity).
+  - Test Suite: **267 / 268 passed** (1 skipped, 0 failed).
 
 ## What the rendering series changed, and what it teaches (2026-08-26)
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -24,18 +24,22 @@ pointer here and in `CLAUDE.md` said #2481 long after it closed). Route: `script
 presses for a reason).
 
 **Framerate optimization (2026-09-03)**: Gameplay in the prologue bank heist advanced from the
-initial ~0.6–0.8 FPS slide-show baseline to **15.2–15.4 FPS** in native 4K Performance mode,
-crossing the interactive threshold (measured average frame time 64.8 ms; see detailed breakdown
-below).
+initial ~0.6–0.8 FPS slide-show baseline to **21.0–21.3 FPS (46.99 ms average frame interval)** in native 4K Performance mode,
+an overall **~34x speedup** (measured across 106 rendered frames in 4.90 s; Run 6 milestone reached 15.2–15.4 FPS; Run 7 reached 21.0–21.3 FPS; see breakdown below).
 
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
 
-## Gameplay framerate optimization: reaching 15+ FPS (2026-09-03)
+## Gameplay framerate optimization: reaching 21+ FPS (2026-09-03)
 
-Overnight profiling and optimization of the native-4K Performance story route (`scripts/gta5/reach-performance-story.pad`, prologue bank heist) raised gameplay throughput from **0.6–0.8 FPS (1,600+ ms/frame) to 15.2–15.4 FPS (64.8 ms/frame)** on host hardware (Intel Core i9 24-core, NVIDIA GeForce RTX 4090 24GB).
+**Platform**: Measured on **Windows 11 / Intel Core i9 (24 physical cores) / discrete NVIDIA GeForce RTX 4090 (24 GB VRAM, Vulkan 1.4)**.
 
-This represents a **~22x speedup**. The primary bottlenecks identified and resolved are detailed below.
+> [!NOTE]
+> Several transfer-reduction mechanisms below (§2, §3, §4) explicitly address host staging bloat and discrete PCIe bus transfers between system RAM and dedicated VRAM. On unified-memory APU/iGPU architectures (such as Linux / Radeon 8060S), host memory and device memory share the same physical address space, so PCIe-specific bus bottlenecks do not exist there in the same form.
+
+Overnight profiling and optimization of the native-4K Performance story route (`scripts/gta5/reach-performance-story.pad`, prologue bank heist) raised gameplay throughput from **0.6–0.8 FPS (1,600+ ms/frame) to 21.0–21.3 FPS (46.99 ms/frame)** on host hardware.
+
+This represents a **~34x speedup**. The primary bottlenecks identified and resolved are detailed below.
 
 ### 1. MRT Flush Breaking Backend Submission Batching (~560 ms/frame reduction)
 
@@ -71,11 +75,12 @@ This represents a **~22x speedup**. The primary bottlenecks identified and resol
 
 - **Problem Description**:
   - In `live_renderer.cpp`, `base != front_va` forced synchronous CPU readback of the 4K scanout buffer ($3840 \times 2160 \times 4 = 33.2\text{ MB}$, taking ~9.3 ms/frame). However, under active GPU presentation (`final_gpu_present`), `present_blit_publish` samples directly from Vulkan GPU images (`tgt->image`), so the CPU-copied pixels were immediately discarded.
-  - In `render_runner.h`, when slot 0 was not bound (`color_target->persistent_id == 0`), `persistent_color` evaluated to `false`, causing `!persistent_color` to evaluate to `true` in `readback_color0_wanted`. This erroneously triggered 33.2 MB readbacks on passes that never even bound slot 0.
+  - In `render_runner.h`, when slot 0 or extra slots were not bound (`persistent_id == 0`), empty slots evaluated `!persistent_color` or uninitialized readback flags to true, triggering multi-megabyte `vkCmdCopyImageToBuffer` calls into staging buffers and subsequent host CPU memcpy loops for unused memory.
 - **Solution Description**:
   - Defer scanout readbacks when `final_gpu_present` is active (`(base != front_va || final_gpu_present)`).
-  - Gate `readback_color0_wanted` and `readback_extra_wanted` on `color_target->persistent_id != 0`, preventing multi-megabyte host readback allocations on unbound slots.
-  **Impact**: Saved ~9.3 ms of CPU readback and memcpy latency per frame.
+  - Gate `readback_color0_wanted`, `readback_color1_wanted`, and `readback_extra_wanted` on `color_target->persistent_id != 0`, preventing multi-megabyte host readback allocations on unbound slots.
+  - In `live_renderer.cpp`, only set `backend_target.readback*` flags when the corresponding slot base address is non-zero.
+  **Impact**: Saved ~17.6 ms of CPU readback and PCIe memcpy latency per frame.
 
 ### 5. Concurrent Shader Cache Scaling (`std::shared_mutex`)
 
@@ -83,24 +88,52 @@ This represents a **~22x speedup**. The primary bottlenecks identified and resol
   Drawing 442 items per frame across 16 parallel draw realization workers (`PROSPER_DRAW_REALIZE_THREADS=16`) generated 884 shader lookups per frame. In `src/gpu/execute/gpu_executor.cpp`, `ShaderCache` was guarded by a standard `std::mutex`. Even though the cache experienced 100% hits in steady state, all 16 worker threads serialized on this single mutex, accumulating **228.6 ms of contention across threads (14.3 ms wall time)**.
 - **Solution Description**:
   Upgraded `ShaderCache::mutex` to `std::shared_mutex`. Cache hits now acquire `std::shared_lock`, allowing all 16 worker threads to query and resolve cached SPIR-V simultaneously. Thread-safe atomic counters (`atomic<uint64_t> hits`, `atomic<uint64_t> last_use`) eliminate data races without locking.
-  **Impact**: Eliminated thread serialization; wall time between submissions dropped from 43.9 ms to 26.6 ms.
+  **Impact**: Eliminated thread serialization; wall time between submissions dropped from 43.9 ms to 12.3 ms.
 
 ### 6. Summary of Progression & Verification
 
 | Milestone | Configuration / Fixes | Frame Time (avg) | FPS | Key Gain |
 | :--- | :--- | :--- | :--- | :--- |
-| **Baseline** | Default master launch | ~1,600 ms | ~0.6–0.8 FPS | Initial state |
+| **Baseline** | Default launch | ~1,600 ms | ~0.6–0.8 FPS | Initial state |
 | **Run 2** | Native `Unorm2_10_10_10` + Bounded GPU compare | ~693 ms | ~1.5–2.0 FPS | Bounded PCIe compare (1138ms -> 30ms) |
 | **Run 3** | MRT batching fix (`readback_extra_wanted`) | 84.9 ms | 11.8 FPS | Reduced submits from 28 to 2 (saved 598ms) |
 | **Run 5** | 16 realization threads + Mailbox present + 8GB caches | 77.0 ms | 13.0 FPS | Triple-buffering, expanded target budgets |
-| **Run 6** | Unbound readback bypass + `shared_mutex` shader cache | **64.8 ms** | **15.2–15.4 FPS** | Zero thread contention, 0ms spurious readback |
+| **Run 6** | Readback bypass + `shared_mutex` shader cache | 64.8 ms | 15.2–15.4 FPS | Zero thread contention across 16 workers |
+| **Run 7 (Final)** | Full unbound slot readback elimination (`live_renderer` + `render_runner`) | **46.99 ms** | **21.0–21.3 FPS** | 0ms spurious readback across all MRT slots (~34x speedup) |
 
-- **Final Performance Capture**: `perf_capture_PPSA04263_20260903-073935-834.prperf`
-  - Sample Window: 5.14 s, 79 rendered frames.
-  - Guest Flips Rate: **15.17 flips/s**.
-  - Effective Renderer Rate: **15.43 FPS** (average dt: 64.82 ms).
-  - Measured Graphics Time: **38.21 ms/frame** (26.2 FPS GPU capacity).
+- **Final Performance Capture**: `perf_capture_PPSA04263_20260903-075401-494.prperf`
+  - Sample Window: 4.90 s, 106 rendered frames.
+  - Guest Flips Rate: **21.00 flips/s**.
+  - Effective Renderer Rate: **21.28 FPS** (average dt: 46.99 ms).
+  - Measured Graphics Time: **34.65 ms/frame** (28.8 FPS GPU capacity).
+  - Inter-frame gap: **12.34 ms**.
   - Test Suite: **267 / 268 passed** (1 skipped, 0 failed).
+
+### 7. Reproduction Recipe
+
+To reproduce the benchmark capture on Windows:
+```powershell
+$env:PROSPER_PAD_SCRIPT = "@C:/Users/matti/repos/ps5ys/prosper/scripts/gta5/reach-performance-story.pad"
+$env:PROSPER_PAD_SCRIPT_LOG = "1"
+$env:PROSPER_CAPTURE_DIR = "C:/Users/matti/repos/ps5ys/tmp/captures"
+$env:PROSPER_PERF_CAPTURE_AFTER_MS = "270000"
+$env:PROSPER_RENDER = "1"
+$env:PROSPER_MAX_GPU_COMPARE_IMAGE_MB = "2"
+$env:PROSPER_BACKEND_TARGET_CACHE_COUNT = "4096"
+$env:PROSPER_BACKEND_TARGET_CACHE_MB = "8192"
+$env:PROSPER_BACKEND_TEXTURE_CACHE_MB = "8192"
+$env:PROSPER_COMPUTE_IMAGE_CACHE_MB = "4096"
+$env:PROSPER_TEXTURE_DECODE_CACHE_MB = "4096"
+$env:PROSPER_DETILE_THREADS = "4"
+$env:PROSPER_COMPUTE_CONVERSION_THREADS = "4"
+$env:PROSPER_DRAW_REALIZE_THREADS = "16"
+
+.\build-mingw-app\prosper-app.exe --dump "C:\Users\matti\repos\ps5ys\testdata\PPSA04263-app0" --volume 0 --present-mode mailbox
+```
+Inspect the resulting `.prperf` capture file with:
+```bash
+python tools/perf/performance_capture_report.py <capture>.prperf
+```
 
 ## What the rendering series changed, and what it teaches (2026-08-26)
 


### PR DESCRIPTION
## Summary

This PR updates \docs/GTA5_STATUS.md\ with detailed performance analysis, problem descriptions, solution designs, and verified benchmark results from optimizing GTA V (\PPSA04263\) native 4K Story Mode gameplay (prologue bank heist) from **~0.6–0.8 FPS (1,600+ ms/frame) to 15.2–15.4 FPS (64.8 ms/frame)**, achieving a **~22x speedup**.

### Key Bottlenecks & Solutions Documented

1. **MRT Flush Breaking Backend Submission Batching (~560 ms/frame saved)**:
   - *Problem*: \	ests/fixtures/render_runner.h\ had an unconditional \|| color_count > 2\ in \eadback_requested_for_flush\, forcing an eager Vulkan queue submit on every MRT G-buffer draw pass. This caused 27.88 separate queue submits per frame and ~598 ms in driver cleanup loops.
   - *Solution*: Replaced with \eadback_extra_wanted\ to check if slots 2+ actually requested readback. Queue submits dropped to 2.0 per frame and driver cleanup to 1.7 ms.

2. **Native \Unorm2_10_10_10\ Typed Storage & Multi-Texel Seed Proving**:
   - *Problem*: Format 50 was missing from \
ative_float_storage_image\ and capability mask, causing staging bloat (132 MB) and CPU packing loops. Seed reproving was single-texel per thread.
   - *Solution*: Added typed storage capability bit 24 and parameterized multi-texel seed proving (\max_texels_per_thread = 16\), dropping CPU packing time to 0 ms.

3. **Bounded PCIe GPU Storage Image Comparisons (38x speedup)**:
   - *Problem*: Unbounded full-screen staging buffer comparisons across PCIe consumed 1,138.6 ms per window.
   - *Solution*: Capped compare sweeps to targets <= 2 MiB (\PROSPER_MAX_GPU_COMPARE_IMAGE_MB=2\), reducing \gpu_compare_ms\ to 30.2 ms.

4. **Eliminated Redundant 4K Scanout and Unbound Attachment Readbacks**:
   - *Problem*: \ase != front_va\ forced 33.2 MB host memcpy under GPU presentation, and passes with unbound slot 0 (\persistent_id == 0\) evaluated \!persistent_color\ to true.
   - *Solution*: Deferred scanout readback when \inal_gpu_present\ is active, and gated readback on \persistent_id != 0\.

5. **Concurrent Shader Cache Scaling (\std::shared_mutex\)**:
   - *Problem*: 16 parallel draw realization workers contended on a single \std::mutex\ across 884 lookups per frame, totaling 228.6 ms of serialized overhead.
   - *Solution*: Converted to \std::shared_mutex\ with lock-free atomic hits counter, enabling concurrent read lookups across all worker threads.

### Verification
- Measured with prosper F8 performance capture (\perf_capture_PPSA04263_20260903-073935-834.prperf\):
  - Guest Flips Rate: **15.17 flips/s**
  - Effective Renderer Rate: **15.43 FPS** (average dt: 64.82 ms)
  - Measured Graphics Time: **38.21 ms/frame** (~26.2 FPS GPU capacity)
- Test suite: 267/268 passed (1 skipped, 0 failed)