### PR TITLE
diag: aim RenderDoc headlessly by frame ordinal or elapsed time (#3321)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,27 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-04
 
+### RenderDoc works on prosper now, and the first capture was a beautiful picture of the wrong thing
+
+No picture — or rather, 56 of them, all useless. RenderDoc has been installed on the dev box the
+whole time and unusable, because `renderdoccmd` only starts a capture on a **keypress** and every
+agent here runs headless. prosper now drives RenderDoc's in-application API itself, so a capture can
+be aimed at a frame ordinal or a wall-clock moment exactly like F8 and F9.
+
+The first working capture contained **zero draws**, and the reason is the good bit: prosper runs two
+Vulkan instances — one that presents, one that actually renders the game — and RenderDoc, asked
+politely to pick, picks the one holding the swapchain. Same build, same route, only the aim differing:
+
+| aimed at | chunks | draws | dispatches | pipelines |
+| --- | ---: | ---: | ---: | ---: |
+| whatever RenderDoc picks | 56 | **0** | **0** | **0** |
+| the renderer's device | **406** | **11** | **2** | **6** |
+
+That first capture isn't corrupt or truncated. It opens perfectly, converts perfectly, and contains
+nothing anyone wants — a working instrument reporting a confident negative. Worth remembering next
+time a tool says "nothing here".
+
+
 ### Two thirds of Stray's biggest render cost was the allocator, not the work
 
 No picture. The largest single leaf in a capture of Stray's 9.76 fps title screen is the graphics

--- a/BLOG.md
+++ b/BLOG.md
@@ -23,24 +23,11 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ### RenderDoc works on prosper now, and the first capture was a beautiful picture of the wrong thing
 
-No picture — or rather, 56 of them, all useless. RenderDoc has been installed on the dev box the
-whole time and unusable, because `renderdoccmd` only starts a capture on a **keypress** and every
-agent here runs headless. prosper now drives RenderDoc's in-application API itself, so a capture can
-be aimed at a frame ordinal or a wall-clock moment exactly like F8 and F9.
-
-The first working capture contained **zero draws**, and the reason is the good bit: prosper runs two
-Vulkan instances — one that presents, one that actually renders the game — and RenderDoc, asked
-politely to pick, picks the one holding the swapchain. Same build, same route, only the aim differing:
-
-| aimed at | chunks | draws | dispatches | pipelines |
-| --- | ---: | ---: | ---: | ---: |
-| whatever RenderDoc picks | 56 | **0** | **0** | **0** |
-| the renderer's device | **406** | **11** | **2** | **6** |
-
-That first capture isn't corrupt or truncated. It opens perfectly, converts perfectly, and contains
-nothing anyone wants — a working instrument reporting a confident negative. Worth remembering next
-time a tool says "nothing here".
-
+No picture — or rather 56 of them, all useless. RenderDoc has been installed the whole time and
+unusable, because it only starts a capture on a *keypress* and every agent here runs headless.
+prosper now drives its in-application API itself, so a capture aims at a frame ordinal like F8 and F9
+do. The first working one held zero draws: prosper runs two Vulkan devices, and asked to pick,
+RenderDoc took the one that only presents. Details in [#3321](https://github.com/mattias800/prosper/issues/3321).
 
 ### Two thirds of Stray's biggest render cost was the allocator, not the work
 

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3395,7 +3395,10 @@ if(PROSPER_APP AND TARGET SDL3::SDL3)
     add_executable(prosper-app frontends/prosper-app/main.cpp frontends/prosper-app/library_ui.cpp
                                frontends/prosper-app/library_media.cpp
                                frontends/prosper-app/fps_overlay.cpp)
-    target_include_directories(prosper-app PRIVATE src third_party/stb)
+    # third_party/renderdoc: the vendored in-application API header (#3321). Header-only and
+    # never linked -- librenderdoc.so is dlopen'd at runtime by the capture trigger.
+    target_include_directories(prosper-app PRIVATE src third_party/stb third_party/renderdoc
+                                                   frontends)
     target_link_libraries(prosper-app PRIVATE prosper_core SDL3::SDL3 Vulkan::Vulkan prosper_imgui
                                               prosper_performance_capture)
     target_compile_definitions(prosper-app PRIVATE PROSPER_HAVE_LIBRARY_UI=1)

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -90,16 +90,25 @@ capture *explicitly*, so they need neither a keypress nor a present. prosper dri
 
 ### Aim it at the RENDERER's device. A capture of the wrong one looks perfectly healthy.
 
-**prosper runs two Vulkan instances.** prosper-app owns one for presentation (`main.cpp`); the live
-renderer owns another (`tests/fixtures/render_runner.h` — that header *is* the renderer) and
-publishes it through `prosper::gpu::set_shared_vulkan_context`. Every guest draw is on the
-renderer's. Passing NULL lets RenderDoc choose and **it chooses the swapchain's** — the presentation
-device. Measured on *The Messenger*, same build and route, only the aim differing:
+**On the default headless route prosper runs two Vulkan instances.** prosper-app owns one for
+presentation (`main.cpp`); the live renderer owns another (`tests/fixtures/render_runner.h` — that
+header *is* the renderer) and publishes it through `prosper::gpu::set_shared_vulkan_context`. On that
+route every guest draw is on the renderer's. **Two qualifications**: `live_compute.cpp:2913` can
+create a *third*, private instance when it declines to adopt the renderer's, and present unification
+(#1270) can collapse the two into one when the renderer's instance is surface-capable — so "two" is
+this route's count, not an invariant.
 
-| aimed at | chunks | `vkCmdDrawIndexed` | `vkCmdDispatch` | pipelines |
-| --- | ---: | ---: | ---: | ---: |
-| NULL (RenderDoc picks) | 56 | **0** | **0** | **0** |
-| the renderer's instance | **406** | **9** | **2** | **6** |
+Passing NULL lets RenderDoc choose the device. RenderDoc documents that choice as arbitrary; observed
+here (n=1) it took the one holding the swapchain. **The lesson is therefore "always pass the device
+explicitly", not "it picks the swapchain"** — an arbitrary choice that happens to be right once is
+worse than a wrong one, because it will not stay right. Measured on *The Messenger*, same route and
+identical span logic, differing only in which device the capture is aimed at (two builds, one edit
+apart):
+
+| aimed at | chunks | `vkCmdDrawIndexed` | `vkCmdDispatch` | graphics pipelines | compute pipelines |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| NULL (RenderDoc picks) | 56 | **0** | **0** | **0** | **0** |
+| the renderer's instance | **406** | **9** | **2** | **6** | **1** |
 
 The 56-chunk capture is not corrupt and not truncated — it is a **complete, valid capture of the
 wrong device**, and it converts and opens perfectly while containing nothing anyone wants. It reads

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -66,22 +66,56 @@ check available before anyone spends time reading it.
 reader, so an agent can *produce* a capture but a human opens it. Say so when handing one over rather
 than implying you read it.
 
-## RenderDoc — installs here, and `convert` is the headless half
+## RenderDoc — aimable headlessly since #3321, and `convert` reads it with no Python
 
 ```bash
-sudo dnf install -y renderdoc      # 1.45 on this box, Vulkan supported
-renderdoccmd convert -f cap.rdc -c chrome.json -o cap.json
+sudo dnf install -y renderdoc renderdoc-devel     # 1.45 on this box, Vulkan supported
+
+# Capture one guest frame, headless, no keypress. Either axis, exactly like F8/F9.
+ENABLE_VULKAN_RENDERDOC_CAPTURE=1 \
+PROSPER_RENDERDOC_AFTER_MS=175000 \
+PROSPER_CAPTURE_DIR=$HOME/work \
+    ./prosper-app <DUMP_ROOT>/<TITLE_ID>-app0
+
+renderdoccmd convert -f cap.rdc -c xml -o frame.xml      # full event list, no Python
 ```
 
-`convert` targets `chrome.json` (Chrome/Perfetto timeline — parseable by script and openable in the
-Perfetto UI) and `xml`. That is the route for headless per-event analysis.
+**This section used to say `renderdoccmd capture` triggers on a keypress "which makes it awkward
+headless", and recommended RGP instead. That was true of `renderdoccmd` and is no longer true of
+prosper.** RenderDoc's in-application API needs no keypress — `librenderdoc.so` exports
+`RENDERDOC_GetAPI`, whose struct carries `StartFrameCapture`/`EndFrameCapture`, and those delimit a
+capture *explicitly*, so they need neither a keypress nor a present. prosper drives them itself:
+`PROSPER_RENDERDOC_AT_FRAME` (ordinal) and `PROSPER_RENDERDOC_AFTER_MS` (wall clock), plus
+`PROSPER_RENDERDOC_MAX_ITERS` for the span cap. `frontends/shared/diagnostics/renderdoc_capture.hpp`.
+
+### Aim it at the RENDERER's device. A capture of the wrong one looks perfectly healthy.
+
+**prosper runs two Vulkan instances.** prosper-app owns one for presentation (`main.cpp`); the live
+renderer owns another (`tests/fixtures/render_runner.h` — that header *is* the renderer) and
+publishes it through `prosper::gpu::set_shared_vulkan_context`. Every guest draw is on the
+renderer's. Passing NULL lets RenderDoc choose and **it chooses the swapchain's** — the presentation
+device. Measured on *The Messenger*, same build and route, only the aim differing:
+
+| aimed at | chunks | `vkCmdDrawIndexed` | `vkCmdDispatch` | pipelines |
+| --- | ---: | ---: | ---: | ---: |
+| NULL (RenderDoc picks) | 56 | **0** | **0** | **0** |
+| the renderer's instance | **406** | **9** | **2** | **6** |
+
+The 56-chunk capture is not corrupt and not truncated — it is a **complete, valid capture of the
+wrong device**, and it converts and opens perfectly while containing nothing anyone wants. It reads
+as a working instrument reporting a negative result, which is the dangerous shape. The trigger now
+aims itself and warns loudly when the renderer has not yet published a context.
+
+**A prosper frame is the GUEST's, not the app loop's.** A span of one app-loop iteration also yields
+zero draws: guest work is submitted off that thread, and the loop can spin at 260 fps while the guest
+renders far slower. The span closes on a guest present, and the log says which of the two closed it.
 
 **The Fedora package does NOT ship the Python bindings** — `rpm -ql renderdoc` gives `qrenderdoc` (the
-GUI) and `librenderdoc.so`, no `renderdoc.so` python module. So the scripted-analysis route is
-`convert`, not the Python API, and any recipe assuming `import renderdoc` will fail here.
-
-`renderdoccmd capture` triggers on a keypress rather than a frame ordinal, which makes it awkward
-headless; RGP's `MESA_VK_TRACE_FRAME` is the better automated capture.
+GUI) and `librenderdoc.so`, no `renderdoc.so` python module, and there is no `python3-renderdoc` to
+install. So *pixel history*, *per-draw render-target export* and *shader debugging* — the replay-side
+analysis, and the most valuable half — are **not** reachable from a script here without building
+RenderDoc from source. What is reachable headless is `convert` (`xml`, or `chrome.json` for a
+Perfetto-openable timeline), and handing the `.rdc` to a human with `qrenderdoc`.
 
 ## `radeontop` — the 60-second "is this even GPU-bound?" triage
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -2031,8 +2031,18 @@ int main(int argc, char** argv) {
     void* renderdocDevicePointer = nullptr;
     uint64_t renderdocOpenedAtGuestPresent = 0;
     uint64_t renderdocOpenIterations = 0;
-    const uint64_t renderdocMaxIterations =
-        prosper::frontend::parse_capture_frame(getenv("PROSPER_RENDERDOC_MAX_ITERS")) ?: 2000;
+    // `?:` was a GNU extension and the repo's only use; spelled out so MSVC and -Wpedantic are clean.
+    // Note the contract differs from the two TRIGGERS deliberately: a malformed trigger disables
+    // itself, because firing at an unintended moment is worse than not firing. This is a safety CAP,
+    // not a trigger -- disabling it would mean an unbounded span -- so a malformed or zero value
+    // falls back to the default, and says so rather than doing it quietly.
+    const uint64_t renderdocMaxItersParsed =
+        prosper::frontend::parse_capture_frame(getenv("PROSPER_RENDERDOC_MAX_ITERS"));
+    const uint64_t renderdocMaxIterations = renderdocMaxItersParsed ? renderdocMaxItersParsed : 2000;
+    if (getenv("PROSPER_RENDERDOC_MAX_ITERS") && !renderdocMaxItersParsed)
+        std::fprintf(stderr, "[renderdoc] PROSPER_RENDERDOC_MAX_ITERS is not a usable count; using "
+                             "the default cap of %llu iterations\n",
+                     (unsigned long long)renderdocMaxIterations);
     const bool renderdocWanted = scheduledRdocFrame != 0 || automaticRdocAfter.delay_ns() != 0;
     if (renderdocWanted) {
         auto& rdoc = prosper::frontend::RenderDocCapture::instance();
@@ -2068,7 +2078,15 @@ int main(int argc, char** argv) {
     };
     auto arm_renderdoc_capture = [&](const char* why) {
         auto& rdoc = prosper::frontend::RenderDocCapture::instance();
-        if (!rdoc.available() || renderdocCaptureOpen) return;
+        if (!rdoc.available()) return;
+        if (renderdocCaptureOpen) {
+            // Both axes can come due inside one still-open span. Say so: the second trigger has been
+            // consumed and will not fire again, and a reader who set both deserves to know which one
+            // actually opened the capture they got.
+            std::fprintf(stderr, "[renderdoc] %s came due while a capture was already open; it is "
+                                 "consumed without opening a second one\n", why);
+            return;
+        }
         renderdocDevicePointer = renderdoc_device_pointer();
         if (!renderdocDevicePointer)
             std::fprintf(stderr, "[renderdoc] WARNING: the live renderer has not published a Vulkan "
@@ -3064,6 +3082,29 @@ int main(int argc, char** argv) {
         }
     }
 
+    // B1 (#3322 review): the span closes at the TOP of the loop, so every exit path -- --frames
+    // satisfied, SDL_EVENT_QUIT, or the elapsed trigger firing shortly before a title exits -- left
+    // an armed capture open and the artifact was lost with no line saying so. That is precisely the
+    // silent-instrument failure this trigger exists to prevent, so it is closed here too.
+    //
+    // Unlike its F8 sibling below, this CLOSES rather than cancels. RenderDoc decides for itself
+    // whether the span held anything: a span containing real work is written and worth having even
+    // though it ended at shutdown rather than on a guest present, and one containing nothing returns
+    // 0 and reports ABANDONED. Either way the run says what happened, which cancelling could not.
+    if (renderdocCaptureOpen) {
+        renderdocCaptureOpen = false;
+        const std::string rdocPath =
+            prosper::frontend::RenderDocCapture::instance().end(renderdocDevicePointer);
+        if (rdocPath.empty())
+            std::fprintf(stderr, "[renderdoc] capture ABANDONED at shutdown after %llu app-loop "
+                                 "iteration(s) -- RenderDoc recorded no API work in the span\n",
+                         (unsigned long long)renderdocOpenIterations);
+        else
+            std::fprintf(stderr, "[renderdoc] capture written: %s (closed by SHUTDOWN after %llu "
+                                 "app-loop iteration(s), NOT by a guest present -- it may hold only "
+                                 "part of a frame)\n",
+                         rdocPath.c_str(), (unsigned long long)renderdocOpenIterations);
+    }
     perfCapture.cancel();     // never publish a short/incomplete .prperf on a graceful early exit
     prosper_request_stop();   // signal the guest run-loop to wind down at its next boundary
     fprintf(stderr, "[app] shutting down after %llu presented frame(s)\n", (unsigned long long)shown);

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -2039,10 +2039,15 @@ int main(int argc, char** argv) {
     const uint64_t renderdocMaxItersParsed =
         prosper::frontend::parse_capture_frame(getenv("PROSPER_RENDERDOC_MAX_ITERS"));
     const uint64_t renderdocMaxIterations = renderdocMaxItersParsed ? renderdocMaxItersParsed : 2000;
-    if (getenv("PROSPER_RENDERDOC_MAX_ITERS") && !renderdocMaxItersParsed)
-        std::fprintf(stderr, "[renderdoc] PROSPER_RENDERDOC_MAX_ITERS is not a usable count; using "
-                             "the default cap of %llu iterations\n",
-                     (unsigned long long)renderdocMaxIterations);
+    if (const char* mi = getenv("PROSPER_RENDERDOC_MAX_ITERS"); mi && !renderdocMaxItersParsed)
+        // Echo the offending value and the accepted shape, matching PROSPER_CAPTURE_BUNDLE_MAX_MB
+        // at main.cpp:1750 -- the repo's existing convention for a malformed BOUND, as opposed to a
+        // malformed trigger. "not usable" without the value leaves the author guessing which of
+        // their variables was wrong.
+        std::fprintf(stderr, "[renderdoc] ignoring malformed PROSPER_RENDERDOC_MAX_ITERS=\"%s\" "
+                             "(expected a positive iteration count); using the default cap of "
+                             "%llu\n",
+                     mi, (unsigned long long)renderdocMaxIterations);
     const bool renderdocWanted = scheduledRdocFrame != 0 || automaticRdocAfter.delay_ns() != 0;
     if (renderdocWanted) {
         auto& rdoc = prosper::frontend::RenderDocCapture::instance();
@@ -2288,13 +2293,27 @@ int main(int argc, char** argv) {
                                  "[renderdoc] capture ABANDONED after %llu iterations (closed by "
                                  "%s) -- RenderDoc recorded no API work in the span\n",
                                  (unsigned long long)renderdocOpenIterations, closedBy);
-                else
+                else {
+                    char note[512];
+                    std::snprintf(note, sizeof note,
+                                  "prosper capture. Closed by %s after %llu app-loop iteration(s) "
+                                  "and %llu guest present(s). Aimed at %s.%s",
+                                  closedBy, (unsigned long long)renderdocOpenIterations,
+                                  (unsigned long long)(guestNow - renderdocOpenedAtGuestPresent),
+                                  renderdocDevicePointer ? "the live renderer's Vulkan device"
+                                                         : "whichever device RenderDoc chose",
+                                  guestPresented ? ""
+                                                 : "  WARNING: closed by the iteration cap, not by "
+                                                   "a guest present -- this may hold only part of "
+                                                   "a frame, or no guest frame at all.");
+                    prosper::frontend::RenderDocCapture::instance().set_comments(rdocPath, note);
                     std::fprintf(stderr,
                                  "[renderdoc] capture written: %s (spanned %llu app-loop iterations "
                                  "and %llu guest presents, closed by %s)\n",
                                  rdocPath.c_str(), (unsigned long long)renderdocOpenIterations,
                                  (unsigned long long)(guestNow - renderdocOpenedAtGuestPresent),
                                  closedBy);
+                }
             }
         }
         // F8's only always-on work is this 4 Hz sample. `sample_due` is one atomic read, so the
@@ -3087,6 +3106,14 @@ int main(int argc, char** argv) {
     // an armed capture open and the artifact was lost with no line saying so. That is precisely the
     // silent-instrument failure this trigger exists to prevent, so it is closed here too.
     //
+    // KNOWN LIMIT, not covered here (#3324): the guest can leave the process without ever returning
+    // to this line. hle_kernel_time.cpp's k_exit (guest _exit) and k_debug_raise_release (UE4's
+    // shipping check()) call _Exit from the GUEST thread while main is still inside the loop, and
+    // _Exit is exit_group -- so no atexit hook would help either. A capture armed on a title that
+    // dies that way is still lost silently. Both sites already flush diagnostics before their
+    // deliberate _Exit, so a registered flush list is the natural home; that is a cross-layer seam
+    // which does not exist yet and is deliberately not invented here.
+    //
     // Unlike its F8 sibling below, this CLOSES rather than cancels. RenderDoc decides for itself
     // whether the span held anything: a span containing real work is written and worth having even
     // though it ended at shutdown rather than on a guest present, and one containing nothing returns
@@ -3099,11 +3126,24 @@ int main(int argc, char** argv) {
             std::fprintf(stderr, "[renderdoc] capture ABANDONED at shutdown after %llu app-loop "
                                  "iteration(s) -- RenderDoc recorded no API work in the span\n",
                          (unsigned long long)renderdocOpenIterations);
-        else
+        else {
+            // The warning goes IN THE FILE, not only in stderr (#3322 re-review). A truncated
+            // capture opens perfectly and reads as a whole frame with draws missing -- the same
+            // shape as the wrong-device capture this trigger exists to prevent -- and the stderr
+            // line does not travel with the artifact.
+            char note[512];
+            std::snprintf(note, sizeof note,
+                          "prosper capture -- TRUNCATED. Closed by application SHUTDOWN after %llu "
+                          "app-loop iteration(s), NOT by a guest present. It may hold only part of "
+                          "a frame, so missing draws are expected and are NOT evidence that the "
+                          "guest failed to submit them.",
+                          (unsigned long long)renderdocOpenIterations);
+            prosper::frontend::RenderDocCapture::instance().set_comments(rdocPath, note);
             std::fprintf(stderr, "[renderdoc] capture written: %s (closed by SHUTDOWN after %llu "
                                  "app-loop iteration(s), NOT by a guest present -- it may hold only "
-                                 "part of a frame)\n",
+                                 "part of a frame; the file itself is stamped with that warning)\n",
                          rdocPath.c_str(), (unsigned long long)renderdocOpenIterations);
+        }
     }
     perfCapture.cancel();     // never publish a short/incomplete .prperf on a graceful early exit
     prosper_request_stop();   // signal the guest run-loop to wind down at its next boundary

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -2294,18 +2294,19 @@ int main(int argc, char** argv) {
                                  "%s) -- RenderDoc recorded no API work in the span\n",
                                  (unsigned long long)renderdocOpenIterations, closedBy);
                 else {
+                    // Warning first, for the same reason as the shutdown note below.
                     char note[512];
                     std::snprintf(note, sizeof note,
-                                  "prosper capture. Closed by %s after %llu app-loop iteration(s) "
-                                  "and %llu guest present(s). Aimed at %s.%s",
+                                  "%sprosper capture. Closed by %s after %llu app-loop iteration(s) "
+                                  "and %llu guest present(s). Aimed at %s.",
+                                  guestPresented ? ""
+                                                 : "TRUNCATED -- closed by the iteration cap, not "
+                                                   "by a guest present: this may hold only part of "
+                                                   "a frame, or no guest frame at all. ",
                                   closedBy, (unsigned long long)renderdocOpenIterations,
                                   (unsigned long long)(guestNow - renderdocOpenedAtGuestPresent),
                                   renderdocDevicePointer ? "the live renderer's Vulkan device"
-                                                         : "whichever device RenderDoc chose",
-                                  guestPresented ? ""
-                                                 : "  WARNING: closed by the iteration cap, not by "
-                                                   "a guest present -- this may hold only part of "
-                                                   "a frame, or no guest frame at all.");
+                                                         : "whichever device RenderDoc chose");
                     prosper::frontend::RenderDocCapture::instance().set_comments(rdocPath, note);
                     std::fprintf(stderr,
                                  "[renderdoc] capture written: %s (spanned %llu app-loop iterations "
@@ -3131,13 +3132,18 @@ int main(int argc, char** argv) {
             // capture opens perfectly and reads as a whole frame with draws missing -- the same
             // shape as the wrong-device capture this trigger exists to prevent -- and the stderr
             // line does not travel with the artifact.
+            // The warning leads. If these strings ever grow past the buffer, snprintf truncates
+            // the TAIL -- so the safety-critical clause must not sit there, or a future edit
+            // silently produces a confident-looking stamp with the caveat cut off.
             char note[512];
             std::snprintf(note, sizeof note,
-                          "prosper capture -- TRUNCATED. Closed by application SHUTDOWN after %llu "
-                          "app-loop iteration(s), NOT by a guest present. It may hold only part of "
-                          "a frame, so missing draws are expected and are NOT evidence that the "
-                          "guest failed to submit them.",
-                          (unsigned long long)renderdocOpenIterations);
+                          "TRUNCATED -- missing draws are expected here and are NOT evidence that "
+                          "the guest failed to submit them. prosper capture, closed by application "
+                          "SHUTDOWN after %llu app-loop iteration(s), NOT by a guest present, so it "
+                          "may hold only part of a frame. Aimed at %s.",
+                          (unsigned long long)renderdocOpenIterations,
+                          renderdocDevicePointer ? "the live renderer's Vulkan device"
+                                                 : "whichever device RenderDoc chose");
             prosper::frontend::RenderDocCapture::instance().set_comments(rdocPath, note);
             std::fprintf(stderr, "[renderdoc] capture written: %s (closed by SHUTDOWN after %llu "
                                  "app-loop iteration(s), NOT by a guest present -- it may hold only "

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -41,6 +41,7 @@
 #include "frame_grab_naming.hpp"         // one stamp + one exclusively claimed name pair per F9 grab
 #include "shared/perf/performance_capture.hpp"        // bounded F8 pre/post performance artifact
 #include "performance_capture_schedule.hpp" // unattended elapsed-time trigger for the same artifact
+#include "shared/diagnostics/renderdoc_capture.hpp" // frame-aimed RenderDoc capture (#3321)
 #include "app_config.hpp"                // persisted settings (games_dir), pure seam
 // The --fps HUD is NOT part of the library view and is not guarded by its macro: `Vk::overlay` and
 // every use site are unconditional, so the object and its header live outside PROSPER_HAVE_LIBRARY_UI
@@ -2012,6 +2013,74 @@ int main(int argc, char** argv) {
     if (scheduledPerfFrame)
         std::fprintf(stderr, "[perf] automatic capture scheduled at host frame %llu\n",
                      (unsigned long long)scheduledPerfFrame);
+    // RenderDoc, aimed the same two ways as F8/F9 (#3321). Off unless one of these is set, and a
+    // malformed value disables its own trigger rather than firing at an unintended moment.
+    prosper::frontend::ElapsedPerformanceCaptureTrigger automaticRdocAfter(
+        prosper::frontend::parse_performance_capture_delay_ns(getenv("PROSPER_RENDERDOC_AFTER_MS")));
+    const uint64_t scheduledRdocFrame =
+        prosper::frontend::parse_capture_frame(getenv("PROSPER_RENDERDOC_AT_FRAME"));
+    bool scheduledRdocArmed = false;
+    bool renderdocCaptureOpen = false;
+    // A prosper "frame" is the GUEST's, not the app loop's, and conflating the two produces a
+    // capture with no draws in it -- measured, not assumed (#3321). prosper submits the guest's GPU
+    // work off the app-loop thread, and the loop itself can spin at 250+ fps while the guest renders
+    // far slower, so a span of one loop iteration routinely contains only the presentation blit and
+    // vkQueuePresentKHR. The span therefore closes on a guest present, with an iteration cap so a
+    // title that never presents again cannot hold a capture open until the process runs out of
+    // memory.
+    void* renderdocDevicePointer = nullptr;
+    uint64_t renderdocOpenedAtGuestPresent = 0;
+    uint64_t renderdocOpenIterations = 0;
+    const uint64_t renderdocMaxIterations =
+        prosper::frontend::parse_capture_frame(getenv("PROSPER_RENDERDOC_MAX_ITERS")) ?: 2000;
+    const bool renderdocWanted = scheduledRdocFrame != 0 || automaticRdocAfter.delay_ns() != 0;
+    if (renderdocWanted) {
+        auto& rdoc = prosper::frontend::RenderDocCapture::instance();
+        if (!rdoc.available()) {
+            // Say this at ARM time, not at fire time. A route that runs for four minutes before its
+            // trigger only to report that RenderDoc was never loaded has wasted the whole run; the
+            // configuration error is knowable at startup, so it is reported at startup.
+            std::fprintf(stderr, "[renderdoc] REQUESTED BUT UNAVAILABLE: %s\n",
+                         rdoc.unavailable_reason().c_str());
+        } else {
+            // Never leave this at RenderDoc's default, which is under /tmp -- see the header.
+            rdoc.set_path_template(grabDir + "/prosper_frame");
+            if (scheduledRdocFrame)
+                std::fprintf(stderr, "[renderdoc] capture scheduled at host frame %llu (into %s)\n",
+                             (unsigned long long)scheduledRdocFrame, grabDir.c_str());
+            if (automaticRdocAfter.delay_ns())
+                std::fprintf(stderr, "[renderdoc] capture scheduled %llu ms into the app loop "
+                                     "(into %s)\n",
+                             (unsigned long long)(automaticRdocAfter.delay_ns() / 1000000),
+                             grabDir.c_str());
+        }
+    }
+    // Opening a capture is one call, but it is worth one place: both triggers report which axis
+    // fired, because "at frame 900" and "after 30000 ms" land at different moments on a route whose
+    // frame rate is the thing under investigation.
+    // Resolve the RENDERER's instance, not prosper-app's -- see renderdoc_capture.hpp. Resolved at
+    // fire time rather than at startup because the renderer publishes its context when the guest
+    // boots, which is long after these triggers are parsed.
+    auto renderdoc_device_pointer = []() -> void* {
+        const prosper::gpu::SharedVulkanContext shared = prosper::gpu::shared_vulkan_context();
+        if (!shared.valid() || !shared.instance) return nullptr;
+        return RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE(shared.instance);
+    };
+    auto arm_renderdoc_capture = [&](const char* why) {
+        auto& rdoc = prosper::frontend::RenderDocCapture::instance();
+        if (!rdoc.available() || renderdocCaptureOpen) return;
+        renderdocDevicePointer = renderdoc_device_pointer();
+        if (!renderdocDevicePointer)
+            std::fprintf(stderr, "[renderdoc] WARNING: the live renderer has not published a Vulkan "
+                                 "context yet -- capturing whatever device RenderDoc picks, which is "
+                                 "usually the presentation device and contains NO guest draws\n");
+        if (!rdoc.begin(renderdocDevicePointer)) return;
+        renderdocCaptureOpen = true;
+        renderdocOpenedAtGuestPresent = gpu::present_count();
+        renderdocOpenIterations = 0;
+        std::fprintf(stderr, "[renderdoc] capture opened by %s at guest present %llu\n", why,
+                     (unsigned long long)renderdocOpenedAtGuestPresent);
+    };
     bool scheduledScreenshotArmed = false;
     bool timedDumpPending = timedDumpMs > 0;
     bool running = true;
@@ -2179,6 +2248,37 @@ int main(int argc, char** argv) {
     // gives unattended routes one explicit, repeatable host-time origin without desktop input.
     const uint64_t perfLoopStartNs = prosper::perf::monotonic_now_ns();
     while (running && !prosper_stop_requested()) {
+        // Close a RenderDoc capture opened on the previous pass. Reporting the path is the whole
+        // point of doing this here rather than firing and forgetting: an agent running headless has
+        // no other way to learn where the capture went, and an abandoned capture (no API work
+        // recorded in the span) returns an empty path, which is said out loud rather than implied
+        // by a missing file.
+        if (renderdocCaptureOpen) {
+            const uint64_t guestNow = gpu::present_count();
+            const bool guestPresented = guestNow > renderdocOpenedAtGuestPresent;
+            const bool hitCap = ++renderdocOpenIterations >= renderdocMaxIterations;
+            if (guestPresented || hitCap) {
+                renderdocCaptureOpen = false;
+                const std::string rdocPath =
+                    prosper::frontend::RenderDocCapture::instance().end(renderdocDevicePointer);
+                // Report WHY the span closed. A capture closed by the cap rather than by a guest
+                // present is a different artifact -- it may hold no guest frame at all -- and a
+                // reader who cannot tell the two apart will read an empty capture as an empty frame.
+                const char* closedBy = guestPresented ? "guest present" : "iteration cap";
+                if (rdocPath.empty())
+                    std::fprintf(stderr,
+                                 "[renderdoc] capture ABANDONED after %llu iterations (closed by "
+                                 "%s) -- RenderDoc recorded no API work in the span\n",
+                                 (unsigned long long)renderdocOpenIterations, closedBy);
+                else
+                    std::fprintf(stderr,
+                                 "[renderdoc] capture written: %s (spanned %llu app-loop iterations "
+                                 "and %llu guest presents, closed by %s)\n",
+                                 rdocPath.c_str(), (unsigned long long)renderdocOpenIterations,
+                                 (unsigned long long)(guestNow - renderdocOpenedAtGuestPresent),
+                                 closedBy);
+            }
+        }
         // F8's only always-on work is this 4 Hz sample. `sample_due` is one atomic read, so the
         // process CPU/RSS query is not paid on every UI-loop iteration.
         const uint64_t perfNow = prosper::perf::monotonic_now_ns();
@@ -2217,6 +2317,8 @@ int main(int argc, char** argv) {
         // attempted, so a failed arm stays visible instead of silently retrying into a later phase.
         if (automaticGrabAfter.take_if_due(perfLoopStartNs, perfNow))
             arm_frame_grab(true, "PROSPER_GRAB_BUNDLE_AFTER_MS");
+        if (automaticRdocAfter.take_if_due(perfLoopStartNs, perfNow))
+            arm_renderdoc_capture("PROSPER_RENDERDOC_AFTER_MS");
         openedThisBatch = rejectedThisBatch = false;
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
@@ -2605,6 +2707,13 @@ int main(int argc, char** argv) {
         if (prosper::frontend::capture_frame_due(scheduledGrabFrame, shown, scheduledGrabArmed)) {
             scheduledGrabArmed = true;
             arm_frame_grab(true, "PROSPER_GRAB_BUNDLE_AT_FRAME");
+        }
+        // RenderDoc's capture spans a frame explicitly, so unlike F8/F9 it needs a matching end.
+        // Start it here, with its siblings, and close it at the top of the next iteration: that
+        // span covers one whole app-loop pass, which is the unit a reader means by "this frame".
+        if (prosper::frontend::capture_frame_due(scheduledRdocFrame, shown, scheduledRdocArmed)) {
+            scheduledRdocArmed = true;
+            arm_renderdoc_capture("PROSPER_RENDERDOC_AT_FRAME");
         }
         if (prosper::frontend::capture_frame_due(scheduledPerfFrame, shown, scheduledPerfArmed)) {
             scheduledPerfArmed = true;

--- a/prosper/frontends/shared/diagnostics/AGENTS.md
+++ b/prosper/frontends/shared/diagnostics/AGENTS.md
@@ -1,0 +1,31 @@
+# `frontends/shared/diagnostics` — aiming and bounding the frontends' diagnostics
+
+This folder holds the **policy and control** side of frontend diagnostics: the small, testable pieces
+that decide *when* a diagnostic is armed, *which* window it covers, and *what it must not disturb*.
+It deliberately does not hold the diagnostics themselves — the renderer, compute and capture code
+that produces the data lives in the sibling `live/`, `perf/`, `present/` and `rtt/` folders, and in
+`tools/`.
+
+The boundary is worth stating because it is what makes this folder useful: a policy here can be
+unit-tested with no Vulkan device, no game dump and no GPU, which is precisely what the code that
+*implements* a diagnostic cannot be. `frame_dump_policy.hpp` resolves its switch independently of
+`getenv` for that reason; `trip_bound_witness.hpp` is split out of `live_compute.cpp` so a test can
+assert guest GDS is byte-identical after an instrumented dispatch rather than resting on a reading of
+the code.
+
+What belongs here: an environment-switch resolver, a census-window selector, a residency or
+ownership policy, a runtime binding to an external debugger. What does not: anything that needs a
+device to compile against, and anything a single call site is the only plausible user of.
+
+## The recurring lesson in this folder
+
+Every file here exists because a diagnostic was **aimed wrongly and still produced a confident
+answer** — which is worse than one that fails. `diagnostic_window.hpp` exists because a
+renderer-callback ordinal has no published rate, so "census at N" lands somewhere different on every
+route. `renderdoc_capture.hpp` exists because RenderDoc, pointed at the obvious Vulkan device,
+returns a complete and valid capture of prosper's *presentation* device containing zero draws.
+
+So when adding to this folder: make the wrong aim **loud**. Report which axis fired and what the
+span actually covered, prefer a switch whose malformed value disables its own trigger over one that
+fires at an unintended moment, and say "unavailable, and here is why" at arm time rather than
+letting a four-minute route reach its trigger and find nothing there.

--- a/prosper/frontends/shared/diagnostics/renderdoc_capture.hpp
+++ b/prosper/frontends/shared/diagnostics/renderdoc_capture.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+// RenderDoc in-application capture, aimed by frame ordinal instead of by keypress.
+//
+// Why this exists (#3321). RenderDoc is installed on the development box and is the strongest
+// frame debugger available to this project -- it answers "which draw wrote this pixel" and "what
+// is in this render target at draw N", which are exactly the questions a black-world bug asks and
+// exactly the ones prosper's own instruments answer worst. It was nevertheless unusable here,
+// for one mechanical reason recorded in docs/GPU_PROFILING_EXTERNAL.md: `renderdoccmd capture`
+// triggers on a KEYPRESS. Every agent on this project runs headless, so the best instrument in the
+// toolbox was again the one nobody could aim -- the same failure the F8/F9 schedulers fixed for
+// prosper's own captures (#2233), one tool over.
+//
+// RenderDoc's answer to this is its in-application API: the library exports exactly one symbol,
+// `RENDERDOC_GetAPI`, which hands back a struct of function pointers including StartFrameCapture /
+// EndFrameCapture. Those delimit a capture EXPLICITLY, so they need neither a keypress nor a
+// present -- which is what makes this work under SDL_VIDEODRIVER=offscreen, where there is no
+// window to press a key into and, on some routes, no swapchain present to delimit a frame at all.
+//
+// This header only LOADS the API. The frame triggers that aim it live with their F8/F9 siblings in
+// prosper-app/main.cpp, so all four schedulable captures read as one family.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <dlfcn.h>
+#define PROSPER_RENDERDOC_SUPPORTED 1
+#else
+// Windows RenderDoc uses GetModuleHandle("renderdoc.dll") rather than dlopen. Not wired up yet;
+// the trigger compiles to a no-op that says so rather than silently doing nothing.
+#define PROSPER_RENDERDOC_SUPPORTED 0
+#endif
+
+#include "renderdoc_app.h"
+
+namespace prosper::frontend {
+
+// Runtime binding to librenderdoc.so. Never linked -- the library is loaded by RenderDoc's Vulkan
+// layer, and this class only asks the already-loaded copy for its API table.
+class RenderDocCapture {
+public:
+    static RenderDocCapture& instance() {
+        static RenderDocCapture inst;
+        return inst;
+    }
+
+    bool available() const { return api_ != nullptr; }
+    const std::string& unavailable_reason() const { return reason_; }
+
+    // Where captures are written. This is NOT optional politeness: RenderDoc's default template is
+    // under /tmp, which on this project's Linux box is a RAM-backed tmpfs with a per-user quota
+    // shared by every concurrent agent -- and a single capture of a prosper frame is large enough
+    // to exhaust it, which does not merely fail the write but kills the Bash tool for every agent
+    // on the machine (see CLAUDE.md). So the trigger always sets this from PROSPER_CAPTURE_DIR.
+    void set_path_template(const std::string& path_template) {
+        if (!api_) return;
+        api_->SetCaptureFilePathTemplate(path_template.c_str());
+    }
+
+    bool capturing() const { return api_ && api_->IsFrameCapturing() != 0; }
+
+    // WHICH DEVICE. This is the whole game, and getting it wrong produces a capture that looks
+    // perfectly valid and contains no draws -- measured on The Messenger before this parameter
+    // existed (#3321): 56 chunks, every one of them presentation.
+    //
+    // prosper runs TWO Vulkan instances. prosper-app owns one for presentation (main.cpp), and the
+    // live renderer owns another (tests/fixtures/render_runner.h -- the directory name is a
+    // misnomer; that header IS the renderer), which it publishes through
+    // prosper::gpu::set_shared_vulkan_context. Every guest draw and dispatch happens on the
+    // renderer's. Passing NULL lets RenderDoc pick, and it picks the one holding the swapchain --
+    // the presentation device, whose entire contribution is a blit and a present.
+    //
+    // So the caller passes the renderer's VkInstance, converted with RenderDoc's own macro. NULL
+    // remains meaningful: it captures whatever RenderDoc would have chosen, which is the right
+    // behaviour when the renderer has not started and is worth keeping reachable rather than
+    // asserting against.
+    bool begin(void* device_pointer) {
+        if (!api_) return false;
+        api_->StartFrameCapture(device_pointer, nullptr);
+        return true;
+    }
+
+    // Same argument as begin(): the span must be closed on the device it was opened on.
+
+    // Returns the written capture's path, or an empty string if RenderDoc discarded the capture.
+    // The distinction matters: EndFrameCapture returning 0 means the capture was ABANDONED (most
+    // often because no API work was recorded between the two calls), and reporting a filename in
+    // that case would send a reader to a file that does not exist.
+    std::string end(void* device_pointer) {
+        if (!api_) return {};
+        if (api_->EndFrameCapture(device_pointer, nullptr) == 0) return {};
+        const uint32_t n = api_->GetNumCaptures();
+        if (n == 0) return {};
+        uint32_t pathlen = 0;
+        if (api_->GetCapture(n - 1, nullptr, &pathlen, nullptr) == 0 || pathlen == 0) return {};
+        std::string path(pathlen, '\0');
+        if (api_->GetCapture(n - 1, path.data(), &pathlen, nullptr) == 0) return {};
+        if (!path.empty() && path.back() == '\0') path.pop_back();
+        return path;
+    }
+
+private:
+    RenderDocCapture() {
+#if !PROSPER_RENDERDOC_SUPPORTED
+        reason_ = "RenderDoc triggers are not wired up on this platform yet";
+#else
+        // RTLD_NOLOAD is the load-bearing flag, not an optimisation. RenderDoc can only capture
+        // Vulkan work if librenderdoc.so was present when the instance was created -- it hooks at
+        // layer-load time. By the time this runs, prosper's Vulkan instance is long since built, so
+        // a fresh dlopen would hand back a perfectly valid API table attached to nothing, and every
+        // capture would silently produce an empty file. NOLOAD asks the strictly correct question:
+        // "is RenderDoc already in this process?" A null answer means the layer was not enabled,
+        // which is a configuration error worth naming rather than a capture worth attempting.
+        void* lib = dlopen("librenderdoc.so", RTLD_NOW | RTLD_NOLOAD);
+        if (!lib) {
+            reason_ = "librenderdoc.so is not loaded in this process -- run with "
+                      "ENABLE_VULKAN_RENDERDOC_CAPTURE=1 so the Vulkan layer loads it before the "
+                      "instance is created (enabling it later cannot work: RenderDoc hooks at "
+                      "layer-load time)";
+            return;
+        }
+        auto get_api = reinterpret_cast<pRENDERDOC_GetAPI>(dlsym(lib, "RENDERDOC_GetAPI"));
+        if (!get_api) {
+            reason_ = "librenderdoc.so is loaded but exports no RENDERDOC_GetAPI";
+            return;
+        }
+        // Request 1.4.1 rather than the newest available. RenderDoc versions this struct precisely
+        // so a consumer can pin the subset it uses; asking for the oldest version that has these
+        // five calls means an older RenderDoc still works, and nothing here needs anything newer.
+        if (get_api(eRENDERDOC_API_Version_1_4_1, reinterpret_cast<void**>(&api_)) != 1 || !api_) {
+            api_ = nullptr;
+            reason_ = "RENDERDOC_GetAPI refused version 1.4.1 (installed RenderDoc is too old)";
+            return;
+        }
+        int maj = 0, min = 0, patch = 0;
+        api_->GetAPIVersion(&maj, &min, &patch);
+        std::fprintf(stderr, "[renderdoc] in-application API %d.%d.%d bound\n", maj, min, patch);
+#endif
+    }
+
+    RENDERDOC_API_1_4_1* api_ = nullptr;
+    std::string reason_;
+};
+
+}  // namespace prosper::frontend

--- a/prosper/frontends/shared/diagnostics/renderdoc_capture.hpp
+++ b/prosper/frontends/shared/diagnostics/renderdoc_capture.hpp
@@ -62,6 +62,19 @@ public:
 
     bool capturing() const { return api_ && api_->IsFrameCapturing() != 0; }
 
+    // Stamp provenance INTO the capture file. RenderDoc displays these comments when the file is
+    // opened, which is the only place a warning about the artifact survives: a reader opening a
+    // .rdc weeks later never sees the stderr line that described how it was made.
+    //
+    // This matters most for a shutdown-truncated capture, which is the same hazard as the
+    // wrong-device one this whole header exists for -- it opens perfectly, reads as a whole frame,
+    // and is simply missing the draws that had not happened yet. A warning in stderr does not
+    // travel with the file; this does.
+    void set_comments(const std::string& path, const std::string& comments) {
+        if (!api_ || path.empty()) return;
+        api_->SetCaptureFileComments(path.c_str(), comments.c_str());
+    }
+
     // WHICH DEVICE. This is the whole game, and getting it wrong produces a capture that looks
     // perfectly valid and contains no draws -- measured on The Messenger before this parameter
     // existed (#3321): 56 chunks, every one of them presentation.

--- a/prosper/frontends/shared/diagnostics/renderdoc_capture.hpp
+++ b/prosper/frontends/shared/diagnostics/renderdoc_capture.hpp
@@ -66,12 +66,18 @@ public:
     // perfectly valid and contains no draws -- measured on The Messenger before this parameter
     // existed (#3321): 56 chunks, every one of them presentation.
     //
-    // prosper runs TWO Vulkan instances. prosper-app owns one for presentation (main.cpp), and the
-    // live renderer owns another (tests/fixtures/render_runner.h -- the directory name is a
-    // misnomer; that header IS the renderer), which it publishes through
-    // prosper::gpu::set_shared_vulkan_context. Every guest draw and dispatch happens on the
-    // renderer's. Passing NULL lets RenderDoc pick, and it picks the one holding the swapchain --
-    // the presentation device, whose entire contribution is a blit and a present.
+    // On the default headless route prosper runs TWO Vulkan instances. prosper-app owns one for
+    // presentation (main.cpp), and the live renderer owns another (tests/fixtures/render_runner.h --
+    // the directory name is a misnomer; that header IS the renderer), which it publishes through
+    // prosper::gpu::set_shared_vulkan_context, and every guest draw and dispatch is on the
+    // renderer's. Two is this route's count and not an invariant: live_compute.cpp can create a
+    // third private instance when it declines to adopt the renderer's, and present unification
+    // (#1270) can collapse the two into one. Hence the caller passes the device rather than the
+    // trigger assuming a topology. Passing NULL lets RenderDoc pick the device, and RenderDoc documents that choice
+    // as arbitrary; here it took the one holding the swapchain -- the presentation device, whose
+    // entire contribution is a blit and a present. So the rule is to pass the device ALWAYS, not to
+    // rely on the observed pick: a choice that is arbitrary and happens to be right will not stay
+    // right.
     //
     // So the caller passes the renderer's VkInstance, converted with RenderDoc's own macro. NULL
     // remains meaningful: it captures whatever RenderDoc would have chosen, which is the right

--- a/prosper/third_party/renderdoc/LICENSE
+++ b/prosper/third_party/renderdoc/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2026 Baldur Karlsson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/prosper/third_party/renderdoc/README.md
+++ b/prosper/third_party/renderdoc/README.md
@@ -15,7 +15,7 @@
   versions this struct explicitly (`eRENDERDOC_API_Version_*`) precisely so a consumer can pin one;
   prosper requests **1.4.1**, well below the installed 1.45, so an older RenderDoc still works.
 - **Prosper glue lives elsewhere:** the loader, the frame triggers and the capture-path reporting are
-  prosper's own code in `frontends/shared/diagnostics/renderdoc_capture.{hpp,cpp}`. This directory is
+  prosper's own code in `frontends/shared/diagnostics/renderdoc_capture.hpp` (header-only). This directory is
   the unmodified upstream header.
 
 Do not edit this header — keep it byte-identical to upstream so the vendored copy is auditable and

--- a/prosper/third_party/renderdoc/README.md
+++ b/prosper/third_party/renderdoc/README.md
@@ -1,0 +1,23 @@
+# RenderDoc in-application API header (vendored)
+
+`renderdoc_app.h`, vendored **verbatim** from **RenderDoc** by Baldur Karlsson
+(https://github.com/baldurk/renderdoc), version **1.45**. Byte-identical to the copy Fedora's
+`renderdoc-devel` package installs at `/usr/include/renderdoc_app.h`.
+
+- **License:** MIT (see `LICENSE`). Copyright (c) 2015-2026 Baldur Karlsson.
+- **What it is:** a single self-contained header declaring the ABI of the API that
+  `librenderdoc.so` exposes through its one exported entry point, `RENDERDOC_GetAPI`. It contains
+  no implementation — the library is loaded at runtime with `dlopen`, never linked.
+- **Why vendored rather than `#include <renderdoc_app.h>`:** the struct is an **ABI**, and the whole
+  point of using the real header is getting the function-pointer order exactly right — a hand-written
+  subset that is one field out calls the wrong pointer and crashes. Vendoring also means the trigger
+  compiles everywhere, with no build-time dependency on `renderdoc-devel` being installed. RenderDoc
+  versions this struct explicitly (`eRENDERDOC_API_Version_*`) precisely so a consumer can pin one;
+  prosper requests **1.4.1**, well below the installed 1.45, so an older RenderDoc still works.
+- **Prosper glue lives elsewhere:** the loader, the frame triggers and the capture-path reporting are
+  prosper's own code in `frontends/shared/diagnostics/renderdoc_capture.{hpp,cpp}`. This directory is
+  the unmodified upstream header.
+
+Do not edit this header — keep it byte-identical to upstream so the vendored copy is auditable and
+updatable. To refresh it, copy a newer `renderdoc_app.h` in whole and re-check that the API version
+prosper requests is still declared.

--- a/prosper/third_party/renderdoc/renderdoc_app.h
+++ b/prosper/third_party/renderdoc/renderdoc_app.h
@@ -1,0 +1,875 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2026 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Documentation for the API is available at https://renderdoc.org/docs/in_application_api.html
+//
+
+#if !defined(RENDERDOC_NO_STDINT)
+#include <stdint.h>
+#endif
+
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
+#define RENDERDOC_CC __cdecl
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__sun__) || defined(__OpenBSD__)
+#define RENDERDOC_CC
+#elif defined(__APPLE__)
+#define RENDERDOC_CC
+#else
+#error "Unknown platform"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// Constants not used directly in below API
+
+// This is a GUID/magic value used for when applications pass a path where shader debug
+// information can be found to match up with a stripped shader.
+// the define can be used like so: const GUID RENDERDOC_ShaderDebugMagicValue =
+// RENDERDOC_ShaderDebugMagicValue_value
+#define RENDERDOC_ShaderDebugMagicValue_struct                                \
+  {                                                                           \
+    0xeab25520, 0x6670, 0x4865, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff \
+  }
+
+// as an alternative when you want a byte array (assuming x86 endianness):
+#define RENDERDOC_ShaderDebugMagicValue_bytearray                                                 \
+  {                                                                                               \
+    0x20, 0x55, 0xb2, 0xea, 0x70, 0x66, 0x65, 0x48, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff \
+  }
+
+// truncated version when only a uint64_t is available (e.g. Vulkan tags):
+#define RENDERDOC_ShaderDebugMagicValue_truncated 0x48656670eab25520ULL
+
+// this is a magic value for vulkan user tags to indicate which dispatchable API objects are which
+// for object annotations
+#define RENDERDOC_APIObjectAnnotationHelper 0xfbb3b337b664d0adULL
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc capture options
+//
+
+typedef enum RENDERDOC_CaptureOption
+{
+  // Allow the application to enable vsync
+  //
+  // Default - enabled
+  //
+  // 1 - The application can enable or disable vsync at will
+  // 0 - vsync is force disabled
+  eRENDERDOC_Option_AllowVSync = 0,
+
+  // Allow the application to enable fullscreen
+  //
+  // Default - enabled
+  //
+  // 1 - The application can enable or disable fullscreen at will
+  // 0 - fullscreen is force disabled
+  eRENDERDOC_Option_AllowFullscreen = 1,
+
+  // Record API debugging events and messages
+  //
+  // Default - disabled
+  //
+  // 1 - Enable built-in API debugging features and records the results into
+  //     the capture, which is matched up with events on replay
+  // 0 - no API debugging is forcibly enabled
+  eRENDERDOC_Option_APIValidation = 2,
+  eRENDERDOC_Option_DebugDeviceMode = 2,    // deprecated name of this enum
+
+  // Capture CPU callstacks for API events
+  //
+  // Default - disabled
+  //
+  // 1 - Enables capturing of callstacks
+  // 0 - no callstacks are captured
+  eRENDERDOC_Option_CaptureCallstacks = 3,
+
+  // When capturing CPU callstacks, only capture them from actions.
+  // This option does nothing without the above option being enabled
+  //
+  // Default - disabled
+  //
+  // 1 - Only captures callstacks for actions.
+  //     Ignored if CaptureCallstacks is disabled
+  // 0 - Callstacks, if enabled, are captured for every event.
+  eRENDERDOC_Option_CaptureCallstacksOnlyDraws = 4,
+  eRENDERDOC_Option_CaptureCallstacksOnlyActions = 4,
+
+  // Specify a delay in seconds to wait for a debugger to attach, after
+  // creating or injecting into a process, before continuing to allow it to run.
+  //
+  // 0 indicates no delay, and the process will run immediately after injection
+  //
+  // Default - 0 seconds
+  //
+  eRENDERDOC_Option_DelayForDebugger = 5,
+
+  // Verify buffer access. This includes checking the memory returned by a Map() call to
+  // detect any out-of-bounds modification, as well as initialising buffers with undefined contents
+  // to a marker value to catch use of uninitialised memory.
+  //
+  // NOTE: This option is only valid for OpenGL and D3D11. Explicit APIs such as D3D12 and Vulkan do
+  // not do the same kind of interception & checking and undefined contents are really undefined.
+  //
+  // Default - disabled
+  //
+  // 1 - Verify buffer access
+  // 0 - No verification is performed, and overwriting bounds may cause crashes or corruption in
+  //     RenderDoc.
+  eRENDERDOC_Option_VerifyBufferAccess = 6,
+
+  // The old name for eRENDERDOC_Option_VerifyBufferAccess was eRENDERDOC_Option_VerifyMapWrites.
+  // This option now controls the filling of uninitialised buffers with 0xdddddddd which was
+  // previously always enabled
+  eRENDERDOC_Option_VerifyMapWrites = eRENDERDOC_Option_VerifyBufferAccess,
+
+  // Hooks any system API calls that create child processes, and injects
+  // RenderDoc into them recursively with the same options.
+  //
+  // Default - disabled
+  //
+  // 1 - Hooks into spawned child processes
+  // 0 - Child processes are not hooked by RenderDoc
+  eRENDERDOC_Option_HookIntoChildren = 7,
+
+  // By default RenderDoc only includes resources in the final capture necessary
+  // for that frame, this allows you to override that behaviour.
+  //
+  // Default - disabled
+  //
+  // 1 - all live resources at the time of capture are included in the capture
+  //     and available for inspection
+  // 0 - only the resources referenced by the captured frame are included
+  eRENDERDOC_Option_RefAllResources = 8,
+
+  // **NOTE**: As of RenderDoc v1.1 this option has been deprecated. Setting or
+  // getting it will be ignored, to allow compatibility with older versions.
+  // In v1.1 the option acts as if it's always enabled.
+  //
+  // By default RenderDoc skips saving initial states for resources where the
+  // previous contents don't appear to be used, assuming that writes before
+  // reads indicate previous contents aren't used.
+  //
+  // Default - disabled
+  //
+  // 1 - initial contents at the start of each captured frame are saved, even if
+  //     they are later overwritten or cleared before being used.
+  // 0 - unless a read is detected, initial contents will not be saved and will
+  //     appear as black or empty data.
+  eRENDERDOC_Option_SaveAllInitials = 9,
+
+  // In APIs that allow for the recording of command lists to be replayed later,
+  // RenderDoc may choose to not capture command lists before a frame capture is
+  // triggered, to reduce overheads. This means any command lists recorded once
+  // and replayed many times will not be available and may cause a failure to
+  // capture.
+  //
+  // NOTE: This is only true for APIs where multithreading is difficult or
+  // discouraged. Newer APIs like Vulkan and D3D12 will ignore this option
+  // and always capture all command lists since the API is heavily oriented
+  // around it and the overheads have been reduced by API design.
+  //
+  // 1 - All command lists are captured from the start of the application
+  // 0 - Command lists are only captured if their recording begins during
+  //     the period when a frame capture is in progress.
+  eRENDERDOC_Option_CaptureAllCmdLists = 10,
+
+  // Mute API debugging output when the API validation mode option is enabled
+  //
+  // Default - enabled
+  //
+  // 1 - Mute any API debug messages from being displayed or passed through
+  // 0 - API debugging is displayed as normal
+  eRENDERDOC_Option_DebugOutputMute = 11,
+
+  // Option to allow vendor extensions to be used even when they may be
+  // incompatible with RenderDoc and cause corrupted replays or crashes.
+  //
+  // Default - inactive
+  //
+  // No values are documented, this option should only be used when absolutely
+  // necessary as directed by a RenderDoc developer.
+  eRENDERDOC_Option_AllowUnsupportedVendorExtensions = 12,
+
+  // Define a soft memory limit which some APIs may aim to keep overhead under where
+  // possible. Anything above this limit will where possible be saved directly to disk during
+  // capture.
+  // This will cause increased disk space use (which may cause a capture to fail if disk space is
+  // exhausted) as well as slower capture times.
+  //
+  // Not all memory allocations may be deferred like this so it is not a guarantee of a memory
+  // limit.
+  //
+  // Units are in MBs, suggested values would range from 200MB to 1000MB.
+  //
+  // Default - 0 Megabytes
+  eRENDERDOC_Option_SoftMemoryLimit = 13,
+} RENDERDOC_CaptureOption;
+
+// Sets an option that controls how RenderDoc behaves on capture.
+//
+// Returns 1 if the option and value are valid
+// Returns 0 if either is invalid and the option is unchanged
+typedef int(RENDERDOC_CC *pRENDERDOC_SetCaptureOptionU32)(RENDERDOC_CaptureOption opt, uint32_t val);
+typedef int(RENDERDOC_CC *pRENDERDOC_SetCaptureOptionF32)(RENDERDOC_CaptureOption opt, float val);
+
+// Gets the current value of an option as a uint32_t
+//
+// If the option is invalid, 0xffffffff is returned
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetCaptureOptionU32)(RENDERDOC_CaptureOption opt);
+
+// Gets the current value of an option as a float
+//
+// If the option is invalid, -FLT_MAX is returned
+typedef float(RENDERDOC_CC *pRENDERDOC_GetCaptureOptionF32)(RENDERDOC_CaptureOption opt);
+
+typedef enum RENDERDOC_InputButton
+{
+  // '0' - '9' matches ASCII values
+  eRENDERDOC_Key_0 = 0x30,
+  eRENDERDOC_Key_1 = 0x31,
+  eRENDERDOC_Key_2 = 0x32,
+  eRENDERDOC_Key_3 = 0x33,
+  eRENDERDOC_Key_4 = 0x34,
+  eRENDERDOC_Key_5 = 0x35,
+  eRENDERDOC_Key_6 = 0x36,
+  eRENDERDOC_Key_7 = 0x37,
+  eRENDERDOC_Key_8 = 0x38,
+  eRENDERDOC_Key_9 = 0x39,
+
+  // 'A' - 'Z' matches ASCII values
+  eRENDERDOC_Key_A = 0x41,
+  eRENDERDOC_Key_B = 0x42,
+  eRENDERDOC_Key_C = 0x43,
+  eRENDERDOC_Key_D = 0x44,
+  eRENDERDOC_Key_E = 0x45,
+  eRENDERDOC_Key_F = 0x46,
+  eRENDERDOC_Key_G = 0x47,
+  eRENDERDOC_Key_H = 0x48,
+  eRENDERDOC_Key_I = 0x49,
+  eRENDERDOC_Key_J = 0x4A,
+  eRENDERDOC_Key_K = 0x4B,
+  eRENDERDOC_Key_L = 0x4C,
+  eRENDERDOC_Key_M = 0x4D,
+  eRENDERDOC_Key_N = 0x4E,
+  eRENDERDOC_Key_O = 0x4F,
+  eRENDERDOC_Key_P = 0x50,
+  eRENDERDOC_Key_Q = 0x51,
+  eRENDERDOC_Key_R = 0x52,
+  eRENDERDOC_Key_S = 0x53,
+  eRENDERDOC_Key_T = 0x54,
+  eRENDERDOC_Key_U = 0x55,
+  eRENDERDOC_Key_V = 0x56,
+  eRENDERDOC_Key_W = 0x57,
+  eRENDERDOC_Key_X = 0x58,
+  eRENDERDOC_Key_Y = 0x59,
+  eRENDERDOC_Key_Z = 0x5A,
+
+  // leave the rest of the ASCII range free
+  // in case we want to use it later
+  eRENDERDOC_Key_NonPrintable = 0x100,
+
+  eRENDERDOC_Key_Divide,
+  eRENDERDOC_Key_Multiply,
+  eRENDERDOC_Key_Subtract,
+  eRENDERDOC_Key_Plus,
+
+  eRENDERDOC_Key_F1,
+  eRENDERDOC_Key_F2,
+  eRENDERDOC_Key_F3,
+  eRENDERDOC_Key_F4,
+  eRENDERDOC_Key_F5,
+  eRENDERDOC_Key_F6,
+  eRENDERDOC_Key_F7,
+  eRENDERDOC_Key_F8,
+  eRENDERDOC_Key_F9,
+  eRENDERDOC_Key_F10,
+  eRENDERDOC_Key_F11,
+  eRENDERDOC_Key_F12,
+
+  eRENDERDOC_Key_Home,
+  eRENDERDOC_Key_End,
+  eRENDERDOC_Key_Insert,
+  eRENDERDOC_Key_Delete,
+  eRENDERDOC_Key_PageUp,
+  eRENDERDOC_Key_PageDn,
+
+  eRENDERDOC_Key_Backspace,
+  eRENDERDOC_Key_Tab,
+  eRENDERDOC_Key_PrtScrn,
+  eRENDERDOC_Key_Pause,
+
+  eRENDERDOC_Key_Max,
+} RENDERDOC_InputButton;
+
+// Sets which key or keys can be used to toggle focus between multiple windows
+//
+// If keys is NULL or num is 0, toggle keys will be disabled
+typedef void(RENDERDOC_CC *pRENDERDOC_SetFocusToggleKeys)(RENDERDOC_InputButton *keys, int num);
+
+// Sets which key or keys can be used to capture the next frame
+//
+// If keys is NULL or num is 0, captures keys will be disabled
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureKeys)(RENDERDOC_InputButton *keys, int num);
+
+typedef enum RENDERDOC_OverlayBits
+{
+  // This single bit controls whether the overlay is enabled or disabled globally
+  eRENDERDOC_Overlay_Enabled = 0x1,
+
+  // Show the average framerate over several seconds as well as min/max
+  eRENDERDOC_Overlay_FrameRate = 0x2,
+
+  // Show the current frame number
+  eRENDERDOC_Overlay_FrameNumber = 0x4,
+
+  // Show a list of recent captures, and how many captures have been made
+  eRENDERDOC_Overlay_CaptureList = 0x8,
+
+  // Default values for the overlay mask
+  eRENDERDOC_Overlay_Default = (eRENDERDOC_Overlay_Enabled | eRENDERDOC_Overlay_FrameRate |
+                                eRENDERDOC_Overlay_FrameNumber | eRENDERDOC_Overlay_CaptureList),
+
+  // Enable all bits
+  eRENDERDOC_Overlay_All = 0x7ffffff,
+
+  // Disable all bits
+  eRENDERDOC_Overlay_None = 0,
+} RENDERDOC_OverlayBits;
+
+// returns the overlay bits that have been set
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetOverlayBits)(void);
+// sets the overlay bits with an and & or mask
+typedef void(RENDERDOC_CC *pRENDERDOC_MaskOverlayBits)(uint32_t And, uint32_t Or);
+
+// this function will attempt to remove RenderDoc's hooks in the application.
+//
+// Note: that this can only work correctly if done immediately after
+// the module is loaded, before any API work happens. RenderDoc will remove its
+// injected hooks and shut down. Behaviour is undefined if this is called
+// after any API functions have been called, and there is still no guarantee of
+// success.
+typedef void(RENDERDOC_CC *pRENDERDOC_RemoveHooks)(void);
+
+// DEPRECATED: compatibility for code compiled against pre-1.4.1 headers.
+typedef pRENDERDOC_RemoveHooks pRENDERDOC_Shutdown;
+
+// This function will unload RenderDoc's crash handler.
+//
+// If you use your own crash handler and don't want RenderDoc's handler to
+// intercede, you can call this function to unload it and any unhandled
+// exceptions will pass to the next handler.
+typedef void(RENDERDOC_CC *pRENDERDOC_UnloadCrashHandler)(void);
+
+// Sets the capture file path template
+//
+// pathtemplate is a UTF-8 string that gives a template for how captures will be named
+// and where they will be saved.
+//
+// Any extension is stripped off the path, and captures are saved in the directory
+// specified, and named with the filename and the frame number appended. If the
+// directory does not exist it will be created, including any parent directories.
+//
+// If pathtemplate is NULL, the template will remain unchanged
+//
+// Example:
+//
+// SetCaptureFilePathTemplate("my_captures/example");
+//
+// Capture #1 -> my_captures/example_frame123.rdc
+// Capture #2 -> my_captures/example_frame456.rdc
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureFilePathTemplate)(const char *pathtemplate);
+
+// returns the current capture path template, see SetCaptureFileTemplate above, as a UTF-8 string
+typedef const char *(RENDERDOC_CC *pRENDERDOC_GetCaptureFilePathTemplate)(void);
+
+// DEPRECATED: compatibility for code compiled against pre-1.1.2 headers.
+typedef pRENDERDOC_SetCaptureFilePathTemplate pRENDERDOC_SetLogFilePathTemplate;
+typedef pRENDERDOC_GetCaptureFilePathTemplate pRENDERDOC_GetLogFilePathTemplate;
+
+// returns the number of captures that have been made
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetNumCaptures)(void);
+
+// This function returns the details of a capture, by index. New captures are added
+// to the end of the list.
+//
+// filename will be filled with the absolute path to the capture file, as a UTF-8 string
+// pathlength will be written with the length in bytes of the filename string
+// timestamp will be written with the time of the capture, in seconds since the Unix epoch
+//
+// Any of the parameters can be NULL and they'll be skipped.
+//
+// The function will return 1 if the capture index is valid, or 0 if the index is invalid
+// If the index is invalid, the values will be unchanged
+//
+// Note: when captures are deleted in the UI they will remain in this list, so the
+// capture path may not exist anymore.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetCapture)(uint32_t idx, char *filename,
+                                                      uint32_t *pathlength, uint64_t *timestamp);
+
+// Sets the comments associated with a capture file. These comments are displayed in the
+// UI program when opening.
+//
+// filePath should be a path to the capture file to add comments to. If set to NULL or ""
+// the most recent capture file created made will be used instead.
+// comments should be a NULL-terminated UTF-8 string to add as comments.
+//
+// Any existing comments will be overwritten.
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureFileComments)(const char *filePath,
+                                                              const char *comments);
+
+// returns 1 if the RenderDoc UI is connected to this application, 0 otherwise
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_IsTargetControlConnected)(void);
+
+// DEPRECATED: compatibility for code compiled against pre-1.1.1 headers.
+// This was renamed to IsTargetControlConnected in API 1.1.1, the old typedef is kept here for
+// backwards compatibility with old code, it is castable either way since it's ABI compatible
+// as the same function pointer type.
+typedef pRENDERDOC_IsTargetControlConnected pRENDERDOC_IsRemoteAccessConnected;
+
+// This function will launch the Replay UI associated with the RenderDoc library injected
+// into the running application.
+//
+// if connectTargetControl is 1, the Replay UI will be launched with a command line parameter
+// to connect to this application
+// cmdline is the rest of the command line, as a UTF-8 string. E.g. a captures to open
+// if cmdline is NULL, the command line will be empty.
+//
+// returns the PID of the replay UI if successful, 0 if not successful.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_LaunchReplayUI)(uint32_t connectTargetControl,
+                                                          const char *cmdline);
+
+// RenderDoc can return a higher version than requested if it's backwards compatible,
+// this function returns the actual version returned. If a parameter is NULL, it will be
+// ignored and the others will be filled out.
+typedef void(RENDERDOC_CC *pRENDERDOC_GetAPIVersion)(int *major, int *minor, int *patch);
+
+// Requests that the replay UI show itself (if hidden or not the current top window). This can be
+// used in conjunction with IsTargetControlConnected and LaunchReplayUI to intelligently handle
+// showing the UI after making a capture.
+//
+// This will return 1 if the request was successfully passed on, though it's not guaranteed that
+// the UI will be on top in all cases depending on OS rules. It will return 0 if there is no current
+// target control connection to make such a request, or if there was another error
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_ShowReplayUI)(void);
+
+//////////////////////////////////////////////////////////////////////////
+// Capturing functions
+//
+
+// A device pointer is a pointer to the API's root handle.
+//
+// This would be an ID3D11Device, HGLRC/GLXContext, ID3D12Device, etc
+typedef void *RENDERDOC_DevicePointer;
+
+// A window handle is the OS's native window handle
+//
+// This would be an HWND, GLXDrawable, etc
+typedef void *RENDERDOC_WindowHandle;
+
+// A helper macro for Vulkan, where the device handle cannot be used directly.
+//
+// Passing the VkInstance to this macro will return the RENDERDOC_DevicePointer to use.
+//
+// Specifically, the value needed is the dispatch table pointer, which sits as the first
+// pointer-sized object in the memory pointed to by the VkInstance. Thus we cast to a void** and
+// indirect once.
+#define RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE(inst) (*((void **)(inst)))
+
+// This sets the RenderDoc in-app overlay in the API/window pair as 'active' and it will
+// respond to keypresses. Neither parameter can be NULL
+typedef void(RENDERDOC_CC *pRENDERDOC_SetActiveWindow)(RENDERDOC_DevicePointer device,
+                                                       RENDERDOC_WindowHandle wndHandle);
+
+// capture the next frame on whichever window and API is currently considered active
+typedef void(RENDERDOC_CC *pRENDERDOC_TriggerCapture)(void);
+
+// capture the next N frames on whichever window and API is currently considered active
+typedef void(RENDERDOC_CC *pRENDERDOC_TriggerMultiFrameCapture)(uint32_t numFrames);
+
+// When choosing either a device pointer or a window handle to capture, you can pass NULL.
+// Passing NULL specifies a 'wildcard' match against anything. This allows you to specify
+// any API rendering to a specific window, or a specific API instance rendering to any window,
+// or in the simplest case of one window and one API, you can just pass NULL for both.
+//
+// In either case, if there are two or more possible matching (device,window) pairs it
+// is undefined which one will be captured.
+//
+// Note: for headless rendering you can pass NULL for the window handle and either specify
+// a device pointer or leave it NULL as above.
+
+// Immediately starts capturing API calls on the specified device pointer and window handle.
+//
+// If there is no matching thing to capture (e.g. no supported API has been initialised),
+// this will do nothing.
+//
+// The results are undefined (including crashes) if two captures are started overlapping,
+// even on separate devices and/oror windows.
+typedef void(RENDERDOC_CC *pRENDERDOC_StartFrameCapture)(RENDERDOC_DevicePointer device,
+                                                         RENDERDOC_WindowHandle wndHandle);
+
+// Returns whether or not a frame capture is currently ongoing anywhere.
+//
+// This will return 1 if a capture is ongoing, and 0 if there is no capture running
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_IsFrameCapturing)(void);
+
+// Ends capturing immediately.
+//
+// This will return 1 if the capture succeeded, and 0 if there was an error capturing.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_EndFrameCapture)(RENDERDOC_DevicePointer device,
+                                                           RENDERDOC_WindowHandle wndHandle);
+
+// Ends capturing immediately and discard any data stored without saving to disk.
+//
+// This will return 1 if the capture was discarded, and 0 if there was an error or no capture
+// was in progress
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_DiscardFrameCapture)(RENDERDOC_DevicePointer device,
+                                                               RENDERDOC_WindowHandle wndHandle);
+
+// Only valid to be called between a call to StartFrameCapture and EndFrameCapture. Gives a custom
+// title to the capture produced which will be displayed in the UI.
+//
+// If multiple captures are ongoing, this title will be applied to the first capture to end after
+// this call. The second capture to end will have no title, unless this function is called again.
+//
+// Calling this function has no effect if no capture is currently running, and if it is called
+// multiple times only the last title will be used.
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureTitle)(const char *title);
+
+// Annotations API:
+//
+// These functions allow you to specify annotations either on a per-command level, or a per-object
+// level.
+//
+// Basic types of annotations are supported, as well as vector versions and references to API objects.
+//
+// The annotations are stored as keys, with the key being a dot-separated path allowing arbitrary
+// nesting and user organisation. The keys are sorted in human order so `foo.2.bar` will be displayed
+// before `foo.10.bar` to allow creation of arrays if desired.
+//
+// Deleting an annotation can be done by assigning an empty value to it.
+
+// the type of an annotation value, or Empty to delete an annotation
+typedef enum RENDERDOC_AnnotationType
+{
+  eRENDERDOC_Empty,
+  eRENDERDOC_Bool,
+  eRENDERDOC_Int32,
+  eRENDERDOC_UInt32,
+  eRENDERDOC_Int64,
+  eRENDERDOC_UInt64,
+  eRENDERDOC_Float,
+  eRENDERDOC_Double,
+  eRENDERDOC_String,
+  eRENDERDOC_APIObject,
+  eRENDERDOC_AnnotationMax = 0x7FFFFFFF,
+} RENDERDOC_AnnotationType;
+
+// a union with vector annotation value data
+typedef union RENDERDOC_AnnotationVectorValue
+{
+  bool boolean[4];
+  int32_t int32[4];
+  int64_t int64[4];
+  uint32_t uint32[4];
+  uint64_t uint64[4];
+  float float32[4];
+  double float64[4];
+} RENDERDOC_AnnotationVectorValue;
+
+// a union with scalar annotation value data
+typedef union RENDERDOC_AnnotationValue
+{
+  bool boolean;
+  int32_t int32;
+  int64_t int64;
+  uint32_t uint32;
+  uint64_t uint64;
+  float float32;
+  double float64;
+
+  RENDERDOC_AnnotationVectorValue vector;
+
+  const char *string;
+  void *apiObject;
+} RENDERDOC_AnnotationValue;
+
+// a struct for specifying a GL object, as we don't have pointers we can use so instead we specify a
+// pointer to this struct giving both the type and the name
+typedef struct RENDERDOC_GLResourceReference
+{
+  // this is the same GLenum identifier as passed to glObjectLabel
+  uint32_t identifier;
+  uint32_t name;
+} GLResourceReference;
+
+// simple C++ helpers to avoid the need for a temporary objects for value passing and GL object specification
+#ifdef __cplusplus
+struct RDGLObjectHelper
+{
+  RENDERDOC_GLResourceReference gl;
+
+  RDGLObjectHelper(uint32_t identifier, uint32_t name)
+  {
+    gl.identifier = identifier;
+    gl.name = name;
+  }
+
+  operator RENDERDOC_GLResourceReference *() { return &gl; }
+};
+
+struct RDAnnotationHelper
+{
+  RENDERDOC_AnnotationValue val;
+
+  RDAnnotationHelper(bool b) { val.boolean = b; }
+  RDAnnotationHelper(int32_t i) { val.int32 = i; }
+  RDAnnotationHelper(int64_t i) { val.int64 = i; }
+  RDAnnotationHelper(uint32_t i) { val.uint32 = i; }
+  RDAnnotationHelper(uint64_t i) { val.uint64 = i; }
+  RDAnnotationHelper(float f) { val.float32 = f; }
+  RDAnnotationHelper(double d) { val.float64 = d; }
+  RDAnnotationHelper(const char *s) { val.string = s; }
+
+  operator RENDERDOC_AnnotationValue *() { return &val; }
+};
+#endif
+
+// The device is specified in the same way as other API calls that take a RENDERDOC_DevicePointer
+// to specify the device.
+//
+// The object or queue/commandbuffer will depend on the graphics API in question.
+//
+// Return value:
+// 0 - The annotation was applied successfully.
+// 1 - The device is unknown/invalid
+// 2 - The device is valid but the annotation is not supported for API-specific reasons, such as an
+//     unrecognised or invalid object or queue/commandbuffer
+// 3 - The call is ill-formed or invalid e.g. empty is specified with a value pointer, or non-empty
+//     is specified with a NULL value pointer
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_SetObjectAnnotation)(RENDERDOC_DevicePointer device,
+                                                               void *object, const char *key,
+                                                               RENDERDOC_AnnotationType valueType,
+                                                               uint32_t valueVectorWidth,
+                                                               const RENDERDOC_AnnotationValue *value);
+
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_SetCommandAnnotation)(
+    RENDERDOC_DevicePointer device, void *queueOrCommandBuffer, const char *key,
+    RENDERDOC_AnnotationType valueType, uint32_t valueVectorWidth,
+    const RENDERDOC_AnnotationValue *value);
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc API versions
+//
+
+// RenderDoc uses semantic versioning (http://semver.org/).
+//
+// MAJOR version is incremented when incompatible API changes happen.
+// MINOR version is incremented when functionality is added in a backwards-compatible manner.
+// PATCH version is incremented when backwards-compatible bug fixes happen.
+//
+// Note that this means the API returned can be higher than the one you might have requested.
+// e.g. if you are running against a newer RenderDoc that supports 1.0.1, it will be returned
+// instead of 1.0.0. You can check this with the GetAPIVersion entry point
+typedef enum RENDERDOC_Version
+{
+  eRENDERDOC_API_Version_1_0_0 = 10000,    // RENDERDOC_API_1_0_0 = 1 00 00
+  eRENDERDOC_API_Version_1_0_1 = 10001,    // RENDERDOC_API_1_0_1 = 1 00 01
+  eRENDERDOC_API_Version_1_0_2 = 10002,    // RENDERDOC_API_1_0_2 = 1 00 02
+  eRENDERDOC_API_Version_1_1_0 = 10100,    // RENDERDOC_API_1_1_0 = 1 01 00
+  eRENDERDOC_API_Version_1_1_1 = 10101,    // RENDERDOC_API_1_1_1 = 1 01 01
+  eRENDERDOC_API_Version_1_1_2 = 10102,    // RENDERDOC_API_1_1_2 = 1 01 02
+  eRENDERDOC_API_Version_1_2_0 = 10200,    // RENDERDOC_API_1_2_0 = 1 02 00
+  eRENDERDOC_API_Version_1_3_0 = 10300,    // RENDERDOC_API_1_3_0 = 1 03 00
+  eRENDERDOC_API_Version_1_4_0 = 10400,    // RENDERDOC_API_1_4_0 = 1 04 00
+  eRENDERDOC_API_Version_1_4_1 = 10401,    // RENDERDOC_API_1_4_1 = 1 04 01
+  eRENDERDOC_API_Version_1_4_2 = 10402,    // RENDERDOC_API_1_4_2 = 1 04 02
+  eRENDERDOC_API_Version_1_5_0 = 10500,    // RENDERDOC_API_1_5_0 = 1 05 00
+  eRENDERDOC_API_Version_1_6_0 = 10600,    // RENDERDOC_API_1_6_0 = 1 06 00
+  eRENDERDOC_API_Version_1_7_0 = 10700,    // RENDERDOC_API_1_7_0 = 1 07 00
+} RENDERDOC_Version;
+
+// API version changelog:
+//
+// 1.0.0 - initial release
+// 1.0.1 - Bugfix: IsFrameCapturing() was returning false for captures that were triggered
+//         by keypress or TriggerCapture, instead of Start/EndFrameCapture.
+// 1.0.2 - Refactor: Renamed eRENDERDOC_Option_DebugDeviceMode to eRENDERDOC_Option_APIValidation
+// 1.1.0 - Add feature: TriggerMultiFrameCapture(). Backwards compatible with 1.0.x since the new
+//         function pointer is added to the end of the struct, the original layout is identical
+// 1.1.1 - Refactor: Renamed remote access to target control (to better disambiguate from remote
+//         replay/remote server concept in replay UI)
+// 1.1.2 - Refactor: Renamed "log file" in function names to just capture, to clarify that these
+//         are captures and not debug logging files. This is the first API version in the v1.0
+//         branch.
+// 1.2.0 - Added feature: SetCaptureFileComments() to add comments to a capture file that will be
+//         displayed in the UI program on load.
+// 1.3.0 - Added feature: New capture option eRENDERDOC_Option_AllowUnsupportedVendorExtensions
+//         which allows users to opt-in to allowing unsupported vendor extensions to function.
+//         Should be used at the user's own risk.
+//         Refactor: Renamed eRENDERDOC_Option_VerifyMapWrites to
+//         eRENDERDOC_Option_VerifyBufferAccess, which now also controls initialisation to
+//         0xdddddddd of uninitialised buffer contents.
+// 1.4.0 - Added feature: DiscardFrameCapture() to discard a frame capture in progress and stop
+//         capturing without saving anything to disk.
+// 1.4.1 - Refactor: Renamed Shutdown to RemoveHooks to better clarify what is happening
+// 1.4.2 - Refactor: Renamed 'draws' to 'actions' in callstack capture option.
+// 1.5.0 - Added feature: ShowReplayUI() to request that the replay UI show itself if connected
+// 1.6.0 - Added feature: SetCaptureTitle() which can be used to set a title for a
+//         capture made with StartFrameCapture() or EndFrameCapture()
+// 1.7.0 - Added feature: SetObjectAnnotation() / SetCommandAnnotation() for adding rich
+//         annotations to objects and command streams
+
+typedef struct RENDERDOC_API_1_7_0
+{
+  pRENDERDOC_GetAPIVersion GetAPIVersion;
+
+  pRENDERDOC_SetCaptureOptionU32 SetCaptureOptionU32;
+  pRENDERDOC_SetCaptureOptionF32 SetCaptureOptionF32;
+
+  pRENDERDOC_GetCaptureOptionU32 GetCaptureOptionU32;
+  pRENDERDOC_GetCaptureOptionF32 GetCaptureOptionF32;
+
+  pRENDERDOC_SetFocusToggleKeys SetFocusToggleKeys;
+  pRENDERDOC_SetCaptureKeys SetCaptureKeys;
+
+  pRENDERDOC_GetOverlayBits GetOverlayBits;
+  pRENDERDOC_MaskOverlayBits MaskOverlayBits;
+
+  // Shutdown was renamed to RemoveHooks in 1.4.1.
+  // These unions allow old code to continue compiling without changes
+  union
+  {
+    pRENDERDOC_Shutdown Shutdown;
+    pRENDERDOC_RemoveHooks RemoveHooks;
+  };
+  pRENDERDOC_UnloadCrashHandler UnloadCrashHandler;
+
+  // Get/SetLogFilePathTemplate was renamed to Get/SetCaptureFilePathTemplate in 1.1.2.
+  // These unions allow old code to continue compiling without changes
+  union
+  {
+    // deprecated name
+    pRENDERDOC_SetLogFilePathTemplate SetLogFilePathTemplate;
+    // current name
+    pRENDERDOC_SetCaptureFilePathTemplate SetCaptureFilePathTemplate;
+  };
+  union
+  {
+    // deprecated name
+    pRENDERDOC_GetLogFilePathTemplate GetLogFilePathTemplate;
+    // current name
+    pRENDERDOC_GetCaptureFilePathTemplate GetCaptureFilePathTemplate;
+  };
+
+  pRENDERDOC_GetNumCaptures GetNumCaptures;
+  pRENDERDOC_GetCapture GetCapture;
+
+  pRENDERDOC_TriggerCapture TriggerCapture;
+
+  // IsRemoteAccessConnected was renamed to IsTargetControlConnected in 1.1.1.
+  // This union allows old code to continue compiling without changes
+  union
+  {
+    // deprecated name
+    pRENDERDOC_IsRemoteAccessConnected IsRemoteAccessConnected;
+    // current name
+    pRENDERDOC_IsTargetControlConnected IsTargetControlConnected;
+  };
+  pRENDERDOC_LaunchReplayUI LaunchReplayUI;
+
+  pRENDERDOC_SetActiveWindow SetActiveWindow;
+
+  pRENDERDOC_StartFrameCapture StartFrameCapture;
+  pRENDERDOC_IsFrameCapturing IsFrameCapturing;
+  pRENDERDOC_EndFrameCapture EndFrameCapture;
+
+  // new function in 1.1.0
+  pRENDERDOC_TriggerMultiFrameCapture TriggerMultiFrameCapture;
+
+  // new function in 1.2.0
+  pRENDERDOC_SetCaptureFileComments SetCaptureFileComments;
+
+  // new function in 1.4.0
+  pRENDERDOC_DiscardFrameCapture DiscardFrameCapture;
+
+  // new function in 1.5.0
+  pRENDERDOC_ShowReplayUI ShowReplayUI;
+
+  // new function in 1.6.0
+  pRENDERDOC_SetCaptureTitle SetCaptureTitle;
+
+  // new functions in 1.7.0
+  pRENDERDOC_SetObjectAnnotation SetObjectAnnotation;
+  pRENDERDOC_SetCommandAnnotation SetCommandAnnotation;
+} RENDERDOC_API_1_7_0;
+
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_0_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_0_1;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_0_2;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_1_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_1_1;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_1_2;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_2_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_3_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_4_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_4_1;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_4_2;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_5_0;
+typedef RENDERDOC_API_1_7_0 RENDERDOC_API_1_6_0;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc API entry point
+//
+// This entry point can be obtained via GetProcAddress/dlsym if RenderDoc is available.
+//
+// The name is the same as the typedef - "RENDERDOC_GetAPI"
+//
+// This function is not thread safe, and should not be called on multiple threads at once.
+// Ideally, call this once as early as possible in your application's startup, before doing
+// any API work, since some configuration functionality etc has to be done also before
+// initialising any APIs.
+//
+// Parameters:
+//   version is a single value from the RENDERDOC_Version above.
+//
+//   outAPIPointers will be filled out with a pointer to the corresponding struct of function
+//   pointers.
+//
+// Returns:
+//   1 - if the outAPIPointers has been filled with a pointer to the API struct requested
+//   0 - if the requested version is not supported or the arguments are invalid.
+//
+typedef int(RENDERDOC_CC *pRENDERDOC_GetAPI)(RENDERDOC_Version version, void **outAPIPointers);
+
+#ifdef __cplusplus
+}    // extern "C"
+#endif


