### PR TITLE
env: refuse a malformed value on the 23 PROSPER_* knobs where 0 is a setting, not "off" (#3267)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -373,6 +373,15 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME cached_env_arming_logic
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/env/check_cached_env.py"
                    "${CMAKE_SOURCE_DIR}")
+  # The coverage half of test_env_numeric_sites (#3267). That test MIRRORS each converted site
+  # rather than calling it -- the sites cache their reads in function-local statics, so a runtime
+  # arm would go vacuous exactly as cached_env_arming_logic above describes -- and a mirror drifts
+  # silently: convert a site, forget the arm, suite stays green. This refuses that by comparing the
+  # set of knobs parsed through diagnostics/env_numeric.hpp against the set the test arms. It is a
+  # text scan, so it needs nothing built.
+  add_test(NAME env_numeric_arms
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/env/check_env_numeric_arms.py"
+                   "${CMAKE_SOURCE_DIR}")
   # stdout carries BYTES, and Windows decodes them as cp1252/cp437. One em dash in a printf literal
   # therefore reaches a Windows user as three mojibake characters, so a grep for the line the tool
   # itself printed does not match it -- and a test asserting on the rendered string fails on
@@ -1474,6 +1483,16 @@ if(TARGET prosper_core)
   add_executable(test_env_cache tests/diagnostics/test_env_cache.cpp)
   target_include_directories(test_env_cache PRIVATE src)
   add_test(NAME diagnostics_env_cache COMMAND test_env_cache)
