### PR TITLE
tests: test_trap_linux asserted The Messenger's import count, not its own subject (#2997)

### DIFF
--- a/prosper/docs/VERIFICATION.md
+++ b/prosper/docs/VERIFICATION.md
@@ -176,10 +176,23 @@ cases carry assertions that only run with a dump — `module_loads_eboot`, `nid_
 so a regression in the paths they cover is caught only by an agent who happens to run the suite
 locally with that title installed, which is not a gate. #2567 carries the measured per-case census.
 
-**Five of the six cannot be synthesized and should not be.** They are pinned to one real title's
+**Four of the six cannot be synthesized and should not be.** They are pinned to one real title's
 bytes — `PPSA24651`'s import counts, its IL2CPP module layout, the RDNA2 blobs embedded in its
 eboot. A synthetic fixture would be a *different* test wearing the same name, which is worse than an
 honest skip.
+
+**Ruled out: `trap_identifies_imports` was never one of them (#2997).** It was counted here because
+it asserted `prog.slots.size() > 500` — PPSA24651's slot count — but that assertion was incidental
+to what the case tests, which is the title-agnostic link → map → stub → dispatch chain. Measured
+across all 55 local dumps: slot counts run from 179 (`PPSA16901`) to over 500, and **all 55 dispatch
+all four probed libraries correctly**. The count made it *fail* — not skip — on four titles,
+including `PPSA15552` (*Dead Cells*, rung 6, guarded) and `PPSA03839` (*Tactics Ogre*, rung 3). With
+the assertion made title-agnostic it passes on 55 of 55, so it is dump-*requiring* but not
+title-pinned, and it needs neither a gate nor a synthetic fixture.
+
+The distinction is the one worth carrying forward: a case that *needs a dump* is not the same as a
+case *pinned to one title's bytes*, and reaching for `prosper_add_title_gated_test` on the first kind
+trades a false red for lost coverage on every other dump.
 
 **`plugin_autolink`'s dump-gated block was the exception, and is now covered without a dump.** What it
 guards — `link_program`'s export table, the duplicate-export collision guard (#1609) and the alias

--- a/prosper/tests/misc/test_trap_linux.cpp
+++ b/prosper/tests/misc/test_trap_linux.cpp
@@ -23,11 +23,28 @@ int main(int argc, char** argv) {
     if (!link_program({ { dump + "/eboot.bin", 0x400000000ull } }, 0x600000000ull, prog, &err)) {
         printf("  [FAIL] link: %s\n", err.c_str()); return 1;
     }
-    CHECK(prog.slots.size() > 500, "expected many stub slots, got %zu", prog.slots.size());
+    // > 0, not > 500 (#2997). The old threshold was PPSA24651's import count, and this test is not
+    // about how many imports a title has -- it is about the link -> map -> stub -> dispatch chain,
+    // which is title-agnostic. Measured across all 55 local dumps: import tables run from 179 slots
+    // (PPSA16901) to well over 500, so the threshold failed FOUR titles on a property none of them
+    // was doing anything wrong about -- including PPSA15552 (Dead Cells, rung 6) and PPSA03839
+    // (Tactics Ogre, rung 3), so this was not confined to new bring-ups.
+    //
+    // A red case is materially worse than a skip here: an agent bringing up a title has to prove a
+    // failure is pre-existing before it can trust anything else in the run. Skipping on a
+    // non-Messenger dump was the other option and is what #1573 did for its three siblings, but it
+    // would drop this chain's coverage on the other 54 dumps -- and the chain working is exactly
+    // what a bring-up agent wants to know first.
+    CHECK(!prog.slots.empty(), "link produced no import stub slots at all");
     for (auto& img : prog.imgs) CHECK(map_image(img, &err), "map: %s", err.c_str());
     CHECK(install_stubs(prog.slots, prog.stub_base, prog.stub_size, &err), "install_stubs: %s", err.c_str());
     install_trap_handler();
 
+    // These four are the real coverage, and the four names are MEASURED rather than assumed: all 55
+    // local dumps import all four and dispatch all four correctly (#2997). If a future title does
+    // not import one of them, this loop fails with "no stub slot for <lib>" -- which names the cause
+    // directly, so it stays a fixed list rather than becoming adaptive on a case that has never
+    // occurred.
     for (const char* lib : {"libkernel", "libSceAgc", "libc", "libSceVideoOut"}) {
         long slot = -1;
         for (size_t i = 0; i < prog.slots.size(); i++) if (prog.slots[i].lib == lib) { slot = (long)i; break; }

--- a/prosper/tests/misc/test_trap_linux.cpp
+++ b/prosper/tests/misc/test_trap_linux.cpp
@@ -23,19 +23,29 @@ int main(int argc, char** argv) {
     if (!link_program({ { dump + "/eboot.bin", 0x400000000ull } }, 0x600000000ull, prog, &err)) {
         printf("  [FAIL] link: %s\n", err.c_str()); return 1;
     }
-    // > 0, not > 500 (#2997). The old threshold was PPSA24651's import count, and this test is not
-    // about how many imports a title has -- it is about the link -> map -> stub -> dispatch chain,
-    // which is title-agnostic. Measured across all 55 local dumps: import tables run from 179 slots
-    // (PPSA16901) to well over 500, so the threshold failed FOUR titles on a property none of them
-    // was doing anything wrong about -- including PPSA15552 (Dead Cells, rung 6) and PPSA03839
-    // (Tactics Ogre, rung 3), so this was not confined to new bring-ups.
+    // NOT `> 500` (#2997). That threshold was PPSA24651's slot count, and this test is not about how
+    // many imports a title has -- it is about the link -> map -> stub -> dispatch chain, which is
+    // title-agnostic. Measured across all 55 local dumps: slot counts run from 179 (PPSA16901) to
+    // over 500, so the threshold FAILED four titles on a property none of them was doing anything
+    // wrong about -- including PPSA15552 (Dead Cells, rung 6) and PPSA03839 (Tactics Ogre, rung 3).
+    // A red case is worse than a skip: it forces a bring-up agent to prove a failure is pre-existing
+    // before trusting anything else in the run.
     //
-    // A red case is materially worse than a skip here: an agent bringing up a title has to prove a
-    // failure is pre-existing before it can trust anything else in the run. Skipping on a
-    // non-Messenger dump was the other option and is what #1573 did for its three siblings, but it
-    // would drop this chain's coverage on the other 54 dumps -- and the chain working is exactly
-    // what a bring-up agent wants to know first.
-    CHECK(!prog.slots.empty(), "link produced no import stub slots at all");
+    // What replaces it is NOT `!slots.empty()`. Review showed that would be strictly SUBSUMED by the
+    // four `slot >= 0` probes below -- no state fails it while those pass -- so it would read as an
+    // assertion while carrying no weight. These are the linker's own accounting invariants instead,
+    // and they are title-agnostic in the way the count only pretended to be:
+    //   * the module imports something at all;
+    //   * every import is accounted for as either cross-module-resolved or stubbed -- this is what
+    //     catches a linker that silently DROPS imports (e.g. deduplicating on the wrong key), which
+    //     a slot-count floor cannot distinguish from a title that simply imports less;
+    //   * every stubbed import actually got a slot, which is the precondition for everything below.
+    CHECK(prog.total_imports > 0, "link produced no imports at all");
+    CHECK(prog.total_imports == prog.resolved_cross_module + prog.stubbed,
+          "import accounting does not close: %zu total != %zu cross-module + %zu stubbed",
+          prog.total_imports, prog.resolved_cross_module, prog.stubbed);
+    CHECK(prog.stubbed == prog.slots.size(),
+          "%zu imports stubbed but %zu slots emitted", prog.stubbed, prog.slots.size());
     for (auto& img : prog.imgs) CHECK(map_image(img, &err), "map: %s", err.c_str());
     CHECK(install_stubs(prog.slots, prog.stub_base, prog.stub_size, &err), "install_stubs: %s", err.c_str());
     install_trap_handler();

--- a/prosper/tests/misc/test_trap_linux.cpp
+++ b/prosper/tests/misc/test_trap_linux.cpp
@@ -36,10 +36,17 @@ int main(int argc, char** argv) {
     // assertion while carrying no weight. These are the linker's own accounting invariants instead,
     // and they are title-agnostic in the way the count only pretended to be:
     //   * the module imports something at all;
-    //   * every import is accounted for as either cross-module-resolved or stubbed -- this is what
-    //     catches a linker that silently DROPS imports (e.g. deduplicating on the wrong key), which
-    //     a slot-count floor cannot distinguish from a title that simply imports less;
-    //   * every stubbed import actually got a slot, which is the precondition for everything below.
+    //   * every import is accounted for as either cross-module-resolved or stubbed. This cannot fail
+    //     on any input: pass 2's body increments total_imports and then exactly one of the other two
+    //     (linker.cpp:115 / :119 / :131), with no third path. It is an EDIT guard, not a detector --
+    //     it fires if a future filter or early-out counts an import without accounting for it.
+    //   * every stubbed import got its OWN slot. This is the one that carries weight: deduplicating
+    //     on the wrong key (lib instead of NID) leaves the accounting identity intact -- 612 == 0 +
+    //     612 on PPSA24651 -- while collapsing 612 slots to 35, which is what a slot-count floor
+    //     could not tell apart from a title that simply imports less. It is an equality only because
+    //     no eboot imports the same NID twice: MEASURED at 0 duplicates across all 55 dumps, not
+    //     derived (module.cpp:221 does not dedupe imports, and linker.cpp:122 keys the slot table on
+    //     the NID alone).
     CHECK(prog.total_imports > 0, "link produced no imports at all");
     CHECK(prog.total_imports == prog.resolved_cross_module + prog.stubbed,
           "import accounting does not close: %zu total != %zu cross-module + %zu stubbed",


### PR DESCRIPTION
Fixes #2997.

## The defect

`tests/misc/test_trap_linux.cpp:26` asserted `prog.slots.size() > 500`. That number is *The
Messenger's* import count. The test's actual subject is the **link → map → stub → dispatch chain**,
which is title-agnostic — nothing in it depends on how many imports a title has. So any dump with a
smaller import table came back as a **failure** rather than a skip.

## Census: four titles, and two of them are not new bring-ups

The binary takes the dump as `argv[1]`, so the already-built executable can be pointed at every local
dump without reconfiguring. Ran all **55**, capturing the real exit code (a `| tail` would have
discarded it):

| titles | slots | result |
| --- | --- | --- |
| 51 | > 500 | `15 passed, 0 failed`, rc 0 |
| PPSA03839 — *Tactics Ogre: Reborn*, rung 3 | 406 | `14 passed, 1 failed`, rc 1 |
| PPSA31334 | 364 | `14 passed, 1 failed`, rc 1 |
| PPSA15552 — *Dead Cells*, **rung 6, guarded** | 310 | `14 passed, 1 failed`, rc 1 |
| PPSA16901 | 179 | `14 passed, 1 failed`, rc 1 |

The issue reported one affected title; it is four, and two of them are titles the project actively
works on — so this was not confined to new bring-ups.

Every one of the four fails **only** this assertion, and all 55 dumps dispatch all four probed
libraries correctly. The chain works everywhere; the single Messenger-shaped constant was the entire
defect.

## Why the title-agnostic assertion rather than the title-gated skip

The issue offers both. #1573 chose the skip for `module_loads_eboot`, `boot_reaches_first_syscall`
and `real_shader_render`, and that is correct for those — their assertions really do pin PPSA24651's
own bytes.

This case is different. Gating it on PPSA24651 would trade a false red for **lost coverage on 54
dumps** of exactly the chain a bring-up agent wants confirmed first. And a red case is materially
worse than a skip in a way that compounds: it forces whoever is bringing up a title to prove a
failure is pre-existing before they can trust any other result in the run.

So `> 500` becomes `!prog.slots.empty()`, with the measured range and the reasoning in a comment so
the constant does not grow back.

## A hypothesis the census killed

I expected the hardcoded library list (`libkernel`, `libSceAgc`, `libc`, `libSceVideoOut`) to be a
**second** Messenger assumption hiding behind the first — a title that did not import one of them
would fail even after the count was fixed.

**All 55 dumps import all four and dispatch all four.** So the list stays fixed rather than becoming
an adaptive lookup for a case that has never occurred, and the comment now records that as measured
rather than assumed. Recording the dead hypothesis because it is exactly the kind of plausible
second-order guess that otherwise gets "fixed" at cost.

## Verification

Exact head, Linux, in the distrobox:

| | before | after |
| --- | --- | --- |
| dumps with rc 0 | 51 / 55 | **55 / 55** |
| PPSA03839 / PPSA31334 / PPSA15552 / PPSA16901 | `14 passed, 1 failed` | `15 passed, 0 failed` |

```
cmake --build prosper/build-linux -j4                        # exit 0
ctest --no-tests=error --output-on-failure --timeout 900     # exit 0, 353/353 at this exact head, 127.22s
```

### Correction after review — the first replacement was subsumed

The first version of this fix replaced `> 500` with `!prog.slots.empty()`. **Review showed that is
strictly subsumed by the four `slot >= 0` probes below it** — no state fails it while those pass — so
it read as an assertion while carrying no weight, and my mutation for it (clearing slots in the
test) was a same-source control demonstrating the CHECK was *wired*, not that it was non-trivial.
That was an overclaim and it is corrected rather than softened.

It is now the linker's own accounting invariants, which are title-agnostic in the way the count only
pretended to be:

```cpp
CHECK(prog.total_imports > 0, …);
CHECK(prog.total_imports == prog.resolved_cross_module + prog.stubbed, …);
CHECK(prog.stubbed == prog.slots.size(), …);
```

The middle one carries the weight: it catches a linker that silently **drops** imports, which a
slot-count floor cannot distinguish from a title that simply imports fewer.

### Mutation arms — demonstrated against the reviewer's counterexample, not one of my choosing

Verdicts are test exit codes.

| | mutation | before (`!empty()`) | now |
| --- | --- | --- | --- |
| **dedupe stub slots on `imp.lib_name` instead of `imp.nid`** (`linker.cpp:122`/`:127`) — collapses PPSA24651 from 612 imports to 35 slots | **passed 15/15** | **rc 1**, `612 imports stubbed but 35 slots emitted` |
| dispatcher returns 1 instead of 0 | rc 4, `11 passed, 4 failed` | rc 4 |
| none (baseline) | rc 0 | rc 0, `17 passed` |

The first row is the point: it is the breakage review offered as evidence the old assertion was
weak, and it is now caught.

### Blocking finding — `VERIFICATION.md` corrected

`docs/VERIFICATION.md:179` claimed **five** of the six dump-gated cases "cannot be synthesized and
should not be… pinned to one real title's bytes — `PPSA24651`'s import counts", counting
`trap_identifies_imports` among them. The census falsifies that, and that file is what an agent reads
when choosing between a gate and a synthetic fixture — the exact decision #2997 is about. It now
reads **four**, with a `## Ruled out` entry recording the measurement and the distinction that
matters: *a case that needs a dump is not the same as a case pinned to one title's bytes.*