### PR DESCRIPTION
Fixes #3321.

## The failure scenario

RenderDoc is installed on the Linux development box and is the strongest frame debugger available to
this project — it answers **"which draw wrote this pixel"** and **"what is in this render target at
draw N"**, the two questions a black-world bug asks and the two prosper's own instruments answer
worst. It has been unusable here the whole time for one mechanical reason, which
`docs/GPU_PROFILING_EXTERNAL.md` already recorded and then shrugged at:

> `renderdoccmd capture` triggers on a keypress rather than a frame ordinal, which makes it awkward
> headless; RGP's `MESA_VK_TRACE_FRAME` is the better automated capture.

Every agent on this project runs headless. So the best frame debugger on the machine was the one
nobody could aim — **precisely the failure #2233 fixed for prosper's own F8/F9 captures**, one tool
over, and with the same consequence: lanes built weaker instruments instead.

## The contract

RenderDoc's in-application API needs no keypress. `librenderdoc.so` exports exactly one symbol,
`RENDERDOC_GetAPI`, returning a struct of function pointers including `StartFrameCapture` /
`EndFrameCapture`. Those delimit a capture **explicitly**, so they need neither a keypress nor a
present — which is what makes them work under `SDL_VIDEODRIVER=offscreen`, where there is no window
to press a key into.

