### PR TITLE
fix(gta5): address #3276 follow-ups (env parsing & readback buffer sizing)

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1215,12 +1215,10 @@ size_t cold_storage_result_snapshot_defer_min_bytes() {
 size_t max_gpu_compare_image_bytes() {
     static const size_t bytes = [] {
         const char* value = std::getenv("PROSPER_MAX_GPU_COMPARE_IMAGE_MB");
-        char* end = nullptr;
-        const uint64_t parsed = value ? std::strtoull(value, &end, 10) : 2ull;
-        const uint64_t mib = value && (!end || *end) ? 2ull : parsed;
-        return static_cast<size_t>(
-            std::min<uint64_t>(mib, SIZE_MAX / (1024ull * 1024ull)) *
-            (1024ull * 1024ull));
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_MAX_GPU_COMPARE_IMAGE_MB", value, 2ull,
+            SIZE_MAX / (1024ull * 1024ull), "MiB");
+        return static_cast<size_t>(mib * (1024ull * 1024ull));
     }();
     return bytes;
 }

--- a/prosper/frontends/shared/present/readback_policy.hpp
+++ b/prosper/frontends/shared/present/readback_policy.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace prosper::frontend {
@@ -29,6 +30,26 @@ constexpr bool is_color_target_readback_wanted(bool has_color_target,
     if (!has_color_target) return true;
     if (target_readback) return true;
     return persistent_id != 0 && !persistent_color;
+}
+
+// Calculates the required staging buffer size covering only the active readback slots (#3276).
+// Sizing the allocation to max(offsets[slot] + bytes[slot]) over the selected slots captures
+// the common case of unbound higher MRT slots without disturbing the absolute offsets.
+template <size_t N, typename OffsetArray, typename BytesArray, typename WantedPred>
+constexpr uint64_t compute_active_readback_bytes(size_t count,
+                                                 const OffsetArray& offsets,
+                                                 const BytesArray& bytes,
+                                                 WantedPred&& is_wanted) {
+    uint64_t max_extent = 0;
+    const size_t limit = count < N ? count : N;
+    for (size_t slot = 0; slot < limit; ++slot) {
+        if (is_wanted(slot)) {
+            const uint64_t extent = static_cast<uint64_t>(offsets[slot]) +
+                                    static_cast<uint64_t>(bytes[slot]);
+            if (extent > max_extent) max_extent = extent;
+        }
+    }
+    return max_extent;
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/tests/test_readback_policy.cpp
+++ b/prosper/frontends/shared/tests/test_readback_policy.cpp
@@ -37,6 +37,31 @@ int main() {
     // When there is no color target struct at all, default readback behavior is preserved.
     CHECK(is_color_target_readback_wanted(false, 0, false, false));
 
+    // Active readback sizing (#3276): staging buffer is sized only to the maximum extent of
+    // selected slots, while preserving absolute offsets.
+    using prosper::frontend::compute_active_readback_bytes;
+    const uint64_t offsets[4] = {0, 33u << 20, 66u << 20, 99u << 20};
+    const uint64_t bytes[4] = {33u << 20, 33u << 20, 33u << 20, 33u << 20};
+
+    // Slot 0 only selected (common case: unbound higher MRT slots): only 33 MB, not 132 MB.
+    CHECK(compute_active_readback_bytes<4>(4, offsets, bytes, [](size_t s) { return s == 0; }) ==
+          (33u << 20));
+
+    // Slots 0 and 1 selected: 66 MB.
+    CHECK(compute_active_readback_bytes<4>(4, offsets, bytes, [](size_t s) { return s <= 1; }) ==
+          (66u << 20));
+
+    // Slot 2 selected (with holes at slots 0 and 1): covers up to end of slot 2 (99 MB).
+    CHECK(compute_active_readback_bytes<4>(4, offsets, bytes, [](size_t s) { return s == 2; }) ==
+          (99u << 20));
+
+    // All slots selected: full 132 MB.
+    CHECK(compute_active_readback_bytes<4>(4, offsets, bytes, [](size_t) { return true; }) ==
+          (132u << 20));
+
+    // No slots selected: 0 bytes.
+    CHECK(compute_active_readback_bytes<4>(4, offsets, bytes, [](size_t) { return false; }) == 0);
+
     if (!failures) std::printf("readback_policy: OK\n");
     return failures ? 1 : 0;
 }

--- a/prosper/frontends/shared/tests/test_write_watch_policy.cpp
+++ b/prosper/frontends/shared/tests/test_write_watch_policy.cpp
@@ -227,6 +227,18 @@ int main() {
             "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", "eight", 8)) * (1u << 20));
         CHECK(kept_budget.try_consume(64u << 20));
         CHECK(!kept_budget.try_consume(64u << 20));  // bounded, which is what was asked for
