### PR TITLE
perf(texture): vectorize tile_surface (sw64kb_copy) to accelerate compute writeback (#3284)

### DIFF
--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -794,12 +794,11 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
     static const bool row_major_tile = std::getenv("PROSPER_TILE_ROW_MAJOR") != nullptr;
     if ((!ToTiled && !row_major_detile) || (ToTiled && !row_major_tile)) {
 #if defined(PROSPER_HAVE_TARGET_AVX2)
-        static const bool use_avx2_gather =
-            std::getenv("PROSPER_NO_AVX2_DETILE") == nullptr &&
-            __builtin_cpu_supports("avx2");
-        static const bool use_avx2_tile =
-            std::getenv("PROSPER_NO_AVX2_TILE") == nullptr &&
-            __builtin_cpu_supports("avx2");
+        static const bool cpu_has_avx2 = __builtin_cpu_supports("avx2");
+        const bool use_avx2_gather = cpu_has_avx2 &&
+            std::getenv("PROSPER_NO_AVX2_DETILE") == nullptr;
+        const bool use_avx2_tile = cpu_has_avx2 &&
+            std::getenv("PROSPER_NO_AVX2_TILE") == nullptr;
 #endif
             const uint32_t surface_block_rows = (eh + bh - 1) / bh;
             const uint32_t surface_block_cols = (ew + bw - 1) / bw;

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -761,7 +761,7 @@ void tile_full_block_row_avx2(uint8_t* tiled_block, const uint8_t* linear_src,
 template <bool ToTiled>
 void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uint32_t pitch,
                  uint32_t bpe, size_t tiled_bytes, uint32_t tile_mode,
-                 size_t tiled_origin = 0) {
+                 size_t tiled_origin = 0, bool allow_avx2 = true) {
     uint32_t el = sw64kb_elem_log2(bpe);
     if (el == UINT32_MAX) {
         const size_t n = (size_t)ew * eh * bpe;
@@ -795,9 +795,9 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
     if ((!ToTiled && !row_major_detile) || (ToTiled && !row_major_tile)) {
 #if defined(PROSPER_HAVE_TARGET_AVX2)
         static const bool cpu_has_avx2 = __builtin_cpu_supports("avx2");
-        const bool use_avx2_gather = cpu_has_avx2 &&
+        const bool use_avx2_gather = allow_avx2 && cpu_has_avx2 &&
             std::getenv("PROSPER_NO_AVX2_DETILE") == nullptr;
-        const bool use_avx2_tile = cpu_has_avx2 &&
+        const bool use_avx2_tile = allow_avx2 && cpu_has_avx2 &&
             std::getenv("PROSPER_NO_AVX2_TILE") == nullptr;
 #endif
             const uint32_t surface_block_rows = (eh + bh - 1) / bh;
@@ -1397,7 +1397,8 @@ std::vector<uint8_t> detile_surface(const std::vector<uint8_t>& src, uint32_t wi
 }
 
 void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
-                  uint32_t tile_mode, uint32_t pitch, uint32_t bytes_per_texel) {
+                  uint32_t tile_mode, uint32_t pitch, uint32_t bytes_per_texel,
+                  bool allow_avx2) {
     tile_census_note("tile_surface", width, height, bytes_per_texel, tile_mode);
     if (!tile_mode_is_tiled(tile_mode)) { std::memcpy(dst, src, (size_t)width * height * bytes_per_texel); return; }
     const size_t dst_bytes = tiled_surface_bytes(width, height, tile_mode, pitch, bytes_per_texel);
@@ -1431,7 +1432,8 @@ void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t hei
         return;
     }
     if (is_64kb_mode(tile_mode)) {
-        sw64kb_copy<true>(dst, src, width, height, pitch, bytes_per_texel, dst_bytes, tile_mode);
+        sw64kb_copy<true>(dst, src, width, height, pitch, bytes_per_texel, dst_bytes, tile_mode,
+                          0, allow_avx2);
         return;
     }
     sw4kb_copy<true>(dst, src, width, height, pitch, bytes_per_texel, dst_bytes);

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -677,6 +677,80 @@ void detile_full_block_row_avx2(uint8_t* dst, const uint8_t* tiled_block,
                               tiled_block + (x_offsets[x] ^ y_offset), bpe);
 }
 
+__attribute__((target("avx2")))
+void tile_full_block_row_avx2(uint8_t* tiled_block, const uint8_t* linear_src,
+                              const uint16_t* x_offsets, uint16_t y_offset,
+                              uint32_t columns, uint32_t bpe) {
+    uint32_t x = 0;
+    const __m128i y = _mm_set1_epi16(static_cast<int16_t>(y_offset));
+    static const bool paired_tiles =
+        std::getenv("PROSPER_NO_PAIRED_AVX2_TILE") == nullptr;
+    const __m128i even_offsets = _mm_setr_epi8(
+        0, 1, 4, 5, 8, 9, 12, 13, -1, -1, -1, -1, -1, -1, -1, -1);
+    if (bpe == 2 && paired_tiles) {
+        for (; x + 8 <= columns; x += 8) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(x_offsets + x)), y);
+            const __m128i pair_offsets16 = _mm_shuffle_epi8(offsets16, even_offsets);
+            const uint16_t off0 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 0));
+            const uint16_t off1 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 1));
+            const uint16_t off2 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 2));
+            const uint16_t off3 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 3));
+            const uint32_t* src32 =
+                reinterpret_cast<const uint32_t*>(linear_src + static_cast<size_t>(x) * 2);
+            *reinterpret_cast<uint32_t*>(tiled_block + off0) = src32[0];
+            *reinterpret_cast<uint32_t*>(tiled_block + off1) = src32[1];
+            *reinterpret_cast<uint32_t*>(tiled_block + off2) = src32[2];
+            *reinterpret_cast<uint32_t*>(tiled_block + off3) = src32[3];
+        }
+    } else if (bpe == 4 && paired_tiles) {
+        for (; x + 8 <= columns; x += 8) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(x_offsets + x)), y);
+            const __m128i pair_offsets16 = _mm_shuffle_epi8(offsets16, even_offsets);
+            const uint16_t off0 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 0));
+            const uint16_t off1 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 1));
+            const uint16_t off2 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 2));
+            const uint16_t off3 = static_cast<uint16_t>(_mm_extract_epi16(pair_offsets16, 3));
+            const uint64_t* src64 =
+                reinterpret_cast<const uint64_t*>(linear_src + static_cast<size_t>(x) * 4);
+            *reinterpret_cast<uint64_t*>(tiled_block + off0) = src64[0];
+            *reinterpret_cast<uint64_t*>(tiled_block + off1) = src64[1];
+            *reinterpret_cast<uint64_t*>(tiled_block + off2) = src64[2];
+            *reinterpret_cast<uint64_t*>(tiled_block + off3) = src64[3];
+        }
+    } else if (bpe == 8) {
+        for (; x + 4 <= columns; x += 4) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(x_offsets + x)), y);
+            const uint16_t off0 = static_cast<uint16_t>(_mm_extract_epi16(offsets16, 0));
+            const uint16_t off1 = static_cast<uint16_t>(_mm_extract_epi16(offsets16, 2));
+            const __m128i val0 = _mm_loadu_si128(
+                reinterpret_cast<const __m128i*>(linear_src + static_cast<size_t>(x) * 8));
+            const __m128i val1 = _mm_loadu_si128(
+                reinterpret_cast<const __m128i*>(linear_src + static_cast<size_t>(x) * 8 + 16));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(tiled_block + off0), val0);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(tiled_block + off1), val1);
+        }
+    } else if (bpe == 16) {
+        for (; x + 2 <= columns; x += 2) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_cvtsi32_si128(*reinterpret_cast<const int32_t*>(x_offsets + x)), y);
+            const uint16_t off0 = static_cast<uint16_t>(_mm_extract_epi16(offsets16, 0));
+            const uint16_t off1 = static_cast<uint16_t>(_mm_extract_epi16(offsets16, 1));
+            const __m128i val0 = _mm_loadu_si128(
+                reinterpret_cast<const __m128i*>(linear_src + static_cast<size_t>(x) * 16));
+            const __m128i val1 = _mm_loadu_si128(
+                reinterpret_cast<const __m128i*>(linear_src + static_cast<size_t>(x) * 16 + 16));
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(tiled_block + off0), val0);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(tiled_block + off1), val1);
+        }
+    }
+    for (; x < columns; ++x)
+        copy_swizzled_element(tiled_block + (x_offsets[x] ^ y_offset),
+                              linear_src + static_cast<size_t>(x) * bpe, bpe);
+}
+
 #endif
 
 // The 64KB tiled<->linear walk. The pattern offset is XOR-separable in x and y (each offset bit is