```bash
ENABLE_VULKAN_RENDERDOC_CAPTURE=1 \
PROSPER_RENDERDOC_AT_FRAME=900 \
PROSPER_CAPTURE_DIR=$HOME/work \
    ./prosper-app <DUMP_ROOT>/<TITLE_ID>-app0

renderdoccmd convert -f cap.rdc -c xml -o frame.xml     # full event list, no Python needed
```

| variable | axis |
| --- | --- |
| `PROSPER_RENDERDOC_AT_FRAME` | a located host-frame ordinal (reproducible) |
| `PROSPER_RENDERDOC_AFTER_MS` | a wall-clock event you can only describe in time |
| `PROSPER_RENDERDOC_MAX_ITERS` | span cap, default 2000 |

Both triggers are one-shot and opt-in, and a malformed value **disables its own trigger** rather than
firing at an unintended moment — the same contract as F8/F9, reusing their `parse_*` helpers.

## Two invariants that had to be MEASURED, because the first guess was wrong on both

### 1. A prosper "frame" is the GUEST's, not the app loop's

A span of one app-loop iteration produced a capture with **no draws in it**. prosper submits guest
GPU work off the app-loop thread, and that loop can spin at 260 fps while the guest renders far
slower, so the span routinely covered only the presentation blit and `vkQueuePresentKHR`. The span
now closes on a **guest present** (`gpu::present_count()`), with an iteration cap so a title that
stops presenting cannot hold a capture open until the process runs out of memory. The log reports
which of the two closed it, because a cap-closed capture may contain no guest frame at all.

