### PR TITLE
perf(compute): fast-decline unmaterializable compute image binding shapes (#3290)

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5393,9 +5393,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      [](const ShaderResource& resource) {
                          return is_gta5_cf9200_no_backing_marker_candidate(resource) &&
                                 !is_proven_gta5_cf9200_no_backing(resource);
-                     }))) return decline("cf9200-no-backing-unproven");
-    double setup_validate_ms = std::chrono::duration<double, std::milli>(
-        ComputeClock::now() - setup_validate_start).count();
+                      }))) return decline("cf9200-no-backing-unproven");
     double setup_buffers_ms = 0.0;
 
     std::vector<SpirvDescriptorBinding> descriptors;       // storage buffers
@@ -5416,6 +5414,46 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 return decline("unsupported-descriptor-kind");
         }
     }
+
+    // Fast pre-validation of image bindings: decline immediately if any image descriptor is
+    // degenerate, has an unsupported storage numeric class, or declares an unmaterializable
+    // mip chain (e.g. aliasing a live render target). This avoids burning dozens of milliseconds
+    // allocating staging buffers, mapping host memory, and running CPU de-tiling for doomed dispatches.
+    for (const auto& descriptor : image_descriptors) {
+        const ShaderResource* r = item.resources ? item.resources->by_binding(descriptor.binding) : nullptr;
+        if (!r || !r->width || !r->height) {
+            return decline("no/degenerate resource");
+        }
+        if (descriptor.kind == SpirvDescriptorKind::StorageImage) {
+            if (descriptor.image_numeric_class != SpirvImageNumericClass::Float &&
+                descriptor.image_numeric_class != SpirvImageNumericClass::Uint) {
+                return decline("storage image has unknown or unsupported signed numeric class");
+            }
+        } else {
+            const uint32_t declared_chain_levels =
+                prosper::gpu::shader_resource_compute_mip_chain_levels(*r);
+            if (declared_chain_levels > 1u) {
+                const bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
+                if (!compute_binding_mip_chain_materializable(*r, renderer_owned)) {
+                    static std::atomic<uint64_t> chain_shape_declines{0};
+                    const uint64_t occurrence =
+                        chain_shape_declines.fetch_add(1, std::memory_order_relaxed) + 1u;
+                    if ((occurrence & (occurrence - 1u)) == 0u) {
+                        std::fprintf(stderr,
+                                     "[compute-mip-chain] declined binding=%u addr=0x%llx "
+                                     "levels=%u imported=0 rtt=%u (occurrence %llu; this "
+                                     "dispatch is dropped every frame)\n",
+                                     descriptor.binding, (unsigned long long)r->gpu_addr,
+                                     declared_chain_levels, renderer_owned ? 1u : 0u,
+                                     (unsigned long long)occurrence);
+                    }
+                    return decline("declared mip chain not materializable for this binding shape");
+                }
+            }
+        }
+    }
+    double setup_validate_ms = std::chrono::duration<double, std::milli>(
+        ComputeClock::now() - setup_validate_start).count();
     // A compute program whose every external RAW access either has NUM_RECORDS=0 or is a proven
     // unreachable store contains no storage/image operation after recompilation. Treat only those
     // exact runtime contracts as a successful no-op: reporting failure here would publish an unknown
@@ -10415,6 +10453,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 }
 
 } // namespace