@@ -723,6 +797,9 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
         static const bool use_avx2_gather =
             std::getenv("PROSPER_NO_AVX2_DETILE") == nullptr &&
             __builtin_cpu_supports("avx2");
+        static const bool use_avx2_tile =
+            std::getenv("PROSPER_NO_AVX2_TILE") == nullptr &&
+            __builtin_cpu_supports("avx2");
 #endif
             const uint32_t surface_block_rows = (eh + bh - 1) / bh;
             const uint32_t surface_block_cols = (ew + bw - 1) / bw;
@@ -743,16 +820,28 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
                         for (uint32_t iy = 0; iy < rows; ++iy) {
                             const uint32_t y = y0 + iy;
                             const uint16_t y_offset = fy[y];
-                            uint8_t* linear = nullptr;
+                            uint8_t* linear_dst = nullptr;
+                            const uint8_t* linear_src = nullptr;
                             if constexpr (!ToTiled)
-                                linear = dst + (static_cast<size_t>(y) * ew + x0) * bpe;
+                                linear_dst = dst + (static_cast<size_t>(y) * ew + x0) * bpe;
+                            else
+                                linear_src = src + (static_cast<size_t>(y) * ew + x0) * bpe;
 #if defined(PROSPER_HAVE_TARGET_AVX2)
                             if constexpr (!ToTiled) {
                                 if (full_block && (bpe == 2 || bpe == 4 || bpe == 8)) {
                                     if (use_avx2_gather) {
-                                        detile_full_block_row_avx2(linear, src + block_base,
+                                        detile_full_block_row_avx2(linear_dst, src + block_base,
                                                                   fx.data() + x0, y_offset,
                                                                   columns, bpe);
+                                        continue;
+                                    }
+                                }
+                            } else {
+                                if (full_block && (bpe == 2 || bpe == 4 || bpe == 8 || bpe == 16)) {
+                                    if (use_avx2_tile) {
+                                        tile_full_block_row_avx2(dst + block_base, linear_src,
+                                                                fx.data() + x0, y_offset,
+                                                                columns, bpe);
                                         continue;
                                     }
                                 }
@@ -778,18 +867,17 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
                                     if (full_block ||
                                         (tiled <= tiled_bytes && bytes <= tiled_bytes - tiled))
                                         copy_swizzled_element(dst + tiled,
-                                                              src + (static_cast<size_t>(y) * ew +
-                                                                     x0 + ix) * bpe,
+                                                              linear_src + static_cast<size_t>(ix) * bpe,
                                                               bytes);
                                 } else {
                                     if (full_block ||
                                         (tiled <= tiled_bytes && bytes <= tiled_bytes - tiled))
                                         copy_swizzled_element(
-                                            linear + static_cast<size_t>(ix) * bpe,
+                                            linear_dst + static_cast<size_t>(ix) * bpe,
                                             src + tiled, bytes);
                                     else
                                         zero_swizzled_element(
-                                            linear + static_cast<size_t>(ix) * bpe, bytes);
+                                            linear_dst + static_cast<size_t>(ix) * bpe, bytes);
                                 }
                                 ix += run;
                             }

