### PR TITLE
hle: answer sceHttpUriBuild and sceHttpTerm honestly, and validate the HTTP context id (#2930)

### DIFF
--- a/prosper/docs/PGA_TOUR_2K25_STATUS.md
+++ b/prosper/docs/PGA_TOUR_2K25_STATUS.md
@@ -118,11 +118,31 @@ dereference stale pointer fields."*
 
 The fix is to implement libSceHttp2's lifecycle honestly — local resource creation genuinely
 succeeds, setters genuinely record state, and anything that would need a network answer **reports
-failure instead of `SCE_OK`**, leaving out-parameters untouched. That was deliberately **not** done
-in this session: the correct Sony error values for the libSceHttp2 facility are not derivable from
-the dump, from `../PS5-3.20_Libs/` (which gives names and NIDs only, no values), or from prosper's
-existing `0x8043xxxx` libSceHttp constants, and inventing one would be fabrication rather than
-reimplementation. Tracked separately.
+failure instead of `SCE_OK`**, leaving out-parameters untouched. Tracked as #2894.
+
+**The reason this was deferred no longer holds — see `## Ruled out`.** This paragraph used to say
+the v2 error encodings were not derivable from anything on hand. They are, and the answer changes
+what an implementer must do: **libSceHttp2's facility is `0x817b____`, not v1's `0x8043____`**, so
+prosper's existing libSceHttp constants are *not* reusable across the two even though the low code
+bytes are shared. `<DUMP_ROOT>/sprx/` ships `libSceHttp.sprx` and `libSceHttp2.sprx` as plain ELF
+(entropy 5.417 / 5.403 bits/byte), and this title's own error classifier at `eboot+0x142ddf0`
+confirms the facility independently.
+
+The behavioural finding matters more than the constant. **Any non-zero return is handled
+gracefully; only `0` crashes this title.** The classifier's sole zero-returning path is a literal
+`test eax,eax`, all 33 targets of its `0x817b1064..0x817b1084` jump table return non-zero, and at
+the send site a non-zero classification makes the caller store the error and *return* without ever
+reaching the response parser above. So the fault at `eboot+0x142d5e0` is caused specifically by the
+false `SCE_OK` — the title was always prepared to be told the request failed. Picking the exact
+constant is a correctness question, not a safety one.
+
+For the send path specifically, the real library does not return an HTTP error at all: on a connect
+failure it propagates the **raw libSceNet error**, pinned by `0x80410124` being special-cased as
+*not* a failure at libSceHttp2's `sceNetConnect` site (`0x24` = 36 = `EINPROGRESS`), which fixes the
+encoding as `0x80410100 | BSD errno`. That makes `ENETUNREACH` the honest offline answer, and it is
+consistent with what prosper already tells this guest through `sceNetCtlGetState`
+(`SCE_NET_CTL_ERROR_NOT_CONNECTED`). Full derivation, per-NID export map and argument shapes are on
+#2894; start there rather than re-deriving.
 
 Other unimplemented NIDs seen on the same boot, none of which is implicated in the fault:
 `sceNpAuthCreateAsyncRequest`, `sceNpAuthGetAuthorizationCodeV3`, `sceNpAuthWaitAsync`,
@@ -150,6 +170,26 @@ HTTP fault, so no hypothesis is recorded here yet.
 
 ## Ruled out
 
+- **"The correct Sony error values for the libSceHttp2 facility are not derivable from the dump,
+  from `../PS5-3.20_Libs/`, or from prosper's existing `0x8043xxxx` constants, so implementing the
+  lifecycle honestly would require fabricating one."** Falsified 2026-09-03 (#2894, PR #3295 for
+  the v1 sibling). They are derivable, from two independent primary sources that agree. The dump's
+  own `sprx/` directory ships `libSceHttp2.sprx` as a **plain ELF** — entropy 5.403 bits/byte, so
+  nothing is decrypted to read it — and every export's shared stack-guard prologue returns
+  `0x817b1076`, dating the facility as **`0x817b____`**, *not* v1's `0x8043____`. This title's own
+  error classifier at `eboot+0x142ddf0` compares against `0x817b1220` and dispatches
+  `0x817b1064..0x817b1084` through a 33-entry jump table, confirming the facility from the guest
+  side. The claim was not merely incomplete but load-bearing in the wrong direction: it said the
+  work could not be started, when in fact the send path does not use an HTTP error at all — the
+  library propagates the raw libSceNet error, whose encoding (`0x80410100 | BSD errno`) is pinned by
+  `0x80410124` = `EINPROGRESS` being treated as a non-failure at the connect site. Independently
+  re-derived from the bytes by a second reader before this row was written.
+- **"Any error prosper invents here risks being read as data, so returning one is hazardous."**
+  Falsified 2026-09-03 by enumerating all 33 jump-table targets: they return five distinct non-zero
+  categories and **none** reaches the classifier's zero-return `ret`, which is reachable only for an
+  input of exactly `0`. So every non-zero value is classified as a failure and handled the same way,
+  and the caller returns before touching the response parser. A wrong constant here is wrong, not
+  dangerous — which removes the safety argument for deferring the whole lifecycle.
 - **"The `only_if_imported` filter (#2870/#2890) drops `sce_module/libSceNpCppWebApi.prx` for this
   title, and that is what makes the PSN handshake fail."** Falsified 2026-08-22 on `af481db2`:
   `PROSPER_INITLOG=1` lists it as **module 8, base `0x4d0000000`** — it is linked, mapped and

--- a/prosper/docs/PGA_TOUR_2K25_STATUS.md
+++ b/prosper/docs/PGA_TOUR_2K25_STATUS.md
@@ -140,8 +140,9 @@ For the send path specifically, the real library does not return an HTTP error a
 failure it propagates the **raw libSceNet error**, pinned by `0x80410124` being special-cased as
 *not* a failure at libSceHttp2's `sceNetConnect` site (`0x24` = 36 = `EINPROGRESS`), which fixes the
 encoding as `0x80410100 | BSD errno`. That makes `ENETUNREACH` the honest offline answer, and it is
-consistent with what prosper already tells this guest through `sceNetCtlGetState`
-(`SCE_NET_CTL_ERROR_NOT_CONNECTED`). Full derivation, per-NID export map and argument shapes are on
+consistent with what prosper already tells this guest through NetCtl: `sceNetCtlGetState` writes
+`SCE_NET_CTL_STATE_DISCONNECTED` and `sceNetCtlGetInfo` returns `SCE_NET_CTL_ERROR_NOT_CONNECTED`
+(`hle_service.cpp:4795`, `:4830`). Full derivation, per-NID export map and argument shapes are on
 #2894; start there rather than re-deriving.
 
 Other unimplemented NIDs seen on the same boot, none of which is implicated in the fault:

--- a/prosper/src/hle/net/AGENTS.md
+++ b/prosper/src/hle/net/AGENTS.md
@@ -1,0 +1,51 @@
+# `src/hle/net` — Sony networking libraries
+
+Reimplementations of the PS5 networking libraries that prosper answers itself. Today that is
+**libSceHttp** (`hle_http.cpp`): the URI helper family and the library/template id lifecycle.
+
+## The policy this folder exists to hold
+
+**prosper has no network, and acquiring one is not the plan.** That makes the interesting question
+per entry point *"is this answerable from local state?"* rather than *"can we connect?"* — and the
+two halves of the answer are both obligations:
+
+- **Anything computable offline is implemented, not stubbed.** The URI helpers are ordinary string
+  code; there is no network anywhere in parsing or rebuilding a URI, so leaving them to the
+  dispatcher is a false success rather than a limitation. Same for id lifecycles: a template really
+  is allocated locally, so it gets a real id from a real table.
+- **Anything that genuinely needs a network answer must FAIL, and fail loudly.** The dispatcher's
+  unregistered default is `0`, which is `SCE_OK` — so an unregistered send path reports that a
+  request nobody sent succeeded, and a response getter reports success while writing nothing to its
+  out-parameters. That is the specific shape that crashes callers (#2894), and it is worse than a
+  reported error, because the guest's own error handling never runs.
+
+Registering a NID can therefore be worse than leaving it unregistered, and the deciding question is
+what the guest does with the *value*. An **id**-returning contract must never answer `0` — that is a
+plausible-looking handle the guest will carry into later calls — and must never answer a
+zero-extended error either; sign-extend so `int32` and `int64` reads both see it as negative. An
+**SCE_OK-or-error** contract keeps the 32-bit form the library returns in `eax`. Both conventions
+live in `hle_http.cpp` with comments saying which is which.
+
+## Where the evidence comes from
+
+Contracts here are read off the shipped modules rather than guessed. `<DUMP_ROOT>/sprx/` carries
+`libSceHttp.sprx` and `libSceHttp2.sprx` as **plain ELF** — nothing is decrypted to read them — so
+argument shapes, per-component length caps, emission order and error constants can be derived
+directly, and a claim in this folder should cite the offset it came from. Two facts worth not
+re-deriving: **libSceHttp2's error facility is `0x817b____`, not v1's `0x8043____`** (the low code
+bytes are shared, so the v1 constants are not reusable across the two), and on a connect failure the
+library propagates the **raw libSceNet error**, encoded `0x80410100 | BSD errno`. See #2894.
+
+## The boundary against its siblings
+
+This folder is smaller than "prosper's networking" — several networking surfaces are answered
+elsewhere, and looking for them here is the mistake to avoid:
+
+- **`sceHttp2Init`, `sceNetCtlGetState` and the NetCtl/NP service surface live in
+  `../service/hle_service.cpp`**, not here. That is why `libSceHttp2` looks absent from this folder
+  while one of its entry points is already registered.
+- Answers must not contradict each other across that boundary. `sceNetCtlGetState` already reports
+  `SCE_NET_CTL_ERROR_NOT_CONNECTED`, so an HTTP layer that reported a successful request would be
+  telling the same guest two incompatible things.
+
+New Sony networking libraries that prosper answers itself belong here, one file per library.

--- a/prosper/src/hle/net/AGENTS.md
+++ b/prosper/src/hle/net/AGENTS.md
@@ -44,8 +44,10 @@ elsewhere, and looking for them here is the mistake to avoid:
 - **`sceHttp2Init`, `sceNetCtlGetState` and the NetCtl/NP service surface live in
   `../service/hle_service.cpp`**, not here. That is why `libSceHttp2` looks absent from this folder
   while one of its entry points is already registered.
-- Answers must not contradict each other across that boundary. `sceNetCtlGetState` already reports
-  `SCE_NET_CTL_ERROR_NOT_CONNECTED`, so an HTTP layer that reported a successful request would be
-  telling the same guest two incompatible things.
+- Answers must not contradict each other across that boundary. prosper already tells the guest it
+  is offline there — `sceNetCtlGetState` writes `SCE_NET_CTL_STATE_DISCONNECTED` and
+  `sceNetCtlGetInfo` returns `SCE_NET_CTL_ERROR_NOT_CONNECTED` (`hle_service.cpp:4795`, `:4830`) —
+  so an HTTP layer that reported a successful request would be telling the same guest two
+  incompatible things.
 
 New Sony networking libraries that prosper answers itself belong here, one file per library.

--- a/prosper/src/hle/net/hle_http.cpp
+++ b/prosper/src/hle/net/hle_http.cpp
@@ -204,16 +204,29 @@ constexpr size_t kUriTextMax = 0x3fff;
 
 size_t capped_len(const char* text, size_t cap) { return text ? strnlen(text, cap) : 0; }
 
-// The library upper-cases the scheme and matches "HTTPS" then "HTTP"; anything else has no
-// default port. It then compares a third literal that string-merging left as "TTP", which no
-// real scheme can reach -- deliberately not reproduced. Matching is exact here rather than the
-// library's prefix compare, which is unreachable for a scheme that parsed.
+// The library upper-cases the scheme into a stack buffer and then runs three PREFIX compares --
+// strncmp(upper, LIT, strlen(LIT)) -- against "HTTPS" (443, +0x21aa2), "HTTP" (80, +0x21aab) and
+// a third literal that string merging left as "TTP" (+0x326ac). That third arm ends in
+// `mov eax,0x50 / cmovne eax,ecx` with ecx zeroed, and cmovne fires on MISMATCH: a "TTP" prefix
+// yields 80, and only a non-match yields "no default port".
+//
+// Reproduced rather than narrowed to exact equality, which is what this comment used to claim was
+// safe. element->scheme is GUEST-supplied and need not have come from our own parser, so "httpx"
+// prefix-matches "HTTP" and takes 80 on hardware; under exact matching prosper would answer 0 and
+// then emit a ":80" that the library suppresses. Divergence for a scheme nobody uses, but the
+// contract this file claims is fidelity to the shipped library, so match it.
 uint16_t default_port_for_scheme(const char* scheme) {
     const size_t length = capped_len(scheme, kUriSchemeMax);
     if (length == 0) return 0;
     const std::string_view value(scheme, length);
-    if (ascii_ieq(value, "https")) return 443;
-    if (ascii_ieq(value, "http")) return 80;
+    // strncmp against a shorter buffer stops at its NUL, so a prefix match needs the whole literal.
+    const auto prefixed = [value](std::string_view literal) {
+        return value.size() >= literal.size() &&
+               ascii_ieq(value.substr(0, literal.size()), literal);
+    };
+    if (prefixed("https")) return 443;
+    if (prefixed("http")) return 80;
+    if (prefixed("ttp")) return 80;
     return 0;
 }
 
@@ -328,9 +341,15 @@ HLE(h_http_uri_build) { // (out, required, pool_size, element, flags)
 // census noise without fabricating an SDK error encoding.
 //
 // CreateTemplate now VALIDATES its library context id rather than accepting whatever it is
-// given. The encoding is not invented: the shipped PS5 3.20 libSceHttp contains the id
-// validator itself, which range-checks (1..0x80) and cross-checks the table slot and answers
-// 0x80431100 on either failure. CONFIDENCE: HIGH.
+// given. The encoding is not invented: sceHttpCreateTemplate (+0x107f0) calls the validator at
+// +0xb070, which range-checks the id (1..0x80), cross-checks the slot in the 0xd0-stride context
+// table, and answers 0x80431100 on either failure. That is the validator on this call path, not
+// a same-shaped neighbour. CONFIDENCE: HIGH.
+//
+// Known fidelity gap, seen and not missed: the library answers 0x80431001 (BEFORE_INIT) when
+// sceHttpInit was never called and only reaches the id validator once the library is up, while
+// prosper answers 0x80431100 for both. Derivable locally -- no live context means never inited --
+// but the guest classifies the two identically, so it is not worth a second code path yet.
 //
 // This comment used to say "PS5 3.20 libSceHttp exports no sceHttpTerminate: contexts live for
 // the process". The name is wrong, and so was the conclusion drawn from it - the export is
@@ -339,7 +358,7 @@ HLE(h_http_uri_build) { // (out, required, pool_size, element, flags)
 // dry by a title that inits and terminates repeatedly.
 
 struct HttpLibCtx   { bool in_use = false; };
-struct HttpTemplate { bool in_use = false; };
+struct HttpTemplate { bool in_use = false; int owner = 0; };
 constexpr int kMaxHttpLibs      = 4;
 constexpr int kMaxHttpTemplates = 16;
 
@@ -366,10 +385,19 @@ bool http_ctx_is_live(uint64_t raw) {
     return id >= 1 && id <= kMaxHttpLibs && g_http_libs[id - 1].in_use;
 }
 
-HLE(h_http_term) { // sceHttpTerm(libCtxId) -> SCE_OK, releasing the context
+HLE(h_http_term) { // sceHttpTerm(libCtxId) -> SCE_OK, releasing the context AND what it owns
     std::lock_guard<std::mutex> lk(g_http_mx);
     if (!http_ctx_is_live(a0)) return http::kErrorInvalidId;
-    g_http_libs[(int32_t)a0 - 1].in_use = false;
+    const int id = (int32_t)a0;
+    // Term does not merely drop the context. After the refcount decrement at +0x1068b the shipped
+    // sceHttpTerm runs four per-context teardown helpers (+0x83f0, +0x1c8e0, +0x35b0, +0xaf90),
+    // each taking the ctx id in edi; +0xaf90 re-validates the id against the same slot table the
+    // create path uses. Releasing only the slot would leak every template created under it, and
+    // the template table is 16 deep -- so a title that inits, creates one template and terms in a
+    // loop would exhaust it and start getting -1 from a table that is really empty.
+    for (auto& tmpl : g_http_templates)
+        if (tmpl.in_use && tmpl.owner == id) tmpl = {};
+    g_http_libs[id - 1].in_use = false;
     return 0;
 }
 
@@ -380,6 +408,7 @@ HLE(h_http_create_template) { // sceHttpCreateTemplate(libCtxId, ...) -> templat
     for (int i = 0; i < kMaxHttpTemplates; i++) {
         if (g_http_templates[i].in_use) continue;
         g_http_templates[i].in_use = true;
+        g_http_templates[i].owner = (int32_t)a0;  // so sceHttpTerm can reclaim it
         return (uint64_t)(i + 1);
     }
     return (uint64_t)(int64_t)-1;
@@ -388,7 +417,7 @@ HLE(h_http_create_template) { // sceHttpCreateTemplate(libCtxId, ...) -> templat
 HLE(h_http_delete_template) { // sceHttpDeleteTemplate(templateId) -> SCE_OK offline
     std::lock_guard<std::mutex> lk(g_http_mx);
     if (int id = (int32_t)a0; id >= 1 && id <= kMaxHttpTemplates)
-        g_http_templates[id - 1].in_use = false;
+        g_http_templates[id - 1] = {};
     return 0;
 }
 } // namespace

--- a/prosper/src/hle/net/hle_http.cpp
+++ b/prosper/src/hle/net/hle_http.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <mutex>
 #include <string>
@@ -173,18 +174,169 @@ HLE(h_http_uri_parse) { // (out, src_uri, pool, required_size, pool_size)
     return 0;
 }
 
+// --- sceHttpUriBuild (#2930) --------------------------------------------------------------
+// The inverse of sceHttpUriParse, and like it a purely local, deterministic computation - no
+// network is involved in turning a SceHttpUriElement back into a string. Left to the
+// dispatcher it answered SCE_OK with the caller's buffer untouched, so the caller read
+// whatever already happened to be in that buffer as a URI. Sifu is the surveyed caller.
+//
+// Contract read off the shipped PS5 3.20 libSceHttp (sceHttpUriBuild, 5LZA+KPISVA), whose URI
+// helpers are ordinary local string code:
+//
+//   int32_t sceHttpUriBuild(char* out, size_t* required, size_t pool_size,
+//                           const SceHttpUriElement* element, uint32_t flags);
+//
+//   element == nullptr                       -> kErrorInvalidUrl   (checked FIRST, before out)
+//   out == nullptr && required == nullptr    -> kErrorInvalidValue
+//   *required                                -> assembled length INCLUDING the NUL, and it is
+//                                               stored BEFORE the buffer check, so a caller
+//                                               given kErrorOutOfMemory still learns the size
+//   out == nullptr                           -> size query only, SCE_OK
+//   needed > pool_size                       -> kErrorOutOfMemory
+//
+// Emission order is scheme ':' "//" user ':' pass '@' host ':' port path query fragment, each
+// part gated by its flag bit, with per-component strnlen caps matching the library's.
+// CONFIDENCE: HIGH.
+constexpr size_t kUriSchemeMax = 0x20;
+constexpr size_t kUriUserMax = 0x100;
+constexpr size_t kUriHostMax = 0xff;
+constexpr size_t kUriTextMax = 0x3fff;
+
+size_t capped_len(const char* text, size_t cap) { return text ? strnlen(text, cap) : 0; }
+
+// The library upper-cases the scheme and matches "HTTPS" then "HTTP"; anything else has no
+// default port. It then compares a third literal that string-merging left as "TTP", which no
+// real scheme can reach -- deliberately not reproduced. Matching is exact here rather than the
+// library's prefix compare, which is unreachable for a scheme that parsed.
+uint16_t default_port_for_scheme(const char* scheme) {
+    const size_t length = capped_len(scheme, kUriSchemeMax);
+    if (length == 0) return 0;
+    const std::string_view value(scheme, length);
+    if (ascii_ieq(value, "https")) return 443;
+    if (ascii_ieq(value, "http")) return 80;
+    return 0;
+}
+
+// The library reads the leading dword and treats "opaque" as exactly 1; any other value means
+// an authority follows and "//" is emitted. Read it the same way rather than through the bool.
+bool element_is_opaque(const SceHttpUriElement* element) {
+    uint32_t raw = 0;
+    std::memcpy(&raw, element, sizeof(raw));
+    return raw == 1u;
+}
+
+HLE(h_http_uri_build) { // (out, required, pool_size, element, flags)
+    (void)a5;
+    const auto* element = reinterpret_cast<const SceHttpUriElement*>(a3);
+    if (!element) return http::kErrorInvalidUrl;
+    auto* out = reinterpret_cast<char*>(a0);
+    auto* required_out = reinterpret_cast<uint64_t*>(a1);
+    if (!out && !required_out) return http::kErrorInvalidValue;
+    const size_t pool_size = a2;
+    const auto flags = static_cast<uint32_t>(a4);
+
+    size_t needed = 0;
+
+    size_t scheme_len = 0;
+    if (flags & http::kUriBuildScheme) {
+        scheme_len = capped_len(element->scheme, kUriSchemeMax);
+        if (scheme_len) needed += scheme_len + 1;  // + ':'
+    }
+    const bool opaque = element_is_opaque(element);
+    if (!opaque) needed += 2;  // "//" is emitted whenever an authority follows
+
+    size_t user_len = 0;
+    if (flags & http::kUriBuildUsername) {
+        user_len = capped_len(element->username, kUriUserMax);
+        if (user_len) needed += user_len + 1;  // + '@'
+    }
+    size_t pass_len = 0;
+    if (flags & http::kUriBuildPassword) {
+        pass_len = capped_len(element->password, kUriUserMax);
+        if (pass_len) {
+            needed += pass_len + 1;             // + ':'
+            if (!user_len) needed += 1;         // ...and the '@' the username would have paid
+        }
+    }
+
+    size_t host_len = 0;
+    if (flags & http::kUriBuildHostname) host_len = capped_len(element->hostname, kUriHostMax);
+    needed += host_len;
+
+    // The port is decided from element->scheme whether or not the SCHEME bit is set: it is
+    // omitted when it merely restates the scheme's default, and when it is zero.
+    char port_text[8] = {};
+    size_t port_len = 0;
+    if (flags & http::kUriBuildPort) {
+        bool emit = true;
+        if (element->scheme) {
+            const uint16_t fallback = default_port_for_scheme(element->scheme);
+            if (fallback != 0) {
+                emit = element->port != fallback;
+            } else if (ascii_ieq(std::string_view(element->scheme,
+                                                  capped_len(element->scheme, kUriSchemeMax)),
+                                 "mailto")) {
+                emit = element->port != 0;
+            }
+        }
+        if (emit && element->port != 0) {
+            std::snprintf(port_text, sizeof(port_text), ":%d", (int)element->port);
+            port_len = strnlen(port_text, sizeof(port_text));
+            needed += port_len;
+        }
+    }
+
+    size_t path_len = 0, query_len = 0, fragment_len = 0;
+    if (flags & http::kUriBuildPath) path_len = capped_len(element->path, kUriTextMax);
+    if (flags & http::kUriBuildQuery) query_len = capped_len(element->query, kUriTextMax);
+    if (flags & http::kUriBuildFragment) fragment_len = capped_len(element->fragment, kUriTextMax);
+    needed += path_len + query_len + fragment_len;
+    needed += 1;  // NUL
+
+    // Stored before the size check on purpose: an under-sized pool still learns what it needs.
+    if (required_out) *required_out = needed;
+    if (!out) return 0;
+    if (needed > pool_size) return http::kErrorOutOfMemory;
+
+    char* cursor = out;
+    auto append = [&cursor](const char* text, size_t length) {
+        if (length) std::memcpy(cursor, text, length);
+        cursor += length;
+    };
+    if (scheme_len) { append(element->scheme, scheme_len); *cursor++ = ':'; }
+    if (!opaque) { *cursor++ = '/'; *cursor++ = '/'; }
+    if (user_len) append(element->username, user_len);
+    if (pass_len) { *cursor++ = ':'; append(element->password, pass_len); }
+    if (user_len || pass_len) *cursor++ = '@';
+    append(element->hostname, host_len);
+    append(port_text, port_len);
+    append(element->path, path_len);
+    append(element->query, query_len);
+    append(element->fragment, fragment_len);
+    *cursor = '\0';
+    return 0;
+}
+
 // --- Library/template id lifecycle (#2930) ----------------------------------------------
 // sceHttpInit and sceHttpCreateTemplate return IDS, and an id-returning contract must never
 // answer 0: the dispatcher's unregistered default is a valid-looking context/template id that
 // six of eight surveyed titles carry into later calls. Offline there is no network behind these
 // objects, but the ids are real - allocated here, tracked, deletable.
 //
-// Deliberately not invented until a live caller supplies evidence (id positivity itself is
-// CONFIDENCE: HIGH from the published contract): repeated Init hands out a further independent
-// context, CreateTemplate accepts whatever context it is given, and DeleteTemplate answers
-// SCE_OK for any argument - the dispatcher default it replaces was also 0, so registering the
-// explicit no-op removes census noise without fabricating an SDK error encoding. PS5 3.20
-// libSceHttp exports no sceHttpTerminate: contexts live for the process.
+// Repeated Init hands out a further independent context, and DeleteTemplate answers SCE_OK for
+// any argument - the dispatcher default it replaces was also 0, so the explicit no-op removes
+// census noise without fabricating an SDK error encoding.
+//
+// CreateTemplate now VALIDATES its library context id rather than accepting whatever it is
+// given. The encoding is not invented: the shipped PS5 3.20 libSceHttp contains the id
+// validator itself, which range-checks (1..0x80) and cross-checks the table slot and answers
+// 0x80431100 on either failure. CONFIDENCE: HIGH.
+//
+// This comment used to say "PS5 3.20 libSceHttp exports no sceHttpTerminate: contexts live for
+// the process". The name is wrong, and so was the conclusion drawn from it - the export is
+// sceHttpTerm (Ik-KpLTlf7Q), it does exist, and it takes the library context id. It is
+// registered below, so a context is now releasable and the four-slot table cannot be leaked
+// dry by a title that inits and terminates repeatedly.
 
 struct HttpLibCtx   { bool in_use = false; };
 struct HttpTemplate { bool in_use = false; };
@@ -205,8 +357,26 @@ HLE(h_http_init) { // sceHttpInit() -> library context id (>0)
     return (uint64_t)(int64_t)-1;  // table exhausted: negative, never an id-shaped answer
 }
 
+// Both id-returning entry points below sign-extend their error, so a guest that reads the
+// answer as int32 OR as int64 sees it as negative. The SCE_OK-or-error entry points keep the
+// zero-extended 32-bit form the URI helpers already use -- the conventions differ because the
+// contracts do, not by accident.
+bool http_ctx_is_live(uint64_t raw) {
+    const int id = (int32_t)raw;
+    return id >= 1 && id <= kMaxHttpLibs && g_http_libs[id - 1].in_use;
+}
+
+HLE(h_http_term) { // sceHttpTerm(libCtxId) -> SCE_OK, releasing the context
+    std::lock_guard<std::mutex> lk(g_http_mx);
+    if (!http_ctx_is_live(a0)) return http::kErrorInvalidId;
+    g_http_libs[(int32_t)a0 - 1].in_use = false;
+    return 0;
+}
+
 HLE(h_http_create_template) { // sceHttpCreateTemplate(libCtxId, ...) -> template id (>0)
     std::lock_guard<std::mutex> lk(g_http_mx);
+    if (!http_ctx_is_live(a0))
+        return (uint64_t)(int64_t)(int32_t)http::kErrorInvalidId;
     for (int i = 0; i < kMaxHttpTemplates; i++) {
         if (g_http_templates[i].in_use) continue;
         g_http_templates[i].in_use = true;
@@ -229,6 +399,9 @@ void register_http_hle() {
     Hle::register_fn("A9cVMUtEp4Y", (HleFn)h_http_init, "sceHttpInit");
     Hle::register_fn("0gYjPTR-6cY", (HleFn)h_http_create_template, "sceHttpCreateTemplate");
     Hle::register_fn("4I8vEpuEhZ8", (HleFn)h_http_delete_template, "sceHttpDeleteTemplate");
+    Hle::register_fn("Ik-KpLTlf7Q", (HleFn)h_http_term, "sceHttpTerm");
+    // Offline-computable, so there is no reason for it to answer a false success (#2930).
+    Hle::register_fn("5LZA+KPISVA", (HleFn)h_http_uri_build, "sceHttpUriBuild");
 }
 
 } // namespace prosper

--- a/prosper/src/hle/net/hle_http.hpp
+++ b/prosper/src/hle/net/hle_http.hpp
@@ -28,4 +28,21 @@ constexpr uint32_t kErrorOutOfMemory = 0x80431022u;
 constexpr uint32_t kErrorInvalidValue = 0x804311feu;
 constexpr uint32_t kErrorInvalidUrl = 0x80433060u;
 
+// The library's own id validator answers exactly this for an out-of-range or unallocated
+// library context id. CONFIDENCE: HIGH -- read off the validator itself rather than inferred
+// from an error-name table (see hle_http.cpp's note on where these came from).
+constexpr uint32_t kErrorInvalidId = 0x80431100u;
+
+// sceHttpUriBuild component selectors. Each bit gates one SceHttpUriElement field; the caller
+// passes the union of the parts it wants emitted.
+constexpr uint32_t kUriBuildScheme = 0x01u;
+constexpr uint32_t kUriBuildHostname = 0x02u;
+constexpr uint32_t kUriBuildPort = 0x04u;
+constexpr uint32_t kUriBuildPath = 0x08u;
+constexpr uint32_t kUriBuildUsername = 0x10u;
+constexpr uint32_t kUriBuildPassword = 0x20u;
+constexpr uint32_t kUriBuildQuery = 0x40u;
+constexpr uint32_t kUriBuildFragment = 0x80u;
+constexpr uint32_t kUriBuildAll = 0xffu;
+
 } // namespace prosper::http

--- a/prosper/tests/hle/net/test_http.cpp
+++ b/prosper/tests/hle/net/test_http.cpp
@@ -113,6 +113,36 @@ int main() {
           std::strcmp(built.data(), "http://alice:secret@2001:db8::1:8080/x#frag") == 0,
           "userinfo, explicit port, path and fragment are assembled in the library's order");
 
+    // A guest-supplied element need not have come from our own parser, so build one BY HAND to
+    // reach the library's PREFIX-compare default-port lookup: "httpx" takes HTTP's 80 and the
+    // port is therefore suppressed. An exact-match lookup would emit ":80" here.
+    char hand_scheme[] = "httpx";
+    char hand_host[] = "example.test";
+    char hand_empty[] = "";
+    http::SceHttpUriElement hand{};
+    hand.opaque = false;
+    hand.scheme = hand_scheme;
+    hand.username = hand_empty;
+    hand.password = hand_empty;
+    hand.hostname = hand_host;
+    hand.path = hand_empty;
+    hand.query = hand_empty;
+    hand.fragment = hand_empty;
+    hand.port = 80;
+    std::memset(built.data(), 0, built.size());
+    CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), (uint64_t)&hand,
+                http::kUriBuildAll, 0) == 0 &&
+          std::strcmp(built.data(), "httpx://example.test") == 0,
+          "a prefix-matching scheme takes HTTP's default port, so \":80\" is suppressed");
+    // The contrasting arm: without this a lookup that suppressed every port would also pass above.
+    char hand_ftp[] = "ftp";
+    hand.scheme = hand_ftp;
+    std::memset(built.data(), 0, built.size());
+    build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), (uint64_t)&hand,
+          http::kUriBuildAll, 0);
+    CHECK(std::strcmp(built.data(), "ftp://example.test:80") == 0,
+          "a scheme with no default port emits \":80\" rather than suppressing it");
+
     // Error paths. None of these values can come from the dispatcher default.
     CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), 0,
                 http::kUriBuildAll, 0) == http::kErrorInvalidUrl,
