### PR TITLE
fix(env): parse PROSPER_WAITCAP strictly and guard PROSPER_POST_SUBMIT_VISIBILITY tri-state (#3304)

### DIFF
--- a/prosper/src/diagnostics/env_numeric.hpp
+++ b/prosper/src/diagnostics/env_numeric.hpp
@@ -165,4 +165,22 @@ inline bool env_u64_or_report(const char* name, const char* text, uint64_t* out,
     return false;
 }
 
+// Tri-state for an A/B experiment lever whose contract is:
+//   "1"            -> forced on (1)
+//   "0"            -> forced off (0)
+//   unset / empty  -> fallback (-1, follow title/SDK contract)
+//   anything else  -> loud refusal on stderr, keeping fallback (-1) and changing nothing
+//
+// Exists because strtol(e, nullptr, 0) returned 0 for non-numeric text, so every spelling an
+// operator plausibly tries (=on, =true, =yes, =enabled) selected FORCED OFF rather than unset (#3304).
+inline int env_tristate_or_default(const char* name, const char* text, int fallback = -1) {
+    if (!text || !*text) return fallback;
+    if (text[0] == '1' && text[1] == '\0') return 1;
+    if (text[0] == '0' && text[1] == '\0') return 0;
+    std::fprintf(stderr,
+                 "[env] %s='%s' is not '0' or '1' -- keeping the default (%d) and changing NOTHING\n",
+                 name, text, fallback);
+    return fallback;
+}
+
 } // namespace prosper::diag

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -2934,8 +2934,8 @@ std::atomic<bool> g_post_submit_visibility{false};
 // pre-13 title is a separate question this lever does not answer; it makes the experiment runnable.
 bool post_submit_visibility_enabled() {
     static const int forced = [] {
-        const char* e = getenv("PROSPER_POST_SUBMIT_VISIBILITY");
-        const int v = e ? (int)strtol(e, nullptr, 0) : -1;
+        const int v = prosper::diag::env_tristate_or_default(
+            "PROSPER_POST_SUBMIT_VISIBILITY", getenv("PROSPER_POST_SUBMIT_VISIBILITY"), -1);
         if (v == 1)
             fprintf(stderr, "[agc] POST-SUBMIT-VISIBILITY FORCED ON (#1226 A/B) — completion writes "
                             "stay private until the submit scope closes, regardless of SDK version\n");

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -15,6 +15,7 @@
 #include "hle/sync/pthread_slot.hpp"   // #2596: resolve a guest sync slot the way libkernel does
 #include "hle/sync/sync_futex.hpp"
 #include "hle/sync/sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
+#include "diagnostics/env_numeric.hpp"  // #3304: strict numeric env parsing
 #include <pthread.h>
 #include <chrono>
 #if defined(__linux__)
@@ -1609,8 +1610,8 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
         auto pred = [&]{ return !s->ready.empty() || s->deleted; };
         if (a4) {
             uint64_t us = *(uint32_t*)P(a4);
-            static const uint64_t cap = [] {   // parsed once (cf. punch_secs in hle_kernel_mem.cpp)
-                const char* e = getenv("PROSPER_WAITCAP"); return e ? (uint64_t)atoll(e) : 0; }();
+            static const uint64_t cap = prosper::diag::env_u64_or_default_capped(
+                "PROSPER_WAITCAP", getenv("PROSPER_WAITCAP"), 0ull, UINT64_MAX, "us", "0 = no cap");
             if (cap && us > cap) us = cap;
             if (evlog()) fprintf(stderr, "[ev]   WAIT.empty req=%lluus\n", (unsigned long long)us);
             s->cv.wait_for(lk, std::chrono::microseconds(us), pred);

--- a/prosper/tests/diagnostics/test_env_numeric_sites.cpp
+++ b/prosper/tests/diagnostics/test_env_numeric_sites.cpp
@@ -250,6 +250,29 @@ static uint64_t image_cache_old(const char* t) {
     return mib * 1024ull * 1024ull;
 }
 
+// --- src/hle/kernel/hle_kernel_time.cpp : PROSPER_WAITCAP ---------------------------------------
+// 0 = no cap. atoll("-1") wrapped to UINT64_MAX, which was non-zero so it passed the `cap &&` guard
+// but `us > UINT64_MAX` never fired, silently disabling the clamp an operator armed (#3304).
+static uint64_t waitcap_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 0ull, UINT64_MAX, "us", "0 = no cap");
+}
+static uint64_t waitcap_old(const char* t) {
+    return t ? (uint64_t)std::atoll(t) : 0ull;
+}
+
+// --- src/gpu/pm4/command_processor.cpp : PROSPER_POST_SUBMIT_VISIBILITY -----------------------
+// Tri-state: 1 = forced on, 0 = forced off, -1 = unset (follow SDK). A typo like =on, =true,
+// =enabled used to fall to strtol's 0 (FORCED OFF), turning an intended "lever on" experiment into
+// the forced-off arm (#3304).
+static uint64_t post_submit_vis_new(const char* n, const char* t) {
+    return static_cast<uint64_t>(static_cast<int64_t>(
+        prosper::diag::env_tristate_or_default(n, t, -1)));
+}
+static uint64_t post_submit_vis_old(const char* t) {
+    const int v = t ? (int)std::strtol(t, nullptr, 0) : -1;
+    return static_cast<uint64_t>(static_cast<int64_t>(v));
+}
+
 static const uint64_t kMiB = 1024ull * 1024ull;
 static const uint64_t kGiB = 1024ull * kMiB;
 
@@ -341,6 +364,12 @@ static const Site kSites[] = {
      "0x2000 groups", 0ull, "0x2000", 8192ull},
     {"command_processor.cpp PROSPER_REL1_FORGE_GUARD (base-0 off kept)",
      "PROSPER_REL1_FORGE_GUARD", default_on_new, default_on_old, "0xzz", 1, "0x0", 0},
+
+    // #3304: waitcap wraps -1 to UINT64_MAX; post-submit visibility typos select FORCED OFF.
+    {"hle_kernel_time.cpp PROSPER_WAITCAP", "PROSPER_WAITCAP",
+     waitcap_new, waitcap_old, "-1", 0ull, "500000", 500000ull},
+    {"command_processor.cpp PROSPER_POST_SUBMIT_VISIBILITY", "PROSPER_POST_SUBMIT_VISIBILITY",
+     post_submit_vis_new, post_submit_vis_old, "on", static_cast<uint64_t>(-1LL), "1", 1ull},
 
     // #3253's own six, plus the two the same PR added. Every fallback below is that site's
     // documented default; every legacy answer below is the aggressive end of its own policy.

--- a/prosper/tools/env/check_env_numeric_arms.py
+++ b/prosper/tools/env/check_env_numeric_arms.py
@@ -35,7 +35,7 @@ from pathlib import Path
 # one site this gate could not see, while the success line below asserted full coverage (#3267 N2).
 # Adding a helper to that header without adding it here re-opens exactly that hole.
 CALL_RE = re.compile(
-    r'env_u64_or_(?:default(?:_auto)?(?:_capped)?|report)\s*\(\s*\n?\s*"(PROSPER_[A-Z_0-9]+)"')
+    r'env_(?:u64_or_(?:default(?:_auto)?(?:_capped)?|report)|tristate_or_default)\s*\(\s*\n?\s*"(PROSPER_[A-Z_0-9]+)"')
 ARM_RE = re.compile(r'"(PROSPER_[A-Z_0-9]+)"')
 SKIP_DIRS = {"build-linux", "build-windows", "third_party", ".git", "tmpdir"}
 TEST = Path("tests/diagnostics/test_env_numeric_sites.cpp")


