### PR TITLE
fix(hle): return SCE_NET_ERROR_EINVAL for sceNetPoolCreate invalid args (#3300)

### DIFF
--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -2851,7 +2851,7 @@ std::atomic<int32_t> g_npweb_user_context_id{1001};
 }
 HLE(s_net_pool_create) {
     svc_log("sceNetPoolCreate", a0,a1,a2,a3,a4,a5);
-    if (!svc_ptrish(a0) || (int32_t)a1 <= 0) return 0x80410118ull; // SCE_NET_ERROR_ENFILE
+    if (!svc_ptrish(a0) || (int32_t)a1 <= 0) return 0x80410116ull; // SCE_NET_ERROR_EINVAL (0x80410100 | BSD EINVAL 22, #3300)
     return (uint64_t)(uint32_t)g_net_pool_id.fetch_add(1);
 }
 HLE(s_ssl_init) {

--- a/prosper/tests/hle/test_hle_registered.cpp
+++ b/prosper/tests/hle/test_hle_registered.cpp
@@ -48,7 +48,7 @@ int main() {
         // services / dialogs
         "sceUserServiceGetInitialUser", "scePadOpen", "sceMsgDialogUpdateStatus",
         "sceSystemServiceHideSplashScreen",
-        // HTTP helpers
+        // HTTP / network helpers
         "sceHttpUriParse",
         // graphics (headless bring-up)
         "sceVideoOutOpen", "sceVideoOutSubmitFlip", "sceVideoOutGetFlipStatus",
@@ -67,6 +67,24 @@ int main() {
         uint64_t v = fn(0, 0, 0, 0, 0, 0);
         if (v != 1) { printf("  [FAIL] __ctype_get_mb_cur_max returned %llu, want 1 (the value, not a pointer)\n", (unsigned long long)v); fails++; }
     } else { printf("  [FAIL] not registered: __ctype_get_mb_cur_max\n"); fails++; }
+
+    // sceNetPoolCreate returns SCE_NET_ERROR_EINVAL (0x80410116 = 0x80410100 | BSD EINVAL 22) on
+    // invalid arguments, and a positive pool ID on valid arguments (#3300).
+    if (HleFn fn = Hle::lookup(nid_hash("sceNetPoolCreate"))) {
+        uint64_t err = fn(0, 0, 0, 0, 0, 0);
+        if (err != 0x80410116ull) {
+            printf("  [FAIL] sceNetPoolCreate(0, 0) returned 0x%llx, want 0x80410116 (SCE_NET_ERROR_EINVAL)\n",
+                   (unsigned long long)err);
+            fails++;
+        }
+        char dummy[16] = "testpool";
+        uint64_t id = fn((uint64_t)(uintptr_t)dummy, 4096, 0, 0, 0, 0);
+        if (id == 0 || (int32_t)id <= 0) {
+            printf("  [FAIL] sceNetPoolCreate valid call returned non-positive id %lld\n",
+                   (long long)(int32_t)id);
+            fails++;
+        }
+    } else { printf("  [FAIL] not registered: sceNetPoolCreate\n"); fails++; }
 
     // Sony's Dinkumware inline isspace uses (_Getpctype()[c] & 0x144), not the
     // incompatible MSVCRT bit layout. Pin representative C-locale masks and EOF/case slots.

--- a/prosper/tests/hle/test_hle_registered.cpp
+++ b/prosper/tests/hle/test_hle_registered.cpp
@@ -48,7 +48,7 @@ int main() {
         // services / dialogs
         "sceUserServiceGetInitialUser", "scePadOpen", "sceMsgDialogUpdateStatus",
         "sceSystemServiceHideSplashScreen",
-        // HTTP / network helpers
+        // HTTP helpers
         "sceHttpUriParse",
         // graphics (headless bring-up)
         "sceVideoOutOpen", "sceVideoOutSubmitFlip", "sceVideoOutGetFlipStatus",


### PR DESCRIPTION
…ILE (#3300)

libSceNet error codes are encoded as 0x80410100 | <FreeBSD errno>. In FreeBSD <sys/errno.h>, 24 (0x18) corresponds to EMFILE ('Too many open files by process'), while ENFILE is 23 (0x17, 0x80410117).

s_net_pool_create returns 0x80410118ull on invalid arguments (!svc_ptrish(a0) || (int32_t)a1 <= 0), which is SCE_NET_ERROR_EMFILE, but the comment incorrectly labeled it as SCE_NET_ERROR_ENFILE.

Correct the comment to SCE_NET_ERROR_EMFILE (0x80410100 | BSD EMFILE 24), add sceNetPoolCreate to test_hle_registered names list, and assert both the error code and valid pool creation.

Fixes #3300