@@ -152,14 +182,34 @@ int main() {
               "a terminated context no longer creates templates");
         CHECK(term(ctx, 0, 0, 0, 0, 0) == http::kErrorInvalidId,
               "terminating an already-released context returns INVALID_ID");
-        // ...and the slot really is reusable, so a title that init/terms repeatedly cannot
-        // exhaust the four-slot table.
-        for (int i = 0; i < 16; i++) {
+        // Kills a Term that releases the context slot but leaves its templates allocated. Fill
+        // the template table from one context, terminate it, and a fresh context must be able to
+        // fill it to the same depth -- which it cannot if the templates outlived their owner.
+        //
+        // The arm this replaces ran 16 init/term cycles that created NO templates, so it could
+        // not express the case it claimed to guard: a template leak was structurally invisible
+        // to it. Same vacuity class as #3288.
+        uint64_t owner_ctx = init(0, 0, 0, 0, 0, 0);
+        int first_fill = 0;
+        while ((int64_t)create_tmpl(owner_ctx, 0, 0, 0, 0, 0) > 0) first_fill++;
+        CHECK(first_fill > 0, "the template table fills from a live context");
+        CHECK(term(owner_ctx, 0, 0, 0, 0, 0) == 0,
+              "sceHttpTerm releases a context that still owns templates");
+        uint64_t next_ctx = init(0, 0, 0, 0, 0, 0);
+        int second_fill = 0;
+        while ((int64_t)create_tmpl(next_ctx, 0, 0, 0, 0, 0) > 0) second_fill++;
+        CHECK(second_fill == first_fill,
+              "sceHttpTerm reclaims the templates its context owned");
+        CHECK(term(next_ctx, 0, 0, 0, 0, 0) == 0, "the second context releases cleanly");
+
+        // Context slots are reusable too: more init/term cycles than the table is deep. One
+        // CHECK site, evaluated once, so the executed count and the source count agree.
+        bool ctx_cycles_ok = true;
+        for (int i = 0; i < 16 && ctx_cycles_ok; i++) {
             uint64_t again = init(0, 0, 0, 0, 0, 0);
-            if ((int64_t)again <= 0) { CHECK(false, "init/term cycles do not leak context slots"); break; }
-            term(again, 0, 0, 0, 0, 0);
-            if (i == 15) CHECK(true, "init/term cycles do not leak context slots");
+            ctx_cycles_ok = (int64_t)again > 0 && term(again, 0, 0, 0, 0, 0) == 0;
         }
+        CHECK(ctx_cycles_ok, "16 init/term cycles do not leak context slots");
     }
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/hle/net/test_http.cpp
+++ b/prosper/tests/hle/net/test_http.cpp
@@ -142,6 +142,16 @@ int main() {
           http::kUriBuildAll, 0);
     CHECK(std::strcmp(built.data(), "ftp://example.test:80") == 0,
           "a scheme with no default port emits \":80\" rather than suppressing it");
