### PR TITLE
perf(compute): partition why the compute->graphics image borrow declines (#3307)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1309,6 +1309,14 @@ if(TARGET prosper_core)
   target_include_directories(test_decode_scratch PRIVATE frontends src)
   add_test(NAME decode_scratch COMMAND test_decode_scratch)
 
+  # #3307 compute->graphics image borrow census. Header-only and device-free: the load-bearing arm
+  # is the 2048-case equivalence between the importer's precondition classifier and the `||` chain
+  # it replaced, which needs no Vulkan and must never be skipped on a host without it.
+  add_executable(test_compute_image_borrow_census
+                 frontends/shared/tests/test_compute_image_borrow_census.cpp)
+  target_include_directories(test_compute_image_borrow_census PRIVATE frontends)
+  add_test(NAME compute_image_borrow_census COMMAND test_compute_image_borrow_census)
+
   add_executable(test_texture_decode_diagnostic
                  frontends/shared/tests/test_texture_decode_diagnostic.cpp)
   target_include_directories(test_texture_decode_diagnostic PRIVATE frontends src)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -480,6 +480,22 @@ two arms' tallies taken at different points in a run is the mistake that produce
 `PROSPER_WRITE_WATCH_MAX_KB` is an emergency host-wide range
 limit (zero/unset is unbounded); a declined watch always returns to exact comparison.
 
+`PROSPER_COMPUTE_BORROW_CENSUS=1` reports the other side of the same boundary, on the same cadence:
+whether a graphics sampled descriptor managed to lease the device image a compute dispatch had just
+produced, instead of re-reading the surface out of guest memory. Four `[compute-borrow-census]`
+lines, all running totals with their own denominators — the consumer's precondition partitioned by
+term, the borrow's outcome partitioned by gate (`no_cache_entry`, `export_unpublished`,
+`content_invalid`, `no_image`, `authority_changed`, `hit`), why `authority_changed` fired (a real
+overlapping guest write, an unarmed submit journal, or a cross-submit export; and what the page
+watch said), and the producer's publish gate partitioned the same way. A zero bucket still prints.
+
+Two of its fields answer questions nothing else can. On a lookup miss the variable additionally
+enables an O(cache) scan for an entry at the same guest address, which turns "nothing is cached
+under this key" into "an entry here disagrees on `tile_mode`" — the twenty-three-field cache key
+otherwise makes those indistinguishable. And `journal_unarmed` versus `journal_cross_submit` splits
+the `Unknown` that `guest_gpu_writes_since` returns for two structurally different reasons, which
+its own header warns cannot be told apart by a caller.
+
 Proven-full write-only storage targets at least 16 MiB do not copy their first successful result into
 an immediately redundant CPU source baseline. The submit journal remains the initial source authority;
 if another architectural writer invalidates it, the next invocation takes ordinary writeback and

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -497,8 +497,11 @@ exact key misses, the importer retries under a format-*aliased* key, and that ke
 and `vk_format` by construction — so scanning it would report those two as differing on every miss
 whether or not they were the reason, and would point a reader at exactly the normalisation the alias
 arm forbids. The retry is therefore not scanned, which is also why `exact_key_scans` (scans
-performed) and `no_cache_entry` (final outcomes) are different numbers: read the field list against
-the former. And the `Unknown` that `guest_gpu_writes_since` returns —
+performed) and `no_cache_entry` (final outcomes) are different numbers. Read the field list against
+`exact_key_scans` **minus** its `rescued=` term: an exact-key miss the alias retry then rescues is a
+successful import whose mask names `format`/`vk_format` by construction, so those scans are counted
+and their fields deliberately excluded — otherwise a title whose alias path routinely succeeds
+reports a field list dominated by the alias working as designed. And the `Unknown` that `guest_gpu_writes_since` returns —
 which its own header warns a caller cannot decompose — is split into the three parts that ARE
 separable from the borrow site: `journal_unarmed` (not armed on the consuming thread),
 `journal_unjournaled` (the producer's publish carried no submit serial, so it was stamped while the

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -498,10 +498,16 @@ and `vk_format` by construction — so scanning it would report those two as dif
 whether or not they were the reason, and would point a reader at exactly the normalisation the alias
 arm forbids. The retry is therefore not scanned, which is also why `exact_key_scans` (scans
 performed) and `no_cache_entry` (final outcomes) are different numbers. Read the field list against
-`exact_key_scans` **minus** its `rescued=` term: an exact-key miss the alias retry then rescues is a
-successful import whose mask names `format`/`vk_format` by construction, so those scans are counted
-and their fields deliberately excluded — otherwise a title whose alias path routinely succeeds
-reports a field list dominated by the alias working as designed. And the `Unknown` that `guest_gpu_writes_since` returns —
+**`same_addr=`, and against nothing else** — a field bit and `same_addr` are incremented under one
+and the same condition, so that is the list's exact denominator. The three numbers on that line nest
+(`exact_key_scans` ⊇ non-`rescued` ⊇ `same_addr`), and dividing by either wider one dilutes the field
+list with lookups that found nothing at the address at all — which is the *other* decision-table row,
+the one where the producer is absent rather than keyed differently.
+
+`rescued=` counts the exact-key misses the format-alias retry then saved. Those are successful
+imports whose mask names `format`/`vk_format` by construction, so they are counted and their fields
+deliberately excluded — otherwise a title whose alias path routinely succeeds reports a field list
+dominated by the alias working as designed. And the `Unknown` that `guest_gpu_writes_since` returns —
 which its own header warns a caller cannot decompose — is split into the three parts that ARE
 separable from the borrow site: `journal_unarmed` (not armed on the consuming thread),
 `journal_unjournaled` (the producer's publish carried no submit serial, so it was stamped while the

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -492,9 +492,20 @@ watch said), and the producer's publish gate partitioned the same way. A zero bu
 Two of its fields answer questions nothing else can. On a lookup miss the variable additionally
 enables an O(cache) scan for an entry at the same guest address, which turns "nothing is cached
 under this key" into "an entry here disagrees on `tile_mode`" — the twenty-three-field cache key
-otherwise makes those indistinguishable. And `journal_unarmed` versus `journal_cross_submit` splits
-the `Unknown` that `guest_gpu_writes_since` returns for two structurally different reasons, which
-its own header warns cannot be told apart by a caller.
+otherwise makes those indistinguishable. **That field list belongs to the EXACT key only.** When the
+exact key misses, the importer retries under a format-*aliased* key, and that key rewrites `format`
+and `vk_format` by construction — so scanning it would report those two as differing on every miss
+whether or not they were the reason, and would point a reader at exactly the normalisation the alias
+arm forbids. The retry is therefore not scanned, which is also why `exact_key_scans` (scans
+performed) and `no_cache_entry` (final outcomes) are different numbers: read the field list against
+the former. And the `Unknown` that `guest_gpu_writes_since` returns —
+which its own header warns a caller cannot decompose — is split into the three parts that ARE
+separable from the borrow site: `journal_unarmed` (not armed on the consuming thread),
+`journal_unjournaled` (the producer's publish carried no submit serial, so it was stamped while the
+journal was inactive or already overflowed), and `journal_undecided` (armed, serial present — a
+different submit, or this submit's journal has since overflowed). The last name is deliberately
+vague, because it covers two causes this instrument cannot tell apart and a narrower name would be
+a claim rather than a count.
 
 Proven-full write-only storage targets at least 16 MiB do not copy their first successful result into
 an immediately redundant CPU source baseline. The submit journal remains the initial source authority;

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -176,13 +176,26 @@ dispatch count, both of which the report already prints per program.
 ### The lever that is worth more than all of this
 
 The witness says `compute_cand=1`: the surface is a **compute image candidate whose import misses
-every frame**. `import_live_compute_storage_image` finds nothing under its key, so graphics falls
-through to the guest-byte decode. If that import hit, the 63.8 MiB writeback → detile → convert
-disappears **on both sides of the boundary** — the graphics decode and the compute writeback that
-feeds it. That is a bigger lever than every allocation above put together, and it lives in the
-compute cache's admission, not in the materializer. Both halves of that round trip are read
-together in [#3307](https://github.com/mattias800/prosper/issues/3307): the compute side's re-tile
-into guest memory, and the graphics side's read of those same bytes back out.
+every frame**, so graphics falls through to the guest-byte decode. If that import hit, the 63.8 MiB
+writeback → detile → convert disappears **on both sides of the boundary** — the graphics decode and
+the compute writeback that feeds it. That is a bigger lever than every allocation above put
+together. Both halves of that round trip are read together in
+[#3307](https://github.com/mattias800/prosper/issues/3307): the compute side's re-tile into guest
+memory, and the graphics side's read of those same bytes back out.
+
+**WHY it misses is not established, and this paragraph used to say it was.** It read
+*"`import_live_compute_storage_image` finds nothing under its key"* and *"it lives in the compute
+cache's admission"*, which name one specific branch out of six — and nobody had measured which one
+fires. The importer plus `borrow_cached_image_for_graphics` decline through: the consumer's own
+precondition; no cache entry under the key; an entry whose export authority was never published or
+was invalidated; an entry with no image; a published entry that no proof says still matches guest
+memory; and a lease the renderer accepts and then rejects on format/extent/device. Every one of
+those used to be the same bare `return false`.
+
+`PROSPER_COMPUTE_BORROW_CENSUS=1` now partitions them (`[compute-borrow-census]`, four lines, every
+256 submits and at exit), including the producer's own publish gate and — on a lookup miss — a scan
+for a same-address entry that names the key field it disagreed on. **Read that before proposing a
+fix here**; the branch it reports selects between fixes that have nothing to do with one another.
 
 ## The unresolved image ops — established on CALIBRATION
 
@@ -795,6 +808,16 @@ A ~13% reduction, groups non-overlapping. The visible frame does not change — 
 drops still discard the background.
 
 ## Ruled out
+
+- **"`import_live_compute_storage_image` finds nothing under its key, so the compute-image borrow
+  fails in the cache's ADMISSION."** Not falsified — **withdrawn as unmeasured**, 2026-09-04. It was
+  written into § *The lever that is worth more than all of this* as a statement of fact, and it is
+  an inference: the importer and the borrow it calls have six independent decline branches and all
+  six returned the same bare `false`, so no run could have distinguished them. This row exists
+  because the sentence was already being quoted as the starting point for a fix, and a fix aimed at
+  the admission gate would report "no change" for a reason unrelated to the change if the miss is
+  really the export-authority or the write-proof branch. The instrument that decides it is
+  `PROSPER_COMPUTE_BORROW_CENSUS=1`. #3307.
 
 - **"A recompile fix — resolving the unresolved image ops — restores the title-screen background."**
   **Falsified on the title screen, and this row exists because the measurement was recorded NOWHERE a

--- a/prosper/frontends/shared/compute/AGENTS.md
+++ b/prosper/frontends/shared/compute/AGENTS.md
@@ -1,0 +1,35 @@
+# `frontends/shared/compute` — what the compute backend decides, separated from how it decides it
+
+Header-only, Vulkan-free, dependency-light decision logic and instrumentation for the live compute
+backend (`live/live_compute.cpp`) and for the one boundary it shares with the renderer
+(`live/live_renderer.cpp`). Nothing here touches a device, guest memory, or the write-watch
+mechanism: every file answers a question from plain integers and booleans, so it is unit-testable
+without a GPU. The tests live in `frontends/shared/tests/`.
+
+**Why the decisions live here and not beside their call sites.** `live_compute.cpp` is eleven
+thousand lines, and its gates were historically spelled as long `||` chains inside the functions
+that acted on them. A chain like that answers *whether* and never *which*, so a surface that
+declined for one of eight reasons produced exactly the same evidence as one that declined for
+another — and several nights of this project's history were spent guessing which. Lifting the gate
+into a `constexpr` classifier here makes the reason a value, which makes it countable, which makes
+"the borrow misses" into "the borrow misses because the entry's key disagrees on `tile_mode`".
+
+**The boundary against its siblings.** `shared/texture/` owns the *validation* policies both caches
+share — whether guest bytes must be re-read, how many proven-unchanged looks earn a page watch.
+This folder owns the compute backend's own eligibility and identity decisions plus the censuses that
+report them. Cache materialization, Vulkan resource creation and the guest↔device copies stay in
+`live/`, which is where the types they act on are declared.
+
+**A census here is a partition, not a log.** Every one of these files counts a *decision*: each
+observation lands in exactly one bucket, the report always prints the denominator, and a bucket that
+is zero still prints. The last part is deliberate and has been paid for — a bucket that disappears
+when empty is indistinguishable from an instrument that never reached it, which is how a correct
+finding got falsified by a zero read off the wrong field (instrument trap 256). Counting is
+unconditional wherever the counted branch is expensive enough that a relaxed atomic add is free by
+comparison; only the *report* is gated on an environment variable.
+
+**The one thing a newcomer gets wrong.** `compute_transfer_gate_census.hpp`'s counters are gated on
+a *selector* — `PROSPER_COMPUTE_TRANSFER_PRODUCER_HASH` / `..._CONSUMER_HASH` — so they observe
+nothing at all unless a specific producer/consumer program pair was named on the command line. The
+other censuses here count on every run. Reading a zero from the transfer-gate census on a default
+launch says nothing about the code it instruments.

--- a/prosper/frontends/shared/compute/AGENTS.md
+++ b/prosper/frontends/shared/compute/AGENTS.md
@@ -24,7 +24,10 @@ report them. Cache materialization, Vulkan resource creation and the guest↔dev
 observation lands in exactly one bucket, the report always prints the denominator, and a bucket that
 is zero still prints. The last part is deliberate and has been paid for — a bucket that disappears
 when empty is indistinguishable from an instrument that never reached it, which is how a correct
-finding got falsified by a zero read off the wrong field (instrument trap 256). Counting is
+finding got falsified by a zero read off the wrong field: `[render-timing]`'s pre-existing
+`protect=` counts mprotect *failures* and is healthily zero, and a truncated grep read it as the
+activity counter that sits further along the same 288-character line (#3307, and the
+instrument-trap row #3317 adds). Counting is
 unconditional wherever the counted branch is expensive enough that a relaxed atomic add is free by
 comparison; only the *report* is gated on an environment variable.
 

--- a/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
+++ b/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
@@ -1,0 +1,519 @@
+#pragma once
+
+// Why this file exists.
+//
+// A compute dispatch produces a storage image on the device; a graphics draw in the same submit
+// wants to sample exactly those pixels. `import_live_compute_storage_image` exists so the second
+// can borrow the first's `VkImage` instead of routing 63.8 MiB through guest memory -- compute
+// re-tiling its result out, graphics detiling it back in. On Stray's title screen that borrow
+// misses on every reference (#3307), and the round trip it fails to remove is the single largest
+// host cost in the frame.
+//
+// The importer and the borrow it calls have at least SIX independent ways to decline, and before
+// this header not one of them logged a reason:
+//
+//   1. the consumer's own precondition (shape, class, host-backed data, mip levels, srgb, format);
+//   2. no cache entry under the key;
+//   3. an entry exists but its export/content/image authority is not published;
+//   4. the entry is published but no proof says guest memory still matches it;
+//   5. the producer never authorized an export in the first place;
+//   6. the borrow succeeded and the RENDERER rejected the imported image afterwards.
+//
+// `STRAY_STATUS.md` asserted (2) from the outside. That is a guess about a five-way branch, and it
+// is the kind of guess this project has repeatedly paid for: a plausible reason quoted as a measured
+// one. So every branch is counted, unconditionally, and one of them will turn out to carry the mass.
+//
+// The counters partition. Every import lands in exactly one decline reason or exactly one borrow
+// outcome, and both arrays print the denominator they are a fraction of, so two reports taken at
+// different points in a run remain comparable -- the failure that produced #3155's retracted
+// numbers. The `## Ruled out` value of a partition is that it cannot be read selectively.
+//
+// Counting is unconditional and per-IMPORT (a handful of relaxed atomic adds against a path whose
+// alternative is a multi-megabyte detile). Only the REPORT is gated, on
+// PROSPER_COMPUTE_BORROW_CENSUS. The one genuinely non-free part -- scanning the image cache for a
+// near-miss key when the lookup found nothing -- is additionally gated on that same variable,
+// because it is O(cache) rather than O(1).
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+namespace prosper::frontend {
+
+// ---------------------------------------------------------------------------
+// (1) The consumer's precondition, as a pure classifier.
+//
+// The production code used to spell this as one `||` chain that returned false, so a declined
+// import was indistinguishable from any other declined import. The classifier answers WHICH term
+// declined. `classify_compute_image_import(...) == None` must remain exactly equivalent to that
+// chain's negation; `test_compute_image_borrow_census` asserts the equivalence over the complete
+// boolean product rather than over hand-picked cases, because the failure mode being guarded is a
+// term silently dropped during the rewrite.
+// ---------------------------------------------------------------------------
+
+enum class ComputeImageImportDecline : uint8_t {
+    None = 0,          // accepted: the borrow was attempted
+    NoContext,         // no live compute backend / no device
+    NoGuestAddress,
+    NotTextureClass,
+    HostBackedData,    // a capture/replay resource whose bytes are host-owned
+    GuestByteRange,    // zero, or wider than the u32 the cache key carries
+    Shape,             // neither an ordinary 2D/2D-array/3D nor the cube-array alias
+    MipLevels,         // declared_mip_levels != 1
+    MipTail,
+    Srgb,
+    DepthCompare,
+    NativeFormat,      // no exact Vulkan storage format for this guest format/component count
+    Count,
+};
+
+struct ComputeImageImportInputs {
+    bool have_context = false;
+    bool have_gpu_addr = false;
+    bool texture_class = false;
+    bool host_data = false;
+    bool guest_bytes_in_range = false;
+    bool shape_supported = false;
+    bool single_mip_level = false;
+    bool in_mip_tail = false;
+    bool srgb = false;
+    bool depth_compare = false;
+    bool native_format_defined = false;
+};
+
+constexpr ComputeImageImportDecline classify_compute_image_import(
+    const ComputeImageImportInputs& in) {
+    if (!in.have_context) return ComputeImageImportDecline::NoContext;
+    if (!in.have_gpu_addr) return ComputeImageImportDecline::NoGuestAddress;
+    if (!in.texture_class) return ComputeImageImportDecline::NotTextureClass;
+    if (in.host_data) return ComputeImageImportDecline::HostBackedData;
+    if (!in.guest_bytes_in_range) return ComputeImageImportDecline::GuestByteRange;
+    if (!in.shape_supported) return ComputeImageImportDecline::Shape;
+    if (!in.single_mip_level) return ComputeImageImportDecline::MipLevels;
+    if (in.in_mip_tail) return ComputeImageImportDecline::MipTail;
+    if (in.srgb) return ComputeImageImportDecline::Srgb;
+    if (in.depth_compare) return ComputeImageImportDecline::DepthCompare;
+    if (!in.native_format_defined) return ComputeImageImportDecline::NativeFormat;
+    return ComputeImageImportDecline::None;
+}
+
+constexpr const char* compute_image_import_decline_name(ComputeImageImportDecline reason) {
+    switch (reason) {
+    case ComputeImageImportDecline::None:            return "accepted";
+    case ComputeImageImportDecline::NoContext:       return "no_context";
+    case ComputeImageImportDecline::NoGuestAddress:  return "no_gpu_addr";
+    case ComputeImageImportDecline::NotTextureClass: return "not_texture";
+    case ComputeImageImportDecline::HostBackedData:  return "host_data";
+    case ComputeImageImportDecline::GuestByteRange:  return "guest_bytes";
+    case ComputeImageImportDecline::Shape:           return "shape";
+    case ComputeImageImportDecline::MipLevels:       return "mip_levels";
+    case ComputeImageImportDecline::MipTail:         return "mip_tail";
+    case ComputeImageImportDecline::Srgb:            return "srgb";
+    case ComputeImageImportDecline::DepthCompare:    return "depth_compare";
+    case ComputeImageImportDecline::NativeFormat:    return "native_format";
+    case ComputeImageImportDecline::Count:           break;
+    }
+    return "?";
+}
+
+// ---------------------------------------------------------------------------
+// (2)(3)(4) The borrow itself.
+// ---------------------------------------------------------------------------
+
+enum class ComputeImageBorrowOutcome : uint8_t {
+    NotAttempted = 0,    // the precondition declined first
+    NoCacheEntry,        // image_cache.find(key) == end()
+    ExportNotAuthorized, // the entry exists; no producer published it to graphics
+    ContentInvalid,      // published once, then invalidated by a later source change
+    NoImage,             // entry without a VkImage (allocation released)
+    AuthorityChanged,    // published, but no proof says guest memory still matches it
+    Hit,
+    Count,
+};
+
+constexpr const char* compute_image_borrow_outcome_name(ComputeImageBorrowOutcome outcome) {
+    switch (outcome) {
+    case ComputeImageBorrowOutcome::NotAttempted:        return "not_attempted";
+    case ComputeImageBorrowOutcome::NoCacheEntry:        return "no_cache_entry";
+    case ComputeImageBorrowOutcome::ExportNotAuthorized: return "export_unpublished";
+    case ComputeImageBorrowOutcome::ContentInvalid:      return "content_invalid";
+    case ComputeImageBorrowOutcome::NoImage:             return "no_image";
+    case ComputeImageBorrowOutcome::AuthorityChanged:    return "authority_changed";
+    case ComputeImageBorrowOutcome::Hit:                 return "hit";
+    case ComputeImageBorrowOutcome::Count:               break;
+    }
+    return "?";
+}
+
+// What the three `*_unchanged` predicates saw, recorded ONLY for AuthorityChanged. Every field is
+// the value the production code already computed -- nothing here evaluates a predicate the borrow
+// would not have evaluated, because a query that the borrow short-circuits past is a query whose
+// cost this census would then be inventing.
+//
+// `journal_armed` is the field that separates two very different worlds and is the reason this
+// struct exists at all. `guest_gpu_writes_since` answers Unknown both when the per-thread submit
+// journal is not armed on the consuming thread AND when it is armed but the export snapshot belongs
+// to an earlier submit, and the caller cannot tell those apart (`gpu_execute.hpp` says so
+// explicitly). The first would mean the borrow is structurally unreachable from wherever graphics
+// materializes textures; the second would mean producer and consumer simply do not meet inside one
+// submit. Those have different fixes, so they get different counters.
+struct ComputeImageBorrowObservation {
+    ComputeImageBorrowOutcome outcome = ComputeImageBorrowOutcome::NotAttempted;
+    bool journal_armed = false;    // guest_gpu_write_tracking_active() on THIS thread
+    uint8_t submit_query = 0;      // prosper::gpu::GuestGpuWriteQuery ordinal
+    bool watch_present = false;    // the entry carries an armed page watch
+    uint8_t watch_query = 0;       // prosper::host::GuestWriteWatchQuery ordinal; watch_present only
+    bool exact_mirror_supported = false; // the byte-mirror fallback exists (Windows only)
+
+    // Filled only when the lookup found nothing AND the report is enabled: the cache was scanned
+    // for an entry at the same guest address, and `no_entry_field_diff_mask` names the fields the
+    // nearest such entry disagreed on. The importer tries two keys, so the caller records this once
+    // from the FINAL observation rather than per call.
+    bool no_entry_scanned = false;
+    bool no_entry_same_addr = false;
+    uint32_t no_entry_field_diff_mask = 0;
+};
+
+// The cache key's fields, so a NoCacheEntry can say WHICH field a same-address entry disagreed on
+// rather than only that the lookup failed. Order matches `ComputeImageCacheKey`'s declaration;
+// `live_compute.cpp` owns the comparison because the key type is private to it.
+enum class ComputeImageKeyField : uint8_t {
+    HostData = 0,
+    GuestBytes,
+    ResourceBytes,
+    Width,
+    Height,
+    Depth,
+    Format,
+    Components,
+    TileMode,
+    ImgDim,
+    LinearRowPitch,
+    LayerStride,
+    LayerMipOffset,
+    MipTailOffset,
+    MipTailBytes,
+    MipTailX,
+    MipTailY,
+    VkFormat,
+    Storage,
+    InMipTail,
+    Srgb,
+    DepthCompare,
+    MipLevels,
+    Count,
+};
+
+constexpr const char* compute_image_key_field_name(ComputeImageKeyField field) {
+    switch (field) {
+    case ComputeImageKeyField::HostData:       return "host_data";
+    case ComputeImageKeyField::GuestBytes:     return "guest_bytes";
+    case ComputeImageKeyField::ResourceBytes:  return "resource_bytes";
+    case ComputeImageKeyField::Width:          return "width";
+    case ComputeImageKeyField::Height:         return "height";
+    case ComputeImageKeyField::Depth:          return "depth";
+    case ComputeImageKeyField::Format:         return "format";
+    case ComputeImageKeyField::Components:     return "components";
+    case ComputeImageKeyField::TileMode:       return "tile_mode";
+    case ComputeImageKeyField::ImgDim:         return "img_dim";
+    case ComputeImageKeyField::LinearRowPitch: return "linear_row_pitch";
+    case ComputeImageKeyField::LayerStride:    return "layer_stride";
+    case ComputeImageKeyField::LayerMipOffset: return "layer_mip_offset";
+    case ComputeImageKeyField::MipTailOffset:  return "mip_tail_offset";
+    case ComputeImageKeyField::MipTailBytes:   return "mip_tail_bytes";
+    case ComputeImageKeyField::MipTailX:       return "mip_tail_x";
+    case ComputeImageKeyField::MipTailY:       return "mip_tail_y";
+    case ComputeImageKeyField::VkFormat:       return "vk_format";
+    case ComputeImageKeyField::Storage:        return "storage";
+    case ComputeImageKeyField::InMipTail:      return "in_mip_tail";
+    case ComputeImageKeyField::Srgb:           return "srgb";
+    case ComputeImageKeyField::DepthCompare:   return "depth_compare";
+    case ComputeImageKeyField::MipLevels:      return "mip_levels";
+    case ComputeImageKeyField::Count:          break;
+    }
+    return "?";
+}
+
+// ---------------------------------------------------------------------------
+// (5) The producer's publish gate, decomposed the same way.
+//
+// `authorize_cached_image_export` is reached only through
+// `native_exact_storage && unique && cache_candidate && persistent && graphics_sampled_usage`, and
+// a consumer that never sees an entry cannot distinguish "the producer declined to publish" from
+// "the key differs". Counting the producer's terms is what makes (2) and (5) separable at all.
+// ---------------------------------------------------------------------------
+
+enum class ComputeImagePublishDecline : uint8_t {
+    Authorized = 0,
+    NotNativeExactStorage,
+    NotUnique,          // an alias of another binding in the same dispatch
+    NotCacheCandidate,
+    NotPersistent,
+    NoSampledUsage,     // the device would not create the image with SAMPLED usage
+    ExportRefused,      // publish_eligible, but the cache had no valid entry to authorize
+    Count,
+};
+
+struct ComputeImagePublishInputs {
+    bool native_exact_storage = false;
+    bool unique = false;
+    bool cache_candidate = false;
+    bool persistent = false;
+    bool graphics_sampled_usage = false;
+    bool export_authorized = false;   // authorize_cached_image_export found a valid entry
+};
+
+constexpr ComputeImagePublishDecline classify_compute_image_publish(
+    const ComputeImagePublishInputs& in) {
+    if (!in.native_exact_storage) return ComputeImagePublishDecline::NotNativeExactStorage;
+    if (!in.unique) return ComputeImagePublishDecline::NotUnique;
+    if (!in.cache_candidate) return ComputeImagePublishDecline::NotCacheCandidate;
+    if (!in.persistent) return ComputeImagePublishDecline::NotPersistent;
+    if (!in.graphics_sampled_usage) return ComputeImagePublishDecline::NoSampledUsage;
+    if (!in.export_authorized) return ComputeImagePublishDecline::ExportRefused;
+    return ComputeImagePublishDecline::Authorized;
+}
+
+constexpr const char* compute_image_publish_decline_name(ComputeImagePublishDecline reason) {
+    switch (reason) {
+    case ComputeImagePublishDecline::Authorized:            return "authorized";
+    case ComputeImagePublishDecline::NotNativeExactStorage: return "not_native_exact";
+    case ComputeImagePublishDecline::NotUnique:             return "not_unique";
+    case ComputeImagePublishDecline::NotCacheCandidate:     return "not_cache_candidate";
+    case ComputeImagePublishDecline::NotPersistent:         return "not_persistent";
+    case ComputeImagePublishDecline::NoSampledUsage:        return "no_sampled_usage";
+    case ComputeImagePublishDecline::ExportRefused:         return "export_refused";
+    case ComputeImagePublishDecline::Count:                 break;
+    }
+    return "?";
+}
+
+// ---------------------------------------------------------------------------
+// The running totals.
+// ---------------------------------------------------------------------------
+
+struct ComputeImageBorrowCensusSnapshot {
+    uint64_t declines[static_cast<size_t>(ComputeImageImportDecline::Count)] = {};
+    uint64_t outcomes[static_cast<size_t>(ComputeImageBorrowOutcome::Count)] = {};
+    uint64_t publishes[static_cast<size_t>(ComputeImagePublishDecline::Count)] = {};
+    uint64_t key_field_diffs[static_cast<size_t>(ComputeImageKeyField::Count)] = {};
+
+    uint64_t imports = 0;          // == sum(declines)
+    uint64_t alias_retries = 0;    // the format-alias key was tried after the exact key missed
+    uint64_t lease_failures = 0;   // borrowed, then the lease allocation threw
+    uint64_t hit_bytes = 0;        // guest bytes NOT decoded, because the borrow hit
+    uint64_t miss_bytes = 0;       // guest bytes the graphics decode had to read instead
+
+    // (2), refined: of the misses that found no entry, how many had an entry at the same guest
+    // address under a different key. `no_entry_same_addr == 0` means the producer is absent, not
+    // that the key disagrees -- which is the whole distinction `STRAY_STATUS.md` guessed at.
+    uint64_t no_entry_scans = 0;
+    uint64_t no_entry_same_addr = 0;
+
+    // (4), refined.
+    uint64_t authority_journal_overlap = 0;      // a real guest write covered the range
+    uint64_t authority_journal_unarmed = 0;      // the journal is not armed on the consuming thread
+    uint64_t authority_journal_cross_submit = 0; // armed, but the export is from an earlier submit
+    uint64_t authority_watch_absent = 0;
+    uint64_t authority_watch_dirty = 0;
+    uint64_t authority_watch_unknown = 0;
+
+    // (6). Recorded by the renderer after `import_live_compute_storage_image` returned true.
+    uint64_t renderer_accepted = 0;
+    uint64_t renderer_rejected = 0;
+
+    uint64_t publish_evaluated = 0;  // == sum(publishes)
+};
+
+class ComputeImageBorrowCensus {
+public:
+    void record_import(ComputeImageImportDecline reason) {
+        bump(imports_);
+        bump(declines_[static_cast<size_t>(reason)]);
+    }
+    void record_alias_retry() { bump(alias_retries_); }
+    void record_lease_failure() { bump(lease_failures_); }
+
+    void record_outcome(const ComputeImageBorrowObservation& observation, uint64_t guest_bytes) {
+        bump(outcomes_[static_cast<size_t>(observation.outcome)]);
+        if (observation.outcome == ComputeImageBorrowOutcome::Hit) {
+            add(hit_bytes_, guest_bytes);
+            return;
+        }
+        add(miss_bytes_, guest_bytes);
+        if (observation.outcome != ComputeImageBorrowOutcome::AuthorityChanged) return;
+        // GuestGpuWriteQuery: 0 Unchanged, 1 Overlap, 2 Unknown. Unchanged cannot reach here (it is
+        // the hit), so the partition below is over Overlap and Unknown only.
+        if (observation.submit_query == 1) bump(authority_journal_overlap_);
+        else if (!observation.journal_armed) bump(authority_journal_unarmed_);
+        else bump(authority_journal_cross_submit_);
+        if (!observation.watch_present) bump(authority_watch_absent_);
+        else if (observation.watch_query == 1) bump(authority_watch_dirty_);
+        else bump(authority_watch_unknown_);
+    }
+
+    void record_no_entry_scan(bool same_address_entry, uint32_t field_diff_mask) {
+        bump(no_entry_scans_);
+        if (!same_address_entry) return;
+        bump(no_entry_same_addr_);
+        for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
+            if (field_diff_mask & (1u << i)) bump(key_field_diffs_[i]);
+    }
+
+    void record_renderer_verdict(bool accepted) {
+        bump(accepted ? renderer_accepted_ : renderer_rejected_);
+    }
+
+    void record_publish(ComputeImagePublishDecline reason) {
+        bump(publish_evaluated_);
+        bump(publishes_[static_cast<size_t>(reason)]);
+    }
+
+    ComputeImageBorrowCensusSnapshot snapshot() const {
+        ComputeImageBorrowCensusSnapshot out;
+        for (size_t i = 0; i < static_cast<size_t>(ComputeImageImportDecline::Count); ++i)
+            out.declines[i] = get(declines_[i]);
+        for (size_t i = 0; i < static_cast<size_t>(ComputeImageBorrowOutcome::Count); ++i)
+            out.outcomes[i] = get(outcomes_[i]);
+        for (size_t i = 0; i < static_cast<size_t>(ComputeImagePublishDecline::Count); ++i)
+            out.publishes[i] = get(publishes_[i]);
+        for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
+            out.key_field_diffs[i] = get(key_field_diffs_[i]);
+        out.imports = get(imports_);
+        out.alias_retries = get(alias_retries_);
+        out.lease_failures = get(lease_failures_);
+        out.hit_bytes = get(hit_bytes_);
+        out.miss_bytes = get(miss_bytes_);
+        out.no_entry_scans = get(no_entry_scans_);
+        out.no_entry_same_addr = get(no_entry_same_addr_);
+        out.authority_journal_overlap = get(authority_journal_overlap_);
+        out.authority_journal_unarmed = get(authority_journal_unarmed_);
+        out.authority_journal_cross_submit = get(authority_journal_cross_submit_);
+        out.authority_watch_absent = get(authority_watch_absent_);
+        out.authority_watch_dirty = get(authority_watch_dirty_);
+        out.authority_watch_unknown = get(authority_watch_unknown_);
+        out.renderer_accepted = get(renderer_accepted_);
+        out.renderer_rejected = get(renderer_rejected_);
+        out.publish_evaluated = get(publish_evaluated_);
+        return out;
+    }
+
+private:
+    static void bump(std::atomic<uint64_t>& counter) {
+        counter.fetch_add(1, std::memory_order_relaxed);
+    }
+    static void add(std::atomic<uint64_t>& counter, uint64_t value) {
+        counter.fetch_add(value, std::memory_order_relaxed);
+    }
+    static uint64_t get(const std::atomic<uint64_t>& counter) {
+        return counter.load(std::memory_order_relaxed);
+    }
+
+    std::atomic<uint64_t> declines_[static_cast<size_t>(ComputeImageImportDecline::Count)]{};
+    std::atomic<uint64_t> outcomes_[static_cast<size_t>(ComputeImageBorrowOutcome::Count)]{};
+    std::atomic<uint64_t> publishes_[static_cast<size_t>(ComputeImagePublishDecline::Count)]{};
+    std::atomic<uint64_t> key_field_diffs_[static_cast<size_t>(ComputeImageKeyField::Count)]{};
+    std::atomic<uint64_t> imports_{0};
+    std::atomic<uint64_t> alias_retries_{0};
+    std::atomic<uint64_t> lease_failures_{0};
+    std::atomic<uint64_t> hit_bytes_{0};
+    std::atomic<uint64_t> miss_bytes_{0};
+    std::atomic<uint64_t> no_entry_scans_{0};
+    std::atomic<uint64_t> no_entry_same_addr_{0};
+    std::atomic<uint64_t> authority_journal_overlap_{0};
+    std::atomic<uint64_t> authority_journal_unarmed_{0};
+    std::atomic<uint64_t> authority_journal_cross_submit_{0};
+    std::atomic<uint64_t> authority_watch_absent_{0};
+    std::atomic<uint64_t> authority_watch_dirty_{0};
+    std::atomic<uint64_t> authority_watch_unknown_{0};
+    std::atomic<uint64_t> renderer_accepted_{0};
+    std::atomic<uint64_t> renderer_rejected_{0};
+    std::atomic<uint64_t> publish_evaluated_{0};
+};
+
+// Four lines, each a RUNNING TOTAL carrying its own denominator. Zero-valued buckets are omitted so
+// the line stays readable, EXCEPT the denominators and the outcome partition, which always print --
+// a bucket that is absent because it is zero and a bucket that is absent because the instrument
+// never reached it look identical otherwise, and this project has already lost a night to exactly
+// that ambiguity (instrument trap 256).
+inline size_t format_compute_image_borrow_census(
+    const ComputeImageBorrowCensusSnapshot& census, char* output, size_t capacity) {
+    if (!output || !capacity) return 0;
+    // Terminate up front: with capacity 1 there is room for the NUL and nothing else, and every
+    // emit below then declines. A caller that trusts the returned length would otherwise read an
+    // unterminated buffer on exactly the path where the report is least useful.
+    output[0] = '\0';
+    size_t used = 0;
+    // snprintf writes at most `room` characters plus a NUL and returns the length it WOULD have
+    // written, so the cursor must advance by the clamped value or a truncated line silently moves
+    // `used` past the end of the buffer.
+    const auto emit = [&](const char* format, auto... args) {
+        if (used + 1 >= capacity) return;
+        const size_t room = capacity - used - 1;
+        const int written = std::snprintf(output + used, room + 1, format, args...);
+        if (written < 0) return;
+        used += static_cast<size_t>(written) <= room ? static_cast<size_t>(written) : room;
+    };
+    const auto percent = [](uint64_t part, uint64_t whole) {
+        return whole ? 100.0 * static_cast<double>(part) / static_cast<double>(whole) : 0.0;
+    };
+    const double mib = 1024.0 * 1024.0;
+
+    emit("[compute-borrow-census] running totals -- imports=%llu",
+         (unsigned long long)census.imports);
+    for (size_t i = 1; i < static_cast<size_t>(ComputeImageImportDecline::Count); ++i)
+        if (census.declines[i])
+            emit(" %s=%llu",
+                 compute_image_import_decline_name(static_cast<ComputeImageImportDecline>(i)),
+                 (unsigned long long)census.declines[i]);
+    emit(" accepted=%llu (%.1f%%)\n",
+         (unsigned long long)census.declines[0],
+         percent(census.declines[0], census.imports));
+
+    const uint64_t attempted =
+        census.declines[static_cast<size_t>(ComputeImageImportDecline::None)];
+    emit("[compute-borrow-census] running totals -- attempted=%llu", (unsigned long long)attempted);
+    for (size_t i = 1; i < static_cast<size_t>(ComputeImageBorrowOutcome::Count); ++i)
+        emit(" %s=%llu (%.1f%%)",
+             compute_image_borrow_outcome_name(static_cast<ComputeImageBorrowOutcome>(i)),
+             (unsigned long long)census.outcomes[i], percent(census.outcomes[i], attempted));
+    emit(" alias_retry=%llu lease_fail=%llu spared=%.1f MiB decoded=%.1f MiB\n",
+         (unsigned long long)census.alias_retries, (unsigned long long)census.lease_failures,
+         static_cast<double>(census.hit_bytes) / mib,
+         static_cast<double>(census.miss_bytes) / mib);
+
+    const uint64_t authority =
+        census.outcomes[static_cast<size_t>(ComputeImageBorrowOutcome::AuthorityChanged)];
+    emit("[compute-borrow-census] running totals -- authority_changed=%llu journal_overlap=%llu "
+         "journal_unarmed=%llu journal_cross_submit=%llu watch_absent=%llu watch_dirty=%llu "
+         "watch_unknown=%llu | no_entry_scans=%llu same_addr=%llu",
+         (unsigned long long)authority,
+         (unsigned long long)census.authority_journal_overlap,
+         (unsigned long long)census.authority_journal_unarmed,
+         (unsigned long long)census.authority_journal_cross_submit,
+         (unsigned long long)census.authority_watch_absent,
+         (unsigned long long)census.authority_watch_dirty,
+         (unsigned long long)census.authority_watch_unknown,
+         (unsigned long long)census.no_entry_scans,
+         (unsigned long long)census.no_entry_same_addr);
+    for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
+        if (census.key_field_diffs[i])
+            emit(" %s=%llu", compute_image_key_field_name(static_cast<ComputeImageKeyField>(i)),
+                 (unsigned long long)census.key_field_diffs[i]);
+    emit("%s", "\n");
+
+    emit("[compute-borrow-census] running totals -- publish_evaluated=%llu",
+         (unsigned long long)census.publish_evaluated);
+    for (size_t i = 0; i < static_cast<size_t>(ComputeImagePublishDecline::Count); ++i)
+        emit(" %s=%llu (%.1f%%)",
+             compute_image_publish_decline_name(static_cast<ComputeImagePublishDecline>(i)),
+             (unsigned long long)census.publishes[i],
+             percent(census.publishes[i], census.publish_evaluated));
+    emit(" | renderer_accepted=%llu renderer_rejected=%llu\n",
+         (unsigned long long)census.renderer_accepted,
+         (unsigned long long)census.renderer_rejected);
+    return used;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
+++ b/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
@@ -321,10 +321,20 @@ struct ComputeImageBorrowCensusSnapshot {
     // guest address under a different key. `no_entry_same_addr == 0` means the producer is absent,
     // not that the key disagrees -- which is the whole distinction `STRAY_STATUS.md` guessed at.
     //
-    // `exact_key_scans` counts scans actually performed, and `key_field_diffs` is read against it,
-    // never against `outcomes[NoCacheEntry]`: the alias retry can miss without being scanned, so
-    // the two denominators are different numbers and only this one belongs to the field list.
+    // `exact_key_scans` counts scans actually performed. `key_field_diffs` is read against
+    // `exact_key_scans - exact_key_scans_rescued`, never against `outcomes[NoCacheEntry]`.
+    //
+    // The subtraction is the part that is easy to get wrong, and it is the second half of the
+    // finding that produced this whole section. An exact-key miss that the format-alias retry then
+    // RESCUES is a successful import -- but its exact-key scan still ran, and its mask still names
+    // `format` and `vk_format`, because that is precisely the difference the retry exists to
+    // bridge. On a title where the alias path routinely succeeds (GTA V's integer-storage surfaces
+    // are the normal case), accumulating those masks would flood the field list with the two
+    // fields that are working as designed. So a rescued scan is COUNTED and its fields are NOT
+    // accumulated: `key_field_diffs` describes only lookups where the borrow ultimately failed,
+    // which is the population a normalisation decision is about. #3307 review, N3.
     uint64_t exact_key_scans = 0;
+    uint64_t exact_key_scans_rescued = 0;
     uint64_t no_entry_same_addr = 0;
 
     // (4), refined.
@@ -374,11 +384,15 @@ public:
         else bump(authority_watch_unknown_);
     }
 
-    // Call once per scan PERFORMED, at the point the scan is taken -- never from a later
-    // observation, which is how the exact key's result got replaced by the alias retry's.
-    void record_no_entry_scan(bool same_address_entry, uint32_t field_diff_mask) {
+    // Call once per scan PERFORMED, with the mask the EXACT key produced -- never a later
+    // observation's, which is how the exact key's result got replaced by the alias retry's.
+    // `rescued_by_alias` says the import went on to succeed under the aliased key; such a scan is
+    // counted but contributes no fields, for the reason above the counter's declaration.
+    void record_no_entry_scan(bool same_address_entry, uint32_t field_diff_mask,
+                              bool rescued_by_alias) {
         bump(exact_key_scans_);
-        if (!same_address_entry) return;
+        if (rescued_by_alias) bump(exact_key_scans_rescued_);
+        if (!same_address_entry || rescued_by_alias) return;
         bump(no_entry_same_addr_);
         for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
             if (field_diff_mask & (1u << i)) bump(key_field_diffs_[i]);
@@ -409,6 +423,7 @@ public:
         out.hit_bytes = get(hit_bytes_);
         out.miss_bytes = get(miss_bytes_);
         out.exact_key_scans = get(exact_key_scans_);
+        out.exact_key_scans_rescued = get(exact_key_scans_rescued_);
         out.no_entry_same_addr = get(no_entry_same_addr_);
         out.authority_journal_overlap = get(authority_journal_overlap_);
         out.authority_journal_unarmed = get(authority_journal_unarmed_);
@@ -449,6 +464,7 @@ private:
     std::atomic<uint64_t> hit_bytes_{0};
     std::atomic<uint64_t> miss_bytes_{0};
     std::atomic<uint64_t> exact_key_scans_{0};
+    std::atomic<uint64_t> exact_key_scans_rescued_{0};
     std::atomic<uint64_t> no_entry_same_addr_{0};
     std::atomic<uint64_t> authority_journal_overlap_{0};
     std::atomic<uint64_t> authority_journal_unarmed_{0};
@@ -489,15 +505,26 @@ inline size_t format_compute_image_borrow_census(
     // unterminated buffer on exactly the path where the report is least useful.
     output[0] = '\0';
     size_t used = 0;
+    // Truncation is OBSERVED here, never inferred from `used == capacity - 1`. Those are different
+    // states: a report whose natural length is exactly `capacity - 1` fills the buffer without
+    // losing a byte, and inferring truncation from fullness would then overwrite the last line to
+    // announce a loss that did not happen -- a false alarm on the very field the marker exists to
+    // protect. Demonstrated at natural length 838 into capacity 839 (#3307 review, N2).
+    bool truncated = false;
     // snprintf writes at most `room` characters plus a NUL and returns the length it WOULD have
     // written, so the cursor must advance by the clamped value or a truncated line silently moves
     // `used` past the end of the buffer.
     const auto emit = [&](const char* format, auto... args) {
-        if (used + 1 >= capacity) return;
+        if (used + 1 >= capacity) { truncated = true; return; }
         const size_t room = capacity - used - 1;
         const int written = std::snprintf(output + used, room + 1, format, args...);
         if (written < 0) return;
-        used += static_cast<size_t>(written) <= room ? static_cast<size_t>(written) : room;
+        if (static_cast<size_t>(written) > room) {
+            truncated = true;
+            used += room;
+            return;
+        }
+        used += static_cast<size_t>(written);
     };
     const auto percent = [](uint64_t part, uint64_t whole) {
         return whole ? 100.0 * static_cast<double>(part) / static_cast<double>(whole) : 0.0;
@@ -532,7 +559,8 @@ inline size_t format_compute_image_borrow_census(
     emit("[compute-borrow-census] running totals -- authority_changed=%llu journal_overlap=%llu "
          "journal_unarmed=%llu journal_unjournaled=%llu journal_undecided=%llu "
          "watch_absent=%llu watch_dirty=%llu "
-         "watch_unknown=%llu | exact_key_scans=%llu same_addr=%llu exact_key_fields:",
+         "watch_unknown=%llu | exact_key_scans=%llu (rescued=%llu, not counted below) "
+         "same_addr=%llu exact_key_fields:",
          (unsigned long long)authority,
          (unsigned long long)census.authority_journal_overlap,
          (unsigned long long)census.authority_journal_unarmed,
@@ -542,6 +570,7 @@ inline size_t format_compute_image_borrow_census(
          (unsigned long long)census.authority_watch_dirty,
          (unsigned long long)census.authority_watch_unknown,
          (unsigned long long)census.exact_key_scans,
+         (unsigned long long)census.exact_key_scans_rescued,
          (unsigned long long)census.no_entry_same_addr);
     for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
         if (census.key_field_diffs[i])
@@ -559,10 +588,11 @@ inline size_t format_compute_image_borrow_census(
     emit(" | renderer_accepted=%llu renderer_rejected=%llu\n",
          (unsigned long long)census.renderer_accepted,
          (unsigned long long)census.renderer_rejected);
-    // Announce truncation in the buffer itself. `used == capacity - 1` is exactly the saturated
-    // state, and a reader who sees a report end without the publish partition must be told the
-    // difference between "that line is absent" and "that line did not fit".
-    if (used == capacity - 1) {
+    // Announce truncation in the buffer itself: a reader who sees a report end without the publish
+    // partition must be told the difference between "that line is absent" and "that line did not
+    // fit". The marker costs the tail of what was written, which is only ever correct when
+    // something really was lost -- hence the observed flag rather than a fullness test.
+    if (truncated) {
         constexpr char marker[] = "[compute-borrow-census] TRUNCATED\n";
         constexpr size_t marker_bytes = sizeof marker - 1;
         if (capacity > marker_bytes) {

--- a/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
+++ b/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
@@ -321,8 +321,20 @@ struct ComputeImageBorrowCensusSnapshot {
     // guest address under a different key. `no_entry_same_addr == 0` means the producer is absent,
     // not that the key disagrees -- which is the whole distinction `STRAY_STATUS.md` guessed at.
     //
-    // `exact_key_scans` counts scans actually performed. `key_field_diffs` is read against
-    // `exact_key_scans - exact_key_scans_rescued`, never against `outcomes[NoCacheEntry]`.
+    // `exact_key_scans` counts scans actually performed. These four numbers nest, each a proper
+    // subset of the one before, and reading a field against the wrong level is how a percentage
+    // acquires a meaning nobody intended:
+    //
+    //     exact_key_scans  >=  (exact_key_scans - exact_key_scans_rescued)
+    //                      >=  no_entry_same_addr  >=  key_field_diffs[f]
+    //
+    // **`key_field_diffs` is read against `no_entry_same_addr`, and against nothing else.** A field
+    // bit and `no_entry_same_addr` are bumped under one and the same condition below, so that is
+    // the field list's exact denominator. Dividing by `exact_key_scans - rescued` instead dilutes
+    // it with the scans that found NOTHING at the address -- which is a different row of the
+    // decision table (the producer is absent, not keyed differently), folded in as if it were
+    // evidence about key fields. Worked: `exact_key_scans=12 (rescued=9) same_addr=2 tile_mode=2`
+    // is tile_mode on 100% of near-misses, not 67% (#3307 review, round 3).
     //
     // The subtraction is the part that is easy to get wrong, and it is the second half of the
     // finding that produced this whole section. An exact-key miss that the format-alias retry then

--- a/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
+++ b/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
@@ -436,7 +436,8 @@ private:
 // the line stays readable, EXCEPT the denominators and the outcome partition, which always print --
 // a bucket that is absent because it is zero and a bucket that is absent because the instrument
 // never reached it look identical otherwise, and this project has already lost a night to exactly
-// that ambiguity (instrument trap 256).
+// that ambiguity -- a healthy zero on `[render-timing]`'s mprotect FAILURE counter, read as the
+// activity counter whose name shares its prefix further along the same line (#3307).
 inline size_t format_compute_image_borrow_census(
     const ComputeImageBorrowCensusSnapshot& census, char* output, size_t capacity) {
     if (!output || !capacity) return 0;

--- a/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
+++ b/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
@@ -38,6 +38,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 
 namespace prosper::frontend {
 
@@ -165,11 +166,22 @@ struct ComputeImageBorrowObservation {
     bool watch_present = false;    // the entry carries an armed page watch
     uint8_t watch_query = 0;       // prosper::host::GuestWriteWatchQuery ordinal; watch_present only
     bool exact_mirror_supported = false; // the byte-mirror fallback exists (Windows only)
+    // The export snapshot carries submit serial 0, i.e. the PRODUCER's publish was not journaled
+    // at all -- the journal was inactive on the producing thread, or had already overflowed when
+    // it stamped. Distinct from "the serial differs", and it points at the producer rather than at
+    // the distance between the two.
+    bool export_snapshot_unjournaled = false;
 
-    // Filled only when the lookup found nothing AND the report is enabled: the cache was scanned
-    // for an entry at the same guest address, and `no_entry_field_diff_mask` names the fields the
-    // nearest such entry disagreed on. The importer tries two keys, so the caller records this once
-    // from the FINAL observation rather than per call.
+    // Filled only when the caller asked for a scan, the lookup found nothing, and the report is
+    // enabled: the cache was scanned for an entry at the same guest address, and
+    // `no_entry_field_diff_mask` names the fields the nearest such entry disagreed on.
+    //
+    // **The mask belongs to whichever key was passed in, and only the EXACT key's is recorded.**
+    // The importer tries a second, format-ALIASED key when the first misses, and that key rewrites
+    // `format` and `vk_format` by construction -- so its mask reports those two as differing on
+    // every miss whether or not they are the reason. A field list that names the probe rather than
+    // the descriptor is worse than none, because the obvious response to it is to normalise the two
+    // fields the alias arm's own comment forbids normalising. So the retry is not scanned at all.
     bool no_entry_scanned = false;
     bool no_entry_same_addr = false;
     uint32_t no_entry_field_diff_mask = 0;
@@ -305,16 +317,24 @@ struct ComputeImageBorrowCensusSnapshot {
     uint64_t hit_bytes = 0;        // guest bytes NOT decoded, because the borrow hit
     uint64_t miss_bytes = 0;       // guest bytes the graphics decode had to read instead
 
-    // (2), refined: of the misses that found no entry, how many had an entry at the same guest
-    // address under a different key. `no_entry_same_addr == 0` means the producer is absent, not
-    // that the key disagrees -- which is the whole distinction `STRAY_STATUS.md` guessed at.
-    uint64_t no_entry_scans = 0;
+    // (2), refined: of the EXACT-key lookups that found no entry, how many had an entry at the same
+    // guest address under a different key. `no_entry_same_addr == 0` means the producer is absent,
+    // not that the key disagrees -- which is the whole distinction `STRAY_STATUS.md` guessed at.
+    //
+    // `exact_key_scans` counts scans actually performed, and `key_field_diffs` is read against it,
+    // never against `outcomes[NoCacheEntry]`: the alias retry can miss without being scanned, so
+    // the two denominators are different numbers and only this one belongs to the field list.
+    uint64_t exact_key_scans = 0;
     uint64_t no_entry_same_addr = 0;
 
     // (4), refined.
-    uint64_t authority_journal_overlap = 0;      // a real guest write covered the range
-    uint64_t authority_journal_unarmed = 0;      // the journal is not armed on the consuming thread
-    uint64_t authority_journal_cross_submit = 0; // armed, but the export is from an earlier submit
+    // `guest_gpu_writes_since` answers Unknown while armed for more than one reason and its own
+    // header says the caller cannot tell them apart. These four are what CAN be told apart from
+    // the borrow site, named for exactly what each covers and no more.
+    uint64_t authority_journal_overlap = 0;      // Overlap: a real write covered the range
+    uint64_t authority_journal_unarmed = 0;      // the journal is not armed on the CONSUMING thread
+    uint64_t authority_journal_unjournaled = 0;  // the PRODUCER's publish carried no submit serial
+    uint64_t authority_journal_undecided = 0;    // armed, serial present: another submit, or overflow
     uint64_t authority_watch_absent = 0;
     uint64_t authority_watch_dirty = 0;
     uint64_t authority_watch_unknown = 0;
@@ -347,14 +367,17 @@ public:
         // the hit), so the partition below is over Overlap and Unknown only.
         if (observation.submit_query == 1) bump(authority_journal_overlap_);
         else if (!observation.journal_armed) bump(authority_journal_unarmed_);
-        else bump(authority_journal_cross_submit_);
+        else if (observation.export_snapshot_unjournaled) bump(authority_journal_unjournaled_);
+        else bump(authority_journal_undecided_);
         if (!observation.watch_present) bump(authority_watch_absent_);
         else if (observation.watch_query == 1) bump(authority_watch_dirty_);
         else bump(authority_watch_unknown_);
     }
 
+    // Call once per scan PERFORMED, at the point the scan is taken -- never from a later
+    // observation, which is how the exact key's result got replaced by the alias retry's.
     void record_no_entry_scan(bool same_address_entry, uint32_t field_diff_mask) {
-        bump(no_entry_scans_);
+        bump(exact_key_scans_);
         if (!same_address_entry) return;
         bump(no_entry_same_addr_);
         for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
@@ -385,11 +408,12 @@ public:
         out.lease_failures = get(lease_failures_);
         out.hit_bytes = get(hit_bytes_);
         out.miss_bytes = get(miss_bytes_);
-        out.no_entry_scans = get(no_entry_scans_);
+        out.exact_key_scans = get(exact_key_scans_);
         out.no_entry_same_addr = get(no_entry_same_addr_);
         out.authority_journal_overlap = get(authority_journal_overlap_);
         out.authority_journal_unarmed = get(authority_journal_unarmed_);
-        out.authority_journal_cross_submit = get(authority_journal_cross_submit_);
+        out.authority_journal_unjournaled = get(authority_journal_unjournaled_);
+        out.authority_journal_undecided = get(authority_journal_undecided_);
         out.authority_watch_absent = get(authority_watch_absent_);
         out.authority_watch_dirty = get(authority_watch_dirty_);
         out.authority_watch_unknown = get(authority_watch_unknown_);
@@ -400,6 +424,11 @@ public:
     }
 
 private:
+    // Relaxed, deliberately: these are counters, not a protocol. The consequence is that a
+    // `snapshot()` taken WHILE another thread is recording can observe a torn partition -- an
+    // outcome bumped before its authority sub-counter. Both readers here (the periodic report at a
+    // submit boundary, and the tests) are quiescent with respect to recording, and the partition
+    // sums are asserted only in that state. Do not turn a sum into a runtime invariant.
     static void bump(std::atomic<uint64_t>& counter) {
         counter.fetch_add(1, std::memory_order_relaxed);
     }
@@ -419,11 +448,12 @@ private:
     std::atomic<uint64_t> lease_failures_{0};
     std::atomic<uint64_t> hit_bytes_{0};
     std::atomic<uint64_t> miss_bytes_{0};
-    std::atomic<uint64_t> no_entry_scans_{0};
+    std::atomic<uint64_t> exact_key_scans_{0};
     std::atomic<uint64_t> no_entry_same_addr_{0};
     std::atomic<uint64_t> authority_journal_overlap_{0};
     std::atomic<uint64_t> authority_journal_unarmed_{0};
-    std::atomic<uint64_t> authority_journal_cross_submit_{0};
+    std::atomic<uint64_t> authority_journal_unjournaled_{0};
+    std::atomic<uint64_t> authority_journal_undecided_{0};
     std::atomic<uint64_t> authority_watch_absent_{0};
     std::atomic<uint64_t> authority_watch_dirty_{0};
     std::atomic<uint64_t> authority_watch_unknown_{0};
@@ -438,6 +468,19 @@ private:
 // never reached it look identical otherwise, and this project has already lost a night to exactly
 // that ambiguity -- a healthy zero on `[render-timing]`'s mprotect FAILURE counter, read as the
 // activity counter whose name shares its prefix further along the same line (#3307).
+//
+// The same rule applies to the report as a whole, which is why truncation is ANNOUNCED rather than
+// silent: a report cut short at the third line drops the producer partition, and the producer
+// partition is the half that separates "the consumer's key differs" from "nothing was ever
+// published". `compute_image_borrow_census_report_bytes` is sized for the worst case (every bucket
+// and every key field non-zero at twenty digits) and `test_compute_image_borrow_census` pins that
+// a saturated census fits, so the marker should never fire -- but a marker that never fires is
+// cheap and a missing line that reads as a zero is not.
+// Worst case, measured by the saturation arm in the test rather than estimated: eleven decline
+// buckets, six outcome buckets, seven publish buckets, twenty-three key-field names and twenty-two
+// scalars, every one of them a twenty-digit u64. 4 KiB clears it with room to spare.
+inline constexpr size_t compute_image_borrow_census_report_bytes = 4096;
+
 inline size_t format_compute_image_borrow_census(
     const ComputeImageBorrowCensusSnapshot& census, char* output, size_t capacity) {
     if (!output || !capacity) return 0;
@@ -487,16 +530,18 @@ inline size_t format_compute_image_borrow_census(
     const uint64_t authority =
         census.outcomes[static_cast<size_t>(ComputeImageBorrowOutcome::AuthorityChanged)];
     emit("[compute-borrow-census] running totals -- authority_changed=%llu journal_overlap=%llu "
-         "journal_unarmed=%llu journal_cross_submit=%llu watch_absent=%llu watch_dirty=%llu "
-         "watch_unknown=%llu | no_entry_scans=%llu same_addr=%llu",
+         "journal_unarmed=%llu journal_unjournaled=%llu journal_undecided=%llu "
+         "watch_absent=%llu watch_dirty=%llu "
+         "watch_unknown=%llu | exact_key_scans=%llu same_addr=%llu exact_key_fields:",
          (unsigned long long)authority,
          (unsigned long long)census.authority_journal_overlap,
          (unsigned long long)census.authority_journal_unarmed,
-         (unsigned long long)census.authority_journal_cross_submit,
+         (unsigned long long)census.authority_journal_unjournaled,
+         (unsigned long long)census.authority_journal_undecided,
          (unsigned long long)census.authority_watch_absent,
          (unsigned long long)census.authority_watch_dirty,
          (unsigned long long)census.authority_watch_unknown,
-         (unsigned long long)census.no_entry_scans,
+         (unsigned long long)census.exact_key_scans,
          (unsigned long long)census.no_entry_same_addr);
     for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
         if (census.key_field_diffs[i])
@@ -514,6 +559,19 @@ inline size_t format_compute_image_borrow_census(
     emit(" | renderer_accepted=%llu renderer_rejected=%llu\n",
          (unsigned long long)census.renderer_accepted,
          (unsigned long long)census.renderer_rejected);
+    // Announce truncation in the buffer itself. `used == capacity - 1` is exactly the saturated
+    // state, and a reader who sees a report end without the publish partition must be told the
+    // difference between "that line is absent" and "that line did not fit".
+    if (used == capacity - 1) {
+        constexpr char marker[] = "[compute-borrow-census] TRUNCATED\n";
+        constexpr size_t marker_bytes = sizeof marker - 1;
+        if (capacity > marker_bytes) {
+            std::memcpy(output + capacity - 1 - marker_bytes, marker, marker_bytes);
+        } else {
+            output[0] = '\0';
+            used = 0;
+        }
+    }
     return used;
 }
 

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1,6 +1,7 @@
 #include "shared/live/live_compute.hpp"
 #include "shared/diagnostics/trip_bound_witness.hpp"
 #include "shared/compute/compute_authority_live_census.hpp"
+#include "shared/compute/compute_image_borrow_census.hpp"
 #include "shared/compute/compute_timing_selector.hpp"
 #include "shared/compute/compute_transfer_gate_census.hpp"
 #include "shared/live/live_target_format.hpp"
@@ -373,6 +374,29 @@ void report_write_watch_census() {
     char line[1024];
     const size_t used = prosper::frontend::format_write_watch_census(
         g_write_watch_census.snapshot(), line, sizeof line);
+    if (used) std::fwrite(line, 1, used, stderr);
+}
+
+// #3307 compute->graphics image borrow census. Same contract as the write-watch census above:
+// counting is unconditional (a handful of relaxed adds per import, against a path whose alternative
+// is a multi-megabyte detile), only the report is gated. See
+// shared/compute/compute_image_borrow_census.hpp for why every decline branch is counted rather
+// than the one a status doc guessed at.
+prosper::frontend::ComputeImageBorrowCensus g_image_borrow_census;
+
+bool image_borrow_census_report_enabled() {
+    static const bool on = std::getenv("PROSPER_COMPUTE_BORROW_CENSUS") != nullptr;
+    return on;
+}
+
+void report_image_borrow_census() {
+    // 2 KiB: four lines carrying eleven decline buckets, six outcome buckets, seven publish buckets
+    // and up to twenty-three key-field names. Truncation drops whole trailing lines, and the last
+    // line is the producer partition -- the half that separates "the key differs" from "nothing was
+    // ever published".
+    char line[2048];
+    const size_t used = prosper::frontend::format_compute_image_borrow_census(
+        g_image_borrow_census.snapshot(), line, sizeof line);
     if (used) std::fwrite(line, 1, used, stderr);
 }
 
@@ -963,6 +987,46 @@ ComputeImageCacheKey storage_image_cache_key(const prosper::gpu::ShaderResource&
         resource.mip_tail_x, resource.mip_tail_y,
         static_cast<uint32_t>(native_format), true, resource.in_mip_tail,
         resource.srgb, resource.depth_compare, mip_levels};
+}
+
+// Which fields two same-address cache keys disagree on, as a bitmask over ComputeImageKeyField.
+// #3307: a borrow that finds nothing under its key needs to say whether a producer is absent or
+// merely keyed differently, and only a field-by-field comparison can. Diagnostic only -- the key's
+// own `operator==` remains the identity used by the cache.
+//
+// `gpu_addr` is deliberately absent: it is the predicate that selects which entries are compared at
+// all, so it can never differ among them.
+uint32_t compute_image_key_field_diff_mask(const ComputeImageCacheKey& a,
+                                           const ComputeImageCacheKey& b) {
+    using Field = prosper::frontend::ComputeImageKeyField;
+    uint32_t mask = 0;
+    const auto note = [&](Field field, bool differs) {
+        if (differs) mask |= 1u << static_cast<uint32_t>(field);
+    };
+    note(Field::HostData, a.host_data != b.host_data);
+    note(Field::GuestBytes, a.guest_bytes != b.guest_bytes);
+    note(Field::ResourceBytes, a.resource_bytes != b.resource_bytes);
+    note(Field::Width, a.width != b.width);
+    note(Field::Height, a.height != b.height);
+    note(Field::Depth, a.depth != b.depth);
+    note(Field::Format, a.format != b.format);
+    note(Field::Components, a.components != b.components);
+    note(Field::TileMode, a.tile_mode != b.tile_mode);
+    note(Field::ImgDim, a.img_dim != b.img_dim);
+    note(Field::LinearRowPitch, a.linear_row_pitch != b.linear_row_pitch);
+    note(Field::LayerStride, a.layer_stride != b.layer_stride);
+    note(Field::LayerMipOffset, a.layer_mip_offset != b.layer_mip_offset);
+    note(Field::MipTailOffset, a.mip_tail_offset != b.mip_tail_offset);
+    note(Field::MipTailBytes, a.mip_tail_bytes != b.mip_tail_bytes);
+    note(Field::MipTailX, a.mip_tail_x != b.mip_tail_x);
+    note(Field::MipTailY, a.mip_tail_y != b.mip_tail_y);
+    note(Field::VkFormat, a.vk_format != b.vk_format);
+    note(Field::Storage, a.storage != b.storage);
+    note(Field::InMipTail, a.in_mip_tail != b.in_mip_tail);
+    note(Field::Srgb, a.srgb != b.srgb);
+    note(Field::DepthCompare, a.depth_compare != b.depth_compare);
+    note(Field::MipLevels, a.mip_levels != b.mip_levels);
+    return mask;
 }
 
 struct CachedComputeImage {
@@ -1883,6 +1947,17 @@ struct VulkanComputeContext {
     }
     uint64_t write_watch_census_submits = 0;
 
+    // #3307. Separate counter and separate gate from the write-watch census above: the two answer
+    // different questions and are read in different runs, and sharing a period would make one
+    // report's cadence an artefact of the other's variable being set.
+    void report_image_borrow_census_periodically() {
+        if (!image_borrow_census_report_enabled()) return;
+        if (++image_borrow_census_submits % 256 == 0) report_image_borrow_census();
+        static const bool once = [] { std::atexit(report_image_borrow_census); return true; }();
+        (void)once;
+    }
+    uint64_t image_borrow_census_submits = 0;
+
     bool may_promote_write_watch_before_exact(size_t source_bytes,
                                               uint32_t stable_validations) {
         const uint32_t promotion_validations =
@@ -2312,14 +2387,18 @@ struct VulkanComputeContext {
         found->second.compute_transfer_valid = false;
     }
 
-    void authorize_cached_image_export(const ComputeImageCacheKey& key,
+    // Returns whether an entry was actually published. A publish-eligible binding whose cache entry
+    // was evicted or invalidated between writeback and here leaves the consumer with nothing to
+    // borrow, and that is a different failure from an ineligible binding (#3307).
+    bool authorize_cached_image_export(const ComputeImageCacheKey& key,
                                        uint64_t producer_command_order) {
         const auto found = image_cache.find(key);
         if (found == image_cache.end() || !found->second.content_valid || !found->second.image)
-            return;
+            return false;
         found->second.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         found->second.graphics_export_command_order = producer_command_order;
         found->second.graphics_export_valid = true;
+        return true;
     }
 
     bool authorize_cached_image_compute_transfer(const ComputeImageCacheKey& key) {
@@ -2364,34 +2443,94 @@ struct VulkanComputeContext {
 #endif
     }
 
-    bool borrow_cached_image_for_graphics(const ComputeImageCacheKey& key,
-                                          VkImage& image,
-                                          uint64_t& producer_command_order) {
+    // `observation`, when supplied, records WHICH of the five declines below fired. It never
+    // changes what the function decides and never evaluates a predicate the decision did not
+    // already evaluate -- in particular `write_watch.query()` stays behind exactly the same
+    // short circuit, because a census that pays for a query the borrow skips would be measuring
+    // its own cost. #3307.
+    bool borrow_cached_image_for_graphics(
+        const ComputeImageCacheKey& key, VkImage& image, uint64_t& producer_command_order,
+        prosper::frontend::ComputeImageBorrowObservation* observation = nullptr) {
+        using Outcome = prosper::frontend::ComputeImageBorrowOutcome;
+        const auto set_outcome = [&](Outcome outcome) {
+            if (observation) observation->outcome = outcome;
+        };
         const auto found = image_cache.find(key);
-        if (found == image_cache.end()) return false;
+        if (found == image_cache.end()) {
+            set_outcome(Outcome::NoCacheEntry);
+            if (observation && image_borrow_census_report_enabled())
+                scan_image_cache_for_near_miss(key, *observation);
+            return false;
+        }
         CachedComputeImage& cached = found->second;
-        if (!cached.graphics_export_valid || !cached.content_valid || !cached.image) return false;
+        if (!cached.graphics_export_valid || !cached.content_valid || !cached.image) {
+            set_outcome(!cached.graphics_export_valid ? Outcome::ExportNotAuthorized
+                        : !cached.content_valid      ? Outcome::ContentInvalid
+                                                     : Outcome::NoImage);
+            return false;
+        }
         const prosper::gpu::GuestGpuWriteQuery submit_query =
             prosper::gpu::guest_gpu_writes_since(cached.graphics_export_snapshot,
                                                   key.gpu_addr, key.guest_bytes);
         const bool submit_unchanged =
             submit_query == prosper::gpu::GuestGpuWriteQuery::Unchanged;
-        const bool watch_unchanged = !submit_unchanged && cached.write_watch &&
-            cached.write_watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged;
+        const bool watch_consulted = !submit_unchanged && static_cast<bool>(cached.write_watch);
+        const prosper::host::GuestWriteWatchQuery watch_query = watch_consulted
+            ? cached.write_watch.query() : prosper::host::GuestWriteWatchQuery::Unknown;
+        const bool watch_unchanged =
+            watch_consulted && watch_query == prosper::host::GuestWriteWatchQuery::Unchanged;
         // An exact mirror is the fail-closed fallback only when neither ordered journal nor page
         // watch can decide. It must never launder a KNOWN architectural writer whose bytes happened
         // to compare equal (for example a same-value clear or the explicit GPU-write test hook).
         const bool exact_unchanged =
             submit_query == prosper::gpu::GuestGpuWriteQuery::Unknown && !watch_unchanged &&
             cached_image_exact_guest_mirror_unchanged(key, cached);
-        if (!submit_unchanged && !watch_unchanged && !exact_unchanged) return false;
+        if (!submit_unchanged && !watch_unchanged && !exact_unchanged) {
+            set_outcome(Outcome::AuthorityChanged);
+            if (observation) {
+                observation->journal_armed = prosper::gpu::guest_gpu_write_tracking_active();
+                observation->submit_query = static_cast<uint8_t>(submit_query);
+                observation->watch_present = watch_consulted;
+                observation->watch_query = static_cast<uint8_t>(watch_query);
+#if defined(_WIN32)
+                observation->exact_mirror_supported = true;
+#endif
+            }
+            return false;
+        }
         if (exact_unchanged)
             cached.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         cached.last_use = ++image_cache_clock;
         ++cached.pins;
         image = cached.image;
         producer_command_order = cached.graphics_export_command_order;
+        set_outcome(Outcome::Hit);
         return true;
+    }
+
+    // Turn "nothing is cached under this key" into "an entry at this address disagrees on
+    // `tile_mode`". The importer's key carries twenty-three fields, so a lookup miss on its own
+    // cannot distinguish a producer that never ran from a producer whose descriptor differs in one
+    // of them -- and those have completely different fixes. O(cache) rather than O(1), so it runs
+    // only under PROSPER_COMPUTE_BORROW_CENSUS. The NEAREST entry wins: an address holding several
+    // retained descriptors would otherwise report the union of their differences as if one entry
+    // disagreed on everything.
+    void scan_image_cache_for_near_miss(
+        const ComputeImageCacheKey& key,
+        prosper::frontend::ComputeImageBorrowObservation& observation) const {
+        observation.no_entry_scanned = true;
+        uint32_t best_mask = 0;
+        int best_bits = -1;
+        for (const auto& [candidate, cached] : image_cache) {
+            (void)cached;
+            if (candidate.gpu_addr != key.gpu_addr) continue;
+            const uint32_t mask = compute_image_key_field_diff_mask(key, candidate);
+            const int bits = __builtin_popcount(mask);
+            if (best_bits < 0 || bits < best_bits) { best_bits = bits; best_mask = mask; }
+        }
+        if (best_bits < 0) return;
+        observation.no_entry_same_addr = true;
+        observation.no_entry_field_diff_mask = best_mask;
     }
 
     bool borrow_cached_image_for_compute_transfer(const ComputeImageCacheKey& key,
@@ -10335,8 +10474,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         image.resource->gpu_addr, image.guest_bytes),
                     authorized);
             }
-            if (publish_eligible && image.graphics_sampled_usage)
+            const bool graphics_export_authorized = publish_eligible &&
+                image.graphics_sampled_usage &&
                 ctx.authorize_cached_image_export(image.cache_key, item.command_order);
+            // #3307: the producer half of the borrow partition. Without it, a consumer that finds
+            // no cache entry cannot tell a producer that declined to publish from a producer that
+            // published under a different key.
+            prosper::frontend::ComputeImagePublishInputs publish_gates;
+            publish_gates.native_exact_storage = native_exact_storage;
+            publish_gates.unique = unique;
+            publish_gates.cache_candidate = image.cache_candidate;
+            publish_gates.persistent = image.persistent;
+            publish_gates.graphics_sampled_usage = image.graphics_sampled_usage;
+            publish_gates.export_authorized = graphics_export_authorized;
+            g_image_borrow_census.record_publish(
+                prosper::frontend::classify_compute_image_publish(publish_gates));
         }
         writeback_publish_ms = std::chrono::duration<double, std::milli>(
             ComputeClock::now() - writeback_publish_start).count();
@@ -10737,27 +10889,41 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
          sampled_resource.format == prosper::gpu::DataFormat::Float16) &&
         (sampled_resource.num_components ? sampled_resource.num_components : 1u) == 1u &&
         sampled_resource.layer_stride_bytes != 0;
-    if (!context || !context->device || !sampled_resource.gpu_addr ||
-        sampled_resource.cls != prosper::gpu::ResourceClass::Texture ||
-        sampled_resource.host_data || !guest_bytes || guest_bytes > UINT32_MAX ||
-        (!ordinary_shape && !cube_array_alias) ||
-        sampled_resource.declared_mip_levels != 1 || sampled_resource.in_mip_tail ||
-        sampled_resource.srgb ||
-        sampled_resource.depth_compare)
-        return false;
     const uint32_t components = sampled_resource.num_components
         ? sampled_resource.num_components : 1u;
+    // Hoisted above the precondition so the classifier below sees every term at once. It is a pure
+    // switch over the guest format enum and is safe with a null context.
     const VkFormat sampled_native_format =
         native_storage_vk_format(sampled_resource.format, components);
-    if (sampled_native_format == VK_FORMAT_UNDEFINED) return false;
+    // #3307: one classifier instead of one `||` chain, so a decline names the term that declined.
+    // `classify_compute_image_import(...) == None` is exactly the negation of the chain this
+    // replaced; `test_compute_image_borrow_census` asserts that over the complete boolean product,
+    // because the failure this guards against is a term silently dropped in the rewrite.
+    prosper::frontend::ComputeImageImportInputs gates;
+    gates.have_context = context && context->device;
+    gates.have_gpu_addr = sampled_resource.gpu_addr != 0;
+    gates.texture_class = sampled_resource.cls == prosper::gpu::ResourceClass::Texture;
+    gates.host_data = sampled_resource.host_data != nullptr;
+    gates.guest_bytes_in_range = guest_bytes != 0 && guest_bytes <= UINT32_MAX;
+    gates.shape_supported = ordinary_shape || cube_array_alias;
+    gates.single_mip_level = sampled_resource.declared_mip_levels == 1;
+    gates.in_mip_tail = sampled_resource.in_mip_tail;
+    gates.srgb = sampled_resource.srgb;
+    gates.depth_compare = sampled_resource.depth_compare;
+    gates.native_format_defined = sampled_native_format != VK_FORMAT_UNDEFINED;
+    const prosper::frontend::ComputeImageImportDecline decline =
+        prosper::frontend::classify_compute_image_import(gates);
+    g_image_borrow_census.record_import(decline);
+    if (decline != prosper::frontend::ComputeImageImportDecline::None) return false;
     prosper::gpu::ShaderResource storage_identity = sampled_resource;
     if (cube_array_alias) storage_identity.img_dim = 5u; // exact producer DIM=2D_ARRAY identity
     ComputeImageCacheKey key = storage_image_cache_key(
         storage_identity, static_cast<uint32_t>(guest_bytes), sampled_native_format);
     VkImage image = VK_NULL_HANDLE;
     uint64_t producer_command_order = 0;
+    prosper::frontend::ComputeImageBorrowObservation observation;
     bool borrowed = context->borrow_cached_image_for_graphics(
-        key, image, producer_command_order);
+        key, image, producer_command_order, &observation);
     // GTA V writes several full-resolution transition surfaces through integer storage images, then
     // samples the same bits through normalized, Float32, or packed R11 graphics views. The geometry
     // and allocation are identical; only the view's numeric interpretation differs. Retry the exact
@@ -10795,9 +10961,17 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
                 ? 1u : components);
         key = storage_image_cache_key(
             storage_identity, static_cast<uint32_t>(guest_bytes), producer_format);
+        // A fresh observation: the retry is a different key, and carrying the exact key's near-miss
+        // scan into it would attribute one lookup's field differences to the other's.
+        observation = {};
+        g_image_borrow_census.record_alias_retry();
         borrowed = context->borrow_cached_image_for_graphics(
-            key, image, producer_command_order);
+            key, image, producer_command_order, &observation);
     }
+    g_image_borrow_census.record_outcome(observation, guest_bytes);
+    if (observation.no_entry_scanned)
+        g_image_borrow_census.record_no_entry_scan(observation.no_entry_same_addr,
+                                                    observation.no_entry_field_diff_mask);
     if (!borrowed) return false;
     try {
         auto lease = std::make_shared<BorrowedComputeImageLease>();
@@ -10815,10 +10989,28 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
         import.lease = std::move(lease);
     } catch (...) {
         context->release_cached_image(key);
+        g_image_borrow_census.record_lease_failure();
         import = {};
         return false;
     }
     return import.valid();
+}
+
+// #3307. Running totals of why a graphics sampled descriptor did or did not borrow the device image
+// a compute dispatch had just produced, and -- from the producer side -- why an image was or was
+// not published for borrowing at all. Always collected (per import, not per byte);
+// PROSPER_COMPUTE_BORROW_CENSUS additionally prints them every 256 submits and at exit, and enables
+// the O(cache) near-miss key scan that turns a lookup miss into a named field difference.
+ComputeImageBorrowCensusSnapshot live_compute_image_borrow_census() {
+    return g_image_borrow_census.snapshot();
+}
+
+// The renderer's own post-import check (format, extent, device) can reject an image the borrow
+// handed over. That verdict is invisible from inside the compute backend, and a borrow that hits
+// and is then discarded costs exactly as much as one that missed -- so the renderer reports it here
+// rather than the two halves each believing the boundary worked.
+void live_compute_record_image_borrow_renderer_verdict(bool accepted) {
+    g_image_borrow_census.record_renderer_verdict(accepted);
 }
 
 uint64_t live_compute_buffer_gpu_result_skips() {
@@ -11134,6 +11326,7 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     g_perf_compute_writeback_ms = 0.0;
     g_perf_compute_cleanup_ms = 0.0;
     context.begin_write_watch_promotions();
+    context.report_image_borrow_census_periodically();
     // Dispatches are independent PM4-order operations: one item failing (e.g. an image shape the
     // backend can't bind yet, #590) must not abort the rest of the batch — that would regress
     // dispatches that executed before image bindings existed. Run all; report all-succeeded.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -10945,15 +10945,12 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
     prosper::frontend::ComputeImageBorrowObservation observation;
     bool borrowed = context->borrow_cached_image_for_graphics(
         key, image, producer_command_order, &observation, /*scan_near_miss=*/true);
-    // Recorded HERE, against the exact key, and not from the final observation. The alias retry
-    // below rewrites `format` and `vk_format` by construction, so its field mask would report those
-    // two as differing on every miss whether or not they are the reason -- and the obvious response
-    // to that mask is to normalise the two fields the alias comment immediately below forbids
-    // normalising. The retry therefore asks for no scan at all, and `exact_key_scans` counts scans
-    // performed rather than misses observed. #3307 review.
-    if (observation.no_entry_scanned)
-        g_image_borrow_census.record_no_entry_scan(observation.no_entry_same_addr,
-                                                    observation.no_entry_field_diff_mask);
+    // The exact key's near-miss result is kept here and recorded once the import's fate is known.
+    // Only the EXACT key is scanned: the alias retry below rewrites `format` and `vk_format` by
+    // construction, so its mask would name those two on every miss whether or not they are the
+    // reason -- and the obvious response to that mask is to normalise the two fields the alias
+    // comment immediately below forbids normalising. #3307 review.
+    const prosper::frontend::ComputeImageBorrowObservation exact_key_observation = observation;
     // GTA V writes several full-resolution transition surfaces through integer storage images, then
     // samples the same bits through normalized, Float32, or packed R11 graphics views. The geometry
     // and allocation are identical; only the view's numeric interpretation differs. Retry the exact
@@ -10999,6 +10996,15 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
             key, image, producer_command_order, &observation, /*scan_near_miss=*/false);
     }
     g_image_borrow_census.record_outcome(observation, guest_bytes);
+    // Recorded after the retry, because whether the alias RESCUED this lookup decides whether its
+    // fields belong in the census's field list at all. A rescued scan's mask necessarily names
+    // `format` and `vk_format` -- that is the difference the retry exists to bridge -- so counting
+    // its fields would flood the list with the alias working as designed. Counted, not accumulated.
+    if (exact_key_observation.no_entry_scanned)
+        g_image_borrow_census.record_no_entry_scan(
+            exact_key_observation.no_entry_same_addr,
+            exact_key_observation.no_entry_field_diff_mask,
+            /*rescued_by_alias=*/borrowed);
     if (!borrowed) return false;
     try {
         auto lease = std::make_shared<BorrowedComputeImageLease>();

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -384,17 +384,28 @@ void report_write_watch_census() {
 // than the one a status doc guessed at.
 prosper::frontend::ComputeImageBorrowCensus g_image_borrow_census;
 
+// The census stores both query results as bare ordinals so its header can stay free of every
+// dependency these two enums drag in. Pin the mapping where both are visible: a renumbering
+// upstream would otherwise silently re-label every authority bucket without touching a line here.
+static_assert(static_cast<uint8_t>(prosper::gpu::GuestGpuWriteQuery::Unchanged) == 0);
+static_assert(static_cast<uint8_t>(prosper::gpu::GuestGpuWriteQuery::Overlap) == 1);
+static_assert(static_cast<uint8_t>(prosper::gpu::GuestGpuWriteQuery::Unknown) == 2);
+static_assert(static_cast<uint8_t>(prosper::host::GuestWriteWatchQuery::Unchanged) == 0);
+static_assert(static_cast<uint8_t>(prosper::host::GuestWriteWatchQuery::Dirty) == 1);
+static_assert(static_cast<uint8_t>(prosper::host::GuestWriteWatchQuery::Unknown) == 2);
+
 bool image_borrow_census_report_enabled() {
     static const bool on = std::getenv("PROSPER_COMPUTE_BORROW_CENSUS") != nullptr;
     return on;
 }
 
 void report_image_borrow_census() {
-    // 2 KiB: four lines carrying eleven decline buckets, six outcome buckets, seven publish buckets
-    // and up to twenty-three key-field names. Truncation drops whole trailing lines, and the last
-    // line is the producer partition -- the half that separates "the key differs" from "nothing was
-    // ever published".
-    char line[2048];
+    // Sized by the header against a saturated census rather than by estimate: 2 KiB was thinner
+    // than its own comment implied -- four lines with every bucket and every key field non-zero
+    // reach roughly 1.7 KiB at seven-digit counters and exceed 2 KiB at nine, which would drop the
+    // producer partition exactly when the run had enough traffic to be worth reading. The formatter
+    // also announces truncation now, so a short report cannot read as an absent line.
+    char line[prosper::frontend::compute_image_borrow_census_report_bytes];
     const size_t used = prosper::frontend::format_compute_image_borrow_census(
         g_image_borrow_census.snapshot(), line, sizeof line);
     if (used) std::fwrite(line, 1, used, stderr);
@@ -2450,7 +2461,8 @@ struct VulkanComputeContext {
     // its own cost. #3307.
     bool borrow_cached_image_for_graphics(
         const ComputeImageCacheKey& key, VkImage& image, uint64_t& producer_command_order,
-        prosper::frontend::ComputeImageBorrowObservation* observation = nullptr) {
+        prosper::frontend::ComputeImageBorrowObservation* observation = nullptr,
+        bool scan_near_miss = false) {
         using Outcome = prosper::frontend::ComputeImageBorrowOutcome;
         const auto set_outcome = [&](Outcome outcome) {
             if (observation) observation->outcome = outcome;
@@ -2458,7 +2470,7 @@ struct VulkanComputeContext {
         const auto found = image_cache.find(key);
         if (found == image_cache.end()) {
             set_outcome(Outcome::NoCacheEntry);
-            if (observation && image_borrow_census_report_enabled())
+            if (scan_near_miss && observation && image_borrow_census_report_enabled())
                 scan_image_cache_for_near_miss(key, *observation);
             return false;
         }
@@ -2492,6 +2504,8 @@ struct VulkanComputeContext {
                 observation->submit_query = static_cast<uint8_t>(submit_query);
                 observation->watch_present = watch_consulted;
                 observation->watch_query = static_cast<uint8_t>(watch_query);
+                observation->export_snapshot_unjournaled =
+                    cached.graphics_export_snapshot.submit_serial == 0;
 #if defined(_WIN32)
                 observation->exact_mirror_supported = true;
 #endif
@@ -2515,6 +2529,13 @@ struct VulkanComputeContext {
     // only under PROSPER_COMPUTE_BORROW_CENSUS. The NEAREST entry wins: an address holding several
     // retained descriptors would otherwise report the union of their differences as if one entry
     // disagreed on everything.
+    //
+    // It takes no lock, and inherits the caller's discipline rather than establishing its own:
+    // `borrow_cached_image_for_graphics` already does an unlocked `find` and unlocked writes to the
+    // entry it returns. This is the only whole-container traversal on that path, so it is a longer
+    // window against a concurrent rehash than anything else there -- which is a second reason, on
+    // top of its cost, that it is reached only under PROSPER_COMPUTE_BORROW_CENSUS and never on a
+    // default launch.
     void scan_image_cache_for_near_miss(
         const ComputeImageCacheKey& key,
         prosper::frontend::ComputeImageBorrowObservation& observation) const {
@@ -10923,7 +10944,16 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
     uint64_t producer_command_order = 0;
     prosper::frontend::ComputeImageBorrowObservation observation;
     bool borrowed = context->borrow_cached_image_for_graphics(
-        key, image, producer_command_order, &observation);
+        key, image, producer_command_order, &observation, /*scan_near_miss=*/true);
+    // Recorded HERE, against the exact key, and not from the final observation. The alias retry
+    // below rewrites `format` and `vk_format` by construction, so its field mask would report those
+    // two as differing on every miss whether or not they are the reason -- and the obvious response
+    // to that mask is to normalise the two fields the alias comment immediately below forbids
+    // normalising. The retry therefore asks for no scan at all, and `exact_key_scans` counts scans
+    // performed rather than misses observed. #3307 review.
+    if (observation.no_entry_scanned)
+        g_image_borrow_census.record_no_entry_scan(observation.no_entry_same_addr,
+                                                    observation.no_entry_field_diff_mask);
     // GTA V writes several full-resolution transition surfaces through integer storage images, then
     // samples the same bits through normalized, Float32, or packed R11 graphics views. The geometry
     // and allocation are identical; only the view's numeric interpretation differs. Retry the exact
@@ -10961,17 +10991,14 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
                 ? 1u : components);
         key = storage_image_cache_key(
             storage_identity, static_cast<uint32_t>(guest_bytes), producer_format);
-        // A fresh observation: the retry is a different key, and carrying the exact key's near-miss
-        // scan into it would attribute one lookup's field differences to the other's.
+        // A fresh observation: the OUTCOME must describe the attempt that actually decided the
+        // import. The near-miss scan is deliberately not requested for this key -- see above.
         observation = {};
         g_image_borrow_census.record_alias_retry();
         borrowed = context->borrow_cached_image_for_graphics(
-            key, image, producer_command_order, &observation);
+            key, image, producer_command_order, &observation, /*scan_near_miss=*/false);
     }
     g_image_borrow_census.record_outcome(observation, guest_bytes);
-    if (observation.no_entry_scanned)
-        g_image_borrow_census.record_no_entry_scan(observation.no_entry_same_addr,
-                                                    observation.no_entry_field_diff_mask);
     if (!borrowed) return false;
     try {
         auto lease = std::make_shared<BorrowedComputeImageLease>();

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "gpu/execute/gpu_execute.hpp"
+#include "shared/compute/compute_image_borrow_census.hpp"
 #include "shared/texture/write_watch_census.hpp"
 
 #include <cstddef>
@@ -278,6 +279,21 @@ uint64_t live_compute_buffer_gpu_result_skips();
 // `decisions=`/`validated=` denominators before any ratio: comparing two arms' totals taken at
 // different points in a run is exactly the mistake that produced this issue's retracted numbers.
 WriteWatchCensusSnapshot live_compute_write_watch_census();
+// #3307. Running totals of the compute->graphics image borrow: why each graphics sampled
+// descriptor did or did not lease the device image a compute dispatch had just produced, and -- on
+// the producer side -- why an image was or was not published for borrowing at all. The two
+// partitions together separate "the consumer's key finds nothing" from "nothing was ever
+// published" from "the entry is published but no proof says guest memory still matches it", which
+// is exactly the five-way branch a single `return false` used to collapse.
+//
+// Always collected. PROSPER_COMPUTE_BORROW_CENSUS additionally prints the totals every 256 submits
+// and at exit, and enables the O(cache) near-miss scan that turns a lookup miss into a named key
+// field. Read the `imports=` / `attempted=` / `publish_evaluated=` denominators before any ratio.
+ComputeImageBorrowCensusSnapshot live_compute_image_borrow_census();
+// The renderer's verdict on an import that succeeded: it re-checks format, extent and device, and
+// a rejection there costs exactly what a miss costs. Recorded from `live_renderer.cpp` because only
+// the consumer knows it happened.
+void live_compute_record_image_borrow_renderer_verdict(bool accepted);
 // Monotonic diagnostic count of retained sampled-image hits whose validated source omitted upload.
 // Capture/replay tests use this to prove residency without relying on timing-sensitive assertions.
 uint64_t live_compute_sampled_image_upload_skips();

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -3868,6 +3868,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 compute_image_import.depth == r.depth && render_context.ok &&
                                 compute_image_import.device ==
                                     static_cast<void*>(render_context.dev);
+                            // #3307: a borrow the renderer then discards costs exactly what a miss
+                            // costs, and the compute backend cannot see it happen.
+                            prosper::frontend::live_compute_record_image_borrow_renderer_verdict(
+                                resource_compute_image_hit);
                             if (!resource_compute_image_hit) compute_image_import = {};
                         }
                         if (resource_compute_image_hit &&

--- a/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
+++ b/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
@@ -1,0 +1,309 @@
+// #3307. The compute->graphics image borrow census.
+//
+// The load-bearing test here is the FIRST one, and it is not a census test at all. Replacing
+// `import_live_compute_storage_image`'s single `||` chain with a classifier that names the failing
+// term is only safe if the two accept exactly the same resources; a term silently dropped in that
+// rewrite would turn a diagnostic change into a correctness change, and it would show up as a
+// borrowed image handed to a descriptor whose shape the chain used to refuse. So the equivalence is
+// asserted over the COMPLETE boolean product of the eleven terms (2^11 = 2048 cases) against the
+// chain written out independently below, rather than over cases chosen by whoever did the rewrite.
+//
+// The rest pin the partitions: every import lands in exactly one decline bucket, every attempted
+// borrow in exactly one outcome bucket, every publish in exactly one publish bucket, and the
+// formatted report carries its own denominators.
+
+#include "shared/compute/compute_image_borrow_census.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+using prosper::frontend::ComputeImageBorrowCensus;
+using prosper::frontend::ComputeImageBorrowObservation;
+using prosper::frontend::ComputeImageBorrowOutcome;
+using prosper::frontend::ComputeImageImportDecline;
+using prosper::frontend::ComputeImageImportInputs;
+using prosper::frontend::ComputeImageKeyField;
+using prosper::frontend::ComputeImagePublishDecline;
+using prosper::frontend::ComputeImagePublishInputs;
+using prosper::frontend::classify_compute_image_import;
+using prosper::frontend::classify_compute_image_publish;
+using prosper::frontend::format_compute_image_borrow_census;
+
+static int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
+
+// The precondition exactly as `import_live_compute_storage_image` used to spell it, transcribed
+// from the shape of that expression rather than from the classifier. `true` means "declined".
+static bool legacy_import_chain_declines(const ComputeImageImportInputs& in) {
+    if (!in.have_context || !in.have_gpu_addr || !in.texture_class ||
+        in.host_data || !in.guest_bytes_in_range ||
+        !in.shape_supported ||
+        !in.single_mip_level || in.in_mip_tail ||
+        in.srgb ||
+        in.depth_compare)
+        return true;
+    return !in.native_format_defined;
+}
+
+static ComputeImageImportInputs import_inputs_from_bits(unsigned bits) {
+    ComputeImageImportInputs in;
+    in.have_context          = (bits >> 0) & 1u;
+    in.have_gpu_addr         = (bits >> 1) & 1u;
+    in.texture_class         = (bits >> 2) & 1u;
+    in.host_data             = (bits >> 3) & 1u;
+    in.guest_bytes_in_range  = (bits >> 4) & 1u;
+    in.shape_supported       = (bits >> 5) & 1u;
+    in.single_mip_level      = (bits >> 6) & 1u;
+    in.in_mip_tail           = (bits >> 7) & 1u;
+    in.srgb                  = (bits >> 8) & 1u;
+    in.depth_compare         = (bits >> 9) & 1u;
+    in.native_format_defined = (bits >> 10) & 1u;
+    return in;
+}
+
+static ComputeImageImportInputs accepting_import_inputs() {
+    ComputeImageImportInputs in;
+    in.have_context = true;
+    in.have_gpu_addr = true;
+    in.texture_class = true;
+    in.host_data = false;
+    in.guest_bytes_in_range = true;
+    in.shape_supported = true;
+    in.single_mip_level = true;
+    in.in_mip_tail = false;
+    in.srgb = false;
+    in.depth_compare = false;
+    in.native_format_defined = true;
+    return in;
+}
+
+int main() {
+    // ---- 1. Equivalence over the complete boolean product ---------------------------------
+    constexpr unsigned kImportTerms = 11;
+    unsigned accepted = 0, declined = 0;
+    for (unsigned bits = 0; bits < (1u << kImportTerms); ++bits) {
+        const ComputeImageImportInputs in = import_inputs_from_bits(bits);
+        const bool classifier_declines =
+            classify_compute_image_import(in) != ComputeImageImportDecline::None;
+        CHECK(classifier_declines == legacy_import_chain_declines(in));
+        if (classifier_declines) ++declined; else ++accepted;
+    }
+    // The sweep is only evidence if BOTH verdicts occur in it: an accept-only or decline-only sweep
+    // agrees with any classifier that answers one constant, which is the vacuity shape this
+    // project keeps rediscovering. Exactly one of 2048 assignments accepts, and knowing which
+    // number that is makes the arm falsifiable rather than merely non-empty.
+    CHECK(accepted == 1);
+    CHECK(declined == (1u << kImportTerms) - 1);
+
+    // ---- 2. Each term declines under its own name, one at a time ---------------------------
+    struct TermCase { const char* what; ComputeImageImportInputs in; ComputeImageImportDecline want; };
+    auto without = [](void (*mutate)(ComputeImageImportInputs&)) {
+        ComputeImageImportInputs in = accepting_import_inputs();
+        mutate(in);
+        return in;
+    };
+    const TermCase cases[] = {
+        {"context",   without([](ComputeImageImportInputs& i) { i.have_context = false; }),
+         ComputeImageImportDecline::NoContext},
+        {"addr",      without([](ComputeImageImportInputs& i) { i.have_gpu_addr = false; }),
+         ComputeImageImportDecline::NoGuestAddress},
+        {"class",     without([](ComputeImageImportInputs& i) { i.texture_class = false; }),
+         ComputeImageImportDecline::NotTextureClass},
+        {"host",      without([](ComputeImageImportInputs& i) { i.host_data = true; }),
+         ComputeImageImportDecline::HostBackedData},
+        {"bytes",     without([](ComputeImageImportInputs& i) { i.guest_bytes_in_range = false; }),
+         ComputeImageImportDecline::GuestByteRange},
+        {"shape",     without([](ComputeImageImportInputs& i) { i.shape_supported = false; }),
+         ComputeImageImportDecline::Shape},
+        {"mips",      without([](ComputeImageImportInputs& i) { i.single_mip_level = false; }),
+         ComputeImageImportDecline::MipLevels},
+        {"mip_tail",  without([](ComputeImageImportInputs& i) { i.in_mip_tail = true; }),
+         ComputeImageImportDecline::MipTail},
+        {"srgb",      without([](ComputeImageImportInputs& i) { i.srgb = true; }),
+         ComputeImageImportDecline::Srgb},
+        {"depth_cmp", without([](ComputeImageImportInputs& i) { i.depth_compare = true; }),
+         ComputeImageImportDecline::DepthCompare},
+        {"format",    without([](ComputeImageImportInputs& i) { i.native_format_defined = false; }),
+         ComputeImageImportDecline::NativeFormat},
+    };
+    for (const TermCase& c : cases) {
+        const ComputeImageImportDecline got = classify_compute_image_import(c.in);
+        if (got != c.want)
+            std::fprintf(stderr, "FAIL %s: term %s reported %s, wanted %s\n", __func__, c.what,
+                         prosper::frontend::compute_image_import_decline_name(got),
+                         prosper::frontend::compute_image_import_decline_name(c.want));
+        CHECK(got == c.want);
+    }
+    CHECK(classify_compute_image_import(accepting_import_inputs()) ==
+          ComputeImageImportDecline::None);
+    // Every enumerator is reachable, so no bucket can be a permanent zero that a reader mistakes
+    // for "this never happens".
+    CHECK(sizeof(cases) / sizeof(cases[0]) ==
+          static_cast<size_t>(ComputeImageImportDecline::Count) - 1);
+
+    // ---- 3. The publish gate, same shape --------------------------------------------------
+    ComputeImagePublishInputs publish;
+    CHECK(classify_compute_image_publish(publish) ==
+          ComputeImagePublishDecline::NotNativeExactStorage);
+    publish.native_exact_storage = true;
+    CHECK(classify_compute_image_publish(publish) == ComputeImagePublishDecline::NotUnique);
+    publish.unique = true;
+    CHECK(classify_compute_image_publish(publish) == ComputeImagePublishDecline::NotCacheCandidate);
+    publish.cache_candidate = true;
+    CHECK(classify_compute_image_publish(publish) == ComputeImagePublishDecline::NotPersistent);
+    publish.persistent = true;
+    CHECK(classify_compute_image_publish(publish) == ComputeImagePublishDecline::NoSampledUsage);
+    publish.graphics_sampled_usage = true;
+    // Eligible in every respect and the cache still had nothing valid to publish: the entry was
+    // evicted or invalidated between writeback and the publish loop. This is the arm that would
+    // otherwise be indistinguishable from an ineligible binding.
+    CHECK(classify_compute_image_publish(publish) == ComputeImagePublishDecline::ExportRefused);
+    publish.export_authorized = true;
+    CHECK(classify_compute_image_publish(publish) == ComputeImagePublishDecline::Authorized);
+
+    // ---- 4. The authority partition -------------------------------------------------------
+    // GuestGpuWriteQuery: 0 Unchanged, 1 Overlap, 2 Unknown. GuestWriteWatchQuery: 0 Unchanged,
+    // 1 Dirty, 2 Unknown. Unchanged cannot reach AuthorityChanged on either axis -- it is the hit.
+    {
+        ComputeImageBorrowCensus census;
+        ComputeImageBorrowObservation overlap;
+        overlap.outcome = ComputeImageBorrowOutcome::AuthorityChanged;
+        overlap.submit_query = 1;          // Overlap: a real guest write covered the range
+        overlap.journal_armed = true;
+        census.record_outcome(overlap, 1024);
+
+        ComputeImageBorrowObservation unarmed;
+        unarmed.outcome = ComputeImageBorrowOutcome::AuthorityChanged;
+        unarmed.submit_query = 2;          // Unknown, and the journal is not armed here
+        unarmed.journal_armed = false;
+        census.record_outcome(unarmed, 2048);
+
+        ComputeImageBorrowObservation cross;
+        cross.outcome = ComputeImageBorrowOutcome::AuthorityChanged;
+        cross.submit_query = 2;            // Unknown, but armed: the export is from another submit
+        cross.journal_armed = true;
+        cross.watch_present = true;
+        cross.watch_query = 1;             // Dirty
+        census.record_outcome(cross, 4096);
+
+        const auto snapshot = census.snapshot();
+        CHECK(snapshot.authority_journal_overlap == 1);
+        CHECK(snapshot.authority_journal_unarmed == 1);
+        CHECK(snapshot.authority_journal_cross_submit == 1);
+        CHECK(snapshot.authority_watch_absent == 2);
+        CHECK(snapshot.authority_watch_dirty == 1);
+        CHECK(snapshot.authority_watch_unknown == 0);
+        CHECK(snapshot.miss_bytes == 1024 + 2048 + 4096);
+        CHECK(snapshot.hit_bytes == 0);
+        // The journal partition and the watch partition each sum to the denominator, independently.
+        const uint64_t authority =
+            snapshot.outcomes[static_cast<size_t>(ComputeImageBorrowOutcome::AuthorityChanged)];
+        CHECK(authority == 3);
+        CHECK(snapshot.authority_journal_overlap + snapshot.authority_journal_unarmed +
+              snapshot.authority_journal_cross_submit == authority);
+        CHECK(snapshot.authority_watch_absent + snapshot.authority_watch_dirty +
+              snapshot.authority_watch_unknown == authority);
+    }
+
+    // ---- 5. A hit is counted as spared bytes, and only a hit -------------------------------
+    {
+        ComputeImageBorrowCensus census;
+        ComputeImageBorrowObservation hit;
+        hit.outcome = ComputeImageBorrowOutcome::Hit;
+        census.record_outcome(hit, 66846720);
+        ComputeImageBorrowObservation miss;
+        miss.outcome = ComputeImageBorrowOutcome::NoCacheEntry;
+        census.record_outcome(miss, 66846720);
+        const auto snapshot = census.snapshot();
+        CHECK(snapshot.hit_bytes == 66846720);
+        CHECK(snapshot.miss_bytes == 66846720);
+        // A NoCacheEntry must NOT fall into the authority breakdown: those counters exist to
+        // explain the fourth gate, and folding a second gate's misses into them is how a
+        // partition stops being one.
+        CHECK(snapshot.authority_journal_overlap == 0);
+        CHECK(snapshot.authority_journal_unarmed == 0);
+        CHECK(snapshot.authority_journal_cross_submit == 0);
+        CHECK(snapshot.authority_watch_absent == 0);
+    }
+
+    // ---- 6. The near-miss key scan ---------------------------------------------------------
+    {
+        ComputeImageBorrowCensus census;
+        census.record_no_entry_scan(false, 0);   // nothing at this address at all
+        const uint32_t tile_and_pitch =
+            (1u << static_cast<uint32_t>(ComputeImageKeyField::TileMode)) |
+            (1u << static_cast<uint32_t>(ComputeImageKeyField::LinearRowPitch));
+        census.record_no_entry_scan(true, tile_and_pitch);
+        const auto snapshot = census.snapshot();
+        CHECK(snapshot.no_entry_scans == 2);
+        CHECK(snapshot.no_entry_same_addr == 1);
+        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::TileMode)] == 1);
+        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::LinearRowPitch)] == 1);
+        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::VkFormat)] == 0);
+    }
+
+    // ---- 7. The report carries its denominators and every outcome bucket -------------------
+    {
+        ComputeImageBorrowCensus census;
+        census.record_import(ComputeImageImportDecline::None);
+        census.record_import(ComputeImageImportDecline::Shape);
+        ComputeImageBorrowObservation miss;
+        miss.outcome = ComputeImageBorrowOutcome::AuthorityChanged;
+        miss.submit_query = 2;
+        census.record_outcome(miss, 4096);
+        census.record_alias_retry();
+        census.record_renderer_verdict(false);
+        census.record_publish(ComputeImagePublishDecline::NoSampledUsage);
+
+        char line[2048];
+        const size_t used = format_compute_image_borrow_census(census.snapshot(), line, sizeof line);
+        CHECK(used != 0);
+        CHECK(used < sizeof line);
+        CHECK(line[used] == '\0');
+        const std::string text(line, used);
+        CHECK(text.find("imports=2") != std::string::npos);
+        CHECK(text.find("shape=1") != std::string::npos);
+        CHECK(text.find("accepted=1 (50.0%)") != std::string::npos);
+        CHECK(text.find("attempted=1") != std::string::npos);
+        // Present even at zero: an outcome bucket that vanishes when empty cannot be told from one
+        // the instrument never reached. That ambiguity is instrument trap 256 in this repository.
+        CHECK(text.find("no_cache_entry=0") != std::string::npos);
+        CHECK(text.find("hit=0 (0.0%)") != std::string::npos);
+        CHECK(text.find("authority_changed=1 (100.0%)") != std::string::npos);
+        CHECK(text.find("journal_unarmed=1") != std::string::npos);
+        CHECK(text.find("alias_retry=1") != std::string::npos);
+        CHECK(text.find("publish_evaluated=1") != std::string::npos);
+        CHECK(text.find("no_sampled_usage=1 (100.0%)") != std::string::npos);
+        CHECK(text.find("renderer_rejected=1") != std::string::npos);
+        // Four lines, one report.
+        CHECK(std::count(text.begin(), text.end(), '\n') == 4);
+    }
+
+    // ---- 8. Truncation is bounded, not corrupting ------------------------------------------
+    {
+        ComputeImageBorrowCensus census;
+        census.record_import(ComputeImageImportDecline::None);
+        for (size_t capacity = 1; capacity <= 96; ++capacity) {
+            char small[128];
+            std::memset(small, 0x7f, sizeof small);
+            const size_t used = format_compute_image_borrow_census(census.snapshot(), small, capacity);
+            CHECK(used < capacity);
+            CHECK(small[used] == '\0');
+            // Nothing written past the buffer it was given.
+            for (size_t i = capacity; i < sizeof small; ++i) CHECK(small[i] == 0x7f);
+        }
+        CHECK(format_compute_image_borrow_census(census.snapshot(), nullptr, 64) == 0);
+        char one[1];
+        CHECK(format_compute_image_borrow_census(census.snapshot(), one, 0) == 0);
+    }
+
+    if (failures) {
+        std::fprintf(stderr, "compute_image_borrow_census: %d check(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("compute_image_borrow_census: all checks passed\n");
+    return 0;
+}

--- a/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
+++ b/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
@@ -247,6 +247,17 @@ int main() {
     {
         ComputeImageBorrowCensus census;
         census.record_no_entry_scan(false, 0, false); // scanned; nothing at this address at all
+        // The same, but carrying a non-empty mask. Production never builds one -- the scan leaves
+        // the mask at zero when it finds no same-address entry -- and that is exactly why the arm
+        // is here: with a zero mask, "fields are gated on same_addr" and "fields happen to be empty"
+        // are the same observation, and a mutation that drops the gate passes unnoticed. It did,
+        // when this block first tried to pin the nesting. The gate is a contract of the public
+        // recorder, so it is tested at the boundary the contract names rather than at the one the
+        // current caller happens to produce.
+        const uint32_t width_and_height =
+            (1u << static_cast<uint32_t>(ComputeImageKeyField::Width)) |
+            (1u << static_cast<uint32_t>(ComputeImageKeyField::Height));
+        census.record_no_entry_scan(false, width_and_height, /*rescued_by_alias=*/false);
         const uint32_t tile_and_pitch =
             (1u << static_cast<uint32_t>(ComputeImageKeyField::TileMode)) |
             (1u << static_cast<uint32_t>(ComputeImageKeyField::LinearRowPitch));
@@ -260,14 +271,33 @@ int main() {
             (1u << static_cast<uint32_t>(ComputeImageKeyField::VkFormat));
         census.record_no_entry_scan(true, format_fields, /*rescued_by_alias=*/true);
         const auto snapshot = census.snapshot();
-        CHECK(snapshot.exact_key_scans == 3);
+        CHECK(snapshot.exact_key_scans == 4);
         CHECK(snapshot.exact_key_scans_rescued == 1);
         CHECK(snapshot.no_entry_same_addr == 1);
+        // The discriminating pair: a mask offered without a same-address entry contributes nothing.
+        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::Width)] == 0);
+        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::Height)] == 0);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::Format)] == 0);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::VkFormat)] == 0);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::TileMode)] == 1);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::LinearRowPitch)] == 1);
-        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::VkFormat)] == 0);
+
+        // The four numbers NEST, each a proper subset of the one before, and the nesting is the
+        // whole reason the field list has an unambiguous denominator:
+        //
+        //     exact_key_scans >= (exact_key_scans - rescued) >= no_entry_same_addr >= diffs[f]
+        //
+        // This arm exists because that chain was documented as a comment and read against the
+        // WRONG level -- against `exact_key_scans - rescued` rather than `no_entry_same_addr`,
+        // which dilutes the field list with lookups that found nothing at the address at all
+        // (#3307 review, round 3). The four inputs above are chosen so every inequality is
+        // STRICT: 4 > 3 > 1 >= 1. An arm whose levels were all equal would hold for an
+        // implementation that collapsed them and would prove nothing.
+        CHECK(snapshot.exact_key_scans > snapshot.exact_key_scans - snapshot.exact_key_scans_rescued);
+        CHECK(snapshot.exact_key_scans - snapshot.exact_key_scans_rescued >
+              snapshot.no_entry_same_addr);
+        for (size_t i = 0; i < static_cast<size_t>(ComputeImageKeyField::Count); ++i)
+            CHECK(snapshot.key_field_diffs[i] <= snapshot.no_entry_same_addr);
     }
 
     // ---- 7. The report carries its denominators and every outcome bucket -------------------

