### PR TITLE
fix(render): preserve in-flight frame depth under byte-preserving HTILE writebacks

### DIFF
--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -18,6 +18,7 @@
 #include "shared/perf/performance_timing_gate.hpp"
 #include "shared/perf/performance_timing_policy.hpp"
 #include "shared/present/readback_policy.hpp"
+#include "gpu/present/videoout_present.hpp"
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -3351,6 +3352,7 @@ struct PersistentDsImage {
     bool stencil_valid = false;
     uint64_t last_depth_write = 0;   // sampled-bridge recency (#1275)
     uint64_t last_depth_command_order = 0;
+    uint64_t last_depth_present = UINT64_MAX;
 };
 
 inline uint64_t& persistent_ds_write_generation() {
@@ -3395,6 +3397,7 @@ inline void note_persistent_ds_depth_write(PersistentDsImage& image, bool use_de
     if (use_depth && depth_may_be_written) {
         image.last_depth_write = ++persistent_ds_write_generation();
         image.last_depth_command_order = command_order;
+        image.last_depth_present = prosper::gpu::present_count();
     }
 }
 
@@ -3928,7 +3931,15 @@ inline size_t invalidate_persistent_ds_guest_write(uint64_t addr, uint64_t size)
         // refresh. A byte comparison cannot, and the `gpu-preserving` origin is a process-global set
         // by whichever write ran last (gpu_executor.cpp, `g_guest_write_origin`), so keying on it is
         // order-dependent by construction.
-        const bool htile_kill = htile_overlap && htile_invalidates;
+        const bool byte_preserving =
+            std::strcmp(prosper::gpu::guest_gpu_write_origin(), "gpu-preserving") == 0;
+        const uint64_t current_present = prosper::gpu::present_count();
+        const bool current_frame_depth =
+            image.depth_valid && image.last_depth_write > 0 &&
+            image.last_depth_present != UINT64_MAX &&
+            image.last_depth_present == current_present;
+        const bool htile_kill = htile_overlap && htile_invalidates &&
+                                (!byte_preserving || !current_frame_depth);
         if (!depth_overlap && !stencil_overlap && !htile_kill) continue;
         if (depth_overlap || htile_kill) image.depth_valid = false;
         if (stencil_overlap || htile_kill) image.stencil_valid = false;

--- a/prosper/tests/render/test_ds_layer_stride.cpp
+++ b/prosper/tests/render/test_ds_layer_stride.cpp
@@ -266,13 +266,30 @@ int main() {
         auto& image = prosper::test::persistent_ds_cache()[key];
         image.depth_valid = true;
         image.stencil_valid = true;
+        image.last_depth_write = 1;
+        image.last_depth_present = prosper::gpu::present_count();
 
         prosper::gpu::set_guest_gpu_write_origin("gpu-preserving");
         const size_t preserved =
             prosper::test::invalidate_persistent_ds_guest_write(kHtile, 4096);
         prosper::gpu::set_guest_gpu_write_origin(nullptr);
         check(preserved == 0 && image.depth_valid && image.stencil_valid,
-              "a byte-preserving HTILE rewrite preserves both retained aspects (#3121)");
+              "a byte-preserving HTILE rewrite on current-frame depth preserves both retained aspects (#3121)");
+
+        // If the depth was rendered in a prior frame (present_count advanced),
+        // a byte-preserving HTILE clear must discard the stale prior-frame depth
+        // so the new frame starts fresh (Blue Prince #3264).
+        image.depth_valid = true;
+        image.stencil_valid = true;
+        image.last_depth_write = 1;
+        image.last_depth_present = prosper::gpu::present_count() - 1;
+
+        prosper::gpu::set_guest_gpu_write_origin("gpu-preserving");
+        const size_t prior_frame_cleared =
+            prosper::test::invalidate_persistent_ds_guest_write(kHtile, 4096);
+        prosper::gpu::set_guest_gpu_write_origin(nullptr);
+        check(prior_frame_cleared == 1 && !image.depth_valid && !image.stencil_valid,
+              "a byte-preserving HTILE rewrite on prior-frame depth invalidates stale depth (#3264)");
 
         // The changed-origin arm is kept beside it so the assertion above cannot pass merely
         // because HTILE invalidation stopped firing at all -- which is the mutation that would


### PR DESCRIPTION
## Summary

Resolves the rendering conflict between **Blue Prince** (#3264) and **GTA V** (#3121) introduced by #3278.

### Background

- **In Blue Prince (PPSA25009)**: Inter-frame fast clears write all-zero HTILE planes carrying `origin=gpu-preserving` before any geometry in the new frame is drawn. When stale depth from the prior frame was not invalidated, subsequent scene geometry depth-tested against the stale depth and failed, rendering a black screen.
- **In GTA V (PPSA04263)**: 3D world geometry renders into the 4K depth attachment (`0x2052ac0000`). Between the G-buffer and deferred lighting passes, compute shaders touch HTILE (`0x2055310000`) with `origin=gpu-preserving` without modifying guest bytes. In #3278, removing `!byte_preserving` unconditionally wiped `image.depth_valid = false` on `0x2052ac0000` — destroying the geometry depth rendered earlier in that exact frame. Deferred lighting resolve then fell back to the fresh-image approximation, guessing `1.0f` on mixed 7:7 passes and failing all `GREATER` light volumes, while compute program `0x413dc6700` hung the GPU into `VK_ERROR_DEVICE_LOST`.

### Fix

Track `last_depth_present` in `PersistentDsImage` via `prosper::gpu::present_count()` when depth is written by the renderer in `note_persistent_ds_depth_write()`.

When an HTILE write carrying `origin=gpu-preserving` arrives:
- If depth was already written by the renderer during the **current presented frame** (`last_depth_present == gpu::present_count()`), preserve the in-flight geometry depth for downstream passes.
- If depth is from a **prior frame** (`last_depth_present != gpu::present_count()`), invalidate the stale depth so the new frame starts fresh.

### Verification

1. **Blue Prince title guard** (`tools/snapshot/snapshot.py check blue-prince-title`):
   `[check] blue-prince-title: OK (480x270, frames=10, qualifying=10, richest=16102 colors, structural_matches=10, nonblack_matches=10)`
2. **Alex Kidd gameplay guard** (`tools/snapshot/snapshot.py check alexkidd-gameplay`):
   `[check] alexkidd-gameplay: OK (480x270, frames=50, qualifying=50, richest=35471 colors, structural_matches=50, nonblack_matches=50)`
3. **The Messenger scene guard** (`tools/snapshot/snapshot.py check messenger-scene`):
   `[check] messenger-scene: OK (480x270, frames=29, qualifying=29, richest=32 colors, structural_matches=29, nonblack_matches=29)`
4. **Unit test** (`test_ds_layer_stride`):
   Updated to assert both current-frame preservation and prior-frame invalidation under `gpu-preserving` HTILE writes. Both pass.
5. **Full test suite** (`ctest -j16`):
   **100% passed** (350/350 active tests passed).
6. **GTA V live trace**:
   Verified `0x2052ac0000` retains `depth_valid = true` across the G-buffer to lighting transition with 0 unhandled HTILE resolve drops.