+
+        // PROSPER_MAX_GPU_COMPARE_IMAGE_MB (#3276): negative or unit typo keeps default 2 MiB rather
+        // than wrapping to UINT64_MAX or zero.
+        using prosper::diag::env_u64_or_default_capped;
+        CHECK(env_u64_or_default_capped(
+            "PROSPER_MAX_GPU_COMPARE_IMAGE_MB", "-1", 2ull, 1024ull, "MiB") == 2ull);
+        CHECK(env_u64_or_default_capped(
+            "PROSPER_MAX_GPU_COMPARE_IMAGE_MB", "2mb", 2ull, 1024ull, "MiB") == 2ull);
+        CHECK(env_u64_or_default_capped(
+            "PROSPER_MAX_GPU_COMPARE_IMAGE_MB", "8", 2ull, 1024ull, "MiB") == 8ull);
+        CHECK(env_u64_or_default_capped(
+            "PROSPER_MAX_GPU_COMPARE_IMAGE_MB", "2048", 2ull, 1024ull, "MiB") == 1024ull);
     }
 
     if (!failures) std::printf("write_watch_policy: OK\n");

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -8391,6 +8391,22 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         else if (storage_writeback_requested) flush_reason_storage = 1;
         else flush_reason_explicit = 1;
     }
+    // Sizing the readback buffer to the maximum extent over the selected slots captures the common
+    // case of unbound higher MRT slots without disturbing the absolute offsets (#3276).
+    readback_bytes = static_cast<VkDeviceSize>(
+        prosper::frontend::compute_active_readback_bytes<prosper::gpu::kColorTargetCount>(
+            color_count, color_offsets, color_bytes, [&](size_t slot) {
+                if (slot == 0) return readback_color0;
+                if (slot == 1) return readback_color1;
+                const bool persistent_slot = cached_extra[slot] != nullptr;
+                return want_color_readback &&
+                    prosper::frontend::is_color_target_readback_wanted(
+                        color_target != nullptr,
+                        color_target ? color_target->persistent_id_slots[slot] : 0,
+                        persistent_slot,
+                        color_target ? color_target->readback_slots[slot] : false);
+            }));
+
     VkBuffer rb = VK_NULL_HANDLE;
     VkDeviceMemory bmem = VK_NULL_HANDLE;
     if (readback_requested) {


### PR DESCRIPTION
Addresses both findings raised in #3276:

1. **PROSPER_MAX_GPU_COMPARE_IMAGE_MB parsing**:
   - Replaced the hand-rolled strtoull parse in live_compute.cpp with prosper::diag::env_u64_or_default_capped.
   - Now refuses leading signs (-1), unit typos (2mb), and invalid formats loudly on stderr while keeping the default (2 MiB), preventing accidental unbounded comparisons or silent defaults (#3253, #3268).
   - Added test assertions to test_write_watch_policy.cpp validating -1, 2mb, 8, and clamp saturation at 1024.

2. **Readback buffer allocation sizing**:
   - Added compute_active_readback_bytes in readback_policy.hpp which calculates max(offsets[slot] + bytes[slot]) over active readback slots.
   - Sized readback_bytes in render_runner.h using compute_active_readback_bytes, allocating and mapping only the extent needed for requested/active slots (e.g. 33.2 MB instead of 132.7 MB on 4K 4-MRT passes where trailing slots are not read back) without disturbing absolute slot offsets.
   - Added unit test coverage for compute_active_readback_bytes in test_readback_policy.cpp covering single-slot, multi-slot, interleaved holes, full set, and empty set.

Fixes #3276.