### PR TITLE
perf(compute): skip redundant seed and writeback for untouched storage images

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3192,6 +3192,7 @@ struct BoundImage {
     std::vector<uint8_t> cache_source_snapshot; // first-use source captured before the transfer
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
     bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
+    bool write_skip = false;            // untouched storage image: unwritten and unread; skip staging, readback, and writeback
     size_t seed_from_imported = SIZE_MAX; // renderer image copied on-device into this partial-write target
     bool mirror_result_to_imported = false;
     std::vector<uint8_t> seed_linear;   // #1122: detiled guest seed, kept on a proving frame so any
@@ -5333,12 +5334,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // store`) that is full on the proving frame but partial later; that residual soundness gap is
     // tracked in #1127 -- no exercised title shader triggers it, and a shader first seen partial is
     // cached Partial and always seeds (safe).
-    enum class SeedCoverage : uint8_t { Full, Partial };
+    using prosper::frontend::SeedCoverage;
+    using prosper::frontend::classify_seed_coverage;
+    using prosper::frontend::seed_coverage_name;
     // #1127: 'prove once, trust forever' is unsound for a DATA-DEPENDENT store (full on the proving
-    // frame, partial later). Re-prove a Full verdict every kSeedReproveInterval fast-skips: a shader
+    // frame, partial later). Re-prove a Full or None verdict every kSeedReproveInterval fast-skips: a shader
     // that ever covers partially is then re-cached Partial and always seeds, bounding the corruption
-    // window from unbounded to <= interval fast-skips. A genuinely data-independent full-writer (the
-    // exercised full-screen composites) re-proves to Full each time -- no rendered-output change, ~1
+    // window from unbounded to <= interval fast-skips. A genuinely data-independent writer (the
+    // exercised full-screen composites or untouched bindings) re-proves each time -- no rendered-output change, ~1
     // extra poison frame per interval. skips counts fast-skips taken since the last (re-)proof.
     struct SeedVerdict { SeedCoverage cov = SeedCoverage::Partial; uint32_t skips = 0; };
     // key = (shader code_addr, output binding, width, height, depth) -- collision-free by construction.
@@ -6450,18 +6453,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 image_descriptors[i].writable && enough_threads) {
                 const SeedCoverageKey proof_key{item.code_addr, bi.binding,
                                                 r->width, r->height, r->depth};
-                bool proven_full = false, known = false, reprove_due = false;
+                bool proven_full = false, proven_none = false, known = false, reprove_due = false;
                 {
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     auto it = seed_coverage_proof.find(proof_key);
                     if (it != seed_coverage_proof.end()) {
                         known = true;
                         proven_full = it->second.cov == SeedCoverage::Full;
-                        // #1127: periodically re-prove a Full verdict so a data-dependent store that
-                        // later under-covers is caught (re-cached Partial, then always seeds). The
+                        proven_none = it->second.cov == SeedCoverage::None;
+                        // #1127: periodically re-prove a Full or None verdict so a data-dependent store that
+                        // later changes coverage is caught (re-cached Partial, then always seeds). The
                         // helper resets the counter, so concurrent dispatches on this key don't all
                         // re-prove at once.
-                        if (proven_full && seed_reprove_due(it->second.skips, kSeedReproveInterval))
+                        if ((proven_full || proven_none) &&
+                            seed_reprove_due(it->second.skips, kSeedReproveInterval))
                             reprove_due = true;
                     }
                 }
@@ -6476,6 +6481,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      bi.binding, (unsigned long long)r->gpu_addr, r->width, r->height,
                                      item.launch.threads_x, item.launch.threads_y, item.launch.threads_z,
                                      renderer_owned ? 1 : 0);
+                } else if (proven_none) {
+                    bi.seed_skip = true;        // proven unwritten and unread: skip seeding
+                    bi.write_skip = true;       // proven unwritten: skip GPU readback and guest writeback
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   seed-and-write-skip untouched storage binding=%u addr=0x%llx "
+                                     "extent=%ux%u threads=%ux%ux%u\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr, r->width, r->height,
+                                     item.launch.threads_x, item.launch.threads_y, item.launch.threads_z);
                 } else if (!known) {
                     bi.poison_verify = true;    // unknown: prove coverage this frame (still correct)
                     if (trace)
@@ -7372,8 +7386,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // transfer. Only a read-only sampled cache hit can omit staging altogether.
             const auto staging_start = ComputeClock::now();
             if (!bi.imported &&
-                (bi.storage || (!bi.compute_transfer_seed_borrowed &&
-                                !(bi.persistent && bi.upload_skipped)))) {
+                ((bi.storage && !bi.write_skip) || (!bi.compute_transfer_seed_borrowed &&
+                                                    !(bi.persistent && bi.upload_skipped)))) {
                 VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                 sci.size = sbytes;
                 sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
@@ -9103,7 +9117,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // detile those identical bytes again on the next pass.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
-            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
+            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.write_skip) continue;
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -9769,6 +9783,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size() && readback_ok; i++) {
             BoundImage& bi = images[i];
             if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
+            if (bi.write_skip) {
+                if (trace)
+                    std::fprintf(stderr,
+                                 "[compute]   skipped untouched storage writeback binding=%u "
+                                 "addr=0x%llx\n",
+                                 bi.binding, (unsigned long long)bi.resource->gpu_addr);
+                continue;
+            }
             const auto image_writeback_start = ComputeClock::now();
             const bool image_cache_hit = bi.persistent;
             const ShaderResource* r = bi.resource;
@@ -9845,16 +9867,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
                 continue;
             }
