### PR TITLE
fix(tools/nid_census): correct inverted link set caveat and note (#3303)

### DIFF
--- a/prosper/tools/nid_census/nid_census.cpp
+++ b/prosper/tools/nid_census/nid_census.cpp
@@ -149,13 +149,11 @@ std::vector<fs::path> collect_modules(const std::string& input) {
 // that population. `prefix` is "# " for --tsv (comment lines a consumer skips) and "" for the
 // human report.
 //
-// The two divergences worth stating explicitly, because they SILENTLY REMOVE ROWS:
+// The divergence worth stating explicitly, because it SILENTLY REMOVES ROWS:
 //   * a module that failed to parse contributes no imports, so its NIDs read as "not imported
-//     by anything" rather than "not measured";
-//   * this scans the tree for modules, while the loader links a FIXED set (boot_program.cpp) —
-//     it takes exactly two entries from sce_module/, auto-discovers only Media/Plugins/, and
-//     never auto-links .sprx. So a NID satisfied here by a sibling export the loader would not
-//     have linked is excluded from the census but WOULD reach the dispatcher at runtime.
+//     by anything" rather than "not measured".
+// Module discovery uses the loader's actual link set (boot_link_inputs, #2199), so cross-module
+// exclusions match what the guest will actually resolve at runtime.
 void print_scope(const char* prefix, size_t total, size_t modules_read, size_t modules_failed,
                  size_t unregistered, size_t shown, size_t satisfied_cross_module,
                  size_t mismatches, const std::string& lib_filter, bool self_check) {
@@ -180,9 +178,8 @@ void print_scope(const char* prefix, size_t total, size_t modules_read, size_t m
            "listed here may never execute, and a fault is not explained by its presence. For what a "
            "run actually called, use prosper_on_unimpl's first-seen census from a live boot, or "
            "hle_calls (#1980), and bound it to the window the behaviour occurs in.\n", prefix);
-    printf("%sNOTE: module set is a tree scan, not the loader's link set (boot_program.cpp): "
-           "only Media/Plugins is auto-discovered, .sprx is never auto-linked, and sce_module "
-           "contributes exactly two. Cross-module exclusions are computed over THIS set.\n",
+    printf("%sNOTE: module set is the loader's actual link set (boot_program.cpp, #2199) -- "
+           "cross-module exclusions match what the guest will resolve at runtime.\n",
            prefix);
 }
 


### PR DESCRIPTION
## Summary
Resolves #3303 by correcting the stale, inverted caveat in `tools/nid_census/nid_census.cpp`:

- In `:183-186`, `nid_census` printed a `NOTE` in every report warning that the module set was a tree scan rather than the loader's link set, and that cross-module exclusions were computed over that tree scan.
- In reality, since #2199 (`:141`), `collect_modules` builds the module set directly from `prosper::boot_link_inputs(input, /*verbose=*/false)` — the loader's actual link set.
- The inverted caveat warned the reader that census exclusions were unsound in exactly the way they are now sound.

## Changes
- Rewrote the scope comment in `:152-158` to reflect that module discovery uses the loader's actual link set (`boot_link_inputs`, #2199), ensuring cross-module exclusions match runtime resolution.
- Corrected the printed `NOTE` in `:183-186` to state that the module set is the loader's actual link set.

## Verification
- Ran `python prosper/tools/output/check_ascii_output.py prosper` (clean).
- Ran `python prosper/tools/ci/check_contribution_shape.py --github --base upstream/main` (clean).

Fixes #3303