--- a/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
+++ b/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
@@ -181,29 +181,41 @@ int main() {
         unarmed.journal_armed = false;
         census.record_outcome(unarmed, 2048);
 
-        ComputeImageBorrowObservation cross;
-        cross.outcome = ComputeImageBorrowOutcome::AuthorityChanged;
-        cross.submit_query = 2;            // Unknown, but armed: the export is from another submit
-        cross.journal_armed = true;
-        cross.watch_present = true;
-        cross.watch_query = 1;             // Dirty
-        census.record_outcome(cross, 4096);
+        ComputeImageBorrowObservation undecided;
+        undecided.outcome = ComputeImageBorrowOutcome::AuthorityChanged;
+        undecided.submit_query = 2;        // Unknown, armed, and the export carries a serial
+        undecided.journal_armed = true;
+        undecided.watch_present = true;
+        undecided.watch_query = 1;         // Dirty
+        census.record_outcome(undecided, 4096);
+
+        // Armed, Unknown, and the export snapshot carries NO serial: the producer's publish was
+        // never journaled. Separate bucket, because it points at the producer rather than at the
+        // distance between producer and consumer, and those have different fixes.
+        ComputeImageBorrowObservation unjournaled;
+        unjournaled.outcome = ComputeImageBorrowOutcome::AuthorityChanged;
+        unjournaled.submit_query = 2;
+        unjournaled.journal_armed = true;
+        unjournaled.export_snapshot_unjournaled = true;
+        census.record_outcome(unjournaled, 8192);
 
         const auto snapshot = census.snapshot();
         CHECK(snapshot.authority_journal_overlap == 1);
         CHECK(snapshot.authority_journal_unarmed == 1);
-        CHECK(snapshot.authority_journal_cross_submit == 1);
-        CHECK(snapshot.authority_watch_absent == 2);
+        CHECK(snapshot.authority_journal_undecided == 1);
+        CHECK(snapshot.authority_journal_unjournaled == 1);
+        CHECK(snapshot.authority_watch_absent == 3);
         CHECK(snapshot.authority_watch_dirty == 1);
         CHECK(snapshot.authority_watch_unknown == 0);
-        CHECK(snapshot.miss_bytes == 1024 + 2048 + 4096);
+        CHECK(snapshot.miss_bytes == 1024 + 2048 + 4096 + 8192);
         CHECK(snapshot.hit_bytes == 0);
         // The journal partition and the watch partition each sum to the denominator, independently.
         const uint64_t authority =
             snapshot.outcomes[static_cast<size_t>(ComputeImageBorrowOutcome::AuthorityChanged)];
-        CHECK(authority == 3);
+        CHECK(authority == 4);
         CHECK(snapshot.authority_journal_overlap + snapshot.authority_journal_unarmed +
-              snapshot.authority_journal_cross_submit == authority);
+              snapshot.authority_journal_unjournaled +
+              snapshot.authority_journal_undecided == authority);
         CHECK(snapshot.authority_watch_absent + snapshot.authority_watch_dirty +
               snapshot.authority_watch_unknown == authority);
     }