## Verification

| | before | after |
| --- | --- | --- |
| dumps with rc 0 | 51 / 55 | **55 / 55** |
| checks per dump | 15 | **17** |

```
cmake --build prosper/build-linux -j4                        # exit 0
ctest --no-tests=error --output-on-failure --timeout 900     # exit 0, 353/353 at this exact head
```

## Not covered

**The accounting identity cannot fail on any input.** Pass 2's body increments `total_imports` and
then exactly one of the other two counters (`linker.cpp:115` / `:119` / `:131`), with no third path,
so no dump can break it. It is an **edit guard** — it fires if a future filter or early-out counts an
import without accounting for it — not a detector. `stubbed == slots.size()` is the check with
detection power, and it is an equality only because no eboot imports the same NID twice: **measured
at 0 duplicates across all 55 dumps** (independently confirmed in review by `self_dump
--import-slots`, a different code path), not derived.

Which edits each shape does and does not catch:

| edit | identity | caught? |
| --- | --- | --- |
| a `break` **before** `:115` | all three counters stop together | **no** |
| an early-out **after** `:115` | identity breaks | yes |
| dedupe on the wrong key | intact (`612 == 0 + 612`) | yes, by `stubbed == slots.size()` |

Review offered a 4-line recomputation from `mods[0]->imports` that would close the first row
structurally rather than by corpus. I did not adopt it — out of scope for an issue about a
title-pinned constant, and the reviewer confirmed it needs no further review either way.

**Forward note:** `stubbed == slots.size()` is a single-module property. If this case ever links PRXs
alongside the eboot, two modules importing the same unresolved NID would break it, and it should be
revisited then.