### PR TITLE
DO NOT MERGE — HTILE invalidation: breaks GTA V characters/lighting (#3264)

### DIFF
--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -3905,12 +3905,30 @@ inline size_t invalidate_persistent_ds_guest_write(uint64_t addr, uint64_t size)
         // 62,000/62,000, first word 0x00000000 in both, differing only in plane size (73,728 vs
         // 49,152 words, i.e. resolution). A "uniform plane means a fast clear" discriminator was
         // hypothesised and MEASURED FALSE before it was written; PROSPER_HTILE_UNIFORMLOG below is
-        // the instrument that killed it. So this restores behaviour known to be correct for both
-        // titles without knowing why the same event needs opposite handling, and the actual fix the
-        // comment above still names -- decoding HTILE to tell a clear from a refresh -- remains open.
-        const bool byte_preserving =
-            std::strcmp(prosper::gpu::guest_gpu_write_origin(), "gpu-preserving") == 0;
-        const bool htile_kill = htile_overlap && htile_invalidates && !byte_preserving;
+        // the instrument that killed it.
+        // #3264: the `!byte_preserving` term is REMOVED, not weakened. It suppressed the
+        // invalidation whenever the write carried the `gpu-preserving` origin, and that is unsound
+        // for the reason GTA5_STATUS.md's own Ruled out section recorded on 2026-08-28 (#3089), one
+        // day before it was reinstated: prosper never writes rendered HiZ back into the guest HTILE
+        // plane, so the guest copy is a constant the guest's own writes keep reproducing, and the
+        // byte comparator reports `changed=0` for a fast CLEAR exactly as readily as for the
+        // decompress the rule was written for.
+        //
+        // There was never a trade-off between the two titles. Suppressing the invalidation leaves
+        // STALE DEPTH, and the two titles present the same defect differently -- Blue Prince fails
+        // the depth test against it and draws nothing, GTA V samples it and hangs the GPU. Measured
+        // on one binary pair, same session, same routes:
+        //
+        //   Blue Prince title    4/5 frames render (256 distinct)  vs  0/5 (2 distinct)
+        //   GTA V routed world   8/8 render, 0 device losses       vs  3/8 then black, 122 losses
+        //
+        // Dead Cells #611 is the prior counterexample where sparing the invalidation makes gameplay
+        // geometry disappear, so this rule has now cost three titles. Restoring it again needs the
+        // discriminator its own author named and did not build: decode HTILE to tell a clear from a
+        // refresh. A byte comparison cannot, and the `gpu-preserving` origin is a process-global set
+        // by whichever write ran last (gpu_executor.cpp, `g_guest_write_origin`), so keying on it is
+        // order-dependent by construction.
+        const bool htile_kill = htile_overlap && htile_invalidates;
         if (!depth_overlap && !stencil_overlap && !htile_kill) continue;
         if (depth_overlap || htile_kill) image.depth_valid = false;
         if (stencil_overlap || htile_kill) image.stencil_valid = false;


### PR DESCRIPTION
## One term, three titles

`4b2b4ec92` added `&& !byte_preserving` to the depth/stencil invalidation predicate. This removes it.

```cpp
- const bool htile_kill = htile_overlap && htile_invalidates && !byte_preserving;
+ const bool htile_kill = htile_overlap && htile_invalidates;
```

## There was never a trade-off

Suppressing the invalidation leaves **stale depth**. The two titles present that one defect
differently, which is why every previous attempt looked like a trade:

* **Blue Prince** fails the depth test against it and draws nothing → black screen.
* **GTA V** *samples* it and hangs the GPU → `VK_ERROR_DEVICE_LOST` cascade → black world.

Each earlier change fixed one title, measured only that title, and appeared to break the other.

## Measured — one binary pair, same session, same routes, two runs each

| | with the term (`main`) | without it (this PR) |
| --- | --- | --- |
| Blue Prince title | 0/5 frames, **2** distinct of 38,881 | **4/5 frames**, **256** distinct of 38,586 |
| GTA V routed world | 3/8 then black | **8/8 frames render** |
| GTA V device losses | **122** and **175** | **0** and **0** |

The GTA V control goes black at the same frame in both runs — per-frame luminance
`73 115 116 0 0 0 0 0` — and the experiment renders all eight in both, with luminance matching
within ~1 point. So the route lands on the same scenes and this is like-for-like, not two different
moments.

## Guards

| guard | `main` | this PR |
| --- | --- | --- |
| `blue-prince-title` | **FAIL** — qualifying frames 0 < 8 | **OK** |
| `dead-cells-gameplay` | OK | **OK** |
| `messenger-scene` | OK | **OK** |
| `alexkidd-gameplay` | OK | **OK** |

The last three were run as regression controls, because a renderer change that fixes one guard and
quietly breaks others would otherwise read as a win.

## This was recorded as unsound before it shipped

`GTA5_STATUS.md`'s own `## Ruled out`, **2026-08-28** (#3089) — one day before `4b2b4ec92`:

> **The HTILE `gpu-preserving` suppression is load-bearing for GTA V's picture. FALSE, measured.**
> … That rule is **unsound in principle**: prosper never writes rendered HiZ back into the guest
> HTILE plane, so the guest copy is a constant the guest's own writes keep reproducing, and the
> comparator reports `changed=0` for a fast CLEAR exactly as readily as for the decompress it was
> written for.

It also cites **Dead Cells #611**, where sparing the invalidation makes gameplay geometry disappear.
So this rule has now cost **three** titles.

`4b2b4ec92`'s own comment states both halves of the contradiction — that #3093's removal *"fixed Blue
Prince"*, and that restoring it *"restores behaviour known to be correct for both"*. The
measurements say the first is the accurate one.

## What a future attempt needs first

Recorded in the code comment rather than left to be rediscovered: the discriminator `4b2b4ec92`
named and did not build — **decode HTILE to tell a clear from a refresh**. A byte comparison cannot,
and `guest_gpu_write_origin()` returns a **process-global** set by whichever write ran last
(`gpu_executor.cpp`, `g_guest_write_origin`), so keying on it is order-dependent by construction.

That global is also a plausible mechanism for the reported intermittency — *"sometimes Blue Prince
works, sometimes it doesn't"* — and for why `4b2b4ec92`'s author measured Blue Prince at `0.2085`
where every run here reads `0`. Worth its own issue; not fixed here.

## Verification

Build exit 0. Guards as tabled. Two independent A/B runs per arm per title. Void arms (a `127` from
a missing target, and two runs my own concurrent job SIGTERMed) were **discarded, not folded in**.

Not verified: Windows or macOS behaviour — everything here is Linux/RADV on an integrated
Radeon 8060S. The device-loss cascade may be RADV-specific even if the stale-depth defect is not.

Fixes #3264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kwL1ddgwCADK6WPDimaB
