### PR TITLE
perf(compute, render): expand direct compute-to-graphics image import aliasing for Float16 (#3282)

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -10536,6 +10536,11 @@ bool compute_native_2d_transfer_format_compatible(prosper::gpu::DataFormat forma
     return native_storage_vk_format(format, components) != VK_FORMAT_UNDEFINED;
 }
 
+// Import-eligibility table naming which format/component combinations the graphics backend
+// can preserve when leasing an existing compute-produced image. This list governs import
+// admission into graphics views (where formats are reinterpreted, e.g. Float16 <-> Uint16),
+// not image creation: the underlying VkImage was already successfully created and validated
+// by the compute pipeline against the device's confirmed capabilities (via add_native_storage_format).
 uint32_t live_compute_graphics_import_native_format(
     prosper::gpu::DataFormat format, uint32_t components) {
     using prosper::gpu::DataFormat;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -434,6 +434,8 @@ VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t comp
         break;
     case DataFormat::Uint16:
         if (components == 1) return VK_FORMAT_R16_UINT;
+        if (components == 2) return VK_FORMAT_R16G16_UINT;
+        if (components == 4) return VK_FORMAT_R16G16B16A16_UINT;
         break;
     case DataFormat::Uint8:
         if (components == 1) return VK_FORMAT_R8_UINT;
@@ -10547,7 +10549,7 @@ uint32_t live_compute_graphics_import_native_format(
         (format == DataFormat::Unorm16 && components == 1) ||
         (format == DataFormat::Unorm8 && (components == 1 || components == 4)) ||
         (format == DataFormat::Uint32 && components == 1) ||
-        (format == DataFormat::Uint16 && components == 1) ||
+        (format == DataFormat::Uint16 && (components == 1 || components == 2 || components == 4)) ||
         (format == DataFormat::Uint8 && (components == 1 || components == 4));
     return admitted
         ? static_cast<uint32_t>(native_storage_vk_format(format, components))
@@ -10563,13 +10565,15 @@ uint64_t live_compute_graphics_import_guest_bytes(
     const bool r16_cube_array_alias = sampled_resource.img_dim == 3u &&
         sampled_resource.depth == 6u && components == 1u &&
         (sampled_resource.format == DataFormat::Uint16 ||
-         sampled_resource.format == DataFormat::Unorm16);
+         sampled_resource.format == DataFormat::Unorm16 ||
+         sampled_resource.format == DataFormat::Float16);
     if (r16_cube_array_alias)
         return prosper::gpu::gpu_capture_resource_footprint(sampled_resource);
     if (decoded_source_bytes) return decoded_source_bytes;
-    if (components == 1u &&
+    if ((components == 1u || components == 2u || components == 4u) &&
         (sampled_resource.format == DataFormat::Uint16 ||
-         sampled_resource.format == DataFormat::Unorm16))
+         sampled_resource.format == DataFormat::Unorm16 ||
+         sampled_resource.format == DataFormat::Float16))
         return prosper::gpu::gpu_capture_resource_footprint(sampled_resource);
     return 0;
 }
@@ -10600,7 +10604,8 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
     const bool cube_array_alias = sampled_resource.img_dim == 3 &&
         sampled_resource.depth == 6 &&
         (sampled_resource.format == prosper::gpu::DataFormat::Uint16 ||
-         sampled_resource.format == prosper::gpu::DataFormat::Unorm16) &&
+         sampled_resource.format == prosper::gpu::DataFormat::Unorm16 ||
+         sampled_resource.format == prosper::gpu::DataFormat::Float16) &&
         (sampled_resource.num_components ? sampled_resource.num_components : 1u) == 1u &&
         sampled_resource.layer_stride_bytes != 0;
     if (!context || !context->device || !sampled_resource.gpu_addr ||
@@ -10634,6 +10639,9 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
         (components == 1 || components == 4);
     const bool normalized_uint16_alias =
         sampled_resource.format == prosper::gpu::DataFormat::Unorm16 && components == 1;
+    const bool float16_uint16_alias =
+        sampled_resource.format == prosper::gpu::DataFormat::Float16 &&
+        (components == 1 || components == 2 || components == 4);
     const bool float32_uint32_alias =
         sampled_resource.format == prosper::gpu::DataFormat::Float32 && components == 1;
     const bool packed_r11_uint32_alias =
@@ -10641,11 +10649,12 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
     const bool packed_r10_uint32_alias =
         sampled_resource.format == prosper::gpu::DataFormat::Unorm2_10_10_10 && components == 4;
     if (!borrowed && (normalized_uint8_alias || normalized_uint16_alias ||
+                      float16_uint16_alias ||
                       float32_uint32_alias || packed_r11_uint32_alias ||
                       packed_r10_uint32_alias)) {
         if (normalized_uint8_alias)
             storage_identity.format = prosper::gpu::DataFormat::Uint8;
-        else if (normalized_uint16_alias)
+        else if (normalized_uint16_alias || float16_uint16_alias)
             storage_identity.format = prosper::gpu::DataFormat::Uint16;
         else if (float32_uint32_alias || packed_r10_uint32_alias)
             storage_identity.format = prosper::gpu::DataFormat::Uint32;

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -2151,6 +2151,14 @@ int main() {
               "typed R16_UINT storage remains byte-exact for an R16_UNORM graphics consumer");
         CHECK(alias_imported && alias_format == 70u, // VK_FORMAT_R16_UNORM
               "same-submit R16_UNORM consumer leases a mutable view of the exact R16_UINT result");
+        const auto [fp16_executed, fp16_destination, fp16_imported, fp16_format] =
+            run_native_typed_copy(DataFormat::Uint16, kSpirvImageFormatR16ui,
+                                  SpirvImageNumericClass::Uint, 1,
+                                  sizeof(uint16_t), source, DataFormat::Float16);
+        CHECK(fp16_executed && fp16_destination == source,
+              "typed R16_UINT storage remains byte-exact for an R16_SFLOAT graphics consumer");
+        CHECK(fp16_imported && fp16_format == 76u, // VK_FORMAT_R16_SFLOAT
+              "same-submit R16_SFLOAT consumer leases a mutable view of the exact R16_UINT result");
     }
     {
         // GTA V writes a six-layer R16_UINT DIM=2D_ARRAY shadow allocation, then samples the same
@@ -2249,6 +2257,15 @@ int main() {
                         normalized_import.valid() && normalized_import.native_format == 70u &&
                         normalized_import.vertical_stack_layers == layers &&
                         normalized_import.producer_command_order == item.command_order;
+                    ShaderResource float16_cube = cube;
+                    float16_cube.format = DataFormat::Float16;
+                    prosper::frontend::LiveComputeImageImport float16_import;
+                    const bool float16_imported =
+                        prosper::frontend::import_live_compute_storage_image(
+                            float16_cube, float16_cube.size, float16_import) &&
+                        float16_import.valid() && float16_import.native_format == 76u &&
+                        float16_import.vertical_stack_layers == layers &&
+                        float16_import.producer_command_order == item.command_order;
                     ShaderResource mismatch = cube;
                     --mismatch.depth;
                     prosper::frontend::LiveComputeImageImport rejected;
@@ -2260,7 +2277,7 @@ int main() {
                     const bool stride_rejected =
                         !prosper::frontend::import_live_compute_storage_image(
                             mismatch, cube.size, rejected);
-                    mismatches_rejected = depth_rejected && stride_rejected;
+                    mismatches_rejected = depth_rejected && stride_rejected && float16_imported;
                     return RenderedFrame{};
                 },
                 [&](const std::vector<ComputeItem>& items) {


### PR DESCRIPTION
Closes #3282

### Summary
When compute passes produce storage images that are subsequently sampled by graphics shaders, `import_live_compute_storage_image()` allows the renderer to directly lease the existing `VkImage` produced by compute without reading back and re-detiling pixels through the CPU.

Prior to this change:
1. `import_live_compute_storage_image` had aliasing rules for `Unorm8`, `Unorm16`, `Float32`, `Float10_11_11`, and `Unorm2_10_10_10`, but lacked an alias path for `DataFormat::Float16` (`R16F`, `RG16F`, `RGBA16F`) when produced by a storage image declared as `Uint16`.
2. `native_storage_vk_format` lacked cases for 2-component (`VK_FORMAT_R16G16_UINT`) and 4-component (`VK_FORMAT_R16G16B16A16_UINT`) formats.
3. `live_compute_graphics_import_native_format`, `live_compute_graphics_import_guest_bytes`, and `cube_array_alias` were missing `Float16` and multi-component `Uint16` coverage.

### Changes
- Added 2-component (`VK_FORMAT_R16G16_UINT`) and 4-component (`VK_FORMAT_R16G16B16A16_UINT`) support in `native_storage_vk_format`.
- Expanded `live_compute_graphics_import_native_format` and `live_compute_graphics_import_guest_bytes` to admit `Uint16` (1, 2, 4 components) and `Float16`.
- Added `float16_uint16_alias` in `import_live_compute_storage_image` for components 1, 2, and 4 to alias to `DataFormat::Uint16` producer storage identities.
- Extended `cube_array_alias` to accept `Float16` cube sampled descriptors borrowing 6-layer 2D array producers.
- Added regression tests in `test_game_compute.cpp` verifying `R16_SFLOAT` graphics consumer leasing mutable view of exact `R16_UINT` storage results.

### Verification
- `ctest -R game_compute_exec --output-on-failure` passed.
- Full test suite (354 tests) passed with 100% pass rate.