+    // The third literal the library compares is a string-merge artifact, "TTP", and it maps to 80
+    // like "HTTP". Without this arm that branch is dead under test -- deleting it from the source
+    // would leave every other check green, which is a poor outcome for the one line N1 was about.
+    char hand_ttp[] = "ttp";
+    hand.scheme = hand_ttp;
+    std::memset(built.data(), 0, built.size());
+    build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), (uint64_t)&hand,
+          http::kUriBuildAll, 0);
+    CHECK(std::strcmp(built.data(), "ttp://example.test") == 0,
+          "the library's \"TTP\" literal also defaults to 80, so its \":80\" is suppressed too");
 
     // Error paths. None of these values can come from the dispatcher default.
     CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), 0,
@@ -210,6 +220,28 @@ int main() {
             ctx_cycles_ok = (int64_t)again > 0 && term(again, 0, 0, 0, 0, 0) == 0;
         }
         CHECK(ctx_cycles_ok, "16 init/term cycles do not leak context slots");
+
+        // The arm above proves templates die with a Term; it does NOT prove they die SELECTIVELY.
+        // A Term that cleared every slot regardless of owner satisfies it completely, which would
+        // make the owner field itself untested -- the same vacuity one level in. So: two live
+        // contexts, terminate one, and require the other's template to survive.
+        //
+        // Counted rather than probed, because there is no getter for a template. Exactly one slot
+        // must come back: the depth left for ctx_b is first_fill - 1 if only ctx_a's template was
+        // reclaimed, and first_fill if Term cleared the table indiscriminately.
+        uint64_t ctx_a = init(0, 0, 0, 0, 0, 0);
+        uint64_t ctx_b = init(0, 0, 0, 0, 0, 0);
+        uint64_t tmpl_a = create_tmpl(ctx_a, 0, 0, 0, 0, 0);
+        uint64_t tmpl_b = create_tmpl(ctx_b, 0, 0, 0, 0, 0);
+        CHECK((int64_t)ctx_a > 0 && (int64_t)ctx_b > 0 && ctx_a != ctx_b &&
+              (int64_t)tmpl_a > 0 && (int64_t)tmpl_b > 0 && tmpl_a != tmpl_b,
+              "two live contexts hold distinct templates");
+        CHECK(term(ctx_a, 0, 0, 0, 0, 0) == 0, "one of two live contexts terminates");
+        int remaining = 0;
+        while ((int64_t)create_tmpl(ctx_b, 0, 0, 0, 0, 0) > 0) remaining++;
+        CHECK(remaining == first_fill - 1,
+              "sceHttpTerm reclaims ONLY the terminated context's templates");
+        term(ctx_b, 0, 0, 0, 0, 0);
     }
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/hle/net/test_http.cpp
+++ b/prosper/tests/hle/net/test_http.cpp
@@ -60,6 +60,108 @@ int main() {
     CHECK(parse(0, (uint64_t)url, 0, 0, 0, 0) == http::kErrorInvalidValue,
           "size query without required-size output returns INVALID_VALUE");
 
+    // ---- sceHttpUriBuild (#2930) --------------------------------------------------------
+    // Every assertion below is chosen so the dispatcher's unregistered default CANNOT satisfy
+    // it: a return of 0 with the caller's buffer untouched fails the content checks, and the
+    // error paths all answer non-zero.
+    std::printf("-- sceHttpUriBuild --\n");
+    HleFn build = Hle::lookup("5LZA+KPISVA");
+    CHECK(build && std::strcmp(Hle::name_of("5LZA+KPISVA"), "sceHttpUriBuild") == 0,
+          "sceHttpUriBuild registered by its PS5 NID");
+    if (!build) { std::printf("== FAIL: %d ==\n", fails + 1); return 1; }
+
+    // Round-trip the telemetry URL through parse -> build. The default port must NOT reappear.
+    std::memset(&uri, 0, sizeof(uri));
+    std::memset(pool.data(), 0, pool.size());
+    parse((uint64_t)&uri, (uint64_t)url, (uint64_t)pool.data(), (uint64_t)&required, pool.size(), 0);
+    std::array<char, 512> built{};
+    uint64_t build_need = 0;
+    CHECK(build(0, (uint64_t)&build_need, 0, (uint64_t)&uri, http::kUriBuildAll, 0) == 0 &&
+          build_need == std::strlen(url) + 1,
+          "size query reports the assembled length including the NUL");
+    CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), (uint64_t)&uri,
+                http::kUriBuildAll, 0) == 0 &&
+          std::strcmp(built.data(), url) == 0,
+          "parse -> build round-trips the URL, and the default 443 stays suppressed");
+
+    // A port that is NOT the scheme default must be emitted.
+    uri.port = 8443;
+    std::memset(built.data(), 0, built.size());
+    build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), (uint64_t)&uri,
+          http::kUriBuildAll, 0);
+    CHECK(std::strstr(built.data(), "events.backtrace.io:8443/api") != nullptr,
+          "a non-default port is emitted as \":8443\" after the host");
+    uri.port = 443;
+
+    // Flag gating: ask for scheme + host only and nothing else may appear.
+    std::memset(built.data(), 0, built.size());
+    CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), (uint64_t)&uri,
+                http::kUriBuildScheme | http::kUriBuildHostname, 0) == 0 &&
+          std::strcmp(built.data(), "https://events.backtrace.io") == 0,
+          "component flags gate emission -- path and query are absent when unselected");
+
+    // The library emits element->hostname verbatim, so an IPv6 literal that the PARSER stripped
+    // of its brackets is rebuilt without them. Asserted rather than "fixed": matching the
+    // shipped library is the contract, and a guest that re-parses the result depends on it.
+    std::memset(&uri, 0, sizeof(uri));
+    std::memset(pool.data(), 0, pool.size());
+    parse((uint64_t)&uri, (uint64_t)complex, (uint64_t)pool.data(), (uint64_t)&required,
+          pool.size(), 0);
+    std::memset(built.data(), 0, built.size());
+    CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), (uint64_t)&uri,
+                http::kUriBuildAll, 0) == 0 &&
+          std::strcmp(built.data(), "http://alice:secret@2001:db8::1:8080/x#frag") == 0,
+          "userinfo, explicit port, path and fragment are assembled in the library's order");
+
+    // Error paths. None of these values can come from the dispatcher default.
+    CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, built.size(), 0,
+                http::kUriBuildAll, 0) == http::kErrorInvalidUrl,
+          "a null element returns SCE_HTTP_ERROR_INVALID_URL");
+    CHECK(build(0, 0, 0, (uint64_t)&uri, http::kUriBuildAll, 0) == http::kErrorInvalidValue,
+          "neither an output buffer nor a size output returns INVALID_VALUE");
+    build_need = 0;
+    CHECK(build((uint64_t)built.data(), (uint64_t)&build_need, 4, (uint64_t)&uri,
+                http::kUriBuildAll, 0) == http::kErrorOutOfMemory,
+          "an undersized pool returns SCE_HTTP_ERROR_OUT_OF_MEMORY");
+    // The library stores the requirement BEFORE checking the pool, so a caller that was just
+    // refused still learns the size it should retry with. A build that reordered those two
+    // steps would leave this zero.
+    CHECK(build_need == std::strlen("http://alice:secret@2001:db8::1:8080/x#frag") + 1,
+          "the required size is reported even on the OUT_OF_MEMORY path");
+
+    // ---- library context lifecycle (#2930) ----------------------------------------------
+    std::printf("-- sceHttpTerm / context validation --\n");
+    HleFn init = Hle::lookup("A9cVMUtEp4Y");
+    HleFn create_tmpl = Hle::lookup("0gYjPTR-6cY");
+    HleFn term = Hle::lookup("Ik-KpLTlf7Q");
+    CHECK(term && std::strcmp(Hle::name_of("Ik-KpLTlf7Q"), "sceHttpTerm") == 0,
+          "sceHttpTerm registered by its PS5 NID");
+    if (init && create_tmpl && term) {
+        uint64_t ctx = init(0, 0, 0, 0, 0, 0);
+        CHECK((int64_t)ctx > 0, "sceHttpInit hands out a positive library context id");
+        CHECK((int64_t)create_tmpl(ctx, 0, 0, 0, 0, 0) > 0,
+              "a template is created against a live context");
+        // An id nobody handed out is not a context. The encoding is the library's own.
+        CHECK((int32_t)create_tmpl(0, 0, 0, 0, 0, 0) == (int32_t)http::kErrorInvalidId,
+              "sceHttpCreateTemplate rejects context id 0 with INVALID_ID");
+        CHECK((int64_t)create_tmpl(999, 0, 0, 0, 0, 0) < 0,
+              "sceHttpCreateTemplate rejects an out-of-range context, sign-extended negative");
+        CHECK(term(ctx, 0, 0, 0, 0, 0) == 0, "sceHttpTerm releases a live context");
+        // Kills a term whose body is just `return 0`: the released id must stop working.
+        CHECK((int32_t)create_tmpl(ctx, 0, 0, 0, 0, 0) == (int32_t)http::kErrorInvalidId,
+              "a terminated context no longer creates templates");
+        CHECK(term(ctx, 0, 0, 0, 0, 0) == http::kErrorInvalidId,
+              "terminating an already-released context returns INVALID_ID");
+        // ...and the slot really is reusable, so a title that init/terms repeatedly cannot
+        // exhaust the four-slot table.
+        for (int i = 0; i < 16; i++) {
+            uint64_t again = init(0, 0, 0, 0, 0, 0);
+            if ((int64_t)again <= 0) { CHECK(false, "init/term cycles do not leak context slots"); break; }
+            term(again, 0, 0, 0, 0, 0);
+            if (i == 15) CHECK(true, "init/term cycles do not leak context slots");
+        }
+    }
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Closes the three false successes that #2965 left open on #2930, each answered from the shipped
PS5 3.20 `libSceHttp` rather than from a guessed encoding. Refs #2894, whose blocking question this
also settles — and, after review, records that falsification in the status doc the next agent will
actually read.

