### PR TITLE
hle: close the CALL side of the guest-ABI boundary (#3272, #3273)

### DIFF
--- a/prosper/src/hle/dispatch/dispatch.cpp
+++ b/prosper/src/hle/dispatch/dispatch.cpp
@@ -157,6 +157,9 @@ std::vector<RegisteredFn> Hle::registrations() {
                         kv.second.signature, kv.second.guest_abi });
     return out;
 }
+bool Hle::registered(const std::string& nid) {
+    return registry().find(nid) != registry().end();
+}
 const void* Hle::lookup_address(const std::string& nid) {
     auto it = registry().find(nid);
     return it == registry().end() ? nullptr : reinterpret_cast<const void*>(it->second.fn);

--- a/prosper/src/hle/dispatch/dispatch.cpp
+++ b/prosper/src/hle/dispatch/dispatch.cpp
@@ -157,9 +157,39 @@ std::vector<RegisteredFn> Hle::registrations() {
                         kv.second.signature, kv.second.guest_abi });
     return out;
 }
+const void* Hle::lookup_address(const std::string& nid) {
+    auto it = registry().find(nid);
+    return it == registry().end() ? nullptr : reinterpret_cast<const void*>(it->second.fn);
+}
 HleFn Hle::lookup(const std::string& nid) {
     auto it = registry().find(nid);
-    return it == registry().end() ? nullptr : it->second.fn;
+    if (it == registry().end()) return nullptr;
+    if (it->second.guest_abi) {
+        // A programming error, not a runtime condition (#3272). Handing the address back would give
+        // the caller a pointer whose type describes the wrong calling convention, and on every
+        // platform but Windows that compiles and behaves correctly -- so the mistake stays invisible
+        // until the MinGW job dereferences a wild pointer. Refuse, loudly, and name the way out.
+        //
+        // Loud ONCE per NID: this can be reached from a per-import-slot loop, and a message per call
+        // would bury the first one. `nullptr` is deliberately NOT the same answer as "unimplemented"
+        // in the log, because a caller that only checks for null would otherwise report a registered
+        // handler as missing.
+        static std::mutex mx;
+        static std::unordered_map<std::string, bool> warned;
+        bool first = false;
+        {
+            std::lock_guard<std::mutex> lk(mx);
+            first = warned.emplace(nid, true).second;
+        }
+        if (first)
+            fprintf(stderr,
+                    "[prosper] Hle::lookup refused %s (%s): it is a guest-ABI handler and HleFn is "
+                    "the wrong type for one. Call it with Hle::lookup_guest_abi<R, Args...>(nid), or "
+                    "use Hle::lookup_address(nid) if you only need the address.\n",
+                    it->second.name.c_str(), nid.c_str());
+        return nullptr;
+    }
+    return it->second.fn;
 }
 HleReturnHook Hle::return_hook_of(const std::string& nid) {
     auto it = registry().find(nid);

--- a/prosper/src/hle/dispatch/dispatch.hpp
+++ b/prosper/src/hle/dispatch/dispatch.hpp
@@ -162,6 +162,13 @@ public:
     // never call it -- so they are unaffected by the refusal above. Prefer it over `lookup` wherever
     // the value is an address rather than something you intend to invoke.
     static const void* lookup_address(const std::string& nid);
+    // "Is there a handler for this NID at all?" -- a THIRD question, and the one that made the
+    // split necessary rather than merely tidy. It is not "give me something callable" (`lookup`)
+    // and not "give me the address" (`lookup_address`), and before #3272 all three were spelled
+    // `lookup(nid) != nullptr`. Two callers asking it that way broke the moment `lookup` learned to
+    // refuse -- `test_hle_registered` and `nid_census`, the latter with no ctest case, so nothing
+    // would have gone red. Spell the question so a fourth caller does not have to improvise it.
+    static bool registered(const std::string& nid);
     // A pointer type in the GUEST's calling convention. Spelled once, here, so no caller has to.
     template <class R, class... A>
     using GuestAbiFn = PROSPER_GUEST_ABI R (*)(A..., ...);

--- a/prosper/src/hle/dispatch/dispatch.hpp
+++ b/prosper/src/hle/dispatch/dispatch.hpp
@@ -143,7 +143,44 @@ public:
     // tracing thunk that a real handler is expected to replace later). A subsequent register_fn that
     // overwrites a placeholder is NOT flagged as a shadow — that override is the intent.
     static void  register_placeholder(const std::string& nid, HleFn fn, const char* name);
-    static HleFn lookup(const std::string& nid);          // nullptr if unimplemented
+    // An ordinary HOST-ABI handler for a NID; nullptr if unimplemented.
+    //
+    // REFUSES a guest-ABI handler, returning nullptr and complaining once per NID (#3272). Those are
+    // compiled in the guest's convention, and invoking one through `HleFn` places the arguments by
+    // one convention and reads them by the other -- on Windows a printf-family handler's first `%s`
+    // then dereferences whatever landed in rdi. That is not hypothetical: `test_printf` and
+    // `test_guest_log_capture` both did it and SEGFAULTed on the Windows MinGW job the moment these
+    // handlers were tagged, while passing everywhere else, because PROSPER_GUEST_ABI is empty on
+    // every other platform and the two types are then identical.
+    //
+    // So `lookup` now means exactly "a handler I may call through HleFn", and the two other needs
+    // have their own accessors: `lookup_guest_abi` to CALL a guest-ABI handler with a pointer type
+    // this header constructs, and `lookup_address` when the address is all you want.
+    static HleFn lookup(const std::string& nid);
+    // The handler ADDRESS for a NID, with no calling convention attached; nullptr if unimplemented.
+    // This is what the import-stub emitters want -- they only ever patch the value into a jump, and
+    // never call it -- so they are unaffected by the refusal above. Prefer it over `lookup` wherever
+    // the value is an address rather than something you intend to invoke.
+    static const void* lookup_address(const std::string& nid);
+    // A pointer type in the GUEST's calling convention. Spelled once, here, so no caller has to.
+    template <class R, class... A>
+    using GuestAbiFn = PROSPER_GUEST_ABI R (*)(A..., ...);
+    // Look up a handler registered with `register_guest_abi`, as a pointer type THIS ACCESSOR
+    // constructs (#3272). The caller names the return type and the fixed prefix and never names the
+    // calling convention, so an untagged pointer cannot come out of here -- which is the whole
+    // point, since on every platform but Windows an untagged one compiles and behaves identically
+    // and the mistake is invisible until the MinGW job runs.
+    //
+    //     auto guest_printf = Hle::lookup_guest_abi<int, const char*>(nid_hash("printf"));
+    //
+    // nullptr if the NID is unimplemented OR is not a guest-ABI handler -- asking for the guest
+    // convention on an ordinary host handler is the same category error in the other direction, and
+    // silently handing back a mis-typed pointer is exactly what this accessor exists to stop.
+    template <class R, class... A>
+    static GuestAbiFn<R, A...> lookup_guest_abi(const std::string& nid) {
+        if (!guest_abi_nid(nid)) return nullptr;
+        return reinterpret_cast<GuestAbiFn<R, A...>>(const_cast<void*>(lookup_address(nid)));
+    }
     static HleReturnHook return_hook_of(const std::string& nid); // called by the import return trampoline
     static const char* name_of(const std::string& nid);   // registered display name or ""
     // Every NID that was registered 2+ times with DIFFERING handlers, in registration order. Empty

--- a/prosper/src/host/image/exec_image_linux.cpp
+++ b/prosper/src/host/image/exec_image_linux.cpp
@@ -3057,11 +3057,16 @@ bool map_image(const LoadedImage& img, std::string* err) {
 // byte-identical stubs for the same slot, or a runtime-loaded module's imports would take a
 // different path into the HLE than the pre-linked ones.
 static size_t emit_one_stub(uint8_t* slot, const ImportSlot& s, uint32_t idx, bool swap) {
-    HleFn fn = Hle::lookup(s.nid);
+    // lookup_ADDRESS, not lookup (#3272): this value is only ever patched into the emitted stub as a
+    // jump target, never invoked from here, so the calling convention of the handler behind it is
+    // none of this function's business -- and `lookup` now refuses the guest-ABI handlers precisely
+    // because it hands back a type that claims one.
+    const void* fn = Hle::lookup_address(s.nid);
     HleReturnHook return_hook = Hle::return_hook_of(s.nid);
     if (fn) {
-        if (return_hook) return emit_impl_hook(slot, (uint64_t)fn, (uint64_t)return_hook, swap);
-        return swap ? emit_impl_swap(slot, (uint64_t)fn) : emit_impl(slot, (uint64_t)fn);
+        const uint64_t target = (uint64_t)(uintptr_t)fn;
+        if (return_hook) return emit_impl_hook(slot, target, (uint64_t)return_hook, swap);
+        return swap ? emit_impl_swap(slot, target) : emit_impl(slot, target);
     }
     return swap ? emit_unimpl_swap(slot, idx, (uint64_t)&prosper_on_unimpl)
                 : emit_unimpl(slot, idx, (uint64_t)&prosper_on_unimpl);

--- a/prosper/src/host/image/exec_image_win.cpp
+++ b/prosper/src/host/image/exec_image_win.cpp
@@ -1194,14 +1194,19 @@ bool map_image(const LoadedImage& img, std::string* err) {
 // byte-identical stubs for the same slot, or a runtime-loaded module's imports would take a
 // different path into the HLE than the pre-linked ones.
 static size_t emit_one_stub(uint8_t* slot, const ImportSlot& s, uint32_t idx, size_t capacity) {
-    HleFn fn = Hle::lookup(s.nid);
+    // lookup_ADDRESS, not lookup (#3272): this value is only ever patched into the emitted stub as a
+    // jump target, never invoked from here, so the calling convention of the handler behind it is
+    // none of this function's business -- and `lookup` now refuses the guest-ABI handlers precisely
+    // because it hands back a type that claims one. `guest_abi_nid` below is what actually decides
+    // the stub's shape for those.
+    const void* fn = Hle::lookup_address(s.nid);
     const uint64_t return_hook = (uint64_t)(uintptr_t)Hle::return_hook_of(s.nid);
     // Stage, then copy. The bridge's length depends on the handler's declared signature, and a stub
     // that does not fit its slot must be REPORTED rather than written: emitting straight into the
     // table would already have overrun the next slot by the time the caller compared the length.
     uint8_t staged[abi::kMaxBridgeBytes];
     const size_t emitted =
-        fn ? emit_impl(staged, (uint64_t)fn, return_hook, Hle::signature_of_nid(s.nid),
+        fn ? emit_impl(staged, (uint64_t)(uintptr_t)fn, return_hook, Hle::signature_of_nid(s.nid),
                        Hle::guest_abi_nid(s.nid))
            : emit_unimpl(staged, idx, (uint64_t)&prosper_on_unimpl);
     if (emitted <= capacity) memcpy(slot, staged, emitted);

--- a/prosper/tests/gpu/test_guest_log_capture.cpp
+++ b/prosper/tests/gpu/test_guest_log_capture.cpp
@@ -68,10 +68,10 @@ int main() {
     // must carry PROSPER_GUEST_ABI -- on Windows that is `sysv_abi`, and calling it through an
     // untagged type places the arguments by the wrong convention. The integer handlers below are
     // ordinary host functions and need no tag.
-    using PrintfFn = PROSPER_GUEST_ABI int (*)(const char*, ...);
+    // `lookup_guest_abi` constructs the tagged pointer type (#3272); the integer handlers below stay
+    // on plain `lookup`, which now means exactly "a handler HleFn describes correctly".
     using HleFn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
-    auto guest_printf = reinterpret_cast<PrintfFn>(
-        reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("printf"))));
+    auto guest_printf = prosper::Hle::lookup_guest_abi<int, const char*>(prosper::nid_hash("printf"));
     auto guest_fputs = reinterpret_cast<HleFn>(
         reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("fputs"))));
     auto guest_fwrite = reinterpret_cast<HleFn>(

--- a/prosper/tests/hle/test_hle_registered.cpp
+++ b/prosper/tests/hle/test_hle_registered.cpp
@@ -13,8 +13,15 @@
 using namespace prosper;
 
 static int fails = 0;
+// "Is this NID registered?" is a THIRD question, distinct from both "give me a handler I may call
+// through HleFn" and "give me a guest-ABI handler" -- and `lookup` used to answer all three. It no
+// longer answers this one for the printf family, which are guest-ABI (#3272): `lookup` refuses
+// those, so asking it about `snprintf` here reported a registered handler as missing. That is the
+// whole reason the accessor was split; `lookup_address` is the one that means existence.
 static void must(const char* name) {
-    if (Hle::lookup(nid_hash(name)) == nullptr) { printf("  [FAIL] not registered: %s\n", name); fails++; }
+    if (Hle::lookup_address(nid_hash(name)) == nullptr) {
+        printf("  [FAIL] not registered: %s\n", name); fails++;
+    }
 }
 
 int main() {
@@ -52,7 +59,7 @@ int main() {
     };
     for (const char* n : names) must(n);
     // sync_on_address futex is registered by raw NID (no symbol name) — check it directly.
-    if (Hle::lookup("Hc4CaR6JBL0") == nullptr) { printf("  [FAIL] sceKernelWaitOnAddress raw NID\n"); fails++; }
+    if (Hle::lookup_address("Hc4CaR6JBL0") == nullptr) { printf("  [FAIL] sceKernelWaitOnAddress raw NID\n"); fails++; }
 
     // __ctype_get_mb_cur_max returns the VALUE of MB_CUR_MAX (1 in the "C" locale we
     // present), not a pointer to it — guest code sizes buffers as MB_CUR_MAX*n (#141).

--- a/prosper/tests/hle/test_hle_registered.cpp
+++ b/prosper/tests/hle/test_hle_registered.cpp
@@ -17,9 +17,9 @@ static int fails = 0;
 // through HleFn" and "give me a guest-ABI handler" -- and `lookup` used to answer all three. It no
 // longer answers this one for the printf family, which are guest-ABI (#3272): `lookup` refuses
 // those, so asking it about `snprintf` here reported a registered handler as missing. That is the
-// whole reason the accessor was split; `lookup_address` is the one that means existence.
+// whole reason the accessor was split; `Hle::registered` is the one that means existence.
 static void must(const char* name) {
-    if (Hle::lookup_address(nid_hash(name)) == nullptr) {
+    if (!Hle::registered(nid_hash(name))) {
         printf("  [FAIL] not registered: %s\n", name); fails++;
     }
 }
@@ -59,7 +59,7 @@ int main() {
     };
     for (const char* n : names) must(n);
     // sync_on_address futex is registered by raw NID (no symbol name) — check it directly.
-    if (Hle::lookup_address("Hc4CaR6JBL0") == nullptr) { printf("  [FAIL] sceKernelWaitOnAddress raw NID\n"); fails++; }
+    if (!Hle::registered("Hc4CaR6JBL0")) { printf("  [FAIL] sceKernelWaitOnAddress raw NID\n"); fails++; }
 
     // __ctype_get_mb_cur_max returns the VALUE of MB_CUR_MAX (1 in the "C" locale we
     // present), not a pointer to it — guest code sizes buffers as MB_CUR_MAX*n (#141).

--- a/prosper/tests/hle/test_printf.cpp
+++ b/prosper/tests/hle/test_printf.cpp
@@ -17,19 +17,24 @@ static int fails = 0;
 
 // PROSPER_GUEST_ABI is what makes the comment above TRUE rather than aspirational. These handlers
 // are compiled in the GUEST's convention (#3246), which on Windows is not the host's -- so an
-// untagged pointer type here would place the arguments by Microsoft x64 rules for a callee reading
-// them by System V, and the first `%s` would dereference whatever landed in `rdi`. It did: this test
-// SEGFAULTed on the Windows MinGW job the moment the handlers were tagged. Empty on Linux/macOS.
-using SnprintfFn = PROSPER_GUEST_ABI int (*)(char*, size_t, const char*, ...);
-using SprintfFn  = PROSPER_GUEST_ABI int (*)(char*, const char*, ...);
+// untagged pointer type would place the arguments by Microsoft x64 rules for a callee reading them
+// by System V, and the first `%s` would dereference whatever landed in `rdi`. It did: this test
+// SEGFAULTed on the Windows MinGW job the moment the handlers were tagged.
+//
+// This file used to spell those tagged types itself. It no longer does: `Hle::lookup_guest_abi`
+// constructs them (#3272), so the convention is spelled in one place instead of at every call site
+// that wants one of these handlers.
 
 int main() {
     printf("== test_printf ==\n");
     register_builtin_hle();
 
-    auto snf = (SnprintfFn)(void*)Hle::lookup(nid_hash("snprintf"));
-    auto spf = (SprintfFn)(void*)Hle::lookup(nid_hash("sprintf"));
-    auto snfs = (SnprintfFn)(void*)Hle::lookup(nid_hash("snprintf_s"));
+    // `lookup_guest_abi` builds the PROSPER_GUEST_ABI pointer type itself (#3272), so this file no
+    // longer spells the calling convention and cannot get it wrong -- which matters because an
+    // untagged type compiles and behaves identically everywhere except the MinGW job.
+    auto snf  = Hle::lookup_guest_abi<int, char*, size_t, const char*>(nid_hash("snprintf"));
+    auto spf  = Hle::lookup_guest_abi<int, char*, const char*>(nid_hash("sprintf"));
+    auto snfs = Hle::lookup_guest_abi<int, char*, size_t, const char*>(nid_hash("snprintf_s"));
     CHECK(snf && spf && snfs, "printf-family fns registered");
     if (!(snf && spf && snfs)) { printf("== FAIL ==\n"); return 1; }
 

--- a/prosper/tests/host/abi/test_guest_varargs.cpp
+++ b/prosper/tests/host/abi/test_guest_varargs.cpp
@@ -282,6 +282,26 @@ void check_lookup_accessors() {
            reinterpret_cast<const void*>(printf_fn) == Hle::lookup_address(nid_hash("printf")),
            "lookup_guest_abi returned an address the registry does not hold");
 
+    // (4b) `registered` answers the THIRD question, and must answer it for a guest-ABI handler --
+    //      `lookup` returning nullptr for one must not read as "no handler exists". This is the arm
+    //      that would have caught the `nid_census` miss found in review: that tool reports a NID
+    //      with no registered handler as a return-0 false-success candidate (#2081), so a wrong
+    //      answer here puts five real handlers into a table that is acted on. It has no ctest case
+    //      of its own, so nothing else in the suite can see it.
+    unsigned known = 0;
+    for (const char* name : kGuestAbi) {
+        if (Hle::registered(nid_hash(name))) { ++known; continue; }
+        fail("guest-ABI handlers report as registered",
+             std::string(name) + ": Hle::registered said no handler exists for a registered NID");
+    }
+    expect("registered-arm is not vacuous", known == 5,
+           "expected all five printf-family NIDs to report registered, got " + std::to_string(known));
+    expect("registered agrees with lookup for an ordinary handler",
+           Hle::registered(nid_hash("memcpy")) && Hle::lookup(nid_hash("memcpy")) != nullptr,
+           "registered and lookup disagree about an ordinary host-ABI handler");
+    expect("registered says no for an unregistered NID", !Hle::registered("no-such-nid-xyz"),
+           "Hle::registered claimed a NID that was never registered");
+
     // (5) The category error in the OTHER direction. Asking for the guest convention on an ordinary
     //     host handler must not quietly succeed either -- that mis-types the pointer just as badly,
     //     and it is the mistake a caller makes when they copy the line above to a different NID.
@@ -291,8 +311,10 @@ void check_lookup_accessors() {
 
     // (6) The pointer is USABLE, not merely non-null -- an address that resolves but cannot be
     //     called through would satisfy every arm above. snprintf is the one whose result can be
-    //     asserted without writing to stdout, and the arguments deliberately spill past both
-    //     register files so the call exercises the overflow area rather than registers alone.
+    //     asserted without writing to stdout. Seven integer-class arguments means one spills to the
+    //     overflow area, so the call is not register-only; the single `4.5` uses 1 of the 8 SSE
+    //     slots and does NOT spill, which is fine here -- the FP overflow path is check_executed's
+    //     job, not this arm's.
     auto snprintf_fn =
         Hle::lookup_guest_abi<int, char*, size_t, const char*>(nid_hash("snprintf"));
     expect("lookup_guest_abi resolves snprintf", snprintf_fn != nullptr,

--- a/prosper/tests/host/abi/test_guest_varargs.cpp
+++ b/prosper/tests/host/abi/test_guest_varargs.cpp
@@ -218,6 +218,95 @@ void check_stub_and_registry() {
            "sscanf was routed through the guest-ABI path; #3246 records why it should not be");
 }
 
+// #3272 -- the CALL side of the guest-ABI boundary. #3246 closed registration at compile time; the
+// three accessors below are what close retrieval, and each of these arms is a property of the
+// accessor rather than of the registry it reads.
+//
+// The reason this needs asserting at all is that the failure is INVISIBLE on the platform it is
+// written on: PROSPER_GUEST_ABI expands to nothing outside Windows, so a mis-typed pointer compiles
+// and behaves identically here, and only the MinGW job dereferences the wild pointer. So these arms
+// check the shape of the API surface -- what each accessor refuses -- not the eventual crash.
+void check_lookup_accessors() {
+    // EXPECTED STDERR: arm (1) deliberately drives the refusal path, so this test prints five
+    // "[prosper] Hle::lookup refused ..." lines. They are the fix working, not a failure -- and
+    // their absence would mean the refusal went quiet, which is the outcome the loud path exists to
+    // prevent. Only the "test_guest_varargs: ..." lines report the verdict.
+    register_builtin_hle();
+    static const char* const kGuestAbi[] = { "printf", "sprintf", "snprintf",
+                                             "sprintf_s", "snprintf_s" };
+
+    // (1) `lookup` refuses every guest-ABI handler. This is the defect: it used to hand back a bare
+    //     HleFn, and nothing stopped a caller invoking a System V variadic through it.
+    unsigned refused = 0;
+    for (const char* name : kGuestAbi) {
+        if (Hle::lookup(nid_hash(name)) == nullptr) { ++refused; continue; }
+        fail("lookup refuses guest-ABI handlers",
+             std::string(name) + ": Hle::lookup returned a bare HleFn for a guest-ABI handler");
+    }
+    expect("lookup-refusal arm is not vacuous", refused == 5,
+           "expected all five printf-family NIDs to be refused, got " + std::to_string(refused));
+
+    // (2) DISCRIMINATOR for (1). Refusing everything would satisfy (1) just as well, and would be a
+    //     far worse bug than the one being fixed -- every import in the tree resolves through here.
+    expect("lookup still returns ordinary handlers", Hle::lookup(nid_hash("memcpy")) != nullptr,
+           "Hle::lookup refused an ordinary host-ABI handler; the refusal is not selective");
+
+    // (3) THE REGRESSION GUARD THAT MATTERS. Both import-stub emitters resolve every slot through
+    //     an accessor, and if the guest-ABI NIDs stopped resolving there, `printf` would be emitted
+    //     as an UNIMPLEMENTED stub for every title on both platforms -- a silent, total loss of
+    //     guest stdout that no other arm here would notice. `lookup_address` is the accessor they
+    //     use, and it must answer for a guest-ABI handler exactly as it does for any other.
+    unsigned addressable = 0;
+    for (const char* name : kGuestAbi) {
+        if (Hle::lookup_address(nid_hash(name)) != nullptr) { ++addressable; continue; }
+        fail("guest-ABI handlers remain addressable",
+             std::string(name) + ": lookup_address returned nullptr, so the import stub for it "
+             "would be emitted as unimplemented");
+    }
+    expect("addressability arm is not vacuous", addressable == 5,
+           "expected all five printf-family NIDs to be addressable, got "
+           + std::to_string(addressable));
+    expect("lookup_address agrees with lookup for ordinary handlers",
+           Hle::lookup_address(nid_hash("memcpy"))
+               == reinterpret_cast<const void*>(Hle::lookup(nid_hash("memcpy"))),
+           "the two accessors disagree about an ordinary handler's address");
+    expect("lookup_address reports an unregistered NID as missing",
+           Hle::lookup_address("no-such-nid-xyz") == nullptr,
+           "lookup_address invented an address for a NID that was never registered");
+
+    // (4) `lookup_guest_abi` hands back the SAME handler, through a type it constructs itself.
+    auto printf_fn = Hle::lookup_guest_abi<int, const char*>(nid_hash("printf"));
+    expect("lookup_guest_abi resolves a guest-ABI handler", printf_fn != nullptr,
+           "lookup_guest_abi returned nullptr for printf");
+    expect("lookup_guest_abi returns the registered address",
+           reinterpret_cast<const void*>(printf_fn) == Hle::lookup_address(nid_hash("printf")),
+           "lookup_guest_abi returned an address the registry does not hold");
+
+    // (5) The category error in the OTHER direction. Asking for the guest convention on an ordinary
+    //     host handler must not quietly succeed either -- that mis-types the pointer just as badly,
+    //     and it is the mistake a caller makes when they copy the line above to a different NID.
+    expect("lookup_guest_abi refuses an ordinary handler",
+           Hle::lookup_guest_abi<int, const char*>(nid_hash("memcpy")) == nullptr,
+           "lookup_guest_abi handed back a guest-convention pointer to a host-ABI handler");
+
+    // (6) The pointer is USABLE, not merely non-null -- an address that resolves but cannot be
+    //     called through would satisfy every arm above. snprintf is the one whose result can be
+    //     asserted without writing to stdout, and the arguments deliberately spill past both
+    //     register files so the call exercises the overflow area rather than registers alone.
+    auto snprintf_fn =
+        Hle::lookup_guest_abi<int, char*, size_t, const char*>(nid_hash("snprintf"));
+    expect("lookup_guest_abi resolves snprintf", snprintf_fn != nullptr,
+           "lookup_guest_abi returned nullptr for snprintf");
+    if (snprintf_fn) {
+        char buf[128] = {};
+        const int n = snprintf_fn(buf, sizeof buf, "%s|%d|%d|%d|%.2f", "s", 1, 2, 3, 4.5);
+        expect("a handler called through lookup_guest_abi formats correctly",
+               n == 12 && strcmp(buf, "s|1|2|3|4.50") == 0,
+               std::string("formatted \"") + buf + "\" (n=" + std::to_string(n)
+                   + "), expected \"s|1|2|3|4.50\" (n=12)");
+    }
+}
+
 #if PROSPER_TEST_X86_64
 // ---------------------------------------------------------------------------------------------
 // (1) + (3) Executed: a real System V variadic frame, read, packed, and consumed as Microsoft x64.
@@ -503,8 +592,13 @@ void check_executed() {
         // loop would be green and would be measuring nothing. The table therefore has to contain at
         // least one specifier this CRT rejects, and `%qd` is rejected by both the UCRT and the ANSI
         // stdio implementations, so the guard holds whichever one a build resolves to.
-        expect("CRT subset probe ran", probed == sizeof kSpecs / sizeof *kSpecs,
-               "the specifier table changed but the count did not");
+        // The literal, NOT `sizeof kSpecs / sizeof *kSpecs` (#3273): comparing the count against the
+        // array it was counted from is a tautology, and one in the very file whose subject is arms
+        // that cannot fail. Pinned, an edit to kSpecs reddens this instead of silently changing what
+        // the arm claims to have probed.
+        expect("CRT subset probe ran", probed == 11,
+               "the specifier table changed but the pinned count did not -- update both, and check "
+               "the table still contains a specifier this CRT REJECTS (the guard below)");
         expect("CRT subset probe can see a refusal", crt_rejects > 0,
                "this CRT reports that it consumes an argument for EVERY specifier probed, including "
                "%qd -- the sentinel detector is broken, so the subset rule was never tested");
@@ -551,6 +645,7 @@ void check_executed() {
 int main() {
     check_plans();
     check_stub_and_registry();
+    check_lookup_accessors();
 #if PROSPER_TEST_X86_64
     check_executed();
 #else

--- a/prosper/tests/host/abi/test_guest_varargs.cpp
+++ b/prosper/tests/host/abi/test_guest_varargs.cpp
@@ -283,11 +283,15 @@ void check_lookup_accessors() {
            "lookup_guest_abi returned an address the registry does not hold");
 
     // (4b) `registered` answers the THIRD question, and must answer it for a guest-ABI handler --
-    //      `lookup` returning nullptr for one must not read as "no handler exists". This is the arm
-    //      that would have caught the `nid_census` miss found in review: that tool reports a NID
-    //      with no registered handler as a return-0 false-success candidate (#2081), so a wrong
-    //      answer here puts five real handlers into a table that is acted on. It has no ctest case
-    //      of its own, so nothing else in the suite can see it.
+    //      `lookup` returning nullptr for one must not read as "no handler exists". Why it matters:
+    //      `nid_census` reports a NID with no registered handler as a return-0 false-success
+    //      candidate (#2081), so a wrong answer here puts five real handlers into a table that is
+    //      acted on, and that tool has no ctest case of its own.
+    //
+    //      This arm does NOT close that hole, and saying so is the point. It is a property of
+    //      `Hle::registered`; the miss was `nid_census` calling `lookup`. Had this predicate existed
+    //      then, with nid_census unchanged, this arm would still be green. Nothing here couples a
+    //      CALLER to the accessor it ought to use -- #3297.
     unsigned known = 0;
     for (const char* name : kGuestAbi) {
         if (Hle::registered(nid_hash(name))) { ++known; continue; }

--- a/prosper/tools/nid_census/nid_census.cpp
+++ b/prosper/tools/nid_census/nid_census.cpp
@@ -17,7 +17,7 @@
 //     exact NID set the loader will try to bind;
 //   * cross-module exports come from `module_export_nids`, the loader's own definition of what a
 //     module contributes to the global export table;
-//   * registration comes from `Hle::lookup` after `register_builtin_hle()` — the real runtime
+//   * registration comes from `Hle::registered` after `register_builtin_hle()` — the real runtime
 //     registry, so a NID registered from a table, a loop, or a raw literal is seen identically.
 // A grep over `register_fn(...)` call sites would miss every non-literal registration and would
 // report those as false-success candidates. Asking the registry cannot.
@@ -276,7 +276,7 @@ int main(int argc, char** argv) {
     size_t total = 0, unregistered = 0;
     for (auto& [nid, r] : rows) {
         total++;
-        const bool registered = Hle::lookup(nid) != nullptr;
+        const bool registered = Hle::registered(nid);
         if (!registered) unregistered++;
         if (registered && !show_registered) continue;
         if (auto it = names.by_nid.find(nid); it != names.by_nid.end()) r.name = it->second;
@@ -305,7 +305,7 @@ int main(int argc, char** argv) {
             for (const auto& t : r->titles) { if (!tl.empty()) tl += ","; tl += t; }
             printf("%s\t%s\t%d\t%zu\t%zu\t%s\t%s\n", r->nid.c_str(),
                    r->name.empty() ? "?" : r->name.c_str(),
-                   Hle::lookup(r->nid) != nullptr ? 1 : 0,
+                   Hle::registered(r->nid) ? 1 : 0,
                    r->titles.size(), r->modules, libs.c_str(), tl.c_str());
         }
         print_scope("# ", total, modules_read, modules_failed, unregistered, selected.size(),


### PR DESCRIPTION
Closes #3272. Closes #3273.

## The problem

#3246 closed the **registration** side of the guest-ABI boundary at compile time:
`Hle::register_guest_abi`'s parameter type carries `PROSPER_GUEST_ABI`, so on Windows a handler that
forgot the tag is a hard compile error rather than a stub that reads the wrong registers.

The **call** side stayed open. `Hle::lookup` handed back a bare `HleFn`, so nothing stopped a caller
taking a guest-ABI handler's address out of it and invoking it through an ordinary host-ABI function
pointer. The arguments are then placed by one convention and read by the other, and for a
printf-family handler the first `%s` dereferences whatever landed in `rdi`.

Not hypothetical: during #3246 both `test_printf` and `test_guest_log_capture` did exactly that, and
both **SEGFAULTed on the `Windows MinGW` job** the moment the handlers were tagged — while passing on
every other platform, because `PROSPER_GUEST_ABI` is empty there and the two types are identical.
They were patched by hand-spelling tagged pointer types at each call site, which left the defence as
a comment plus one CI job on a platform nobody develops on.

## The contract

`Hle::lookup` now means exactly one thing: **a handler `HleFn` describes correctly**. The other needs
get their own accessors, so no caller has to spell a calling convention:

| accessor | answers | refuses |
| --- | --- | --- |
| `lookup(nid)` | an ordinary host-ABI handler | a guest-ABI handler — nullptr, and complains once per NID naming the way out |
| `lookup_address(nid)` | the handler address, no convention attached | nothing |
| `lookup_guest_abi<R, A...>(nid)` | a `PROSPER_GUEST_ABI R (*)(A..., ...)` **this header constructs** | a handler that is not guest-ABI — the same category error in the other direction |

The third is load-bearing. The caller names the return type and the fixed prefix and never names the
convention, so an untagged pointer cannot come out of it:

```cpp
auto guest_printf = Hle::lookup_guest_abi<int, const char*>(nid_hash("printf"));
```

Both call sites that previously hand-spelled the tag now go through it and no longer mention
`PROSPER_GUEST_ABI` at all.

## `lookup` was conflating THREE questions, not two — and a test proved it

This is the part worth a reviewer's attention, because I got it wrong first.

I convinced myself by grep that the only callers needing care were the two stub emitters, converted
them to `lookup_address`, and ran the suite. **`hle_functions_registered` failed:**

```
  [FAIL] not registered: snprintf
```

`test_hle_registered.cpp:17` was using `Hle::lookup(...) == nullptr` to ask *"is this NID
registered?"* — a third question, distinct from both "give me something callable" and "give me a
guest-ABI handler". With `lookup` refusing the printf family, a registered handler now read as
missing: exactly the "a caller that only checks for null reports it as unimplemented" failure the
new code comment warns about, landing on the first run.

The fix is to ask the existence question through `lookup_address`, and the incident is the argument
for the split rather than against it — the three questions had genuinely different right answers and
one accessor was giving all three the same one. It also means the grep-based sweep was **not**
sufficient, which is the thing I would most want checked independently.

## Why the emitters had to move first

Both import-stub emitters resolve **every** import slot through this call and only ever patch the
value into a jump target. Had either been missed, `printf` would have resolved to nullptr and been
emitted as an *unimplemented* stub for every title on both platforms — a silent, total loss of guest
stdout.

**An earlier draft of this section claimed arm (3) and mutation M2 cover that. They do not, and the
correction matters more than the claim did.** Arm (3) is a property of `lookup_address`; M2 mutates
`lookup_address`. Nothing couples `emit_one_stub` to the accessor it calls — revert
`exec_image_linux.cpp` to `lookup` today and every new arm stays green. That uncovered gap is
precisely how the `nid_census` miss described below got through, and it is the strongest remaining
argument for reading the caller sweep independently rather than trusting the test count.

## Review found a third missed caller — and a third question

Review rejected the first head on `nid_census.cpp:279` and `:308`, still asking *"is this NID
registered?"* as `Hle::lookup(nid) != nullptr`. With `lookup` refusing the printf family, that tool
would report five real handlers as having **no** handler — into the table `#2081` acts on, i.e. the
"dispatcher silently returns 0" false-success list. The tool's own header states exactly the
invariant this breaks, and it is built unconditionally with **no ctest case**, so `353/353` was fully
consistent with it being broken.

That was the *third* caller of that question, after `test_hle_registered`. So rather than convert two
more sites, the question now has a name — **`Hle::registered(nid)`** — and all three spell it, so a
fourth caller does not have to improvise. New arm (4b) pins it for guest-ABI NIDs specifically.

**Reach — I got this wrong, and the correction is in the record because the wrong version was.** An
earlier draft claimed "0 of 55 local dumps import a printf-family NID", so the wrong table was
unreachable. Review challenged it and it does not survive: **all 55 eboots import the printf family
as real `libc` imports.**

What produced the false zero was not the reviewer's proposed mechanism (`:281` suppressing
registered NIDs — I did pass `--registered`). It is **`nid_census.cpp:264`**, which drops any import
satisfied by a *sibling module's* export before the registration check at `:279`. Pointed at an
app0 directory the tool finds the title's bundled libc and excludes printf; pointed at the eboot
alone it shows it for **55 of 55**. A/B with that one line disabled: 55 of 55 rows appear.

So the blast radius was **not** zero. `nid_census` accepts a module path as well as an app0
directory, and on the eboot-alone invocation the printf family reaches `:279` in every dump. ~~The tool's own header at `:157-158` makes the runtime case sharper still: the loader links a
fixed set and never auto-links `.sprx`, so a NID the census excludes as sibling-satisfied "WOULD
reach the dispatcher at runtime".~~ **Struck — that citation leans on a stale comment.** #2199 made
`nid_census.cpp:141` build its module set from `prosper::boot_link_inputs()`, the loader's real link
set, and `boot_program.hpp:156-159` says outright that the census's cross-module exclusions "are only
sound over the set the loader really links … cannot drift from it." Measured in review: PPSA24651's
tree holds 8 module candidates and directory mode reads **7**, the `.sprx` dropped — link-set
behaviour. So in directory mode the exclusion is *sound*, and the comment I quoted argues the
opposite of what is now true.

The conclusion does not need it. Reach stands on the eboot-alone invocation, and more sharply on the
counterfactual the reviewer measured: the **pre-PR** binary on the eboot alone reports those NIDs
with `registered=1`, so commit 1 flipped exactly those to 0. (The stale comment, and the fact that
`:183-186` prints it in every report, are filed separately.)

The methodological error is worth naming because it is subtler than the one it replaced: I did
correctly reject a vacuous null for the narrow question, then restated the same observation as a
stronger claim about the corpus that it could not support.

## Also fixed: #3273

`test_guest_varargs.cpp` asserted `probed == sizeof kSpecs / sizeof *kSpecs` — the count compared
against the array it was counted from, so the arm could not fail. Pinned to the literal `11`.

**Caveat, stated because the exit code cannot distinguish it:** that arm lives inside
`#if defined(_WIN32)` (`:533-639`) and does not compile on Linux, so my mutation for it — add a
twelfth specifier, expect the pinned count to redden — **passed here**. That is *unverifiable*, not
negative. Its verification is the MinGW job (which does run `ctest --no-tests=error`, `ci.yml:632`)
plus a reading of the table: `kSpecs` has 11 rows and no preprocessor directives inside its
initializer. #3273 carries a measurement of how large that Linux-side blind spot is (102 assertions
across 7 files sit in `_WIN32` regions with no `#else`).

## Verification

Linux, in the distrobox, at this exact head:

```
cmake --build prosper/build-linux -j4                       # exit 0
ctest --no-tests=error --output-on-failure --timeout 900    # exit 0, 353/353 passed, 137.65s
```

Test count unchanged at **353** — this adds arms to existing binaries, not a new target, so a
different count would itself be a red flag.

`test_guest_varargs` prints five `[prosper] Hle::lookup refused …` lines by design: arm (1) drives
the refusal path deliberately, and their absence would mean the loud path went quiet.

### Mutation arms — each new assertion shown to fail without the fix

Every arm below was applied to a clean tree, built, run, and reverted; verdicts are **test exit
codes**, and the named arm that fired is quoted.

| # | mutation | exit | arm that fired |
| --- | --- | --- | --- |
| M0 | none (baseline) | **0** | — |
| M1 | `lookup` does not refuse guest-ABI (the pre-fix behaviour) | **1** | `lookup refuses guest-ABI handlers` |
| M2 | `lookup_address` refuses them too (the missed-emitter regression) | **1** | `guest-ABI handlers remain addressable` |
| M3 | `lookup` refuses *everything* (over-broad refusal) | **1** | `lookup still returns ordinary handlers` |
| M4 | `lookup_guest_abi` drops its `guest_abi_nid` check | **1** | `lookup_guest_abi refuses an ordinary handler` |
| M5 | `kSpecs` grows, pinned count does not (#3273) | **0** | **VOID on Linux — Windows-only block, see caveat above** |
| M6 | restored | **0** | — |

M3 is the discriminator that matters: refusing everything would satisfy M1's arm just as well and
would be a far worse bug than the one being fixed, since every import in the tree resolves here.

Separately, `hle_functions_registered` is an unplanned integration arm for the same property: it went
`8 → 0` across the existence-accessor fix described above.

Re-run at the corrected head `7f4d0ddf`: build exit 0, `ctest --no-tests=error` **353/353**, exit 0.

### Not covered

Nothing here runs a live guest calling `printf` on a Windows host, and these arms check the shape of
the API surface — what each accessor refuses — not the eventual crash. That is deliberate: the
mis-typed-pointer failure is invisible on Linux by construction, so a Linux test cannot assert the
crash, only the guard preventing it. The MinGW job remains the only place the convention mismatch is
observable.

This does **not** address #3271 (the Linux swap stub re-pushes only four spilled words). That issue
now carries a derivation showing the bounded-copy option cannot be made correct at any word count;
the fix is a separate, riskier change to the path every guest import takes, and wants a quiet machine.