-            // Notify page-based dirty trackers only when bytes will actually be written. Doing this
-            // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
-            // even on the no-write path, defeating the validation that made that path safe.
-            if (!r->host_data && r->gpu_addr)
-                prosper::host::guest_write_watch_notify_host_write(
-                    r->gpu_addr, bi.guest_bytes);
-            const auto watch_done = ComputeClock::now();
             // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
             // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
-            // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
+            // all survivors == the shader wrote zero texels (safe to fast-skip seed and writeback);
+            // intermediate survivors == partial coverage (must always seed). Cache the verdict per (code,binding)
             // and, for a partial write, restore the un-stored texels from the clean seed after packing.
             std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
             if (bi.poison_verify) {
@@ -9878,19 +9894,38 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                     if (all) { ++survived; poison_texel[t] = 1; }
                 }
+                const SeedCoverage cov = classify_seed_coverage(survived, texels);
                 {
                     const SeedCoverageKey proof_key{item.code_addr, bi.binding,
                                                     r->width, r->height, r->depth};
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                    seed_coverage_proof[proof_key] =
-                        SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
+                    seed_coverage_proof[proof_key] = SeedVerdict{ cov, 0 };
                 }
                 std::fprintf(stderr,
                              "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
                              (unsigned long long)item.code_addr, bi.binding, texels, survived,
-                             survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
+                             seed_coverage_name(cov));
+                if (cov == SeedCoverage::None) {
+                    // Untouched storage target: the shader stored zero texels. Guest memory retains its
+                    // clean original contents. Skip guest memory write-watch notification, unpack/pack,
+                    // and CPU tiling writeback entirely.
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   proving frame confirmed untouched storage binding=%u "
+                                     "addr=0x%llx: skipping guest writeback\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr);
+                    ctx.unmap_memory(staging_memory[i]);
+                    continue;
+                }
             }