## The failure

`libSceHttp` still had entry points falling to `prosper_on_unimpl`, which returns `0`:

* **`sceHttpUriBuild`** reported `SCE_OK` with the caller's output buffer **untouched**, so the
  caller read whatever already happened to be in that buffer as a URI. *Sifu* is the surveyed caller.
* **`sceHttpTerm`** was unregistered, so a library context could be created but never released.
* **`sceHttpCreateTemplate`** accepted any context id at all, including ones nobody handed out.

## Contract, and where it came from

Not inferred from an error-name table — read off the library itself. `<DUMP_ROOT>/sprx/` carries
`libSceHttp.sprx` as a plain ELF (entropy 5.417 bits/byte; nothing decrypted anywhere in this work),
so its URI helpers and its id validator can be read directly.

`sceHttpUriBuild` (`5LZA+KPISVA`, `+0x21ac0`):

```
int32_t sceHttpUriBuild(char* out, size_t* required, size_t pool_size,
                        const SceHttpUriElement* element, uint32_t flags);
```

* `element == nullptr` -> `INVALID_URL`, checked **before** the output pointer is looked at.
* `out == nullptr && required == nullptr` -> `INVALID_VALUE`.
* `*required` is the assembled length **including the NUL**, and is stored **before** the
  buffer-size check — so a caller refused with `OUT_OF_MEMORY` still learns what to retry with.