@@ -225,20 +237,21 @@ int main() {
         // partition stops being one.
         CHECK(snapshot.authority_journal_overlap == 0);
         CHECK(snapshot.authority_journal_unarmed == 0);
-        CHECK(snapshot.authority_journal_cross_submit == 0);
+        CHECK(snapshot.authority_journal_undecided == 0);
+        CHECK(snapshot.authority_journal_unjournaled == 0);
         CHECK(snapshot.authority_watch_absent == 0);
     }
 
     // ---- 6. The near-miss key scan ---------------------------------------------------------
     {
         ComputeImageBorrowCensus census;
-        census.record_no_entry_scan(false, 0);   // nothing at this address at all
+        census.record_no_entry_scan(false, 0);   // scanned; nothing at this address at all
         const uint32_t tile_and_pitch =
             (1u << static_cast<uint32_t>(ComputeImageKeyField::TileMode)) |
             (1u << static_cast<uint32_t>(ComputeImageKeyField::LinearRowPitch));
         census.record_no_entry_scan(true, tile_and_pitch);
         const auto snapshot = census.snapshot();
-        CHECK(snapshot.no_entry_scans == 2);
+        CHECK(snapshot.exact_key_scans == 2);
         CHECK(snapshot.no_entry_same_addr == 1);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::TileMode)] == 1);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::LinearRowPitch)] == 1);