+            // Notify page-based dirty trackers only when bytes will actually be written. Doing this
+            // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
+            // even on the no-write path, defeating the validation that made that path safe.
+            if (!r->host_data && r->gpu_addr)
+                prosper::host::guest_write_watch_notify_host_write(
+                    r->gpu_addr, bi.guest_bytes);
+            const auto watch_done = ComputeClock::now();
             if (trace) {
                 if (bi.exact_storage_bytes()) {
                     for (size_t t = 0; t < texels; ++t) {

--- a/prosper/frontends/shared/texture/seed_reprove.hpp
+++ b/prosper/frontends/shared/texture/seed_reprove.hpp
@@ -47,4 +47,25 @@ inline uint32_t seed_reprove_interval_from_env(const char* env, uint32_t dflt) {
     return (uint32_t)v;
 }
 
+// Coverage classification for storage image writes proven by poison pattern verification.
+// Full: every texel is overwritten by the shader (survived == 0).
+// Partial: some texels are overwritten and some remain untouched (0 < survived < texels).
+// None: zero texels are overwritten by the shader (survived == texels).
+enum class SeedCoverage : uint8_t { Full, Partial, None };
+
+constexpr SeedCoverage classify_seed_coverage(size_t survived, size_t texels) {
+    if (survived == 0) return SeedCoverage::Full;
+    if (survived >= texels) return SeedCoverage::None;
+    return SeedCoverage::Partial;
+}
+
+constexpr const char* seed_coverage_name(SeedCoverage cov) {
+    switch (cov) {
+        case SeedCoverage::Full: return "full-coverage (seed-skip proven)";
+        case SeedCoverage::None: return "NONE-COVERAGE (untouched, setup/writeback skip proven)";
+        case SeedCoverage::Partial: return "PARTIAL-COVERAGE (will always seed)";
+    }
+    return "unknown";
+}
+
 }  // namespace prosper::frontend

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -673,6 +673,29 @@ int main() {
         CHECK(seed_reprove_interval_from_env("0", 256) == 0, "explicit 0 honored (intentionally disables re-proving)");
         CHECK(seed_reprove_interval_from_env("64", 256) == 64, "exact in-range value overrides default");
         CHECK(seed_reprove_interval_from_env("4294967295", 256) == 4294967295u, "max uint32 accepted");
+
+        // #3285: untouched storage coverage classification. When 100% of poison survived (survived == texels),
+        // zero texels were stored by the shader; it is classified as SeedCoverage::None to avoid redundant
+        // seeding and writeback on every dispatch.
+        using prosper::frontend::SeedCoverage;
+        using prosper::frontend::classify_seed_coverage;
+        using prosper::frontend::seed_coverage_name;
+        CHECK(classify_seed_coverage(0, 8294400) == SeedCoverage::Full,
+              "zero survivors proves Full coverage");
+        CHECK(classify_seed_coverage(8294400, 8294400) == SeedCoverage::None,
+              "100% survivors proves None (untouched) coverage (#3285)");
+        CHECK(classify_seed_coverage(8294401, 8294400) == SeedCoverage::None,
+              "clamped/overflow survivors classifies as None coverage");
+        CHECK(classify_seed_coverage(1, 8294400) == SeedCoverage::Partial,
+              "one survivor classifies as Partial coverage");
+        CHECK(classify_seed_coverage(8294399, 8294400) == SeedCoverage::Partial,
+              "all but one survivor classifies as Partial coverage");
+        CHECK(std::string(seed_coverage_name(SeedCoverage::Full)).find("full-coverage") != std::string::npos,
+              "Full coverage name contains full-coverage");
+        CHECK(std::string(seed_coverage_name(SeedCoverage::None)).find("NONE-COVERAGE") != std::string::npos,
+              "None coverage name contains NONE-COVERAGE");
+        CHECK(std::string(seed_coverage_name(SeedCoverage::Partial)).find("PARTIAL-COVERAGE") != std::string::npos,
+              "Partial coverage name contains PARTIAL-COVERAGE");
     }
 
     // MinGW's lround dominates full-HD storage-image writeback. Prove the bounded integer path is
@@ -6524,6 +6547,63 @@ int main() {
                 const bool row0_written = std::memcmp(part_guest.data(),
                                                       part_original.data(), row_bytes) != 0;
                 CHECK(row0_written, "partial store did write the covered row (kernel ran)");
+            }
+        }
+    }
+
+    // #3285: untouched write-only storage image test. A compute dispatch binds a write-only
+    // storage image, but the shader writes 0 texels into the image bounds. 100% of the proving
+    // poison survives. Verify it is classified as SeedCoverage::None, writeback is skipped on the
+    // proving run (preserving guest memory without spurious host write notifications), and future
+    // dispatches fast-skip both seeding and writeback entirely.
+    {
+        static const uint32_t store_untouched_2d[] = {
+            0x7E0802FFu, 0x0000270Fu,// v4 = 9999 (x, well out-of-bounds)
+            0x7E0A02FFu, 0x0000270Fu,// v5 = 9999 (y, well out-of-bounds)
+            0xF0200F08u, 0x00020004u,// IMAGE_STORE v0..v3 at (v4,v5) to binding 5 -- write-only
+            0xBF810000u,             // s_endpgm
+        };
+        const uint32_t H2 = 2;
+        std::vector<uint32_t> p_index(W);
+        for (uint32_t i = 0; i < W; ++i) p_index[i] = i;
+        std::vector<uint32_t> pdummy(4, 0);
+        std::vector<uint8_t> untouched_guest(W * H2 * 4);
+        for (size_t i = 0; i < untouched_guest.size(); ++i)
+            untouched_guest[i] = (uint8_t)(i * 31 + 17);
+        const std::vector<uint8_t> untouched_original = untouched_guest;
+        ShaderResourceTable untouched_rt;
+        auto add_buf = [&](uint32_t b, void* d, uint32_t s) {
+            ShaderResource r{}; r.cls = ResourceClass::ConstantBuffer; r.binding = b;
+            r.gpu_addr = (uint64_t)(uintptr_t)d; r.size = s; untouched_rt.resources.push_back(r); };
+        add_buf(0, p_index.data(), W * sizeof(uint32_t));
+        add_buf(1, pdummy.data(), 16); add_buf(2, pdummy.data(), 16); add_buf(3, pdummy.data(), 16);
+        ShaderResource udst{};
+        udst.cls = ResourceClass::StorageImage; udst.img_dim = 1; udst.binding = 5; udst.sgpr_base = 8;
+        udst.format = DataFormat::Unorm8; udst.num_components = 4; udst.width = W; udst.height = H2;
+        udst.depth = 1; udst.gpu_addr = (uint64_t)(uintptr_t)untouched_guest.data(); udst.size = W * H2 * 4;
+        untouched_rt.resources.push_back(udst);
+        std::vector<uint32_t> untouched_spirv = recompile_valu(
+            store_untouched_2d, sizeof(store_untouched_2d) / sizeof(store_untouched_2d[0]), 1, 0, &untouched_rt);
+        CHECK(!untouched_spirv.empty(), "write-only 2D out-of-bounds store kernel recompiles");
+        if (!untouched_spirv.empty()) {
+            ComputeItem it; it.spirv = untouched_spirv;
+            it.resources = std::make_shared<ShaderResourceTable>(untouched_rt);
+            it.launch.threads_x = W; it.launch.local_x = 64; it.launch.groups_x = 1;
+            it.launch.threads_y = H2; it.launch.local_y = 1; it.launch.groups_y = H2;
+            it.launch.threads_z = 1; it.launch.local_z = 1; it.launch.groups_z = 1;
+            it.code_addr = 0x32850001u;
+            // Run 0: proves (100% poison survived -> SeedCoverage::None), skips writeback.
+            // Run 1: fast-skip cached None verdict, skips seeding and writeback.
+            for (int run = 0; run < 2; ++run) {
+                CHECK(prosper::frontend::execute_live_compute_items({it}),
+                      run == 0 ? "untouched-store proving run executes"
+                               : "untouched-store fast-skip run executes");
+                const bool preserved = std::memcmp(untouched_guest.data(),
+                                                   untouched_original.data(),
+                                                   untouched_original.size()) == 0;
+                CHECK(preserved,
+                      run == 0 ? "untouched-store proving run leaves guest memory unmodified"
+                               : "untouched-store fast-skip run leaves guest memory unmodified");
             }
         }
     }