+
+bool compute_binding_mip_chain_materializable(const prosper::gpu::ShaderResource& r,
+                                              bool renderer_owned) {
+    const uint32_t declared_chain_levels =
+        prosper::gpu::shader_resource_compute_mip_chain_levels(r);
+    if (declared_chain_levels <= 1u) return true;
+    if (renderer_owned) return false;
+    const auto mip_chain = prosper::gpu::shader_resource_mip_chain_plan(r);
+    if (!mip_chain.valid || mip_chain.level_count != declared_chain_levels) return false;
+    if (r.img_dim != 1 /* 2D */ || r.depth_compare) return false;
+    return true;
+}
 
 uint32_t storage_image_guest_texel_bytes(prosper::gpu::DataFormat format,
                                          uint32_t components) {

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -285,6 +285,10 @@ uint64_t live_compute_sampled_image_upload_skips();
 // transfer contract; resource identity and write authority are checked separately at runtime.
 bool compute_native_2d_transfer_format_compatible(prosper::gpu::DataFormat format,
                                                   uint32_t components);
+// True only when an image resource declaring a compute mip chain can be materialized
+// by the compute backend (excluding live renderer targets and unsupported dimensions).
+bool compute_binding_mip_chain_materializable(const prosper::gpu::ShaderResource& r,
+                                              bool renderer_owned);
 // Monotonic count of sampled 2D/3D images seeded from an exact retained native storage result with a
 // device-local image copy instead of a guest-memory conversion/upload.
 uint64_t live_compute_storage_transfer_seeds();

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -5,6 +5,7 @@
 #include "gpu/capture/gpu_capture.hpp"
 #include "gpu/execute/gpu_execute.hpp"
 #include "gpu/resources/shader_resources.hpp"
+#include "gpu/resources/mip_chain_plan.hpp"
 #include "gpu/texture/tile.hpp"
 #include "host/memory/guest_write_watch.hpp"
 #include "shared/live/live_compute.hpp"
@@ -5251,6 +5252,48 @@ int main() {
                       !prosper::frontend::compute_native_2d_transfer_format_compatible(
                           DataFormat::Float16, 1),
                   "native 2D transfer admits exact formats and packed R11 bit-copy compatibility");
+            {
+                prosper::gpu::ShaderResource single_level{};
+                single_level.cls = prosper::gpu::ResourceClass::Texture;
+                single_level.width = 256;
+                single_level.height = 256;
+                single_level.img_dim = 1;
+                single_level.declared_mip_levels = 1;
+                CHECK(prosper::frontend::compute_binding_mip_chain_materializable(single_level, false) &&
+                      prosper::frontend::compute_binding_mip_chain_materializable(single_level, true),
+                      "single-level compute image binding is viable regardless of render target ownership");
+
+                constexpr uint32_t kWidth = 256, kHeight = 256, kBytesPerBlock = 4;
+                constexpr uint32_t kTile = static_cast<uint32_t>(prosper::gpu::TileMode::Sw64KbRX);
+                constexpr uint32_t kMaxMip = 8;
+                const auto level0 = prosper::gpu::tiled_mip_level_layout(
+                    kWidth, kHeight, kBytesPerBlock, kTile, kMaxMip, 0);
+
+                prosper::gpu::ShaderResource chain{};
+                chain.cls = prosper::gpu::ResourceClass::Texture;
+                chain.format = prosper::gpu::DataFormat::Uint32;
+                chain.num_components = 1;
+                chain.img_dim = 1;
+                chain.width = kWidth;
+                chain.height = kHeight;
+                chain.depth = 1;
+                chain.tile_mode = kTile;
+                chain.declared_mip_levels = kMaxMip + 1;
+                chain.mip_chain_element_width = kWidth;
+                chain.mip_chain_element_height = kHeight;
+                chain.mip_chain_bytes_per_block = kBytesPerBlock;
+                chain.mip_chain_max_level = kMaxMip;
+                chain.mip_chain_base_level = 0;
+                chain.gpu_addr = 0x2026900000ull + level0.byte_offset;
+
+                CHECK(prosper::gpu::shader_resource_compute_mip_chain_levels(chain) == kMaxMip + 1,
+                      "tiled 2D chain declares nine levels");
+                CHECK(prosper::frontend::compute_binding_mip_chain_materializable(chain, false),
+                      "valid non-renderer-owned tiled 2D chain is materializable");
+                // Live render target with multi-level chain cannot be materialized by compute backend (#3290)
+                CHECK(!prosper::frontend::compute_binding_mip_chain_materializable(chain, true),
+                      "multi-level compute image binding is declined when aliasing a live render target");
+            }
             CHECK(prosper::frontend::live_compute_graphics_import_native_format(
                       DataFormat::Float32, 1) == 100u && // VK_FORMAT_R32_SFLOAT
                       prosper::frontend::live_compute_graphics_import_native_format(


### PR DESCRIPTION
## Summary

Closes #3290.

In GTA V performance captures (`perf_capture_PPSA04263_20260903-181319-999.prperf`), compute program `0x205b66f800` was the single largest measured compute component, taking **641.5 ms** across 10 dispatches (**64.15 ms per dispatch**).

Every single frame, binding 54 declares a 6-level mip chain on a live render target (`0x2087e80000`), which cannot be materialized and is declined fail-visibly.

## Problem Analysis

Previously in `frontends/shared/live/live_compute.cpp`, `execute_item` did not check `chain_binding_shape` until iteration 54 of the main image loop.
Before discovering binding 54:
1. It set up and validated all storage buffers.
2. For bindings 0 through 53, it allocated host-visible staging buffers, mapped host memory, executed CPU de-tiling, converted formats, and created Vulkan images/views.
3. At binding 54, it called `skip_image`, breaking out of the loop and aborting the dispatch.
4. All 53 staged and allocated images were immediately destroyed during cleanup.

This burned ~58 ms of CPU time per dispatch on completely discarded staging work.

## Changes

1. Added `compute_binding_mip_chain_materializable(r, renderer_owned)` to test whether a multi-level compute image binding shape can be materialized (excluding render targets and unsupported dimensions).
2. Added early pre-validation in `execute_item` before buffer and staging memory allocations:
   - Validates resource existence and dimensions.
   - Validates storage image numeric classes.
   - Verifies mip chain viability for multi-level sampled textures.
   - If any binding is unviable or unmaterializable, immediately declines via `decline("declared mip chain not materializable for this binding shape")`.
3. Added unit tests in `tests/gpu/recompiler/test_game_compute.cpp` covering single-level, valid multi-level, and renderer-owned multi-level textures.

## Verification

- `test_game_compute` passed all 468 assertions cleanly.
- `test_shader_resources` passed all tests.
- `prosper-app` built and linked cleanly.