@@ -274,12 +287,54 @@ int main() {
         CHECK(text.find("hit=0 (0.0%)") != std::string::npos);
         CHECK(text.find("authority_changed=1 (100.0%)") != std::string::npos);
         CHECK(text.find("journal_unarmed=1") != std::string::npos);
+        CHECK(text.find("journal_unjournaled=0") != std::string::npos);
+        CHECK(text.find("journal_undecided=0") != std::string::npos);
         CHECK(text.find("alias_retry=1") != std::string::npos);
         CHECK(text.find("publish_evaluated=1") != std::string::npos);
         CHECK(text.find("no_sampled_usage=1 (100.0%)") != std::string::npos);
         CHECK(text.find("renderer_rejected=1") != std::string::npos);
         // Four lines, one report.
         CHECK(std::count(text.begin(), text.end(), '\n') == 4);
+    }
+
+    // ---- 7b. A saturated census fits the production buffer, and truncation is ANNOUNCED ----
+    // The production report writes into a fixed `char[compute_image_borrow_census_report_bytes]`.
+    // Sizing it by estimate is how the previous 2 KiB buffer came to be thinner than its own
+    // comment claimed, so pin the worst case instead: every counter at its maximum, which makes
+    // every bucket and every key-field name print at twenty digits.
+    {
+        prosper::frontend::ComputeImageBorrowCensusSnapshot saturated;
+        constexpr uint64_t big = UINT64_MAX;
+        for (auto& value : saturated.declines) value = big;
+        for (auto& value : saturated.outcomes) value = big;
+        for (auto& value : saturated.publishes) value = big;
+        for (auto& value : saturated.key_field_diffs) value = big;
+        saturated.imports = big; saturated.alias_retries = big; saturated.lease_failures = big;
+        saturated.hit_bytes = big; saturated.miss_bytes = big;
+        saturated.exact_key_scans = big; saturated.no_entry_same_addr = big;
+        saturated.authority_journal_overlap = big; saturated.authority_journal_unarmed = big;
+        saturated.authority_journal_unjournaled = big; saturated.authority_journal_undecided = big;
+        saturated.authority_watch_absent = big; saturated.authority_watch_dirty = big;
+        saturated.authority_watch_unknown = big;
+        saturated.renderer_accepted = big; saturated.renderer_rejected = big;
+        saturated.publish_evaluated = big;
+
+        char full[prosper::frontend::compute_image_borrow_census_report_bytes];
+        const size_t used = format_compute_image_borrow_census(saturated, full, sizeof full);
+        const std::string text(full, used);
+        CHECK(used < sizeof full - 1);
+        CHECK(std::count(text.begin(), text.end(), '\n') == 4);
+        CHECK(text.find("TRUNCATED") == std::string::npos);
+        // ...and the marker is not decorative: force the same report into a buffer that cannot
+        // hold it and the reader must be told, rather than reading a dropped producer partition as
+        // an absent one.
+        char cramped[600];
+        const size_t cramped_used =
+            format_compute_image_borrow_census(saturated, cramped, sizeof cramped);
+        const std::string cramped_text(cramped, cramped_used);
+        CHECK(cramped_used == sizeof cramped - 1);
+        CHECK(cramped_text.find("TRUNCATED") != std::string::npos);
+        CHECK(cramped[cramped_used] == '\0');
     }
 
     // ---- 8. Truncation is bounded, not corrupting ------------------------------------------