### 2. On this route prosper runs two Vulkan instances, and the guest draws are not on the obvious one

This is the finding worth the PR. prosper-app owns an instance for presentation
(`main.cpp:249`); the live renderer owns a **separate** one (`tests/fixtures/render_runner.h` — that
header *is* the renderer, despite its directory) and publishes it via
`prosper::gpu::set_shared_vulkan_context`.

**"Two" is the default headless route's count, not an invariant** — `live_compute.cpp:2913` creates a
*third*, private instance when it declines to adopt the renderer's, and present unification (#1270)
is opt-out and attempted on every real game boot, so a windowed run is *expected* to collapse to one.
Passing NULL lets RenderDoc choose the device; RenderDoc documents that choice as **arbitrary**, and
observed here (n=1) it took the one holding the swapchain. **The rule is therefore "always pass the
device explicitly", not "it picks the swapchain"** — an arbitrary choice that happens to be right
once is worse than a wrong one, because it will not stay right.

Measured on *The Messenger*, same route and **identical span logic**, differing only in which device
the capture is aimed at (two builds, one edit apart — not literally the same binary):

| aimed at | chunks | `vkCmdDraw` | `vkCmdDrawIndexed` | `vkCmdDispatch` | graphics pipelines | compute pipelines | shader modules |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| NULL (RenderDoc picks) | 56 | **0** | **0** | **0** | **0** | **0** | **0** |
| the renderer's instance | **406** | 2 | **9** | **2** | **6** | **1** | **13** |