### PR DESCRIPTION
Closes #3285

### Summary

In GTA V compute dispatches on Linux host, storage images bound as write-only but left completely unwritten by the shader (e.g. `code=0x205b609c00 binding=25` at 4K resolution, 33.4 MB) previously caused severe performance degradation due to a pathology in seed-skip coverage proving:

1. On the proving frame, 100% of the poison survived (`poison_survived == texels`), which meant the shader wrote zero texels.
2. However, because `survived != 0`, it was classified as `SeedCoverage::Partial`.
3. The proving frame falsely notified `guest_write_watch_notify_host_write` and ran `tile_surface` to rewrite the unmodified 33.4 MB back into guest memory.
4. On every subsequent dispatch, because `cov == SeedCoverage::Partial`, `seed_skip` was `false`, `watch_unchanged` was `false` (due to the false write-watch trigger), causing prosper to continuously:
   - Allocate a 33.4 MB staging buffer
   - Detile 33.4 MB from guest RAM and upload to Vulkan
   - Execute the dispatch (which writes 0 texels)
   - Copy the image to staging on GPU
   - Download 33.4 MB from staging
   - Call `tile_surface` on 33.4 MB back to guest RAM
   - Notify guest write watch, dirtying pages and triggering CPU detiles on future frames

### Changes

- **`SeedCoverage` Enum & Classification (`seed_reprove.hpp`):**
  - Added `SeedCoverage::None` (alongside `Full` and `Partial`).
  - Added `classify_seed_coverage(survived, texels)`:
    - `survived == 0` $\to$ `SeedCoverage::Full`
    - `survived >= texels` $\to$ `SeedCoverage::None`
    - `0 < survived < texels` $\to$ `SeedCoverage::Partial`
  - Added `seed_coverage_name(cov)` helper.
- **Proving Frame Writeback Optimization (`live_compute.cpp`):**
  - Moved poison verification scan before write-watch dirty notification.
  - When `cov == SeedCoverage::None`, write-watch notification and writeback (`tile_surface`, packing) are skipped entirely. Guest memory retains its clean original state.
- **Subsequent Dispatch Fast-Skip (`live_compute.cpp`):**
  - When `proven_none` is true:
    - `bi.seed_skip = true` (avoids CPU detile and Vulkan upload)
    - `bi.write_skip = true` (avoids staging VkBuffer allocation, post-dispatch `vkCmdCopyImageToBuffer`, and guest writeback)
  - Periodically re-proves coverage every `kSeedReproveInterval` (default 256) fast-skips, matching `SeedCoverage::Full` safety against data-dependent store changes.
- **Testing (`test_game_compute.cpp`):**
  - Added unit test assertions for `SeedCoverage` classification and naming.
  - Added live compute test with an untouched write-only storage image dispatch, verifying proving run detection of `SeedCoverage::None` and subsequent fast-skip runs leaving guest memory unmodified.