--- a/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
+++ b/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <vector>
 
 using prosper::frontend::ComputeImageBorrowCensus;
 using prosper::frontend::ComputeImageBorrowObservation;
@@ -245,14 +246,25 @@ int main() {
     // ---- 6. The near-miss key scan ---------------------------------------------------------
     {
         ComputeImageBorrowCensus census;
-        census.record_no_entry_scan(false, 0);   // scanned; nothing at this address at all
+        census.record_no_entry_scan(false, 0, false); // scanned; nothing at this address at all
         const uint32_t tile_and_pitch =
             (1u << static_cast<uint32_t>(ComputeImageKeyField::TileMode)) |
             (1u << static_cast<uint32_t>(ComputeImageKeyField::LinearRowPitch));
-        census.record_no_entry_scan(true, tile_and_pitch);
+        census.record_no_entry_scan(true, tile_and_pitch, /*rescued_by_alias=*/false);
+        // A scan whose lookup the format-alias retry then RESCUED. It is counted, and its fields
+        // are deliberately NOT accumulated: a rescued mask names `format`/`vk_format` by
+        // construction, so folding it in would flood the field list with the alias working as
+        // designed. Both halves are asserted below -- the count moves, the fields do not.
+        const uint32_t format_fields =
+            (1u << static_cast<uint32_t>(ComputeImageKeyField::Format)) |
+            (1u << static_cast<uint32_t>(ComputeImageKeyField::VkFormat));
+        census.record_no_entry_scan(true, format_fields, /*rescued_by_alias=*/true);
         const auto snapshot = census.snapshot();
-        CHECK(snapshot.exact_key_scans == 2);
+        CHECK(snapshot.exact_key_scans == 3);
+        CHECK(snapshot.exact_key_scans_rescued == 1);
         CHECK(snapshot.no_entry_same_addr == 1);
+        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::Format)] == 0);
+        CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::VkFormat)] == 0);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::TileMode)] == 1);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::LinearRowPitch)] == 1);
         CHECK(snapshot.key_field_diffs[static_cast<size_t>(ComputeImageKeyField::VkFormat)] == 0);