* `out == nullptr` is a size query and returns `SCE_OK`.
* Components are gated by individual flag bits, emitted in the order
  `scheme ':' "//" user ':' pass '@' host ':' port path query fragment`, with the library's own
  per-component `strnlen` caps (`0x20` scheme, `0x100` userinfo, `0xff` host, `0x3fff` path/query/
  fragment).
* The default-port lookup (`+0x21950`) is a **prefix** compare over three literals — `HTTPS`/443,
  `HTTP`/80, and a string-merge artifact `TTP`/80 — reproduced rather than narrowed, because
  `element->scheme` is guest-supplied: `"httpx"` prefix-matches `HTTP` and suppresses `:80` on
  hardware.

`sceHttpTerm` is `Ik-KpLTlf7Q`. The comment this PR replaces asserted that "PS5 3.20 libSceHttp
exports no `sceHttpTerminate`" — the export exists, it is spelled `sceHttpTerm`, and *PGA TOUR 2K25*
imports it. It does not merely drop the context: after the refcount decrement at `+0x1068b` it runs
four per-context teardown helpers (`+0x83f0`, `+0x1c8e0`, `+0x35b0`, `+0xaf90`), so templates are
owned by their context here and reclaimed with it.

The context-id error is `0x80431100`, taken from the validator at **`+0xb070`** — the one
`sceHttpCreateTemplate` (`+0x107f0`) actually calls, not the same-shaped neighbour at `+0xaca0`.
CONFIDENCE: HIGH.