+
+  # One arm per PROSPER_* knob #3267 converted to diagnostics/env_numeric.hpp. Header-only and
+  # environment-free by construction: nearly every converted site caches its read in a
+  # function-local static, so an arm that armed the variable at runtime would go VACUOUS rather
+  # than red (#2214). Each arm therefore calls the same helper the site calls, and also computes
+  # what the site's OLD spelling answered -- so an arm on a knob that never needed converting
+  # fails instead of passing quietly.
+  add_executable(test_env_numeric_sites tests/diagnostics/test_env_numeric_sites.cpp)
+  target_include_directories(test_env_numeric_sites PRIVATE src)
+  add_test(NAME diagnostics_env_numeric_sites COMMAND test_env_numeric_sites)
 
   # Diagnostics: enabled-path and JSON tests (only when feature is built).
   if(PROSPER_DIAGNOSTICS)

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1045,9 +1045,12 @@ bool persistent_compute_buffer_result_enabled(uint32_t bytes) {
 
 VkDeviceSize persistent_compute_buffer_limit() {
     static const VkDeviceSize limit = []() -> VkDeviceSize {
+        // A cache CAP: `-1` saturated this to UINT64_MAX, i.e. unbounded, and `1gb` to 1 MiB.
+        // Both look deliberate afterwards; neither is (#3267).
         const char* value = std::getenv("PROSPER_COMPUTE_BUFFER_CACHE_MB");
-        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 256ull;
-        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_COMPUTE_BUFFER_CACHE_MB", value, 256ull,
+            UINT64_MAX / (1024ull * 1024ull), "MiB");
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
     return limit;
@@ -1093,8 +1096,18 @@ VkDeviceSize persistent_compute_image_limit(
     static const std::optional<VkDeviceSize> override_limit = []()
         -> std::optional<VkDeviceSize> {
         const char* value = std::getenv("PROSPER_COMPUTE_IMAGE_CACHE_MB");
-        if (!value) return std::nullopt;
-        const uint64_t mib = std::strtoull(value, nullptr, 10);
+        if (!value || !*value) return std::nullopt;
+        // There is no numeric default to fall back to -- unset means "derive from device memory" --
+        // so a refusal must fall back to THAT, not to a number. Hence parse_u64_strict plus an
+        // explicit nullopt rather than the or_default helper (#3267).
+        uint64_t mib = 0;
+        if (!prosper::diag::parse_u64_strict(value, &mib)) {
+            std::fprintf(stderr,
+                         "[env] PROSPER_COMPUTE_IMAGE_CACHE_MB='%s' is not a plain non-negative "
+                         "count of MiB -- keeping the device-derived budget and changing NOTHING\n",
+                         value);
+            return std::nullopt;
+        }
         if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
@@ -1244,8 +1257,9 @@ VkDeviceSize compute_memory_pool_limit() {
         // staging allocations. A 256 MiB cache discarded about 200 allocations and repeatedly paid
         // AMD BO page initialization; 640 MiB holds that measured working set with zero discards,
         // while remaining a bounded fraction of the renderer's persistent-target budget.
-        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 640ull;
-        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_COMPUTE_MEMORY_POOL_MB", value, 640ull,
+            UINT64_MAX / (1024ull * 1024ull), "MiB");
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
     return limit;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1097,17 +1097,15 @@ VkDeviceSize persistent_compute_image_limit(
         -> std::optional<VkDeviceSize> {
         const char* value = std::getenv("PROSPER_COMPUTE_IMAGE_CACHE_MB");
         if (!value || !*value) return std::nullopt;
-        // There is no numeric default to fall back to -- unset means "derive from device memory" --
-        // so a refusal must fall back to THAT, not to a number. Hence parse_u64_strict plus an
-        // explicit nullopt rather than the or_default helper (#3267).
+        // There is no numeric default to fall back to -- unset means "derive from device memory"
+        // -- so a refusal must fall back to that CODE PATH, not to a number. env_u64_or_report is
+        // the named helper for that shape; a hand-written fprintf here would be invisible to
+        // tools/env/check_env_numeric_arms.py, which is how the one site with bespoke arithmetic
+        // became the one site the anti-drift gate could not see (#3267 N2).
         uint64_t mib = 0;
-        if (!prosper::diag::parse_u64_strict(value, &mib)) {
-            std::fprintf(stderr,
-                         "[env] PROSPER_COMPUTE_IMAGE_CACHE_MB='%s' is not a plain non-negative "
-                         "count of MiB -- keeping the device-derived budget and changing NOTHING\n",
-                         value);
+        if (!prosper::diag::env_u64_or_report("PROSPER_COMPUTE_IMAGE_CACHE_MB", value, &mib, "MiB",
+                                              "the device-derived budget"))
             return std::nullopt;
-        }
         if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -777,8 +777,13 @@ thread_local TextureDecodeScopeStats g_texture_decode_scope{};
 // that report depend on two switches, which check_diag_gates.py rightly rejects (TWO-GATE).
 inline uint64_t array_decode_budget_bytes() {
     static const uint64_t bytes = [] {
+        // atoll turned `-1` into a budget of 0xFFFFFFFFFFF00000 -- i.e. UNBOUNDED, the one setting
+        // this knob exists to prevent -- and `1gib` into 1 MiB, which reads in the log as a
+        // deliberate choice. Refuse both and keep 1 GiB (#3267).
         const char* e = getenv("PROSPER_ARRAY_DECODE_BUDGET_MIB");
-        return static_cast<uint64_t>(e ? atoll(e) : 1024) << 20;
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_ARRAY_DECODE_BUDGET_MIB", e, 1024ull, UINT64_MAX >> 20, "MiB");
+        return mib << 20;
     }();
     return bytes;
 }

--- a/prosper/src/diagnostics/env_numeric.hpp
+++ b/prosper/src/diagnostics/env_numeric.hpp
@@ -24,6 +24,11 @@
 // whitespace, no `0x`, no suffix. `strtoull` would take a leading space and a leading `-` (wrapping
 // it to a huge unsigned), and both are far likelier to be a typo than an intention. An UNSET or
 // EMPTY variable is not a typo and takes the default in silence.
+//
+// The `_auto` family below widens that to `0x`-hex for the six sites whose PRE-EXISTING spelling was
+// `strtol(e, nullptr, 0)`. That is not a relaxation of the rule but an application of it: on those
+// sites `0x2000` was already a valid input, so refusing it would be this header changing a
+// well-formed setting — the very thing it exists to prevent (#3267 N1).
 #pragma once
 #include <cstdint>
 #include <cstdio>
@@ -53,16 +58,24 @@ inline bool parse_u64_strict(const char* text, uint64_t* out) {
 // `unit` is an optional trailing note for the message ("KiB", "MiB", "validations", ...), because a
 // knob's units live at its call site and a reader who mistyped one wants to be told which was
 // expected. It is rendered as "... is not a plain non-negative count of KiB", so pass a bare noun.
+//
+// `default_note` glosses the default in the message, and exists because on two knobs the default is
+// itself the PERMISSIVE sentinel: `PROSPER_WRITE_WATCH_MAX_KB`'s 0 means "no limit" and
+// `PROSPER_MAX_DISPATCH_GROUPS`'s means "no cap". Telling an operator who typed a value in order to
+// IMPOSE a bound that we are "keeping the default (0) and changing NOTHING" is true and useless --
+// they need to know they still have no bound. Pass "0 = unbounded" and the line says so.
 inline uint64_t env_u64_or_default(const char* name, const char* text, uint64_t fallback,
-                                   const char* unit = nullptr) {
+                                   const char* unit = nullptr,
+                                   const char* default_note = nullptr) {
     uint64_t value = 0;
     if (parse_u64_strict(text, &value)) return value;
     if (!text || !*text) return fallback;   // unset or empty: not a typo, and not worth a line
     std::fprintf(stderr,
-                 "[env] %s='%s' is not a plain non-negative %s%s -- keeping the default (%llu) and "
-                 "changing NOTHING\n",
+                 "[env] %s='%s' is not a plain non-negative %s%s -- keeping the default (%llu%s%s) "
+                 "and changing NOTHING\n",
                  name, text, unit ? "count of " : "integer", unit ? unit : "",
-                 static_cast<unsigned long long>(fallback));
+                 static_cast<unsigned long long>(fallback),
+                 default_note ? ", " : "", default_note ? default_note : "");
     return fallback;
 }
 
@@ -73,9 +86,83 @@ inline uint64_t env_u64_or_default(const char* name, const char* text, uint64_t 
 // the tree scales its number by 1024 or 1024*1024, and a value near UINT64_MAX would wrap that
 // product to something small — the same class of silent wrong setting this header exists to remove.
 inline uint64_t env_u64_or_default_capped(const char* name, const char* text, uint64_t fallback,
-                                          uint64_t cap, const char* unit = nullptr) {
-    const uint64_t value = env_u64_or_default(name, text, fallback, unit);
+                                          uint64_t cap, const char* unit = nullptr,
+                                          const char* default_note = nullptr) {
+    const uint64_t value = env_u64_or_default(name, text, fallback, unit, default_note);
     return value < cap ? value : cap;
+}
+
+// --- the same, for a knob whose pre-existing grammar was strtol/strtoul BASE 0 -------------------
+//
+// Six sites read their value with an explicit base of 0, which makes `0x2000` a WELL-FORMED input
+// there. Converting those to the decimal-only grammar above would refuse a spelling that used to
+// work -- and on `PROSPER_MAX_DISPATCH_GROUPS`, whose fallback is "no cap", refusing `0x2000` would
+// newly introduce the exact "a typo removes the bound" outcome this header exists to remove. So the
+// grammar is widened to match what those sites already accepted, and no further: `[0-9]+` or
+// `0x[0-9a-fA-F]+` (either case of the `x`), still no sign, no whitespace, no suffix, still
+// overflow-checked. Base-0's OCTAL leg is deliberately not carried over -- a leading zero in a
+// hand-typed count is far likelier to be padding than an intent to write base 8, and `010` meaning
+// 8 is its own silent-wrong-setting hazard.
+inline bool parse_u64_auto_base(const char* text, uint64_t* out) {
+    if (!text || !*text || !out) return false;
+    if (text[0] != '0' || (text[1] != 'x' && text[1] != 'X')) return parse_u64_strict(text, out);
+    const char* p = text + 2;
+    if (!*p) return false;                       // a bare "0x" is not a number
+    uint64_t value = 0;
+    for (; *p; ++p) {
+        uint64_t digit;
+        if (*p >= '0' && *p <= '9')      digit = static_cast<uint64_t>(*p - '0');
+        else if (*p >= 'a' && *p <= 'f') digit = static_cast<uint64_t>(*p - 'a') + 10u;
+        else if (*p >= 'A' && *p <= 'F') digit = static_cast<uint64_t>(*p - 'A') + 10u;
+        else return false;
+        if (value > (UINT64_MAX - digit) / 16u) return false;   // would overflow
+        value = value * 16u + digit;
+    }
+    *out = value;
+    return true;
+}
+
+inline uint64_t env_u64_or_default_auto(const char* name, const char* text, uint64_t fallback,
+                                        const char* unit = nullptr,
+                                        const char* default_note = nullptr) {
+    uint64_t value = 0;
+    if (parse_u64_auto_base(text, &value)) return value;
+    if (!text || !*text) return fallback;
+    std::fprintf(stderr,
+                 "[env] %s='%s' is not a decimal or 0x-hex non-negative %s%s -- keeping the default "
+                 "(%llu%s%s) and changing NOTHING\n",
+                 name, text, unit ? "count of " : "integer", unit ? unit : "",
+                 static_cast<unsigned long long>(fallback),
+                 default_note ? ", " : "", default_note ? default_note : "");
+    return fallback;
+}
+
+inline uint64_t env_u64_or_default_auto_capped(const char* name, const char* text, uint64_t fallback,
+                                               uint64_t cap, const char* unit = nullptr,
+                                               const char* default_note = nullptr) {
+    const uint64_t value = env_u64_or_default_auto(name, text, fallback, unit, default_note);
+    return value < cap ? value : cap;
+}
+
+// --- for a knob whose "unset" answer is NOT a number ---------------------------------------------
+//
+// `PROSPER_COMPUTE_IMAGE_CACHE_MB` unset means "derive the budget from device memory", so there is
+// no fallback to hand the functions above -- the refusal has to fall back to a different CODE PATH.
+// Returns true only on a well-formed value; reports and returns false on a malformed one; returns
+// false in silence when unset or empty. Exists as a named helper rather than a hand-written
+// fprintf at the call site so that tools/env/check_env_numeric_arms.py can SEE the site: a bespoke
+// parse is invisible to that gate, which is how the one site with bespoke arithmetic became the one
+// site the anti-drift gate did not cover.
+inline bool env_u64_or_report(const char* name, const char* text, uint64_t* out,
+                              const char* unit = nullptr, const char* unset_note = nullptr) {
+    if (!text || !*text) return false;
+    if (parse_u64_strict(text, out)) return true;
+    std::fprintf(stderr,
+                 "[env] %s='%s' is not a plain non-negative %s%s -- keeping %s and changing "
+                 "NOTHING\n",
+                 name, text, unit ? "count of " : "integer", unit ? unit : "",
+                 unset_note ? unset_note : "the default");
+    return false;
 }
 
 } // namespace prosper::diag

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -6,6 +6,8 @@
 // binary at startup, or a test via render_runner.h), so prosper_core links this without Vulkan.
 #include "gpu/execute/gpu_execute.hpp"
 #include "gpu/diagnostics/watch_list.hpp"   // strict 0x-only watch parsing (shared with the RTT watch)
+#include "diagnostics/env_numeric.hpp"   // #3267: a typo must not silently drop an operator-set cap
+#include <cstdint>
 #include "gpu/capture/gpu_capture.hpp"
 #include "gpu/timeline/gpu_timeline.hpp"
 #include "gpu/capture/capture_compute_policy.hpp"
@@ -7728,8 +7730,13 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
     // reaches 752,646 workgroups in one dispatch and the device is lost permanently a few submits
     // later; with it, the same route can be run to the same point with the size bounded.
     static const uint32_t group_cap = [] {
+        // 0 disables the cap. That is the right DEFAULT and the wrong answer to a typo: this knob
+        // is only ever set to bound a dispatch that loses the device (#1742/#1743), so `=750000`
+        // mistyped as `=750,000` unbounded the very thing being bounded (#3267).
         const char* value = std::getenv("PROSPER_MAX_DISPATCH_GROUPS");
-        return value && *value ? static_cast<uint32_t>(strtoul(value, nullptr, 0)) : 0u;
+        if (!value || !*value) return 0u;
+        return static_cast<uint32_t>(prosper::diag::env_u64_or_default_capped(
+            "PROSPER_MAX_DISPATCH_GROUPS", value, 0ull, UINT32_MAX, "workgroups"));
     }();
     if (group_cap) {
         auto clamp_groups = [&](uint32_t& groups, uint32_t& threads, uint32_t local) {

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -7735,8 +7735,9 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
         // mistyped as `=750,000` unbounded the very thing being bounded (#3267).
         const char* value = std::getenv("PROSPER_MAX_DISPATCH_GROUPS");
         if (!value || !*value) return 0u;
-        return static_cast<uint32_t>(prosper::diag::env_u64_or_default_capped(
-            "PROSPER_MAX_DISPATCH_GROUPS", value, 0ull, UINT32_MAX, "workgroups"));
+        return static_cast<uint32_t>(prosper::diag::env_u64_or_default_auto_capped(
+            "PROSPER_MAX_DISPATCH_GROUPS", value, 0ull, UINT32_MAX, "workgroups",
+            "no cap: nothing is bounded"));
     }();
     if (group_cap) {
         auto clamp_groups = [&](uint32_t& groups, uint32_t& threads, uint32_t local) {

--- a/prosper/src/gpu/execute/mb3_freelist.cpp
+++ b/prosper/src/gpu/execute/mb3_freelist.cpp
@@ -80,7 +80,7 @@ bool central_scan_enabled() {
         // default explicit switched the scan OFF instead (#3267). A refusal keeps ON; `=0` still
         // means off.
         const char* e = getenv("PROSPER_MB3_CENTRAL_SCAN");
-        return prosper::diag::env_u64_or_default("PROSPER_MB3_CENTRAL_SCAN", e, 1ull) != 0;
+        return prosper::diag::env_u64_or_default_auto("PROSPER_MB3_CENTRAL_SCAN", e, 1ull) != 0;
     }();
     return enabled;
 }
@@ -203,7 +203,7 @@ bool mb3_tls_tracking_enabled() {
     static const bool enabled = [] {
         // DEFAULT ON -- same inversion as PROSPER_MB3_CENTRAL_SCAN above (#3267).
         const char* e = getenv("PROSPER_MB3_TRACK_TLS");
-        return prosper::diag::env_u64_or_default("PROSPER_MB3_TRACK_TLS", e, 1ull) != 0;
+        return prosper::diag::env_u64_or_default_auto("PROSPER_MB3_TRACK_TLS", e, 1ull) != 0;
     }();
     return enabled;
 }

--- a/prosper/src/gpu/execute/mb3_freelist.cpp
+++ b/prosper/src/gpu/execute/mb3_freelist.cpp
@@ -1,6 +1,7 @@
 #include "gpu/execute/mb3_freelist.hpp"
 #include "gpu/execute/gpu_execute.hpp"
 #include "host/image/boot_program.hpp"   // #1659: BOOT_EBOOT (the real mapped base)
+#include "diagnostics/env_numeric.hpp"   // #3267: a typo must not switch a default-ON guard off
 
 #include <atomic>
 #include <cstdlib>
@@ -75,8 +76,11 @@ bool scan_chain(uint64_t head, uint64_t block, uint8_t list, uint64_t pool_base,
 
 bool central_scan_enabled() {
     static const bool enabled = [] {
+        // DEFAULT ON. `strtol` answered 0 for `=yes`, `=true` and `=on`, so an operator making the
+        // default explicit switched the scan OFF instead (#3267). A refusal keeps ON; `=0` still
+        // means off.
         const char* e = getenv("PROSPER_MB3_CENTRAL_SCAN");
-        return !e || strtol(e, nullptr, 0) != 0;
+        return prosper::diag::env_u64_or_default("PROSPER_MB3_CENTRAL_SCAN", e, 1ull) != 0;
     }();
     return enabled;
 }
@@ -197,8 +201,9 @@ bool scan_once(uint64_t block, Mb3FreelistMatch* match) {
 
 bool mb3_tls_tracking_enabled() {
     static const bool enabled = [] {
+        // DEFAULT ON -- same inversion as PROSPER_MB3_CENTRAL_SCAN above (#3267).
         const char* e = getenv("PROSPER_MB3_TRACK_TLS");
-        return !e || strtol(e, nullptr, 0) != 0;
+        return prosper::diag::env_u64_or_default("PROSPER_MB3_TRACK_TLS", e, 1ull) != 0;
     }();
     return enabled;
 }

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -1415,7 +1415,7 @@ static bool forge_guard() {
     // DEFAULT ON, and it is the #312 ROOT fix -- so `strtol` answering 0 for `=yes`/`=true`/`=on`
     // silently REMOVED the fix while the operator believed they had pinned it on (#3267).
     static const bool v = [] { const char* e = getenv("PROSPER_REL1_FORGE_GUARD");
-                               return prosper::diag::env_u64_or_default(
+                               return prosper::diag::env_u64_or_default_auto(
                                    "PROSPER_REL1_FORGE_GUARD", e, 1ull) != 0; }();   // default ON
     return v;
 }
@@ -2131,7 +2131,7 @@ bool declines_drifted_pair_release(uint64_t addr, uint64_t value, const char* ki
 static bool rel1_stomp_guard() {
     // DEFAULT ON -- same inversion as PROSPER_REL1_FORGE_GUARD, same #312 fatal family (#3267).
     static const bool v = [] { const char* e = getenv("PROSPER_REL1_STOMP_GUARD");
-                               return prosper::diag::env_u64_or_default(
+                               return prosper::diag::env_u64_or_default_auto(
                                    "PROSPER_REL1_STOMP_GUARD", e, 1ull) != 0; }();   // default ON
     return v;
 }

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -3,6 +3,7 @@
 #include "hle/memory/guest_memory_topology.hpp"
 #include "gpu/diagnostics/diag_ratelimit.hpp"   // #1761: single-sourced ordinal + sparse-tail rule for capped logs
 #include "gpu/execute/mb3_freelist.hpp"
+#include "diagnostics/env_numeric.hpp"   // #3267: a typo must not switch a default-ON guard off
 #include "gpu/pm4/pm4_registers.hpp"
 #include "gpu/capture/writer_provenance.hpp"
 #include "hle/sync/sync_futex.hpp"   // wake_label_waiters (shared with sceKernelWaitOnAddress's futex)
@@ -1411,8 +1412,11 @@ static bool declines_nonheap_ptr(const char* kind, uint64_t dst, uint64_t pre, u
 // write that would forge a freelist next-pointer (see forges_freelist_ptr), gated to the consumed-
 // marker label population so plain fence labels (Messenger) are untouched.
 static bool forge_guard() {
+    // DEFAULT ON, and it is the #312 ROOT fix -- so `strtol` answering 0 for `=yes`/`=true`/`=on`
+    // silently REMOVED the fix while the operator believed they had pinned it on (#3267).
     static const bool v = [] { const char* e = getenv("PROSPER_REL1_FORGE_GUARD");
-                               return !e || strtol(e, nullptr, 0) != 0; }();   // default ON
+                               return prosper::diag::env_u64_or_default(
+                                   "PROSPER_REL1_FORGE_GUARD", e, 1ull) != 0; }();   // default ON
     return v;
 }
 // #1226 decisive A/B arm: suppress EVERY REL1 write matching forges_freelist_ptr(), including the
@@ -2125,8 +2129,10 @@ bool declines_drifted_pair_release(uint64_t addr, uint64_t value, const char* ki
 // guest already freed the recycled label back to the allocator. Writing our 4-byte 1 over +0 forges
 // 0x10000000_00000001 (or a 0x2001... pool pointer) — the exact #312 fatal family. Suppress it.
 static bool rel1_stomp_guard() {
+    // DEFAULT ON -- same inversion as PROSPER_REL1_FORGE_GUARD, same #312 fatal family (#3267).
     static const bool v = [] { const char* e = getenv("PROSPER_REL1_STOMP_GUARD");
-                               return !e || strtol(e, nullptr, 0) != 0; }();   // default ON
+                               return prosper::diag::env_u64_or_default(
+                                   "PROSPER_REL1_STOMP_GUARD", e, 1ull) != 0; }();   // default ON
     return v;
 }
 // --- #1226 clock-fence provenance: persistent per-address record of 64-bit GPU-clock writes. -----

--- a/prosper/src/hle/input/hle_pad.cpp
+++ b/prosper/src/hle/input/hle_pad.cpp
@@ -15,6 +15,7 @@
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/dispatch/nid.hpp"
 #include "input/pad.hpp"
+#include "diagnostics/env_numeric.hpp"   // #3267: a typo must not make every scripted press zero-length
 #include <algorithm>
 #include <cerrno>
 #include <cstdint>
@@ -273,7 +274,13 @@ extern "C" uint64_t prosper_vo_flip_count();
 std::atomic<uint64_t> g_pad_flip0{std::numeric_limits<uint64_t>::max()};
 
 int64_t pad_frame_hold() {   // how many flips to hold a frame-anchored press (default 8)
-    static const int64_t h = [] { const char* e = getenv("PROSPER_PAD_FRAME_HOLD"); return e ? (int64_t)atoll(e) : 8; }();
+    // A hold of 0 flips is a press the guest can miss entirely, and a route that delivers nothing
+    // looks exactly like a render or progression wall rather than like a mistyped variable (#3267).
+    static const int64_t h = [] {
+        const char* e = getenv("PROSPER_PAD_FRAME_HOLD");
+        return (int64_t)prosper::diag::env_u64_or_default_capped(
+            "PROSPER_PAD_FRAME_HOLD", e, 8ull, INT64_MAX, "flips");
+    }();
     return h;
 }
 
@@ -309,8 +316,10 @@ std::atomic<uint64_t> g_pad_read_count{0};
 
 int64_t pad_read_hold() {
     static const int64_t h = [] {
+        // Same as PROSPER_PAD_FRAME_HOLD: 0 reads is a press nothing observes (#3267).
         const char* e = getenv("PROSPER_PAD_READ_HOLD");
-        return e ? (int64_t)atoll(e) : 8;
+        return (int64_t)prosper::diag::env_u64_or_default_capped(
+            "PROSPER_PAD_READ_HOLD", e, 8ull, INT64_MAX, "reads");
     }();
     return h;
 }

--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -15,6 +15,7 @@
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/dispatch/nid.hpp"
 #include "hle/kernel/sce_errno.hpp"
+#include "diagnostics/env_numeric.hpp"   // #3267: a typo must not remove the fairness yield
 #include "host/image/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "host/image/exec_image.hpp"      // describe_code_address (host frame naming)
 #include "host/platform/immortal.hpp"        // #2613: registries a guest thread can reach after exit()
@@ -950,8 +951,10 @@ uint64_t guest_mutex_unlock_slot(uint64_t slot_addr) {
         // earlier, but below ~300 us the render pump (5.33 ms period) starts winning the re-lock
         // race again and the commit re-starves.
         if (had_waiters) {
-            static const int fair_us = getenv("PROSPER_MUTEX_FAIR_US")
-                                           ? atoi(getenv("PROSPER_MUTEX_FAIR_US")) : 3000;
+            // 0 is not "off" -- sleep_for(0us) returns immediately, so a typo removes the yield
+            // entirely and GRIS's bank commit re-starves against the render pump (#2981, #3267).
+            static const int fair_us = static_cast<int>(prosper::diag::env_u64_or_default_capped(
+                "PROSPER_MUTEX_FAIR_US", getenv("PROSPER_MUTEX_FAIR_US"), 3000ull, INT32_MAX, "us"));
             std::this_thread::sleep_for(std::chrono::microseconds(fair_us));
         }
     }

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -14,6 +14,7 @@
 #endif
 #include "hle/dispatch/dispatch.hpp"
 #include "diagnostics/diag_clock.hpp"
+#include "diagnostics/env_numeric.hpp"   // #3267: -1 here overflowed the MiB multiply
 #include "hle/memory/dmem_caller_chain.hpp"
 #include "hle/memory/guest_memory_topology.hpp"
 #include "hle/dispatch/nid.hpp"
@@ -953,7 +954,12 @@ namespace {
     // cross-title verification of a hardware-truthful default.
     const uint64_t kDmemTotal = [] {
         if (const char* v = getenv("PROSPER_DMEM_BUDGET_MB")) {
-            const uint64_t mib = strtoull(v, nullptr, 10);
+            // `-1` reached UINT64_MAX, and `mib * 1024 * 1024` then WRAPPED -- the guest was handed
+            // a budget nobody chose, on the very path #2934 was about (#3267). Refusing keeps the
+            // 16 GiB default, which is also what a sub-1024 value has always done.
+            const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+                "PROSPER_DMEM_BUDGET_MB", v, 16ull * 1024ull,
+                UINT64_MAX / (1024ull * 1024ull), "MiB");
             if (mib >= 1024) return mib * 1024ull * 1024ull;
         }
         return 16ull * 1024 * 1024 * 1024;
@@ -3968,7 +3974,12 @@ namespace {
     // cross-title verification of a hardware-truthful default.
     const uint64_t kDmemTotal = [] {
         if (const char* v = getenv("PROSPER_DMEM_BUDGET_MB")) {
-            const uint64_t mib = strtoull(v, nullptr, 10);
+            // `-1` reached UINT64_MAX, and `mib * 1024 * 1024` then WRAPPED -- the guest was handed
+            // a budget nobody chose, on the very path #2934 was about (#3267). Refusing keeps the
+            // 16 GiB default, which is also what a sub-1024 value has always done.
+            const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+                "PROSPER_DMEM_BUDGET_MB", v, 16ull * 1024ull,
+                UINT64_MAX / (1024ull * 1024ull), "MiB");
             if (mib >= 1024) return mib * 1024ull * 1024ull;
         }
         return 16ull * 1024 * 1024 * 1024;

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -9,6 +9,7 @@
 #include "hle/util/hle_json2.hpp"
 #include "hle/dispatch/nid.hpp"
 #include "hle/kernel/sce_errno.hpp"   // libkernel error encoding (libSceRandom reject arms)
+#include "diagnostics/env_numeric.hpp"   // #3267: a typo must not unregister a default-ON NID family
 #include "hle/dispatch/callback_fs.hpp"
 #include "hle/input/ime_input.hpp"
 #include "hle/service/platform_ui.hpp"
@@ -5286,8 +5287,11 @@ void register_service_hle() {
     // NetCtl offline-console state delivery — default ON since #306 (see block comment above).
     // PROSPER_NETCTL_CB=0 restores the previous unimplemented behavior.
     {
+        // DEFAULT ON since #306. `strtol` answered 0 for `=yes`/`=true`/`=on`, and the consequence
+        // is not a lost diagnostic: the whole NetCtl NID family goes UNREGISTERED, so the guest gets
+        // the pre-#306 unimplemented behaviour from what the operator read as "enable it" (#3267).
         const char* e = getenv("PROSPER_NETCTL_CB");
-        if (!e || strtol(e, nullptr, 0) != 0) {
+        if (prosper::diag::env_u64_or_default("PROSPER_NETCTL_CB", e, 1ull) != 0) {
             R("sceNetCtlRegisterCallback", s_netctl_register_cb);      // UJ+Z7Q+4ck0
             R("sceNetCtlCheckCallback",    s_netctl_check_cb_entry);   // iQw3iQPhvUQ
             R("sceNetCtlGetState",         s_netctl_getstate);         // uBPlr0lbuiI

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -488,7 +488,11 @@ VdecDump& vdec_dump() {
         const char* dir = getenv("PROSPER_VDEC2_DUMP_DIR");
         if (!dir || !*dir) return;
         if (const char* n = getenv("PROSPER_VDEC2_DUMP_FRAMES")) {
-            const unsigned long parsed = strtoul(n, nullptr, 0);
+            // `if (parsed)` refuses only a value that parses to 0. `=-1` saturated to ULONG_MAX and
+            // lifted the 16-frame cap this block's own comment describes as the difference between
+            // 50 MB and 5 GB on disk. Base 0 was the pre-existing grammar, so keep `0x` (#3267 B1).
+            const uint64_t parsed = prosper::diag::env_u64_or_default_auto_capped(
+                "PROSPER_VDEC2_DUMP_FRAMES", n, 16ull, UINT32_MAX, "frames");
             if (parsed) d.limit = (unsigned)parsed;
         }
         const std::string base(dir);
@@ -5288,10 +5292,12 @@ void register_service_hle() {
     // PROSPER_NETCTL_CB=0 restores the previous unimplemented behavior.
     {
         // DEFAULT ON since #306. `strtol` answered 0 for `=yes`/`=true`/`=on`, and the consequence
-        // is not a lost diagnostic: the whole NetCtl NID family goes UNREGISTERED, so the guest gets
-        // the pre-#306 unimplemented behaviour from what the operator read as "enable it" (#3267).
+        // is not a lost diagnostic: the three callback NIDs guarded here (RegisterCallback,
+        // CheckCallback, GetState) go UNREGISTERED, so the guest gets the pre-#306 unimplemented
+        // behaviour from what the operator read as "enable it". GetInfo and GetResult below are
+        // registered unconditionally and are unaffected (#3267).
         const char* e = getenv("PROSPER_NETCTL_CB");
-        if (prosper::diag::env_u64_or_default("PROSPER_NETCTL_CB", e, 1ull) != 0) {
+        if (prosper::diag::env_u64_or_default_auto("PROSPER_NETCTL_CB", e, 1ull) != 0) {
             R("sceNetCtlRegisterCallback", s_netctl_register_cb);      // UJ+Z7Q+4ck0
             R("sceNetCtlCheckCallback",    s_netctl_check_cb_entry);   // iQw3iQPhvUQ
             R("sceNetCtlGetState",         s_netctl_getstate);         // uBPlr0lbuiI

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -1166,7 +1166,8 @@ GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
         // filed about (#3267).
         const char* value = std::getenv("PROSPER_WRITE_WATCH_MAX_KB");
         const uint64_t kib = prosper::diag::env_u64_or_default_capped(
-            "PROSPER_WRITE_WATCH_MAX_KB", value, 0ull, UINT64_MAX / 1024ull, "KiB");
+            "PROSPER_WRITE_WATCH_MAX_KB", value, 0ull, UINT64_MAX / 1024ull, "KiB",
+            "unbounded: no range is too large to watch");
         if (!kib) return uint64_t{UINT64_MAX};
         return uint64_t{kib * 1024ull};
     }();

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -1,5 +1,6 @@
 #include "host/memory/guest_write_watch.hpp"
 #include "host/memory/guest_memory_map.hpp"   // #2393: the guest-page-protection generation invariant
+#include "diagnostics/env_numeric.hpp"        // #3267: a typo must not silently unbound this limit
 
 #include <algorithm>
 #include <atomic>
@@ -1159,10 +1160,15 @@ GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
     // exact byte-comparison fallback (and can register millions of pages while a level loads). Keep
     // dirty tracking for ranges where it amortizes; zero makes the diagnostic limit unbounded.
     static const uint64_t max_watch_bytes = [] {
+        // 0 is not "off" here -- it is the MOST permissive setting, so a bare strtoull would turn
+        // `=8mb` or `=eight` into "no limit at all" while the operator believed they had capped the
+        // watch. That is #3253's shape exactly, in the write-watch implementation the issue was
+        // filed about (#3267).
         const char* value = std::getenv("PROSPER_WRITE_WATCH_MAX_KB");
-        const uint64_t kib = value ? std::strtoull(value, nullptr, 10) : 0ull;
+        const uint64_t kib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_WRITE_WATCH_MAX_KB", value, 0ull, UINT64_MAX / 1024ull, "KiB");
         if (!kib) return uint64_t{UINT64_MAX};
-        return kib > UINT64_MAX / 1024ull ? uint64_t{UINT64_MAX} : uint64_t{kib * 1024ull};
+        return uint64_t{kib * 1024ull};
     }();
     if (watch_bytes > max_watch_bytes) {
         bump(stats().create_oversized);

--- a/prosper/tests/diagnostics/test_env_numeric_sites.cpp
+++ b/prosper/tests/diagnostics/test_env_numeric_sites.cpp
@@ -67,7 +67,8 @@ struct Site {
 // --- src/host/memory/guest_write_watch.cpp : PROSPER_WRITE_WATCH_MAX_KB ------------------------
 // 0 means UNBOUNDED here, so a malformed value used to remove the cap entirely.
 static uint64_t ww_max_new(const char* n, const char* t) {
-    const uint64_t kib = env_u64_or_default_capped(n, t, 0ull, UINT64_MAX / 1024ull, "KiB");
+    const uint64_t kib = env_u64_or_default_capped(n, t, 0ull, UINT64_MAX / 1024ull, "KiB",
+                                                   "unbounded: no range is too large to watch");
     return kib ? kib * 1024ull : UINT64_MAX;
 }
 static uint64_t ww_max_old(const char* t) {
@@ -114,7 +115,7 @@ static uint64_t arena_old(const char* t) {
 
 // --- tests/fixtures/render_runner.h : PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES --------------------
 static uint64_t layout_entries_new(const char* n, const char* t) {
-    return env_u64_or_default_capped(n, t, 256ull, UINT64_MAX, "entries");
+    return env_u64_or_default_capped(n, t, 256ull, SIZE_MAX, "entries");
 }
 static uint64_t layout_entries_old(const char* t) {
     return t ? std::strtoull(t, nullptr, 10) : 256ull;
@@ -140,7 +141,8 @@ static uint64_t dmem_old(const char* t) {
 // only ever set in order to impose a cap.
 static uint64_t dispatch_cap_new(const char* n, const char* t) {
     if (!t || !*t) return 0;
-    return env_u64_or_default_capped(n, t, 0ull, UINT32_MAX, "workgroups");
+    return prosper::diag::env_u64_or_default_auto_capped(n, t, 0ull, UINT32_MAX, "workgroups",
+                                                         "no cap: nothing is bounded");
 }
 static uint64_t dispatch_cap_old(const char* t) {
     return t && *t ? static_cast<uint32_t>(std::strtoul(t, nullptr, 0)) : 0u;
@@ -152,7 +154,7 @@ static uint64_t dispatch_cap_old(const char* t) {
 // inversion is the whole finding: `=yes`, `=true` and `=on` are what a person types to make a
 // default-ON switch explicit, and strtol answers 0 for every one of them -- i.e. OFF.
 static uint64_t default_on_new(const char* n, const char* t) {
-    return env_u64_or_default(n, t, 1ull) != 0 ? 1 : 0;
+    return prosper::diag::env_u64_or_default_auto(n, t, 1ull) != 0 ? 1 : 0;
 }
 static uint64_t default_on_old(const char* t) {
     return (!t || std::strtol(t, nullptr, 0) != 0) ? 1 : 0;
@@ -165,8 +167,11 @@ static uint64_t fair_us_new(const char* n, const char* t) {
 static uint64_t fair_us_old(const char* t) { return t ? (uint64_t)(unsigned)std::atoi(t) : 3000ull; }
 
 // --- src/hle/input/hle_pad.cpp : PROSPER_PAD_FRAME_HOLD / PROSPER_PAD_READ_HOLD ----------------
-static uint64_t pad_hold_new(const char* n, const char* t) {
-    return env_u64_or_default_capped(n, t, 8ull, INT64_MAX, "presses");
+static uint64_t pad_frame_hold_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 8ull, INT64_MAX, "flips");
+}
+static uint64_t pad_read_hold_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 8ull, INT64_MAX, "reads");
 }
 static uint64_t pad_hold_old(const char* t) { return t ? (uint64_t)std::atoll(t) : 8ull; }
 
@@ -188,11 +193,62 @@ static uint64_t kib_cap_old(uint64_t dflt, const char* t) {
 static uint64_t kib_1024_old(const char* t) { return kib_cap_old(1024ull, t); }
 static uint64_t kib_8192_old(const char* t) { return kib_cap_old(8192ull, t); }
 template <uint64_t Default>
+static uint64_t mib_cap_size_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, Default, SIZE_MAX / (1024ull * 1024ull), "MiB")
+           * 1024ull * 1024ull;
+}
+template <uint64_t Default>
 static uint64_t hits_new(const char* n, const char* t) {
     return env_u64_or_default_capped(n, t, Default, UINT32_MAX, "unchanged validations");
 }
 template <uint64_t Default>
 static uint64_t hits_old(const char* t) { return t ? std::strtoull(t, nullptr, 10) : Default; }
+
+// --- tests/fixtures/render_runner.h : PROSPER_BACKEND_TARGET_CACHE_COUNT (#3267 B1) -------------
+// `n ? n : 256` refused a value parsing to 0 and nothing else, so `=-1` saturated, stayed non-zero,
+// and removed the resident-target count bound outright.
+static uint64_t target_count_new(const char* n, const char* t) {
+    const uint64_t v = env_u64_or_default_capped(n, t, 256ull, SIZE_MAX, "targets");
+    return v ? v : 256ull;
+}
+static uint64_t target_count_old(const char* t) {
+    const uint64_t v = t ? std::strtoull(t, nullptr, 10) : 256ull;
+    return v ? v : 256ull;
+}
+
+// --- src/hle/service/hle_service.cpp : PROSPER_VDEC2_DUMP_FRAMES (#3267 B1) ---------------------
+// Same shape, and the bound it lost is a DISK bound: the site's own comment puts the 16-frame cap
+// at 50 MB against 5 GB uncapped.
+static uint64_t vdec_frames_new(const char* n, const char* t) {
+    const uint64_t v = prosper::diag::env_u64_or_default_auto_capped(n, t, 16ull, UINT32_MAX,
+                                                                     "frames");
+    return v ? v : 16ull;
+}
+static uint64_t vdec_frames_old(const char* t) {
+    const uint64_t v = t ? std::strtoul(t, nullptr, 0) : 0ull;
+    return v ? v : 16ull;
+}
+
+// --- frontends/shared/live/live_compute.cpp : PROSPER_COMPUTE_IMAGE_CACHE_MB (#3267 N2) ---------
+// The one converted site whose refusal falls back to a CODE PATH rather than a number: unset means
+// "derive the budget from device memory". kSentinelDerived stands for that path so the arm can be
+// expressed in the same uint64_t table as the rest.
+static const uint64_t kSentinelDerived = ~0ull - 1ull;
+static uint64_t image_cache_new(const char* n, const char* t) {
+    uint64_t mib = 0;
+    if (!prosper::diag::env_u64_or_report(n, t, &mib, "MiB", "the device-derived budget"))
+        return kSentinelDerived;
+    if (mib > UINT64_MAX / (1024ull * 1024ull)) return UINT64_MAX;
+    return mib * 1024ull * 1024ull;
+}
+static uint64_t image_cache_old(const char* t) {
+    // The pre-image had no empty-string check either, so `=""` reached strtoull and selected a
+    // ZERO-byte image cache. That half is a fix too, and this mirror keeps it visible.
+    if (!t) return kSentinelDerived;
+    const uint64_t mib = std::strtoull(t, nullptr, 10);
+    if (mib > UINT64_MAX / (1024ull * 1024ull)) return UINT64_MAX;
+    return mib * 1024ull * 1024ull;
+}
 
 static const uint64_t kMiB = 1024ull * 1024ull;
 static const uint64_t kGiB = 1024ull * kMiB;
@@ -200,9 +256,12 @@ static const uint64_t kGiB = 1024ull * kMiB;
 static const Site kSites[] = {
     // A malformed value used to make the cap 1024x TIGHTER than asked for -- which on this knob
     // means "watch essentially nothing", since every range above 8 KiB is then refused a watch.
-    // NOTE the `-1` case is deliberately absent: strtoull saturates it and the saturation is then
-    // clamped back to UINT64_MAX, which is also what the refusal keeps, so an arm on it would be
-    // void rather than green (this file's own rule, applied to itself).
+    // TWO malformed inputs are deliberately absent, for the same reason: `-1` saturates and is then
+    // clamped back to UINT64_MAX, and `eight` parses to 0 which IS this knob's default -- in both
+    // cases the old spelling already answered what the refusal keeps, so an arm would be void
+    // rather than green (this file's own rule, applied to itself). On those inputs the change here
+    // is the MESSAGE alone, and the same is true of PROSPER_MAX_DISPATCH_GROUPS below; both say so
+    // in their refusal, which is why both pass a gloss naming what their 0 means.
     {"guest_write_watch.cpp PROSPER_WRITE_WATCH_MAX_KB", "PROSPER_WRITE_WATCH_MAX_KB",
      ww_max_new, ww_max_old,
      "8mb", UINT64_MAX /* the documented 0 == unbounded default */, "65536", 65536ull * 1024ull},
@@ -259,9 +318,29 @@ static const Site kSites[] = {
      fair_us_new, fair_us_old, "3ms", 3000ull, "500", 500ull},
 
     {"hle_pad.cpp PROSPER_PAD_FRAME_HOLD", "PROSPER_PAD_FRAME_HOLD",
-     pad_hold_new, pad_hold_old, "16 flips", 8ull, "16", 16ull},
+     pad_frame_hold_new, pad_hold_old, "16 flips", 8ull, "16", 16ull},
     {"hle_pad.cpp PROSPER_PAD_READ_HOLD", "PROSPER_PAD_READ_HOLD",
-     pad_hold_new, pad_hold_old, "-1", 8ull, "4", 4ull},
+     pad_read_hold_new, pad_hold_old, "-1", 8ull, "4", 4ull},
+
+    {"render_runner.h PROSPER_BACKEND_TARGET_CACHE_COUNT", "PROSPER_BACKEND_TARGET_CACHE_COUNT",
+     target_count_new, target_count_old, "-1", 256ull, "512", 512ull},
+    {"hle_service.cpp PROSPER_VDEC2_DUMP_FRAMES", "PROSPER_VDEC2_DUMP_FRAMES",
+     vdec_frames_new, vdec_frames_old, "-1", 16ull, "0x40", 64ull},
+    {"live_compute.cpp PROSPER_COMPUTE_IMAGE_CACHE_MB", "PROSPER_COMPUTE_IMAGE_CACHE_MB",
+     image_cache_new, image_cache_old, "512mb", kSentinelDerived, "512", 512ull * kMiB},
+    {"live_compute.cpp PROSPER_COMPUTE_IMAGE_CACHE_MB (empty string)",
+     "PROSPER_COMPUTE_IMAGE_CACHE_MB", image_cache_new, image_cache_old,
+     "", kSentinelDerived, "1", 1ull * kMiB},
+
+    // N1: `0x…` was well-formed at these six before the conversion, because they read base 0. The
+    // `good` column is the regression: if the _auto family is ever narrowed back to decimal, these
+    // fail. On PROSPER_MAX_DISPATCH_GROUPS refusing `0x2000` would mean NO CAP, i.e. this PR's own
+    // hazard class introduced by the fix for it.
+    {"gpu_executor.cpp PROSPER_MAX_DISPATCH_GROUPS (base-0 spelling kept)",
+     "PROSPER_MAX_DISPATCH_GROUPS", dispatch_cap_new, dispatch_cap_old,
+     "0x2000 groups", 0ull, "0x2000", 8192ull},
+    {"command_processor.cpp PROSPER_REL1_FORGE_GUARD (base-0 off kept)",
+     "PROSPER_REL1_FORGE_GUARD", default_on_new, default_on_old, "0xzz", 1, "0x0", 0},
 
     // #3253's own six, plus the two the same PR added. Every fallback below is that site's
     // documented default; every legacy answer below is the aggressive end of its own policy.
@@ -274,19 +353,19 @@ static const Site kSites[] = {
      "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS", hits_new<3>, hits_old<3>,
      "three", 3ull, "5", 5ull},
     {"live_renderer.cpp PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB",
-     "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", mib_cap_new<8>, mib_cap_old<8>,
+     "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", mib_cap_size_new<8>, mib_cap_old<8>,
      "64mb", 8ull * kMiB, "16", 16ull * kMiB},
     {"live_compute.cpp PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS",
      "PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS", hits_new<3>, hits_old<3>,
      "-1", 3ull, "7", 7ull},
     {"live_compute.cpp PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB",
-     "PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB", mib_cap_new<8>, mib_cap_old<8>,
+     "PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB", mib_cap_size_new<8>, mib_cap_old<8>,
      "eight", 8ull * kMiB, "32", 32ull * kMiB},
     {"live_compute.cpp PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB",
-     "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB", mib_cap_new<16>, mib_cap_old<16>,
+     "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB", mib_cap_size_new<16>, mib_cap_old<16>,
      "64 MB", 16ull * kMiB, "64", 64ull * kMiB},
     {"live_compute.cpp PROSPER_MAX_GPU_COMPARE_IMAGE_MB", "PROSPER_MAX_GPU_COMPARE_IMAGE_MB",
-     mib_cap_new<2>, mib_cap_old<2>, "32mb", 2ull * kMiB, "8", 8ull * kMiB},
+     mib_cap_size_new<2>, mib_cap_old<2>, "32mb", 2ull * kMiB, "8", 8ull * kMiB},
 };
 int main() {
     char msg[512];

--- a/prosper/tests/diagnostics/test_env_numeric_sites.cpp
+++ b/prosper/tests/diagnostics/test_env_numeric_sites.cpp
@@ -1,0 +1,323 @@
+// test_env_numeric_sites — one arm per PROSPER_* knob converted to the strict parser by #3267.
+//
+// WHY THIS SHAPE, AND WHY IT IS NOT A TEST OF THE HELPER. `parse_u64_strict` and
+// `env_u64_or_default*` are already pinned by frontends/shared/tests/test_write_watch_policy.cpp.
+// What that file cannot say is whether a given CALL SITE passes the right fallback and the right
+// cap, and that is where the defect this issue is about actually lives: the helper is correct and
+// the site still selects a dangerous setting if its fallback is wrong.
+//
+// So each arm below reproduces ONE site's arithmetic twice -- once as the site is written now
+// (`converted`), once as it was written before (`legacy`) -- and asserts:
+//
+//   converted(malformed) == expected   the refusal keeps the DEFAULT
+//   legacy(malformed)    != expected   ...and the old spelling did NOT, i.e. the site really was
+//                                      one of the 169, so the arm is not vacuously green
+//   converted(good)      == the parsed setting, so the refusal did not break the knob
+//
+// The second condition is the one that earns the arm. Without it a site that was ALREADY safe --
+// there are 23 such in the census, guarded by a range check or a `> 0` -- would produce an
+// identical-looking pass, and this file would then be asserting a property it never exercised.
+//
+// WHY THE ENVIRONMENT IS NEVER TOUCHED. Almost every converted site caches its read in a
+// function-local `static`, so a test that armed the variable with setenv and then called the site
+// would go VACUOUS rather than red once the static was already initialised (#2214, and
+// tools/env/check_cached_env.py is the gate for it). These arms therefore pass the TEXT directly to
+// the same helper call the site makes, which is a pure function of its arguments. No PROSPER_*
+// variable is set, unset or read here.
+//
+// WHAT THIS THEREFORE DOES NOT PIN, stated plainly because the limitation is the price of the shape
+// above: each arm mirrors its site rather than calling it, so it asserts the CONTRACT (which helper,
+// which fallback, which cap) and not the WIRING. A site edited to pass a different fallback while
+// its arm here stays put would not redden. tools/env/check_env_numeric_arms.py closes the half of
+// that gap which is mechanically checkable -- it fails if a knob is parsed through env_numeric with
+// no arm here, or armed here with no call site left -- and it is registered as `env_numeric_arms`.
+// The remaining gap is a fallback VALUE changed at one end only, which stays a review matter.
+//
+// The expected values are the sites' documented defaults; if a default is deliberately changed, the
+// arm here must change with it, which is the point.
+#include "diagnostics/env_numeric.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <climits>
+
+using prosper::diag::env_u64_or_default;
+using prosper::diag::env_u64_or_default_capped;
+using prosper::diag::parse_u64_strict;
+
+static int fails = 0;
+static void check(bool ok, const char* what) {
+    std::printf("%s %s\n", ok ? "[ok]  " : "[FAIL]", what);
+    if (!ok) ++fails;
+}
+
+// One census row: the site's own arithmetic, before and after.
+struct Site {
+    const char* where;        // file + knob, so a failure names the line to open
+    const char* name;         // the real variable name, so the refusal on stderr is the real one
+    uint64_t (*converted)(const char* name, const char* text);
+    uint64_t (*legacy)(const char* text);
+    const char* malformed;    // the input a person plausibly types
+    uint64_t expected;        // what the converted site must answer for it
+    const char* good;         // a well-formed value...
+    uint64_t good_expected;   // ...and what it must still select
+};
+
+// --- src/host/memory/guest_write_watch.cpp : PROSPER_WRITE_WATCH_MAX_KB ------------------------
+// 0 means UNBOUNDED here, so a malformed value used to remove the cap entirely.
+static uint64_t ww_max_new(const char* n, const char* t) {
+    const uint64_t kib = env_u64_or_default_capped(n, t, 0ull, UINT64_MAX / 1024ull, "KiB");
+    return kib ? kib * 1024ull : UINT64_MAX;
+}
+static uint64_t ww_max_old(const char* t) {
+    const uint64_t kib = t ? std::strtoull(t, nullptr, 10) : 0ull;
+    if (!kib) return UINT64_MAX;
+    return kib > UINT64_MAX / 1024ull ? UINT64_MAX : kib * 1024ull;
+}
+
+// --- frontends/shared/live/live_renderer.cpp : PROSPER_ARRAY_DECODE_BUDGET_MIB -----------------
+static uint64_t array_budget_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 1024ull, UINT64_MAX >> 20, "MiB") << 20;
+}
+static uint64_t array_budget_old(const char* t) {
+    return static_cast<uint64_t>(t ? std::atoll(t) : 1024) << 20;
+}
+
+// --- a byte cap expressed in MiB, the shape shared by six sites --------------------------------
+// live_compute.cpp (BUFFER_CACHE_MB 256, MEMORY_POOL_MB 640) and render_runner.h
+// (BACKEND_TARGET_CACHE_MB 256, BACKEND_TEXTURE_CACHE_MB 1024, MEMORY_POOL_MB 512).
+template <uint64_t Default>
+static uint64_t mib_cap_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, Default, UINT64_MAX / (1024ull * 1024ull), "MiB")
+           * 1024ull * 1024ull;
+}
+template <uint64_t Default>
+static uint64_t mib_cap_old(const char* t) {
+    const uint64_t mib = t ? std::strtoull(t, nullptr, 10) : Default;
+    if (mib > UINT64_MAX / (1024ull * 1024ull)) return UINT64_MAX;
+    return mib * 1024ull * 1024ull;
+}
+
+// --- tests/fixtures/render_runner.h : PROSPER_BACKEND_BUFFER_ARENA_KB --------------------------
+static uint64_t arena_new(const char* n, const char* t) {
+    const uint64_t kib = env_u64_or_default_capped(n, t, 1024ull, UINT64_MAX / 1024ull, "KiB");
+    const uint64_t bytes = kib * 1024ull;
+    return bytes < 4 ? 4 : bytes;
+}
+static uint64_t arena_old(const char* t) {
+    const uint64_t kib = t ? std::strtoull(t, nullptr, 10) : 1024ull;
+    if (kib > UINT64_MAX / 1024ull) return UINT64_MAX;
+    const uint64_t bytes = kib * 1024ull;
+    return bytes < 4 ? 4 : bytes;
+}
+
+// --- tests/fixtures/render_runner.h : PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES --------------------
+static uint64_t layout_entries_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 256ull, UINT64_MAX, "entries");
+}
+static uint64_t layout_entries_old(const char* t) {
+    return t ? std::strtoull(t, nullptr, 10) : 256ull;
+}
+
+// --- src/hle/memory/hle_kernel_mem.cpp : PROSPER_DMEM_BUDGET_MB --------------------------------
+// The `>= 1024` floor already refused small typos; what it could not refuse was `-1`, which
+// saturated and then WRAPPED the MiB multiply.
+static uint64_t dmem_new(const char* n, const char* t) {
+    const uint64_t mib = env_u64_or_default_capped(n, t, 16ull * 1024ull,
+                                                   UINT64_MAX / (1024ull * 1024ull), "MiB");
+    if (mib >= 1024) return mib * 1024ull * 1024ull;
+    return 16ull * 1024 * 1024 * 1024;
+}
+static uint64_t dmem_old(const char* t) {
+    const uint64_t mib = t ? std::strtoull(t, nullptr, 10) : 0ull;
+    if (mib >= 1024) return mib * 1024ull * 1024ull;   // wraps for UINT64_MAX
+    return 16ull * 1024 * 1024 * 1024;
+}
+
+// --- src/gpu/execute/gpu_executor.cpp : PROSPER_MAX_DISPATCH_GROUPS ----------------------------
+// Unset is 0 = "no cap", which is the right default and the wrong answer to a typo: the knob is
+// only ever set in order to impose a cap.
+static uint64_t dispatch_cap_new(const char* n, const char* t) {
+    if (!t || !*t) return 0;
+    return env_u64_or_default_capped(n, t, 0ull, UINT32_MAX, "workgroups");
+}
+static uint64_t dispatch_cap_old(const char* t) {
+    return t && *t ? static_cast<uint32_t>(std::strtoul(t, nullptr, 0)) : 0u;
+}
+
+// --- the four default-ON guards ----------------------------------------------------------------
+// PROSPER_REL1_FORGE_GUARD, PROSPER_REL1_STOMP_GUARD, PROSPER_MB3_CENTRAL_SCAN,
+// PROSPER_MB3_TRACK_TLS and PROSPER_NETCTL_CB all read `!e || strtol(e, nullptr, 0) != 0`. The
+// inversion is the whole finding: `=yes`, `=true` and `=on` are what a person types to make a
+// default-ON switch explicit, and strtol answers 0 for every one of them -- i.e. OFF.
+static uint64_t default_on_new(const char* n, const char* t) {
+    return env_u64_or_default(n, t, 1ull) != 0 ? 1 : 0;
+}
+static uint64_t default_on_old(const char* t) {
+    return (!t || std::strtol(t, nullptr, 0) != 0) ? 1 : 0;
+}
+
+// --- src/hle/kernel/hle_kernel.cpp : PROSPER_MUTEX_FAIR_US -------------------------------------
+static uint64_t fair_us_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 3000ull, INT_MAX, "us");
+}
+static uint64_t fair_us_old(const char* t) { return t ? (uint64_t)(unsigned)std::atoi(t) : 3000ull; }
+
+// --- src/hle/input/hle_pad.cpp : PROSPER_PAD_FRAME_HOLD / PROSPER_PAD_READ_HOLD ----------------
+static uint64_t pad_hold_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 8ull, INT64_MAX, "presses");
+}
+static uint64_t pad_hold_old(const char* t) { return t ? (uint64_t)std::atoll(t) : 8ull; }
+
+
+// --- the six knobs #3253 converted, plus its two siblings ---------------------------------------
+// These were already strict before this file existed; the arms are here because
+// tools/env/check_env_numeric_arms.py requires one per parsed knob, and because #3253 pinned the
+// HELPER's grammar without pinning any individual site's fallback. Their sentinels are the sharpest
+// in the tree: on every one of them 0 is the MOST aggressive setting, not "off".
+static uint64_t kib_cap_1024(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 1024ull, SIZE_MAX / 1024ull, "KiB") * 1024ull;
+}
+static uint64_t kib_cap_8192(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 8192ull, SIZE_MAX / 1024ull, "KiB") * 1024ull;
+}
+static uint64_t kib_cap_old(uint64_t dflt, const char* t) {
+    return (t ? std::strtoull(t, nullptr, 10) : dflt) * 1024ull;
+}
+static uint64_t kib_1024_old(const char* t) { return kib_cap_old(1024ull, t); }
+static uint64_t kib_8192_old(const char* t) { return kib_cap_old(8192ull, t); }
+template <uint64_t Default>
+static uint64_t hits_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, Default, UINT32_MAX, "unchanged validations");
+}
+template <uint64_t Default>
+static uint64_t hits_old(const char* t) { return t ? std::strtoull(t, nullptr, 10) : Default; }
+
+static const uint64_t kMiB = 1024ull * 1024ull;
+static const uint64_t kGiB = 1024ull * kMiB;
+
+static const Site kSites[] = {
+    // A malformed value used to make the cap 1024x TIGHTER than asked for -- which on this knob
+    // means "watch essentially nothing", since every range above 8 KiB is then refused a watch.
+    // NOTE the `-1` case is deliberately absent: strtoull saturates it and the saturation is then
+    // clamped back to UINT64_MAX, which is also what the refusal keeps, so an arm on it would be
+    // void rather than green (this file's own rule, applied to itself).
+    {"guest_write_watch.cpp PROSPER_WRITE_WATCH_MAX_KB", "PROSPER_WRITE_WATCH_MAX_KB",
+     ww_max_new, ww_max_old,
+     "8mb", UINT64_MAX /* the documented 0 == unbounded default */, "65536", 65536ull * 1024ull},
+    {"guest_write_watch.cpp PROSPER_WRITE_WATCH_MAX_KB (spaced unit)",
+     "PROSPER_WRITE_WATCH_MAX_KB", ww_max_new, ww_max_old,
+     "64 MB", UINT64_MAX, "1", 1024ull},
+
+    // A malformed value used to make the decode budget effectively unbounded, or 1024x too small.
+    {"live_renderer.cpp PROSPER_ARRAY_DECODE_BUDGET_MIB", "PROSPER_ARRAY_DECODE_BUDGET_MIB",
+     array_budget_new, array_budget_old, "-1", 1024ull << 20, "2048", 2048ull << 20},
+    {"live_renderer.cpp PROSPER_ARRAY_DECODE_BUDGET_MIB (unit suffix)",
+     "PROSPER_ARRAY_DECODE_BUDGET_MIB", array_budget_new, array_budget_old,
+     "1gib", 1024ull << 20, "512", 512ull << 20},
+
+    {"live_compute.cpp PROSPER_COMPUTE_BUFFER_CACHE_MB", "PROSPER_COMPUTE_BUFFER_CACHE_MB",
+     mib_cap_new<256>, mib_cap_old<256>, "-1", 256ull * kMiB, "512", 512ull * kMiB},
+    {"live_compute.cpp PROSPER_COMPUTE_MEMORY_POOL_MB", "PROSPER_COMPUTE_MEMORY_POOL_MB",
+     mib_cap_new<640>, mib_cap_old<640>, "1gb", 640ull * kMiB, "1024", 1024ull * kMiB},
+    {"render_runner.h PROSPER_BACKEND_TARGET_CACHE_MB", "PROSPER_BACKEND_TARGET_CACHE_MB",
+     mib_cap_new<256>, mib_cap_old<256>, "1gb", 256ull * kMiB, "128", 128ull * kMiB},
+    {"render_runner.h PROSPER_BACKEND_TEXTURE_CACHE_MB", "PROSPER_BACKEND_TEXTURE_CACHE_MB",
+     mib_cap_new<1024>, mib_cap_old<1024>, "eight", 1024ull * kMiB, "2048", 2048ull * kMiB},
+    {"render_runner.h PROSPER_MEMORY_POOL_MB", "PROSPER_MEMORY_POOL_MB",
+     mib_cap_new<512>, mib_cap_old<512>, "-1", 512ull * kMiB, "256", 256ull * kMiB},
+
+    {"render_runner.h PROSPER_BACKEND_BUFFER_ARENA_KB", "PROSPER_BACKEND_BUFFER_ARENA_KB",
+     arena_new, arena_old, "4mb", 1024ull * 1024ull, "2048", 2048ull * 1024ull},
+    {"render_runner.h PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES",
+     "PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES", layout_entries_new, layout_entries_old,
+     "512 entries", 256ull, "512", 512ull},
+
+    {"hle_kernel_mem.cpp PROSPER_DMEM_BUDGET_MB", "PROSPER_DMEM_BUDGET_MB",
+     dmem_new, dmem_old, "-1", 16ull * kGiB, "8192", 8192ull * kMiB},
+
+    {"gpu_executor.cpp PROSPER_MAX_DISPATCH_GROUPS", "PROSPER_MAX_DISPATCH_GROUPS",
+     dispatch_cap_new, dispatch_cap_old,
+     "750,000", 0ull /* refused: no cap, but the refusal SAYS so instead of capping at 750 */,
+     "65536", 65536ull},
+
+    // The default-ON family. One arm per spelling a person actually types to make a default
+    // explicit -- every one of which strtol answers 0 for, i.e. OFF.
+    {"command_processor.cpp PROSPER_REL1_FORGE_GUARD", "PROSPER_REL1_FORGE_GUARD",
+     default_on_new, default_on_old, "yes", 1, "0", 0},
+    {"command_processor.cpp PROSPER_REL1_STOMP_GUARD", "PROSPER_REL1_STOMP_GUARD",
+     default_on_new, default_on_old, "on", 1, "1", 1},
+    {"mb3_freelist.cpp PROSPER_MB3_CENTRAL_SCAN", "PROSPER_MB3_CENTRAL_SCAN",
+     default_on_new, default_on_old, "true", 1, "0", 0},
+    {"mb3_freelist.cpp PROSPER_MB3_TRACK_TLS", "PROSPER_MB3_TRACK_TLS",
+     default_on_new, default_on_old, "enabled", 1, "0", 0},
+    {"hle_service.cpp PROSPER_NETCTL_CB", "PROSPER_NETCTL_CB",
+     default_on_new, default_on_old, "yes", 1, "0", 0},
+
+    {"hle_kernel.cpp PROSPER_MUTEX_FAIR_US", "PROSPER_MUTEX_FAIR_US",
+     fair_us_new, fair_us_old, "3ms", 3000ull, "500", 500ull},
+
+    {"hle_pad.cpp PROSPER_PAD_FRAME_HOLD", "PROSPER_PAD_FRAME_HOLD",
+     pad_hold_new, pad_hold_old, "16 flips", 8ull, "16", 16ull},
+    {"hle_pad.cpp PROSPER_PAD_READ_HOLD", "PROSPER_PAD_READ_HOLD",
+     pad_hold_new, pad_hold_old, "-1", 8ull, "4", 4ull},
+
+    // #3253's own six, plus the two the same PR added. Every fallback below is that site's
+    // documented default; every legacy answer below is the aggressive end of its own policy.
+    {"live_renderer.cpp PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB",
+     "PROSPER_TEXTURE_WRITE_WATCH_DEFER_MIN_KB", kib_cap_8192, kib_8192_old,
+     "8mb", 8192ull * 1024ull, "4096", 4096ull * 1024ull},
+    {"live_renderer.cpp PROSPER_TEXTURE_WRITE_WATCH_MIN_KB", "PROSPER_TEXTURE_WRITE_WATCH_MIN_KB",
+     kib_cap_1024, kib_1024_old, "1mb", 1024ull * 1024ull, "512", 512ull * 1024ull},
+    {"live_renderer.cpp PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS",
+     "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_HITS", hits_new<3>, hits_old<3>,
+     "three", 3ull, "5", 5ull},
+    {"live_renderer.cpp PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB",
+     "PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB", mib_cap_new<8>, mib_cap_old<8>,
+     "64mb", 8ull * kMiB, "16", 16ull * kMiB},
+    {"live_compute.cpp PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS",
+     "PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS", hits_new<3>, hits_old<3>,
+     "-1", 3ull, "7", 7ull},
+    {"live_compute.cpp PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB",
+     "PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB", mib_cap_new<8>, mib_cap_old<8>,
+     "eight", 8ull * kMiB, "32", 32ull * kMiB},
+    {"live_compute.cpp PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB",
+     "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB", mib_cap_new<16>, mib_cap_old<16>,
+     "64 MB", 16ull * kMiB, "64", 64ull * kMiB},
+    {"live_compute.cpp PROSPER_MAX_GPU_COMPARE_IMAGE_MB", "PROSPER_MAX_GPU_COMPARE_IMAGE_MB",
+     mib_cap_new<2>, mib_cap_old<2>, "32mb", 2ull * kMiB, "8", 8ull * kMiB},
+};
+int main() {
+    char msg[512];
+    for (const Site& s : kSites) {
+        const uint64_t got = s.converted(s.name, s.malformed);
+        std::snprintf(msg, sizeof msg, "%s: '%s' keeps the default", s.where, s.malformed);
+        check(got == s.expected, msg);
+
+        // The discriminator. If this fails, the site did not need converting and the arm above
+        // proved nothing.
+        const uint64_t was = s.legacy(s.malformed);
+        std::snprintf(msg, sizeof msg,
+                      "%s: ...and the old spelling did NOT (it selected a different setting)",
+                      s.where);
+        check(was != s.expected, msg);
+
+        const uint64_t good = s.converted(s.name, s.good);
+        std::snprintf(msg, sizeof msg, "%s: '%s' still selects the value asked for", s.where,
+                      s.good);
+        check(good == s.good_expected, msg);
+    }
+
+    // Two properties of the shared grammar that every arm above depends on, asserted once here so a
+    // failure points at the helper rather than at twenty sites.
+    uint64_t parsed = 12345;
+    check(!parse_u64_strict("-1", &parsed) && parsed == 12345,
+          "control: a refusal leaves the caller's variable untouched");
+    check(env_u64_or_default("PROSPER_UNUSED_IN_TREE", nullptr, 7ull) == 7ull &&
+          env_u64_or_default("PROSPER_UNUSED_IN_TREE", "", 7ull) == 7ull,
+          "control: unset and empty take the default in silence, and are not typos");
+
+    std::printf(fails ? "== FAILURES: %d ==\n" : "== all passed (%d failures) ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -10,6 +10,7 @@
 #include "gpu/diagnostics/diagnostic_selectors.hpp"
 #include "gpu/diagnostics/geometry_probe_arming.hpp"
 #include "diagnostics/env_cache.hpp"       // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
+#include "diagnostics/env_numeric.hpp"     // #3267: a typo must not silently re-size a cache
 #include "gpu/state/render_state.hpp"
 #include "gpu/resources/shader_resources.hpp"
 #include "host/platform/gpu_submit_gate.hpp"   // refuse submits once the frontend shuts down (#3225)
@@ -881,8 +882,11 @@ inline bool persistent_pipeline_layout_cache_enabled() {
 
 inline size_t persistent_pipeline_layout_cache_limit() {
     static const size_t limit = [] {
+        // 0 entries is not "off" -- it evicts on every miss, so a typo turns the cache into a
+        // per-draw create/destroy loop that looks like a renderer regression (#3267).
         const char* value = getenv("PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES");
-        return value ? static_cast<size_t>(strtoull(value, nullptr, 10)) : size_t{256};
+        return static_cast<size_t>(prosper::diag::env_u64_or_default_capped(
+            "PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES", value, 256ull, SIZE_MAX, "entries"));
     }();
     return limit;
 }
@@ -2136,8 +2140,9 @@ inline VkDeviceSize persistent_color_target_limit() {
     static const bool have_env = getenv("PROSPER_BACKEND_TARGET_CACHE_MB") != nullptr;
     static const VkDeviceSize env_limit = []() -> VkDeviceSize {
         const char* value = getenv("PROSPER_BACKEND_TARGET_CACHE_MB");
-        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
-        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_BACKEND_TARGET_CACHE_MB", value, 256ull,
+            UINT64_MAX / (1024ull * 1024ull), "MiB");
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
     if (have_env) return env_limit;
@@ -2203,8 +2208,9 @@ inline VkDeviceSize persistent_texture_cache_limit() {
     static const bool have_env = getenv("PROSPER_BACKEND_TEXTURE_CACHE_MB") != nullptr;
     static const VkDeviceSize env_limit = []() -> VkDeviceSize {
         const char* value = getenv("PROSPER_BACKEND_TEXTURE_CACHE_MB");
-        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 1024ull;
-        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_BACKEND_TEXTURE_CACHE_MB", value, 1024ull,
+            UINT64_MAX / (1024ull * 1024ull), "MiB");
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
     if (have_env) return env_limit;
@@ -2407,8 +2413,9 @@ inline bool render_memory_pool_enabled() {
 inline VkDeviceSize render_memory_pool_limit() {
     static const VkDeviceSize limit = []() -> VkDeviceSize {
         const char* value = getenv("PROSPER_MEMORY_POOL_MB");
-        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 512ull;
-        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_MEMORY_POOL_MB", value, 512ull,
+            UINT64_MAX / (1024ull * 1024ull), "MiB");
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
     return limit;
@@ -2629,9 +2636,11 @@ inline VkDeviceSize render_host_buffer_pool_limit() {
 
 inline VkDeviceSize render_host_buffer_arena_size() {
     static const VkDeviceSize bytes = []() -> VkDeviceSize {
+        // The max(4, ...) floor means a typo does not crash -- it silently builds a FOUR-BYTE
+        // arena, which is the worst kind of wrong setting: plausible, survivable, and slow (#3267).
         const char* value = getenv("PROSPER_BACKEND_BUFFER_ARENA_KB");
-        const uint64_t kib = value ? strtoull(value, nullptr, 10) : 1024ull;
-        if (kib > UINT64_MAX / 1024ull) return VkDeviceSize{UINT64_MAX};
+        const uint64_t kib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_BACKEND_BUFFER_ARENA_KB", value, 1024ull, UINT64_MAX / 1024ull, "KiB");
         return std::max<VkDeviceSize>(4, static_cast<VkDeviceSize>(kib) * 1024ull);
     }();
     return bytes;

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2227,7 +2227,12 @@ inline size_t persistent_color_target_count_limit() {
         const char* value = getenv("PROSPER_BACKEND_TARGET_CACHE_COUNT");
         // Raised from the historical 64 so a 4K deferred renderer's targets are bounded by the memory
         // budget (persistent_color_target_limit) rather than an arbitrarily small count (#1177).
-        const uint64_t n = value ? strtoull(value, nullptr, 10) : 256ull;
+        // `n ? n : 256` refuses a value that parses to 0 and NOTHING else: this is an unsigned
+        // parse, so `=-1` saturated to UINT64_MAX, stayed non-zero, and removed the count bound
+        // entirely (SIZE_MAX resident targets). The byte twin of this knob two functions up was
+        // converted while this one was published as "already refuses" -- it was not (#3267 B1).
+        const uint64_t n = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_BACKEND_TARGET_CACHE_COUNT", value, 256ull, SIZE_MAX, "targets");
         return n ? static_cast<size_t>(n) : size_t{256};
     }();
     return count;

--- a/prosper/tools/env/check_env_numeric_arms.py
+++ b/prosper/tools/env/check_env_numeric_arms.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Every knob parsed by diagnostics/env_numeric.hpp has an arm in the site test, and vice versa.
+
+WHY THIS EXISTS. tests/diagnostics/test_env_numeric_sites.cpp cannot CALL the sites it asserts on:
+nearly every one caches its read in a function-local static, so an arm that armed the variable at
+runtime would go vacuous rather than red once the static was initialised (#2214, and
+tools/env/check_cached_env.py is the gate for that hazard). Each arm therefore MIRRORS its site --
+same helper, same fallback, same cap -- which pins the contract but not the wiring. The drift that
+mirror invites is one-directional and silent: somebody converts a twentieth site, forgets the arm,
+and the suite stays green while the new site's fallback is never checked by anything.
+
+So this compares two sets over the whole tree:
+
+    parsed  -- the PROSPER_* name in the FIRST argument of an env_u64_or_default / _capped call
+    armed   -- the PROSPER_* names listed in the site test's table
+
+and fails on either difference. A name in `parsed` and not in `armed` is a converted site with no
+arm; a name in `armed` and not in `parsed` is an arm whose site was reverted or renamed, i.e. an
+assertion about code that no longer exists.
+
+It deliberately checks NAMES only, not fallbacks. Matching a fallback textually would mean parsing
+`16ull * 1024ull` against `16 * 1024`, which is brittle enough that the gate would be regenerated
+rather than read -- and a gate nobody trusts is worse than none (see diag_gate_baseline.txt's own
+header on the same point). The fallback is what the arm itself asserts.
+
+Run standalone against a checkout, or via ctest as env_numeric_arms.
+"""
+import re
+import sys
+from pathlib import Path
+
+CALL_RE = re.compile(r'env_u64_or_default(?:_capped)?\s*\(\s*\n?\s*"(PROSPER_[A-Z_0-9]+)"')
+ARM_RE = re.compile(r'"(PROSPER_[A-Z_0-9]+)"')
+SKIP_DIRS = {"build-linux", "build-windows", "third_party", ".git", "tmpdir"}
+TEST = Path("tests/diagnostics/test_env_numeric_sites.cpp")
+# The helper's own unit test constructs calls with names that are deliberately not call sites --
+# it is testing the parser, not a knob -- so it is not a source of `parsed`.
+EXEMPT_SOURCES = {Path("frontends/shared/tests/test_write_watch_policy.cpp")}
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    parsed: dict[str, list[str]] = {}
+    for path in sorted(root.rglob("*")):
+        if path.suffix not in (".cpp", ".hpp", ".h", ".cc"):
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        rel = path.relative_to(root)
+        if rel == TEST or rel in EXEMPT_SOURCES:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for name in CALL_RE.findall(text):
+            parsed.setdefault(name, []).append(str(rel))
+
+    test_path = root / TEST
+    if not test_path.is_file():
+        print(f"[env-arms] FAIL: {TEST} is missing")
+        return 1
+    body = test_path.read_text(encoding="utf-8", errors="replace")
+    table = body[body.index("static const Site kSites[]"):body.index("int main()")]
+    armed = set(ARM_RE.findall(table))
+
+    missing = sorted(set(parsed) - armed)
+    stale = sorted(armed - set(parsed))
+    for name in missing:
+        print(f"[env-arms] FAIL: {name} is parsed by env_numeric at "
+              f"{', '.join(sorted(set(parsed[name])))} but has no arm in {TEST}")
+    for name in stale:
+        print(f"[env-arms] FAIL: {TEST} arms {name}, but no call site parses it with env_numeric "
+              f"any more -- the arm asserts about code that is gone")
+    if missing or stale:
+        return 1
+    print(f"[env-arms] ok: {len(armed)} knob(s) parsed by env_numeric, every one armed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/env/check_env_numeric_arms.py
+++ b/prosper/tools/env/check_env_numeric_arms.py
@@ -29,7 +29,13 @@ import re
 import sys
 from pathlib import Path
 
-CALL_RE = re.compile(r'env_u64_or_default(?:_capped)?\s*\(\s*\n?\s*"(PROSPER_[A-Z_0-9]+)"')
+# EVERY name-taking entry point in diagnostics/env_numeric.hpp, not just the two the first revision
+# knew about. That omission was not theoretical: env_u64_or_report's call site was the one site with
+# bespoke arithmetic and a non-numeric fallback -- the site most likely to drift -- and it was the
+# one site this gate could not see, while the success line below asserted full coverage (#3267 N2).
+# Adding a helper to that header without adding it here re-opens exactly that hole.
+CALL_RE = re.compile(
+    r'env_u64_or_(?:default(?:_auto)?(?:_capped)?|report)\s*\(\s*\n?\s*"(PROSPER_[A-Z_0-9]+)"')
 ARM_RE = re.compile(r'"(PROSPER_[A-Z_0-9]+)"')
 SKIP_DIRS = {"build-linux", "build-windows", "third_party", ".git", "tmpdir"}
 TEST = Path("tests/diagnostics/test_env_numeric_sites.cpp")
@@ -71,7 +77,12 @@ def main() -> int:
               f"any more -- the arm asserts about code that is gone")
     if missing or stale:
         return 1
-    print(f"[env-arms] ok: {len(armed)} knob(s) parsed by env_numeric, every one armed")
+    # Print the PARSED count, not the armed one. They are equal here by construction -- both
+    # differences were just checked -- but the claim being made is about coverage of the call sites,
+    # and a success line should be phrased in the quantity it is asserting about. The first revision
+    # printed the armed count and so read "27 ... every one armed" while 28 were parsed.
+    print(f"[env-arms] ok: {len(parsed)} knob(s) parsed by env_numeric, every one armed "
+          f"({len(armed)} arm name(s) in the table)")
     return 0
 
 


### PR DESCRIPTION
Refs #3267. Converts the **23 sites where a malformed value removes a bound or disables a
default-ON guard**, and catalogues the rest on the issue rather than sweeping 164 sites in one diff.

> **Head `0edea136` addresses the review of `d0d6c9c5`.** Blocking finding **B1** is fixed: bucket D
> was derived against two of the three malformed rows, it contained a genuine bucket-A site, and
> both of the sites it wrongly cleared are now converted. All five non-blocking items are addressed
> too, including the base-0 grammar loss (**N1**) and the gate's coverage hole (**N2**). Every place
> a number or claim changed is marked *"corrected after review"* below. The original 21 conversions
> are untouched.

## The census, re-derived on current `main`

`b00a1c05`, over `prosper/{src,frontends,tools,tests}`, counting only parses whose input traces to
`getenv`/`PROSPER_ENV_VALUE`:

| | count |
| --- | --- |
| discard the end pointer (or `atoi`-family) | **164** |
| check an end pointer | **72** |

Close to the issue's 169/71 and reached independently; the small gap is window width (8 lines vs 6)
and the two sites #3276 and #3253 already converted.

## The classification, which is the actual deliverable

The issue's own instruction is that this is triage, not a sweep. Buckets are by **what a wrong value
does**, not by how it parses:

| bucket | count | |
| --- | --- | --- |
| **A** — a malformed value REMOVES a bound, or disables a default-ON guard | **23** | converted here |
| **B** — it silently CHANGES a production limit that stays in force | 35 | catalogued on the issue |
| **C** — it only moves a diagnostic's window or level | 57 | catalogued |
| **D** — refuses **all three** malformed rows and keeps the default | **1** | not a defect |
| **H** — hex / signed / float grammar the decimal helper cannot express | 48 | needs helper work first |

> **Corrected after review.** The first revision of this table read A 21 / B 23 / C 49 / D 23 / H 48.
> D had been derived against only two of the issue's three malformed rows — inputs that parse to
> **0**, and **`-1`** — and not against the third, a **numeric prefix** (`8mb` → `8`), which the
> issue body itself calls the nastiest. Re-derived against all three, **D collapses from 23 to 1**:
> `PROSPER_ZEROWATCH_FIND_PREFIX` is the only site in the tree whose guard rejects a prefix parse
> too (its `16..256` range refuses the `8`, loudly). Two of the old D members were bucket **A** —
> both are converted here — twelve are B and eight are C.

The full per-site listing for B, C, D and H is posted on #3267.

## What is in bucket A, and why

**A bound whose zero means "unbounded."** `PROSPER_WRITE_WATCH_MAX_KB` is the sharpest one, and it is
in `src/host/memory/guest_write_watch.cpp` — the write-watch implementation #3253 was filed about,
one file from the six knobs that PR fixed, and missed by it. `=8mb` selected an 8 KiB cap, i.e. no
range large enough to get a watch at all. The MiB-denominated caches (`PROSPER_COMPUTE_BUFFER_CACHE_MB`,
`_IMAGE_CACHE_MB`, `_MEMORY_POOL_MB`, `PROSPER_BACKEND_TARGET_CACHE_MB`, `_TEXTURE_CACHE_MB`,
`PROSPER_MEMORY_POOL_MB`, `PROSPER_BACKEND_BUFFER_ARENA_KB`, `PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES`,
`PROSPER_ARRAY_DECODE_BUDGET_MIB`) all saturate `-1` to `UINT64_MAX`, which their own overflow guard
then turns into "no limit".

**A multiply that wraps.** `PROSPER_DMEM_BUDGET_MB`'s `>= 1024` floor already refused small typos.
What it could not refuse was `-1`: `strtoull` saturated, and `mib * 1024 * 1024` then wrapped — on
the advertised direct-memory budget the guest sizes its pools from, which is the #2934 class exactly.

**A default-ON guard switched OFF by making it explicit.** Five knobs read
`!e || strtol(e, nullptr, 0) != 0`. `=yes`, `=true`, `=on` — what a person types to pin a default-ON
switch on — every one answers 0, i.e. **OFF**. `PROSPER_REL1_FORGE_GUARD` is the #312 ROOT fix and
`PROSPER_REL1_STOMP_GUARD` its stomp guard; `PROSPER_NETCTL_CB` does not merely log less, it leaves
the whole NetCtl NID family **unregistered**, returning the guest to pre-#306 behaviour. Nothing in
the run says so. (`PROSPER_MB3_CENTRAL_SCAN` and `PROSPER_MB3_TRACK_TLS` are the same shape.)

**A bound refused only against a zero.** Two sites guard with `n ? n : <default>` or
`if (parsed)`, which rejects an input parsing to 0 **and nothing else** — so `=-1` saturated, stayed
non-zero, and removed the bound. `PROSPER_BACKEND_TARGET_CACHE_COUNT` lost the resident-target count
bound entirely (`SIZE_MAX` targets); it is the **count twin of `PROSPER_BACKEND_TARGET_CACHE_MB`**,
which this PR converts, ~80 lines away in a file it already edits. `PROSPER_VDEC2_DUMP_FRAMES` lost
a **disk** bound — its own comment puts the 16-frame cap at 50 MB against 5 GB uncapped.

Plus three where the wrong value reads as a different defect entirely:
`PROSPER_MAX_DISPATCH_GROUPS` (a cap only ever set in order to impose one — `750,000` became a cap of
**750**), `PROSPER_MUTEX_FAIR_US` (0 removes the yield and re-starves GRIS's bank commit, #2981), and
`PROSPER_PAD_FRAME_HOLD` / `PROSPER_PAD_READ_HOLD` (a zero-length press the guest never observes,
which looks exactly like a render or progression wall — the recorded input-mapping trap).

## Contract

**Corrected after review.** The first revision said "unchanged for every well-formed value". That
was not accurate: five default-ON guards and `PROSPER_MAX_DISPATCH_GROUPS` read `strtol(e, …, 0)` —
**base 0** — so `0x2000` was well-formed at all six, and the decimal-only grammar refused it. On
`PROSPER_MAX_DISPATCH_GROUPS` the fallback is `0` = **no cap**, so the fix for "a typo removes the
bound" introduced exactly that outcome on the one knob whose only purpose is to impose a bound.

`env_numeric.hpp` therefore gains `parse_u64_auto_base` and an `_auto` family accepting `[0-9]+` **or**
`0x[0-9a-fA-F]+` — no wider than what those six sites already took, and deliberately **without**
base-0's octal leg, because `010` meaning 8 is its own silent-wrong-setting hazard.
`PROSPER_REL1_FORGE_GUARD=0x0` means OFF again, and `PROSPER_MAX_DISPATCH_GROUPS=0x2000` caps at
8192 again. Both are pinned by arms whose `good` column is the hex spelling.

With that in place: **unchanged for every well-formed value.** Unset and empty still take the default
in silence — they are not typos. A malformed value prints one line naming the variable, the text and
the default it is keeping, and changes nothing.

On the two knobs whose default **is** the permissive sentinel (`PROSPER_WRITE_WATCH_MAX_KB`'s `0` =
unbounded, `PROSPER_MAX_DISPATCH_GROUPS`'s `0` = no cap), the line now says so —
`keeping the default (0, unbounded: no range is too large to watch)` — because telling an operator
who typed a value *in order to impose a bound* that nothing changed is true and useless. And on the
subset of typos that parse to **0** on those two, the change is the **message alone**: the fallback
is what `strtoull` already answered. That is recorded in the catalogue and in `kSites`.

## Tests

`tests/diagnostics/test_env_numeric_sites.cpp` — three arms per row, **35 rows over 30 distinct
knobs** (the eight #3253 converted included), **107 assertions**. *(The first revision said "29
knobs"; it was 29 rows over 27 knobs.)*

Each arm **mirrors** its site rather than calling it. That is deliberate: nearly every converted site
caches its read in a function-local `static`, so an arm that armed the variable with `setenv` would
go **vacuous** rather than red once the static was initialised — the #2214 shape that
`tools/env/check_cached_env.py` exists to refuse. No `PROSPER_*` variable is set, unset or read by
this test.

Each arm also computes what the site's **old** spelling answered and asserts it **differed**, so an
arm on a knob that never needed converting fails instead of passing quietly. That caught three of my
own arms being void while writing this (`PROSPER_TEXTURE_WRITE_WATCH_PROMOTE_MB` with `8 MB`,
`PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` with `16mb `, `PROSPER_MAX_GPU_COMPARE_IMAGE_MB` with
`2,048` — in each case `strtoull` happened to answer the default, so the arm was asserting nothing).

`tools/env/check_env_numeric_arms.py` (ctest `env_numeric_arms`) closes the drift a mirror invites:
it fails if a knob is parsed through `env_numeric` with no arm, or armed with no call site left. Its
first run reported **#3253's own eight sites had no per-site arm** — `test_write_watch_policy.cpp`
pins the helper's grammar, not each site's fallback — which is why those eight are armed here too.

**Also corrected after review:** the gate's pattern knew only two of the header's entry points, so
`PROSPER_COMPUTE_IMAGE_CACHE_MB` — the one bespoke conversion, with a code-path fallback rather than
a numeric one, i.e. the site *most* likely to drift — was invisible to it while its success line read
`27 knob(s) … every one armed` with **28** parsed. That site now calls a named helper
(`env_u64_or_report`) instead of a hand-written `fprintf`, the pattern matches every name-taking
entry point, and the line prints the **parsed** count. Mutation **M4** below reproduces the old hole.

Three mirrors also differed from their sites in cap or unit (`UINT64_MAX` vs `SIZE_MAX`, `"presses"`
vs `"flips"`/`"reads"`). Identical on any 64-bit build and message-only — but the stated residual
risk is precisely "a value changed at one end only", so they are now exact.

**What this does NOT pin**, stated in the test's header: a fallback value changed at one end only
still needs a reader. The gate can check names mechanically; it cannot check `16ull * 1024ull`
against `16 * 1024` without becoming the kind of baseline people regenerate instead of reading.

## Verification (exact head `0edea136`, Linux, distrobox `ps5ys`)

```
cmake --build prosper/build-linux -j4        BUILD_RC=0
ctest --no-tests=error -j4                   CTEST_RC=0   100% tests passed out of 355
```

Baseline on `origin/main` `b00a1c05`, same tree, same flags: `BUILD_RC=0`, `CTEST_RC=0`,
**100% passed out of 353**. The two new cases are `diagnostics_env_numeric_sites` and
`env_numeric_arms`.

### Mutation arms — by exit code, not by assertion

| | site test | `env_numeric_arms` |
| --- | --- | --- |
| control (this head) | **exit 0** | **exit 0** |
| M1 — `parse_u64_strict` reverted to a bare `strtoull` | **exit 1**, 33 of 107 arms red | — |
| M2 — one converted site's arm deleted from the table | — | **exit 1**, names `PROSPER_NETCTL_CB` |
| M3 — one production site reverted to a bare `strtoull` | — | **exit 1**, names the now-stale arm |
| **M4 (new)** — the gate's pattern narrowed so a header helper is unknown to it | — | **exit 1**, names `PROSPER_COMPUTE_IMAGE_CACHE_MB` |

M1 mutates a shadow copy of `env_numeric.hpp` ahead of `src` on the include path; M2–M4 mutate a
file, run the scan, and restore from a copy. None touches the build directory. M4 is the regression
guard for N2: it reproduces the exact hole the review found, so narrowing the pattern again fails.

No GPU was used: no `prosper-app`, no `screenshot`, no `gpu_replay`, no snapshots.

## Risk

The behaviour change is confined to values that were **already** being misread — the base-0 regression
the review found is now closed rather than disclosed. The one judgement call worth a reader is the
default-ON family: `=0` and `=0x0` both still mean off (the documented spelling, and what
`docs/DOLL_LOADING_PROGRESSION.md`, `tools/dbg/forge_prove.sh` and the A/B comments use), and only
text that is neither decimal nor `0x`-hex changes meaning — from "off" to "keep the default, loudly".

The reviewer's precision nit is taken: `PROSPER_NETCTL_CB` guards the **three callback NIDs**
(`RegisterCallback`, `CheckCallback`, `GetState`), not the whole NetCtl family — `GetInfo` and
`GetResult` register unconditionally. Corrected in the code comment and the catalogue.