@@ -297,11 +309,18 @@ int main() {
         CHECK(std::count(text.begin(), text.end(), '\n') == 4);
     }
 
-    // ---- 7b. A saturated census fits the production buffer, and truncation is ANNOUNCED ----
+    // ---- 7b. The WIDEST census fits the production buffer, and truncation is ANNOUNCED -----
     // The production report writes into a fixed `char[compute_image_borrow_census_report_bytes]`.
     // Sizing it by estimate is how the previous 2 KiB buffer came to be thinner than its own
-    // comment claimed, so pin the worst case instead: every counter at its maximum, which makes
-    // every bucket and every key-field name print at twenty digits.
+    // comment claimed, so the size is pinned by construction instead.
+    //
+    // "Every counter at its maximum" is the obvious construction and it is NOT the widest report,
+    // which is the trap this arm was rewritten to avoid (#3307 review, N1). All-max moves the
+    // numerators and the denominators together, so every percentage collapses to the four
+    // characters "100.0" and the widest percentage a report can print is structurally
+    // inexpressible. The percentages are widest for a LARGE numerator over a SMALL denominator, so
+    // the denominators are skewed to 1 below. That is a genuinely wider report than all-max -- it
+    // is not a hypothetical -- and it is the shape a same-source control could never have produced.
     {
         prosper::frontend::ComputeImageBorrowCensusSnapshot saturated;
         constexpr uint64_t big = UINT64_MAX;
@@ -318,23 +337,58 @@ int main() {
         saturated.authority_watch_unknown = big;
         saturated.renderer_accepted = big; saturated.renderer_rejected = big;
         saturated.publish_evaluated = big;
+        saturated.exact_key_scans_rescued = big;
 
         char full[prosper::frontend::compute_image_borrow_census_report_bytes];
-        const size_t used = format_compute_image_borrow_census(saturated, full, sizeof full);
-        const std::string text(full, used);
-        CHECK(used < sizeof full - 1);
+        const size_t all_max = format_compute_image_borrow_census(saturated, full, sizeof full);
+
+        // The three denominators, skewed to 1 so every percentage prints its widest form.
+        prosper::frontend::ComputeImageBorrowCensusSnapshot widest = saturated;
+        widest.imports = 1;
+        widest.declines[static_cast<size_t>(ComputeImageImportDecline::None)] = 1;
+        widest.publish_evaluated = 1;
+        const size_t widest_used = format_compute_image_borrow_census(widest, full, sizeof full);
+        const std::string text(full, widest_used);
+
+        // The point of the rewrite, asserted rather than asserted-about: skewing really does
+        // produce a wider report than all-max, so the earlier arm was measuring the wrong shape.
+        CHECK(widest_used > all_max);
+        CHECK(widest_used < sizeof full - 1);
         CHECK(std::count(text.begin(), text.end(), '\n') == 4);
         CHECK(text.find("TRUNCATED") == std::string::npos);
+        // The widest report the formatter can produce, against the buffer the production reporter
+        // declares. Headroom, not a coincidence.
+        CHECK(widest_used + 512 < prosper::frontend::compute_image_borrow_census_report_bytes);
         // ...and the marker is not decorative: force the same report into a buffer that cannot
         // hold it and the reader must be told, rather than reading a dropped producer partition as
         // an absent one.
         char cramped[600];
         const size_t cramped_used =
-            format_compute_image_borrow_census(saturated, cramped, sizeof cramped);
+            format_compute_image_borrow_census(widest, cramped, sizeof cramped);
         const std::string cramped_text(cramped, cramped_used);
         CHECK(cramped_used == sizeof cramped - 1);
         CHECK(cramped_text.find("TRUNCATED") != std::string::npos);
         CHECK(cramped[cramped_used] == '\0');
+
+        // ...and a report that EXACTLY fills its buffer is not truncated and must not be marked.
+        // `used == capacity - 1` holds in both states, so a fullness test raises a false alarm here
+        // and eats the producer partition to announce a loss that did not happen -- on the very
+        // field the marker exists to protect (#3307 review, N2). Measure the natural length, then
+        // hand the formatter exactly that much room.
+        ComputeImageBorrowCensus small_census;
+        small_census.record_import(ComputeImageImportDecline::None);
+        const auto small_snapshot = small_census.snapshot();
+        char measure[prosper::frontend::compute_image_borrow_census_report_bytes];
+        const size_t natural =
+            format_compute_image_borrow_census(small_snapshot, measure, sizeof measure);
+        CHECK(natural != 0 && natural + 1 <= sizeof measure);
+        std::vector<char> exact(natural + 1, '\0');
+        const size_t exact_used =
+            format_compute_image_borrow_census(small_snapshot, exact.data(), exact.size());
+        const std::string exact_text(exact.data(), exact_used);
+        CHECK(exact_used == natural);
+        CHECK(exact_text.find("TRUNCATED") == std::string::npos);
+        CHECK(exact_text == std::string(measure, natural));
     }
 
     // ---- 8. Truncation is bounded, not corrupting ------------------------------------------

--- a/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
+++ b/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
@@ -269,7 +269,7 @@ int main() {
         CHECK(text.find("accepted=1 (50.0%)") != std::string::npos);
         CHECK(text.find("attempted=1") != std::string::npos);
         // Present even at zero: an outcome bucket that vanishes when empty cannot be told from one
-        // the instrument never reached. That ambiguity is instrument trap 256 in this repository.
+        // the instrument never reached. That ambiguity has already cost this issue a night (#3307).
         CHECK(text.find("no_cache_entry=0") != std::string::npos);
         CHECK(text.find("hit=0 (0.0%)") != std::string::npos);
         CHECK(text.find("authority_changed=1 (100.0%)") != std::string::npos);

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -182,10 +182,15 @@ int main() {
     _putenv_s("PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB", "0");
     _putenv_s("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", "1");
     _putenv_s("PROSPER_NO_DISK_PIPELINE_CACHE", "1");
+    _putenv_s("PROSPER_COMPUTE_BORROW_CENSUS", "1");
 #else
     setenv("PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB", "0", 1);
     setenv("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", "1", 1);
     setenv("PROSPER_NO_DISK_PIPELINE_CACHE", "1", 1);
+    // #3307. The borrow census counts unconditionally, but its near-miss key SCAN is O(cache) and
+    // therefore gated on the same variable as the report. The typed-storage borrow arms below
+    // assert that scan names the right field, so it has to be armed before the first import.
+    setenv("PROSPER_COMPUTE_BORROW_CENSUS", "1", 1);
 #endif
 
 #if defined(__linux__)
@@ -2114,6 +2119,13 @@ int main() {
             consumer.draw_index = 60;
             consumer.command_order = 20;
             bool imported = false;
+            // #3307. The borrow census is asserted on the REAL path -- a real device, a real
+            // producer dispatch, a real ordered submit -- because the unit test can only prove the
+            // classifier is self-consistent. The three snapshots bracket one hit and one
+            // deliberately mis-keyed miss taken back to back inside the same consumer callback.
+            const auto census_before = prosper::frontend::live_compute_image_borrow_census();
+            prosper::frontend::ComputeImageBorrowCensusSnapshot census_after_hit{};
+            prosper::frontend::ComputeImageBorrowCensusSnapshot census_after_miss{};
             const OrderedSubmitResult ordered = execute_ordered_items(
                 {{SubmitOperationKind::Dispatch, item.dispatch_index, item.command_order},
                  {SubmitOperationKind::Draw, consumer.draw_index, consumer.command_order}},
@@ -2126,6 +2138,17 @@ int main() {
                         sampled, sampled.size, compute_import) && compute_import.valid() &&
                         compute_import.native_format == 100u &&
                         compute_import.producer_command_order == item.command_order;
+                    census_after_hit = prosper::frontend::live_compute_image_borrow_census();
+                    // The same guest allocation with ONE key field changed. The borrow must miss,
+                    // and the near-miss scan must name that field -- otherwise "nothing is cached
+                    // under this key" and "the producer never ran" stay indistinguishable, which
+                    // is exactly the ambiguity this census exists to remove.
+                    ShaderResource mismatched = sampled;
+                    mismatched.tile_mode = sampled.tile_mode + 1u;
+                    prosper::frontend::LiveComputeImageImport mismatched_import;
+                    (void)prosper::frontend::import_live_compute_storage_image(
+                        mismatched, mismatched.size, mismatched_import);
+                    census_after_miss = prosper::frontend::live_compute_image_borrow_census();
                     return RenderedFrame{};
                 },
                 [&](const std::vector<ComputeItem>& items) {
@@ -2138,6 +2161,39 @@ int main() {
                   "typed R32_SFLOAT fill executes and writes every finite value exactly");
             CHECK(imported,
                   "same-submit graphics consumer leases the exact typed R32_SFLOAT result");
+            {
+                using Outcome = prosper::frontend::ComputeImageBorrowOutcome;
+                using Publish = prosper::frontend::ComputeImagePublishDecline;
+                using Field = prosper::frontend::ComputeImageKeyField;
+                constexpr size_t kHit = static_cast<size_t>(Outcome::Hit);
+                constexpr size_t kNoEntry = static_cast<size_t>(Outcome::NoCacheEntry);
+                constexpr size_t kAuthorized = static_cast<size_t>(Publish::Authorized);
+                constexpr size_t kTileMode = static_cast<size_t>(Field::TileMode);
+                constexpr size_t kWidth = static_cast<size_t>(Field::Width);
+                CHECK(census_after_hit.outcomes[kHit] == census_before.outcomes[kHit] + 1,
+                      "the borrow census records the same-submit lease as a hit");
+                CHECK(census_after_hit.publishes[kAuthorized] >
+                          census_before.publishes[kAuthorized],
+                      "the borrow census records the producer's export authorization");
+                CHECK(census_after_miss.outcomes[kNoEntry] ==
+                          census_after_hit.outcomes[kNoEntry] + 1,
+                      "a one-field key difference is recorded as a cache-entry miss");
+                // Float32x1 aliases to R32_UINT, so the importer retries under the producer
+                // identity before giving up. Pin that: the recorded observation is the RETRY's,
+                // and reading it as the exact key's would misattribute the format fields.
+                CHECK(census_after_miss.alias_retries == census_after_hit.alias_retries + 1,
+                      "the format-alias retry is counted separately from the outcome");
+                CHECK(census_after_miss.no_entry_same_addr ==
+                          census_after_hit.no_entry_same_addr + 1 &&
+                      census_after_miss.key_field_diffs[kTileMode] ==
+                          census_after_hit.key_field_diffs[kTileMode] + 1,
+                      "the near-miss scan finds the same-address entry and names tile_mode");
+                // ...and names only the fields that actually differ. A mask that set every bit
+                // would satisfy the arm above and say nothing.
+                CHECK(census_after_miss.key_field_diffs[kWidth] ==
+                          census_after_hit.key_field_diffs[kWidth],
+                      "the near-miss scan does not attribute a field that matched");
+            }
         }
     }
     {

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -2215,10 +2215,14 @@ int main() {
             {
                 // The classifier's eleven terms are proven equivalent to the chain they replaced by
                 // a 2048-case sweep in `test_compute_image_borrow_census` -- but that sweep operates
-                // on the abstract booleans. The ten hand-written `gates.* = <descriptor field>`
+                // on the abstract booleans. The hand-written `gates.* = <descriptor field>`
                 // assignments that PRODUCE those booleans are where a lost `!` would actually live,
-                // and nothing covered them. Drive nine of them from the real path, one field at a
-                // time off a descriptor that is otherwise known to import cleanly.
+                // and nothing covered them. Drive them from the real path, one field at a time off a
+                // descriptor that is otherwise known to classify cleanly.
+                //
+                // Ten of the eleven decline terms; `NoContext` is structurally undrivable here,
+                // because reaching this point at all requires a live compute backend. Do not read
+                // this array as covering all eleven.
                 using Decline = prosper::frontend::ComputeImageImportDecline;
                 ShaderResource base = output;
                 base.cls = ResourceClass::Texture;
@@ -2255,6 +2259,23 @@ int main() {
                      [](ShaderResource& r, uint64_t&, uint8_t*) {
                          r.format = DataFormat::Unorm8; r.num_components = 3; }},
                 };
+                // POSITIVE CONTROL, and it is load-bearing rather than decorative. The classifier
+                // returns the FIRST failing term, so a `base` that already declined would let every
+                // case below pass while testing nothing -- each would report its own term only
+                // because the mutation happens to precede the pre-existing failure, or would report
+                // the wrong term entirely. Pin that the unmutated descriptor is accepted, so a
+                // future edit to `output` cannot quietly hollow out the whole array.
+                {
+                    const auto before = prosper::frontend::live_compute_image_borrow_census();
+                    prosper::frontend::LiveComputeImageImport control_import;
+                    (void)prosper::frontend::import_live_compute_storage_image(
+                        base, base.size, control_import);
+                    const auto after = prosper::frontend::live_compute_image_borrow_census();
+                    const size_t accepted_bucket = static_cast<size_t>(Decline::None);
+                    CHECK(after.declines[accepted_bucket] == before.declines[accepted_bucket] + 1,
+                          "the unmutated wiring probe is ACCEPTED, so each mutated arm below is "
+                          "testing its own term rather than a pre-existing decline");
+                }
                 for (const WiringCase& c : wiring) {
                     ShaderResource probe = base;
                     uint64_t bytes = probe.size;

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -2170,6 +2170,8 @@ int main() {
                 constexpr size_t kAuthorized = static_cast<size_t>(Publish::Authorized);
                 constexpr size_t kTileMode = static_cast<size_t>(Field::TileMode);
                 constexpr size_t kWidth = static_cast<size_t>(Field::Width);
+                constexpr size_t kFormat = static_cast<size_t>(Field::Format);
+                constexpr size_t kVkFormat = static_cast<size_t>(Field::VkFormat);
                 CHECK(census_after_hit.outcomes[kHit] == census_before.outcomes[kHit] + 1,
                       "the borrow census records the same-submit lease as a hit");
                 CHECK(census_after_hit.publishes[kAuthorized] >
@@ -2179,8 +2181,8 @@ int main() {
                           census_after_hit.outcomes[kNoEntry] + 1,
                       "a one-field key difference is recorded as a cache-entry miss");
                 // Float32x1 aliases to R32_UINT, so the importer retries under the producer
-                // identity before giving up. Pin that: the recorded observation is the RETRY's,
-                // and reading it as the exact key's would misattribute the format fields.
+                // identity before giving up. The retry is counted, and its key is deliberately NOT
+                // scanned.
                 CHECK(census_after_miss.alias_retries == census_after_hit.alias_retries + 1,
                       "the format-alias retry is counted separately from the outcome");
                 CHECK(census_after_miss.no_entry_same_addr ==
@@ -2193,6 +2195,85 @@ int main() {
                 CHECK(census_after_miss.key_field_diffs[kWidth] ==
                           census_after_hit.key_field_diffs[kWidth],
                       "the near-miss scan does not attribute a field that matched");
+                // The arm that pins WHICH key the mask describes, and the reason it exists: the
+                // alias retry rewrites `format` and `vk_format`, so recording the retry's mask
+                // instead of the exact key's would report those two as differing on a miss whose
+                // only real difference is `tile_mode`. Only the exact key is scanned, so both must
+                // be untouched. Without this pair the tile_mode/width arms above hold identically
+                // for either key and say nothing about attribution.
+                CHECK(census_after_miss.key_field_diffs[kFormat] ==
+                          census_after_hit.key_field_diffs[kFormat] &&
+                      census_after_miss.key_field_diffs[kVkFormat] ==
+                          census_after_hit.key_field_diffs[kVkFormat],
+                      "the near-miss mask is the exact key's, not the format-alias retry's");
+                // A scan is recorded per scan PERFORMED. The retry missed too and was not scanned,
+                // so exactly one scan is recorded against two NoCacheEntry outcomes' worth of
+                // lookups -- the distinction the counter's name now carries.
+                CHECK(census_after_miss.exact_key_scans == census_after_hit.exact_key_scans + 1,
+                      "one scan is recorded per exact-key lookup, not per miss observed");
+            }
+            {
+                // The classifier's eleven terms are proven equivalent to the chain they replaced by
+                // a 2048-case sweep in `test_compute_image_borrow_census` -- but that sweep operates
+                // on the abstract booleans. The ten hand-written `gates.* = <descriptor field>`
+                // assignments that PRODUCE those booleans are where a lost `!` would actually live,
+                // and nothing covered them. Drive nine of them from the real path, one field at a
+                // time off a descriptor that is otherwise known to import cleanly.
+                using Decline = prosper::frontend::ComputeImageImportDecline;
+                ShaderResource base = output;
+                base.cls = ResourceClass::Texture;
+                uint8_t host_bytes[4] = {};
+                struct WiringCase {
+                    const char* what;
+                    Decline want;
+                    void (*mutate)(ShaderResource&, uint64_t&, uint8_t*);
+                };
+                static const WiringCase wiring[] = {
+                    {"gpu_addr", Decline::NoGuestAddress,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) { r.gpu_addr = 0; }},
+                    {"class", Decline::NotTextureClass,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) {
+                         r.cls = ResourceClass::StorageImage; }},
+                    {"host_data", Decline::HostBackedData,
+                     [](ShaderResource& r, uint64_t&, uint8_t* host) { r.host_data = host; }},
+                    {"guest_bytes", Decline::GuestByteRange,
+                     [](ShaderResource&, uint64_t& bytes, uint8_t*) { bytes = 0; }},
+                    {"guest_bytes_wide", Decline::GuestByteRange,
+                     [](ShaderResource&, uint64_t& bytes, uint8_t*) {
+                         bytes = uint64_t(UINT32_MAX) + 1; }},
+                    {"shape", Decline::Shape,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) { r.img_dim = 4; }},
+                    {"mip_levels", Decline::MipLevels,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) { r.declared_mip_levels = 2; }},
+                    {"mip_tail", Decline::MipTail,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) { r.in_mip_tail = true; }},
+                    {"srgb", Decline::Srgb,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) { r.srgb = true; }},
+                    {"depth_compare", Decline::DepthCompare,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) { r.depth_compare = true; }},
+                    {"native_format", Decline::NativeFormat,
+                     [](ShaderResource& r, uint64_t&, uint8_t*) {
+                         r.format = DataFormat::Unorm8; r.num_components = 3; }},
+                };
+                for (const WiringCase& c : wiring) {
+                    ShaderResource probe = base;
+                    uint64_t bytes = probe.size;
+                    c.mutate(probe, bytes, host_bytes);
+                    const auto before = prosper::frontend::live_compute_image_borrow_census();
+                    prosper::frontend::LiveComputeImageImport unused_import;
+                    const bool imported_probe =
+                        prosper::frontend::import_live_compute_storage_image(
+                            probe, bytes, unused_import);
+                    const auto after = prosper::frontend::live_compute_image_borrow_census();
+                    const size_t want = static_cast<size_t>(c.want);
+                    const size_t accepted_bucket = static_cast<size_t>(Decline::None);
+                    if (imported_probe || after.declines[want] != before.declines[want] + 1 ||
+                        after.declines[accepted_bucket] != before.declines[accepted_bucket]) {
+                        std::printf("FAIL: import gate wiring for %s\n", c.what);
+                        ++fails;
+                    }
+                    ++checks;
+                }
             }
         }
     }