## Documentation (the blocking review finding)

`prosper/docs/PGA_TOUR_2K25_STATUS.md` still asserted that the libSceHttp2 error values "are not
derivable from the dump, from `../PS5-3.20_Libs/`, or from prosper's existing `0x8043xxxx`
constants". #2894 disproves that, `CLAUDE.md` routes the next PGA TOUR agent to that doc rather than
to an issue comment, and the claim was load-bearing in the wrong direction — it said the work could
not be started. Corrected, with two `## Ruled out` rows recording the facility (`0x817b____`, so the
v1 constants are **not** reusable), the exhaustive 33-target jump-table result, and the
`0x80410100 | BSD errno` encoding.

## Deliberately NOT done

The v1 request path (`CreateConnection*`, `CreateRequest*`, the send path) stays unregistered. The
reason is **scope, not hazard** — an earlier draft of this body said a constant here would be an
"error sentinel read as data", and this PR's own evidence retired that: every non-zero value
classifies identically, so a wrong constant there would be wrong, not dangerous. No surveyed v1
title reaches that path, and the encoding belongs to #2894.

One deliberate infidelity, commented in the source: the parser strips brackets from an IPv6 literal
and the builder does not re-add them, so `http://[::1]:8080/` does not round-trip byte-for-byte.
That is the shipped library's behaviour; it is **asserted** by a test rather than "fixed", because a
guest that re-parses the result depends on it. The `BEFORE_INIT`-vs-`INVALID_ID` distinction the
library draws and prosper collapses is likewise recorded in the comment as seen, not missed.