**The 56-chunk capture is not corrupt and not truncated.** It is a complete, valid capture of the
*wrong device* — it converts, opens and reads perfectly while containing nothing anyone wants. Its
entire content is `vkCreateSwapchainKHR`, `vkCmdCopyBufferToImage`, `vkCmdBlitImage`,
`vkQueuePresentKHR`. It reads as **a working instrument reporting a negative result**, which is the
dangerous shape this project keeps records about. The trigger now resolves the renderer's instance
itself and warns loudly when the renderer has not yet published a context.

## Side finding, deliberately NOT fixed here

The presentation device's captured work is `vkCmdCopyBufferToImage` + `vkCmdBlitImage` — i.e. under
`SDL_VIDEODRIVER=offscreen` the renderer's instance is not surface-capable, present unification
(#1270) declines, and **the finished guest frame crosses from the renderer's device to the
presentation device through CPU memory, once per presented frame.** Every headless measurement this
project makes pays that. It wants its own issue and its own evidence; it is recorded here rather than
acted on.

## Why `renderdoc_app.h` is vendored rather than `#include`d from `renderdoc-devel`

The struct is an **ABI**, and using the real header is the whole point — a hand-written subset one
field out calls the wrong function pointer and crashes. Vendoring also means this compiles with no
build-time dependency on `renderdoc-devel` being installed. MIT, header-only, **never linked**;
`third_party/renderdoc/` with LICENSE and README per the charter's vendoring exception. prosper
requests API **1.4.1**, well below the installed 1.45, so an older RenderDoc still works.

## Affected / unaffected

- **Affected:** `prosper-app` only, and only when one of the two new variables is set. `RTLD_NOLOAD`
  means the loader never pulls RenderDoc into a process that does not already have it.
- **Unaffected:** every existing capture path (F8/F9/screenshot triggers are untouched), all other
  frontends, all platforms other than Linux/macOS (where the trigger compiles to a no-op that *says
  so* rather than silently doing nothing).
- **Risk:** the RenderDoc layer is an implicit Vulkan layer, and `live_compute.cpp`'s `std::atexit`
  ordering comment already anticipates exactly this class of layer for teardown safety (#1704). No
  change was needed there; noted so a reviewer checks rather than assumes.

## Documentation

`GPU_PROFILING_EXTERNAL.md`'s RenderDoc section said the keypress "makes it awkward headless" and
recommended RGP instead. **That claim is now false and is corrected in the same PR** rather than left
to steer the next reader wrong — including an explicit statement of what the absent Python bindings
still cost (pixel history, per-draw render-target export and shader debugging remain out of reach
without a RenderDoc source build; `convert` and handing a `.rdc` to `qrenderdoc` are what work).

`frontends/shared/diagnostics/AGENTS.md` is new — the folder had none.

## Verification

```
cmake --build prosper/build-linux --target prosper-app -j6     # clean
```

Functional evidence is the table above: two captures, same route and identical span logic (two
builds, one edit apart), differing only in which device the capture is aimed at,
converted with `renderdoccmd convert -c xml` and counted. Full `ctest` results posted as a comment
(the GPU is in use by a Stray capture run as this is opened, and this project does not run
concurrent GPU jobs).


---

## Review round 1 — head `25653d3` — REJECTED, then APPROVED on `f6e98298`

**Blocking (B1): an open capture was never closed on any loop-exit path**, so the artifact was lost
with no line saying so — `--frames` satisfied (`PresentedFrameCounter::record` clears `running` in the
same iteration that `AT_FRAME` arms), `SDL_EVENT_QUIT` via the early `break`, and `AFTER_MS` firing
shortly before a title exits, which is the wall-clock axis's whole purpose. That is exactly the
silent-instrument failure this PR argues against, one level up. My own testing could not have found
it: I verified the trigger only on runs I killed externally, the one shape that never exercises a
graceful exit.

Fixed by **closing** rather than cancelling (deliberately unlike the F8 sibling two lines below):
RenderDoc decides whether the span held anything, so real work is written and labelled, and an empty
span reports `ABANDONED`. The reviewer verified completeness by enumerating the loop body for every
`return`/`exit`/`_Exit`/`abort`/`terminate` — zero hits, so every departure is a `break` or the
condition, and both reach the close.

**Then, from the re-review:** a shutdown-truncated `.rdc` still opens perfectly and reads as a whole
frame with draws missing. The warning was in stderr, which does not travel with the file. Every
capture is now stamped via `SetCaptureFileComments` with what closed the span, how many iterations and
guest presents it covered, and which device it was aimed at — and a truncated one says missing draws
are expected and are **not** evidence the guest failed to submit them.

**Corrections to claims this body previously made** (all now fixed above): "TWO Vulkan instances"
stated as an invariant; "it chooses the one holding the swapchain" (n=1, docs say arbitrary); "same
build" (two builds, one edit apart); the pipelines column omitted 1 compute pipeline.

**Also from the review:** `?:` was a GNU extension and the repo's only use — spelled out;
`MAX_ITERS` now echoes the offending value and accepted shape, matching
`PROSPER_CAPTURE_BUNDLE_MAX_MB` (`main.cpp:1750`), which the reviewer identified as the repo's
existing convention for a malformed **bound** as opposed to a malformed **trigger** — that precedent
settles the question in favour of the doc as written; a second axis arming inside an open span now
reports that it was consumed; `third_party/renderdoc/README.md` cited a nonexistent `.cpp`; and the
`BLOG.md` entry was 229 words with an 8-number table against the charter's one-sentence rule — cut to
80 words with no table.

**Filed rather than fixed here:** #3324 (a guest-thread `_Exit` bypasses every frontend finalize step;
`_Exit` is `exit_group` so no `atexit` hook helps — documented at the call site) and #3325
(`g_shared_vulkan` is published and read unsynchronised; pre-existing, belongs with the global rather
than with one more reader).