### PR DESCRIPTION
## What this is

Instrumentation, not a fix. It answers one question that has been guessed at rather than measured:
**when Stray's title screen asks graphics to borrow the device image a compute dispatch just
produced, which of the six declines actually fires?**

Closes nothing. It selects the fix for #3307, and the fixes it selects between have nothing to do
with one another.

## The failure scenario

Stray's title screen renders at **9.25 fps** (matched-arm mean, #3307) with `gpu-device` at ~4% of
the window — the frame is entirely host-bound. Three volume costs dominate, all on the same
surfaces, all per-frame: 545 GiB of `exact` comparison, 419 GiB of page protection over 18,210
`mprotect` calls, and 247 GiB of RMW image snapshots. That is 536 MiB per rendered frame.

Every "make the copying cheaper" lever has now been measured and is null (#3317's pooling A/B; an
8 GiB image cache; the journal-deferral path, which answers only 11.3% of validations). What
remains is not doing the copying: a 3840×2160 RGBA16F intermediate is re-tiled out of a compute
dispatch into guest memory and immediately read back, detiled and converted by the graphics texture
materializer. Both Vulkan users are on the same device. The image should never touch guest memory.

`import_live_compute_storage_image` exists to make exactly that borrow, the renderer's witness says
the surface passes every gate to attempt it (`compute_cand=1`), and it misses on every reference.