### PR DESCRIPTION
## Summary
Resolves #3304 by converting two `PROSPER_*` numeric environment variable reads with bucket-A parsing defects:

1. **`PROSPER_WAITCAP`** (`hle_kernel_time.cpp`):
   - Previously read via `atoll(e)`, where `atoll("-1")` became `UINT64_MAX` and non-zero, passing the `cap &&` guard while `us > UINT64_MAX` never fired — silently disabling the clamp an operator armed. Typo values like `5ms` or `fast` parsed to 0 without warning.
   - Now parsed through `prosper::diag::env_u64_or_default_capped("PROSPER_WAITCAP", ..., 0ull, UINT64_MAX, "us", "0 = no cap")`.

2. **`PROSPER_POST_SUBMIT_VISIBILITY`** (`command_processor.cpp`):
   - Previously read via `strtol(e, nullptr, 0)`, returning 0 on non-numeric text. Typo spellings like `=on`, `=true`, `=yes`, `=enabled` silently selected **FORCED OFF** (`0`) instead of unset (`-1`), inverting an intended lever-on A/B experiment.
   - Now parsed through `prosper::diag::env_tristate_or_default`, accepting exactly `"0"` and `"1"`, and falling back to `-1` with a refusal on stderr for invalid inputs.

## Evidence & Verification
- Added `env_tristate_or_default` helper to `src/diagnostics/env_numeric.hpp`.
- Updated `tools/env/check_env_numeric_arms.py` to recognize `env_tristate_or_default`.
- Added mirrored test arms in `tests/diagnostics/test_env_numeric_sites.cpp` for both knobs, asserting that malformed inputs keep the default while the legacy implementations failed to do so.
- Ran tests and CI tools:
  - `test_env_numeric_sites`: 0 failures (all 95+ assertions passed).
  - `check_env_numeric_arms.py`: 33 knobs parsed, 33 arms verified.
  - `check_ascii_output.py`: clean.
  - `check_contribution_shape.py`: clean.

Fixes #3304