## Verification

Linux, container `ps5ys`, `-j4`, exact head `58632a28c`.

| | build | ctest |
| --- | --- | --- |
| `origin/main` (`e05d71301`) baseline | rc=0 | **353/353**, rc=0 |
| this branch, exact head | rc=0 | **353/353**, rc=0 |

`ctest --no-tests=error -R '^http_hle$'` -> 1/1 passed, rc=0. `diff --check` clean; the numbered-table
docs gate passes over every tracked `.md`.

`test_http` goes **12 -> 41 checks (+29)**. Every `CHECK` site now executes exactly once, so the
source count and the executed count are the same number and the artifacts cannot disagree.
**All 29 were run against mutated builds**; every mutation exits 1 on the checks that name it:

| mutation | exit | checks that failed |
| --- | --- | --- |
| unregister `sceHttpUriBuild` (the original defect) | 1 | registered-by-NID |
| store `*required` **after** the pool-size check | 1 | required-size on the OOM path |
| always emit the port | 1 | size query; round-trip; prefix-scheme suppression |
| drop the context-id validation | 1 | rejects ctx 0; out-of-range; terminated ctx; template reclaim |
| `sceHttpTerm` as a no-op success | 1 | rejects ctx 0; out-of-range; terminated ctx; template reclaim |
| never emit `"//"` | 1 | round-trip; flag gating; assembly order; both port arms |
| **M7** Term frees only the context slot (templates leak) | 1 | template reclaim + owner discrimination |
| **M8** exact-match default port instead of the prefix compare | 1 | both prefix-scheme arms |
| **M9** drop the `"ttp"` prefix arm | 1 | the `"TTP"` arm — *and only that one* |
| **M10** Term clears **every** context's templates, not just the terminated one's | 1 | owner discrimination — *and only that one* |

M7/M8 close the review's N1/N2; M9/M10 close the two coverage gaps found on re-review. The
template-reclaim check replaces one that ran 16 init/term cycles creating **no templates** — a leak
was structurally inexpressible to it, the same vacuity class as #3288. M10 is the reason that fix
needed a second pass: the replacement proved templates *die*, not that they die *selectively*, so a
Term weakened to `if (tmpl.in_use) tmpl = {}` passed everything. The owner field's whole purpose was
untested until the two-context arm existed, and M9/M10 each firing exactly one check is the proof
that neither new arm passes for an unrelated reason.

No snapshots: this touches no renderer path, and the machine's GPU is held by another lane.
No screenshot and no `BLOG.md` entry — this moves no title's rung and produces no image. The finding
worth reading is the #2894 analysis.

Refs #2930
Refs #2894