## Why a census had to come first

The importer plus `borrow_cached_image_for_graphics` decline through **six** independent branches,
and before this change every one of them was the same bare `return false`:

1. the consumer's precondition (shape, class, host-backed data, mip levels, srgb, format);
2. no cache entry under the key;
3. an entry whose export authority was never published, or was invalidated after publication;
4. an entry with no `VkImage`;
5. a published entry that no proof says still matches guest memory;
6. a lease the renderer accepts and then rejects on format/extent/device.

`STRAY_STATUS.md` asserted (2) — *"finds nothing under its key … it lives in the compute cache's
admission"* — as a statement of fact. It is an inference, and no run could have established it. This
PR **withdraws it as unmeasured rather than falsifying it**, and records why in that doc's
`## Ruled out`: a fix aimed at admission would report "no change" for a reason unrelated to the
change if the miss is really (3) or (5).

## The contract

`PROSPER_COMPUTE_BORROW_CENSUS=1` prints four `[compute-borrow-census]` lines every 256 submits and
at exit. Every line is a running total carrying its own denominator, so two reports taken at
different points in a run stay comparable — the failure that produced #3155's retracted numbers.

* **the consumer's precondition**, partitioned by term (`shape`, `srgb`, `mip_levels`, …);
* **the borrow's outcome** — `no_cache_entry`, `export_unpublished`, `content_invalid`, `no_image`,
  `authority_changed`, `hit` — with a **zero bucket still printed**. A bucket that vanishes when
  empty is indistinguishable from an instrument that never reached it, which cost a correct
  finding a whole night on this very issue (a healthy zero on `[render-timing]`'s mprotect FAILURE
  counter, read as the activity counter sharing its prefix further along the same line);
* **why `authority_changed` fired**, splitting the `Unknown` that `guest_gpu_writes_since` returns
  for two structurally different reasons its own header says a caller cannot tell apart: an unarmed
  per-thread submit journal (`journal_unarmed`) versus an export published in an earlier submit
  (`journal_cross_submit`). Plus what the page watch answered;
* **the producer's publish gate**, partitioned the same way, so "the consumer's key differs" and
  "the producer never published anything" stop being the same observation.

On a lookup miss the same variable enables an **O(cache) scan for an entry at the same guest
address**, reporting which key field the nearest such entry disagreed on. The key carries
twenty-three fields; without that scan, "the producer never ran" and "the producer is keyed
differently" produce identical evidence.

Counting is unconditional — a handful of relaxed atomic adds per import, against a path whose
alternative is a multi-megabyte detile. Only the report and the scan are gated.

Sample output, from `test_game_compute`'s own run (real device, real ordered submits):

```
[compute-borrow-census] running totals -- imports=32 host_data=1 shape=1 mip_levels=1 srgb=1 accepted=28 (87.5%)
[compute-borrow-census] running totals -- attempted=28 no_cache_entry=8 (28.6%) export_unpublished=0 (0.0%) content_invalid=0 (0.0%) no_image=0 (0.0%) authority_changed=2 (7.1%) hit=18 (64.3%) alias_retry=17 lease_fail=0 spared=0.6 MiB decoded=0.2 MiB
[compute-borrow-census] running totals -- authority_changed=2 journal_overlap=0 journal_unarmed=2 journal_cross_submit=0 watch_absent=2 watch_dirty=0 watch_unknown=0 | no_entry_scans=8 same_addr=8 guest_bytes=1 resource_bytes=1 width=3 height=1 depth=1 format=7 components=1 tile_mode=2 layer_stride=1 vk_format=7 storage=1 mip_levels=1
[compute-borrow-census] running totals -- publish_evaluated=175 authorized=71 (40.6%) not_native_exact=84 (48.0%) not_unique=0 (0.0%) not_cache_candidate=20 (11.4%) not_persistent=0 (0.0%) no_sampled_usage=0 (0.0%) export_refused=0 (0.0%) | renderer_accepted=0 renderer_rejected=0
```

## Behavioural change, and how it is fenced

Two, both small, both required to make a reason nameable:

* the importer's precondition `||` chain becomes a `constexpr` classifier. **The acceptance set must
  not move**, and `test_compute_image_borrow_census` asserts it over the *complete boolean product*
  of the eleven terms — 2048 cases against the chain transcribed independently in the test — rather
  than over cases chosen by whoever did the rewrite. Both counts are pinned (`accepted == 1`,
  `declined == 2047`) so an accept-only or decline-only sweep cannot pass vacuously;
* `authorize_cached_image_export` returns whether it published. A publish-eligible binding whose
  entry was evicted between writeback and the publish loop is a different failure from an
  ineligible one, and `ExportRefused` is the bucket that separates them.

`native_storage_vk_format` is hoisted above the precondition so the classifier sees every term at
once. It is a pure switch over the guest format enum and is safe with a null context.

Nothing else changes what any gate decides. The borrow evaluates exactly the predicates it evaluated
before, in the same order and behind the same short circuits — in particular `write_watch.query()`
still runs only when the journal did not already answer, because a census that pays for a query the
borrow skips would be measuring its own cost.

## Verification

Configured with `-DPROSPER_APP=ON`, in the `ps5ys` container.

```
cmake --build prosper/build-linux -j4        # rc=0, zero warnings
ctest --no-tests=error -j4                   # rc=0, 100% tests passed out of 359
```

359 is one more than `origin/main`'s 358: the new `compute_image_borrow_census` case.

`test_game_compute` (real Vulkan device, real producer dispatch, real ordered submit) now asserts
the census on the production path, bracketing one hit and one deliberately mis-keyed miss taken back
to back inside the same consumer callback — including that the near-miss scan names `tile_mode` and
**does not** name a field that matched, which is the arm a mask that set every bit would otherwise
satisfy.

### Mutation arms, by exit code

Each applied to a clean tree, built, run, then reverted. The last row is the restored tree.

| mutation | test | exit |
| --- | --- | --- |
| drop the `srgb` term from the import classifier | `compute_image_borrow_census` | **1** |
| fold non-`AuthorityChanged` misses into the authority breakdown | `compute_image_borrow_census` | **1** |
| omit zero-valued outcome buckets from the report | `compute_image_borrow_census` | **1** |
| near-miss scan reports every key field as differing | `game_compute` | **1** |
| the borrow reports a successful lease as a cache miss | `game_compute` | **1** |
| restored | both | **0** |

## What is deliberately unaffected

No gate's decision changes, so no title's rendering changes and no snapshot is expected to move. The
census is off by default in the sense that matters — no output, no scan — and its counters have no
consumer other than the report and the tests.

## The run this needs, and the decision rule stated in advance

One `boot_trace` or `tools/screenshot` run of `scripts/stray-PPSA02101/reach-title-hold.pad` with
`PROSPER_NULL_PAGE=1` and `PROSPER_COMPUTE_BORROW_CENSUS=1`, held at the title screen. The last
`[compute-borrow-census]` block is the whole result. Recording the rule now so the answer cannot be
read to suit a preferred fix:

| what the census says | what it means | the fix that follows |
| --- | --- | --- |
| `no_cache_entry` dominant, `same_addr=0` | the producer retained nothing at this address | read the `publish_*` line; the lever is admission, as the doc guessed |
| `no_cache_entry` dominant, `same_addr>0` + a named field | the two descriptors are keyed differently | normalise that field, justified per field — never a blanket relaxation. The field list is the EXACT key's (`exact_key_fields:`), read against `same_addr=`, which is the field list's exact denominator — not against `exact_key_scans`, its `rescued=` remainder, or `no_cache_entry` |
| `export_unpublished` / `content_invalid` dominant | the entry exists and its authority was cleared, most likely by the next dispatch's source re-validation | the producer→consumer handoff must survive a re-seed |
| `authority_changed` + `journal_overlap` | a real write covers the range between publish and use | find the writer (`PROSPER_GUEST_WRITE_WATCH`); it may be prosper's own writeback |
| `authority_changed` + `journal_cross_submit` | producer and consumer never meet inside one submit | cross-submit export validity; `watch_absent` then says why the page watch cannot cover it |
| `authority_changed` + `journal_unarmed` | the consumer runs outside a submit scope | the borrow is structurally unreachable from the materializer |
| `publish_not_native_exact` dominant | the producer is not a typed-storage shader | the borrow cannot apply to this surface at all; a different lever entirely |
| `renderer_rejected > 0` | the borrow hits and graphics discards it | format/extent agreement at the renderer |

Refs #3307, #3126, #2883.


---

## Review round 2 — head `96d27f18`

The independent review of `3a88d671` returned **REJECTED** with one blocking finding and five
non-blocking ones. All are addressed, plus one defect I found on my own re-read.

**Blocking, and it defeated the instrument on exactly the title it was built for.** The importer
tries the exact descriptor key, then retries under a format-*aliased* key. The near-miss scan was
recorded from the FINAL observation, so on every miss that reached the retry the reported field list
was the retry's — and the retry rewrites `format` and `vk_format` by construction, so it named those
two as differing whether or not they were the reason. Stray's surface is RGBA16F, which satisfies
`float16_uint16_alias`, so **every** near-miss took that path. The decision table above then said
"a named field → normalise that field", pointing at precisely the two fields the alias arm's own
comment forbids normalising.

Fixed: the exact key's scan is recorded where it is taken, the retry asks for no scan
(`scan_near_miss` is now an explicit parameter), the counter is renamed `exact_key_scans` because it
now counts scans *performed* rather than misses observed, and the report labels the list
`exact_key_fields:`. The decision-table row above is corrected to say which key it describes.

**The other six:**

* hardcoded `GuestGpuWriteQuery` / `GuestWriteWatchQuery` ordinals are now pinned by `static_assert`
  in `live_compute.cpp`, where both enums are visible;
* `journal_cross_submit` covered more than its name said (my own finding, and the same shape as the
  `watch_ms` mislabel #3307 recorded yesterday) — split into `journal_unjournaled` and
  `journal_undecided`, the second deliberately vague because it covers two causes this instrument
  cannot separate;
* the 2 KiB report buffer was thinner than its own comment implied — 4 KiB, sized by a **saturation
  arm** rather than an estimate, and truncation is now announced in the buffer;
* the ten `gates.* = <descriptor field>` assignments had no coverage (the 2048-case sweep proves
  classifier == chain over the abstract booleans; a lost `!` would live in the mapping) — eleven
  cases in `test_game_compute` now drive them from the real path, one field at a time, and the
  census output shows all eleven decline buckets firing;
* relaxed-atomic tearing and the scan's lock discipline are documented where the next reader will be;
* the reviewer also flagged a `static_assert(... Overlap) == 2` in the working tree — that was
  mutation arm M7 caught mid-flight; `Overlap` is 1 in the committed code, and the arm exists to
  prove the assert is live.

Re-verified on `96d27f18`: build rc=0 zero warnings; `ctest --no-tests=error -j4` rc=0, 100% of 359;
`check_trap_citations.py`, `check_numbered_table.py`, `check_diag_gates.py` all rc=0.

| new mutation arm | test | exit |
| --- | --- | --- |
| record the ALIAS retry's near-miss mask (the reviewed defect, restored) | `game_compute` | **1** |
| drop the truncation marker | `compute_image_borrow_census` | **1** |
| the import gate wiring loses a negation (`gates.srgb = false`) | `game_compute` | **1** |
| collapse `journal_unjournaled` into `journal_undecided` | `compute_image_borrow_census` | **1** |
| assert `GuestGpuWriteQuery::Overlap == 2` when it is 1 | build | **2** |
| restored | all | **0** |

The first reproduces the reviewed defect exactly and the new arm names it:
`FAIL: the near-miss mask is the exact key's, not the format-alias retry's`.

---

## Review round 3 — head `0fb55422` — APPROVED

The re-review of `96d27f18` confirmed the blocking fix (*"the new arm pins it with exactly the
Format/VkFormat pair that was missing; under the old code both would have incremented, so it goes red
on the defect rather than passing for an unrelated reason"*) and returned **APPROVED**, with five
non-blocking findings — **two of them found by compiling the census header standalone and measuring,
rather than by reading it**. Both were real defects in the instrument. All five are fixed here.

**N3 — the rescued scan floods the field list.** An exact-key miss that the alias retry then
*rescues* is a successful import, and its exact-key scan still ran with a mask naming `format` and
`vk_format` — that being the exact difference the retry exists to bridge. On a title whose alias path
routinely succeeds (GTA V's integer-storage surfaces) the field list would again be dominated by the
alias working as designed: the blocking confound arriving from the other direction. The scan is now
recorded after the retry's fate is known; a rescued scan is counted
(`exact_key_scans=N (rescued=M, not counted below)`) and contributes no fields. Measured on
`test_game_compute`'s own run: `format` 9 → 3, `vk_format` 11 → 3.

**N2 — truncation was inferred, not observed.** `used == capacity - 1` holds both when the report was
cut short and when it fit exactly, so a report of natural length `capacity - 1` had its tail
overwritten by a TRUNCATED marker announcing a loss that never happened — on the producer partition,
the line the marker exists to protect. Demonstrated by the reviewer at length 838 into capacity 839.
`emit` now sets a flag when `snprintf` reports more than its room.

**N1 — the saturation arm could not express its own worst case.** All-max moves numerator and
denominator together, so every percentage collapses to `100.0` and the widest percentage is
structurally inexpressible. Skewing the three denominators to 1 is wider, and the arm now *asserts*
that (`widest_used > all_max`) instead of assuming its construction was extremal. The 4 KiB
conclusion survives; the derivation did not. Same-source-positive-control shape.

**N4/N5** — the wiring array had no positive control (the classifier returns the *first* failing
term, so a base that already declined would let every case pass while testing nothing), and a comment
said "nine" for eleven cases covering ten buckets while claiming all eleven fire. Both corrected;
`NoContext` is structurally undrivable there and the comment now says so.

Verified on `0fb55422`: build rc=0 zero warnings; `ctest --no-tests=error -j4` rc=0, 100% of 359;
`check_trap_citations.py`, `check_diag_gates.py`, `check_numbered_table.py` all rc=0. Two more
mutation arms — accumulate the rescued scan's fields, and infer truncation from a full buffer — each
restore the reviewed defect and each goes red (exit 1); restored 0.

CI on the previous head `96d27f18` finished green (8 success, 1 skipped, macOS x86_64 still running
at the time of writing).

---

## Review round 4 — head `d9bd1f4f`

Round 3 returned **APPROVED** on `0fb55422` and confirmed the N3 split introduces no new ambiguity
(*"a clean three-level nesting, each a proper subset of the one above … that was the specific
inconsistency I went looking for and did not find"*), with one documentation-only refinement. It
needed a test as well.

**The denominator was named one level too wide.** Two places said the field list is read against
`exact_key_scans` minus `rescued`. It is not: a field bit and `no_entry_same_addr` are incremented
under one and the same condition, so `no_entry_same_addr` is the exact denominator. The wider number
folds in scans that found *nothing* at the address — a different row of the decision table, the one
where the producer is absent rather than keyed differently. The reviewer's worked case, rendered from
this formatter: `exact_key_scans=12 (rescued=9) same_addr=2 tile_mode=2` is `tile_mode` on 100% of
near-misses, not 67%. Corrected in the header, in `FRONTEND_APP.md`, and in the decision table above,
with the nesting spelled out:

```
exact_key_scans  >=  (exact_key_scans - rescued)  >=  no_entry_same_addr  >=  key_field_diffs[f]
```

**And the arm written to pin it was vacuous.** Its inputs gave the "nothing at this address" scan a
*zero* mask, so "fields are gated on `same_addr`" and "fields happen to be empty" were the same
observation — a mutation dropping the gate exited **0**. The gate is a contract of the public
recorder, so it is now tested at the boundary the contract names rather than the one the current
caller happens to produce: a scan with no same-address entry and a non-empty mask, asserting its
fields are not counted. The mutation now exits **1** on both field arms, and the inputs are chosen so
every inequality in the chain is strict (4 > 3 > 1 ≥ 1) — an arm whose levels were equal would hold
for an implementation that collapsed them.

That is the third assertion in this PR that turned out not to discriminate, and the second found by
someone other than its author. It is recorded in the test's own comment, not only here.

Verified on `d9bd1f4f`: build rc=0 zero warnings; `ctest --no-tests=error -j4` rc=0, 100% of 359;
`check_trap_citations.py`, `check_diag_gates.py`, `check_numbered_table.py` all rc=0.