--- a/prosper/src/gpu/texture/tile.hpp
+++ b/prosper/src/gpu/texture/tile.hpp
@@ -113,7 +113,8 @@ std::vector<uint8_t> detile_surface(const std::vector<uint8_t>& src, uint32_t wi
 // Inverse of detile_surface (linear -> tiled). Provided for testing the round-trip; the runtime only
 // detiles. Same parameters.
 void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
-                  uint32_t tile_mode, uint32_t pitch = 0, uint32_t bytes_per_texel = 4);
+                  uint32_t tile_mode, uint32_t pitch = 0, uint32_t bytes_per_texel = 4,
+                  bool allow_avx2 = true);
 
 // Exact GFX10 2D-MSAA materialization. The guest swizzle includes sample-coordinate bits in every
 // 64 KiB block; treating it as an ordinary surface both under-reads the allocation and scrambles

--- a/prosper/tests/gpu/texture/test_tile.cpp
+++ b/prosper/tests/gpu/texture/test_tile.cpp
@@ -1238,6 +1238,31 @@ int main() {
         }
     }
 
+    // #3284 AVX2 vectorized tile_surface: verify that tile_full_block_row_avx2 produces byte-for-byte
+    // identical tiled outputs to the unvectorized scalar path across element sizes (2, 4, 8, 16 BPE)
+    // on 1080p surfaces.
+    {
+        const uint32_t modes[] = {(uint32_t)TileMode::Sw64KbS, (uint32_t)TileMode::Sw64KbZX,
+                                  (uint32_t)TileMode::Sw64KbRX};
+        for (const uint32_t M : modes) {
+            for (const uint32_t bpe : {2u, 4u, 8u, 16u}) {
+                const uint32_t W = 1920, H = 1080;
+                std::vector<uint8_t> lin((size_t)W * H * bpe);
+                for (size_t i = 0; i < lin.size(); i++)
+                    lin[i] = static_cast<uint8_t>((i * 13u + 7u) ^ (i >> 8));
+                const size_t tb = tiled_surface_bytes(W, H, M, 0, bpe);
+                std::vector<uint8_t> tiled_avx2(tb, 0);
+                std::vector<uint8_t> tiled_scalar(tb, 0);
+                tile_surface(tiled_avx2.data(), lin.data(), W, H, M, 0, bpe);
+                setenv("PROSPER_NO_AVX2_TILE", "1", 1);
+                tile_surface(tiled_scalar.data(), lin.data(), W, H, M, 0, bpe);
+                unsetenv("PROSPER_NO_AVX2_TILE");
+                CHECK(std::memcmp(tiled_avx2.data(), tiled_scalar.data(), tb) == 0,
+                      "AVX2 tile_surface matches scalar tile_surface byte-for-byte");
+            }
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/gpu/texture/test_tile.cpp
+++ b/prosper/tests/gpu/texture/test_tile.cpp
@@ -15,14 +15,6 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
-static void set_env_var(const char* name, const char* value) {
-#if defined(_WIN32)
-    _putenv_s(name, value ? value : "");
-#else
-    if (value) setenv(name, value, 1);
-    else       unsetenv(name);
-#endif
-}
 
 // A linear image where each texel encodes its (x,y) so any misplacement is detectable.
 static std::vector<uint8_t> make_ref(uint32_t w, uint32_t h) {
@@ -1262,12 +1254,16 @@ int main() {
                 const size_t tb = tiled_surface_bytes(W, H, M, 0, bpe);
                 std::vector<uint8_t> tiled_avx2(tb, 0);
                 std::vector<uint8_t> tiled_scalar(tb, 0);
-                tile_surface(tiled_avx2.data(), lin.data(), W, H, M, 0, bpe);
-                set_env_var("PROSPER_NO_AVX2_TILE", "1");
-                tile_surface(tiled_scalar.data(), lin.data(), W, H, M, 0, bpe);
-                set_env_var("PROSPER_NO_AVX2_TILE", nullptr);
+                tile_surface(tiled_avx2.data(), lin.data(), W, H, M, 0, bpe, /*allow_avx2=*/true);
+                tile_surface(tiled_scalar.data(), lin.data(), W, H, M, 0, bpe, /*allow_avx2=*/false);
                 CHECK(std::memcmp(tiled_avx2.data(), tiled_scalar.data(), tb) == 0,
                       "AVX2 tile_surface matches scalar tile_surface byte-for-byte");
+
+                // Mutation arm: verify the comparison is strictly discriminating by mutating
+                // a byte in the tiled buffer and asserting a mismatch against the scalar baseline.
+                tiled_avx2[tb / 2 + 13] ^= 0xa5;
+                CHECK(std::memcmp(tiled_avx2.data(), tiled_scalar.data(), tb) != 0,
+                      "mutation arm: corrupted tile buffer fails equality against scalar baseline");
             }
         }
     }

--- a/prosper/tests/gpu/texture/test_tile.cpp
+++ b/prosper/tests/gpu/texture/test_tile.cpp
@@ -15,6 +15,15 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+static void set_env_var(const char* name, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1);
+    else       unsetenv(name);
+#endif
+}
+
 // A linear image where each texel encodes its (x,y) so any misplacement is detectable.
 static std::vector<uint8_t> make_ref(uint32_t w, uint32_t h) {
     std::vector<uint8_t> v((size_t)w * h * 4);
@@ -1254,9 +1263,9 @@ int main() {
                 std::vector<uint8_t> tiled_avx2(tb, 0);
                 std::vector<uint8_t> tiled_scalar(tb, 0);
                 tile_surface(tiled_avx2.data(), lin.data(), W, H, M, 0, bpe);
-                setenv("PROSPER_NO_AVX2_TILE", "1", 1);
+                set_env_var("PROSPER_NO_AVX2_TILE", "1");
                 tile_surface(tiled_scalar.data(), lin.data(), W, H, M, 0, bpe);
-                unsetenv("PROSPER_NO_AVX2_TILE");
+                set_env_var("PROSPER_NO_AVX2_TILE", nullptr);
                 CHECK(std::memcmp(tiled_avx2.data(), tiled_scalar.data(), tb) == 0,
                       "AVX2 tile_surface matches scalar tile_surface byte-for-byte");
             }


### PR DESCRIPTION
Closes #3284

### Problem
In the GTA V performance trace on Linux, compute writeback consumed over **417 ms** across compute kernels due to unvectorized CPU surface tiling in `tile_surface`. While the detiling direction (`!ToTiled`) had an optimized AVX2 gather path (`detile_full_block_row_avx2`), the tiling direction (`ToTiled == true`, invoked during compute storage image writeback) executed an unvectorized scalar loop with per-element coordinate math, 64-bit multiplications (`y * ew + x0 + ix`), switch branching, and individual `memcpy` calls for every texel on massive 1080p and 4K surfaces.

### Solution
1. **AVX2 Vectorized Row Tiling:** Implemented `tile_full_block_row_avx2` in `src/gpu/texture/tile.cpp` for `bpe = 2, 4, 8, 16`. It loads contiguous vectors from the linear source, unrolls swizzle offsets, and stores texel pairs/elements directly into 64KB macroblocks using vector registers and aligned/paired stores without per-element multiply or branch overhead.
2. **Loop Address Hoisting:** Hoisted linear base address calculations out of the inner loop in `sw64kb_copy` so even fallback scalar copies do not recompute 64-bit offsets per iteration.
3. **Diagnostics & Verification:** Added `PROSPER_NO_AVX2_TILE` escape hatch and comprehensive golden parity asserts in `test_tile` comparing AVX2 and scalar paths byte-for-byte across `Sw64KbS`, `Sw64KbZX`, and `Sw64KbRX` modes for 2, 4, 8, and 16 BPE.
4. All 353 tests pass in `ctest`.