### PR TITLE
perf(render): evict older targets in copy_persistent_color_target when over capacity

### DIFF
--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -4363,8 +4363,9 @@ inline bool readback_persistent_color_target(uint64_t id, uint32_t width, uint32
 // source — after a #780 guest-write CPU-copy discard, consumers (Blue Prince's compute tonemap)
 // imported the stale image and read black, cascading the #1287 display-chain collapse. Copy the
 // device-local pixels so the destination image is genuinely valid. Creates the destination if
-// absent (same shape/usage as the render path; budget-checked WITHOUT eviction — an allocation
-// failure returns false and the caller keeps the CPU pixels as the only truth, fail-visibly).
+// absent (same shape/usage as the render path; budget-checked with LRU eviction of unpinned older
+// targets — an allocation failure returns false and the caller keeps the CPU pixels as the only truth,
+// fail-visibly).
 inline bool copy_persistent_color_target(uint64_t src_id, uint64_t dst_id, uint32_t width,
                                          uint32_t height, VkFormat format, std::string& error) {
     error.clear();
@@ -4405,12 +4406,20 @@ inline bool copy_persistent_color_target(uint64_t src_id, uint64_t dst_id, uint3
         }
         VkMemoryRequirements ir{}; vkGetImageMemoryRequirements(ctx.dev, img, &ir);
         const VkDeviceSize limit = persistent_color_target_limit();
+        const size_t count_limit = persistent_color_target_count_limit();
+        if (ir.size <= limit) {
+            ++src->pin_count;
+            while ((persistent_color_target_cache().size() > count_limit ||
+                    persistent_color_target_bytes() > limit - ir.size) &&
+                   evict_persistent_color_target(ctx, persistent_color_target_generation())) {}
+            --src->pin_count;
+        }
         VkDeviceMemory imem = VK_NULL_HANDLE;
         VkMemoryAllocateInfo iai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
         iai.allocationSize = ir.size;
         iai.memoryTypeIndex = render_memory_type(ctx.phys, ir.memoryTypeBits, 0);
         if (ir.size > limit || persistent_color_target_bytes() > limit - ir.size ||
-            persistent_color_target_cache().size() > persistent_color_target_count_limit() ||
+            persistent_color_target_cache().size() > count_limit ||
             vkAllocateMemory(ctx.dev, &iai, nullptr, &imem) != VK_SUCCESS || !imem) {
             vkDestroyImage(ctx.dev, img, nullptr);
             persistent_color_target_cache().erase(dst_key);

--- a/prosper/tests/gpu/state/test_multidraw_render.cpp
+++ b/prosper/tests/gpu/state/test_multidraw_render.cpp
@@ -919,6 +919,24 @@ int main() {
                   0x1334000000000003ull, 0x1334000000000004ull, W, H,
                   VK_FORMAT_R8G8B8A8_UNORM, missing_err),
               "a missing source declines the copy");
+
+        // Verify that copy_persistent_color_target evicts older entries when the target cache
+        // reaches capacity, rather than failing and dropping the destination to CPU-only pixels.
+        const size_t count_limit = prosper::test::persistent_color_target_count_limit();
+        const uint64_t evict_dummy_base = 0x1334000000001000ull;
+        size_t dummy_count = 0;
+        while (prosper::test::persistent_color_target_cache().size() < count_limit) {
+            const uint64_t id = evict_dummy_base + dummy_count++;
+            prosper::test::PersistentColorTargetKey key{id, W, H, VK_FORMAT_R8G8B8A8_UNORM};
+            auto& entry = prosper::test::persistent_color_target_cache()[key];
+            entry.last_use = 1; // old generation eligible for eviction
+            entry.valid = false;
+        }
+        std::string evict_copy_err;
+        CHECK(prosper::test::copy_persistent_color_target(
+                  0x1334000000000001ull, 0x1334000000000005ull, W, H,
+                  VK_FORMAT_R8G8B8A8_UNORM, evict_copy_err),
+              "GPU-side persistent color copy succeeds at capacity limit by evicting older target");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Summary

`copy_persistent_color_target` lacked an LRU cache eviction loop, unlike the slot 0, slot 1, and MRT extra slots allocation paths. Once the persistent color target cache reached `persistent_color_target_count_limit()` (256 targets), every subsequent resolve copy failed with:
`[msaa] resolve GPU copy failed (resolve destination exceeds the persistent target budget) — destination keeps CPU pixels only (#1334)`

This stripped `gpu_valid` from the destination image and forced every downstream pass sampling that resolved surface to fall back to CPU de-tiling all 33.4 MB from guest memory on host CPU threads. In GTA V (PPSA04263), the 4K resolve destination `0x204aee0000` was de-tiled on the CPU 89 times per 5s window (~10.4 ms/frame stall).

## Fix

Added LRU cache eviction loop of unpinned older targets under memory or count pressure before allocating the destination image in `copy_persistent_color_target`, protecting the source target with `pin_count` during eviction.

## Before / After Measurements (Linux Windowed Benchmark on Radeon 8060S / Strix Halo)

Measured via automated story mode pad script (`scripts/gta5/reach-performance-story.pad`, prologue bank heist) in live 5-second `.prperf` windowed performance captures:

| Metric | Baseline (`10:11`) | With Fix (`13:52`) | Improvement |
| :--- | :--- | :--- | :--- |
| **`0x204aee0000` (4K resolve dest) CPU de-tile** | **302.50 ms** (89 passes) | **0.00 ms** (0 passes) | **Eliminated (~10.4 ms/frame saved)** |
| **`res_buffer_ms`** | 298.79 ms | 119.98 ms | **~2.5x faster buffer uploads** |
| **`setup_resources_ms`** | 597.37 ms | 410.93 ms | **Saved 186.4 ms per window** |
| **Resolve copy failure warnings** | Logged continuously | **0 occurrences across all frames** | **100% successful GPU resolve copies** |

## Verification

- Added regression test in `tests/gpu/state/test_multidraw_render.cpp` asserting that `copy_persistent_color_target` successfully evicts older targets and succeeds when the persistent color target cache is at capacity limit.
- Verified all 350 active unit tests in `ctest` pass (100%).
- Based on `main`.