### PR TITLE
diag: let a RenderDoc capture span several guest presents (#3321)

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -2036,6 +2036,19 @@ int main(int argc, char** argv) {
     // itself, because firing at an unintended moment is worse than not firing. This is a safety CAP,
     // not a trigger -- disabling it would mean an unbounded span -- so a malformed or zero value
     // falls back to the default, and says so rather than doing it quietly.
+    // How many GUEST presents the span covers, default 1 (#3321). One is right for a title whose
+    // frame is self-contained, and demonstrably wrong for one that builds its screen across several
+    // frames: Stray's title screen renders its 3D element in a frame that carries no UI, so a
+    // one-present capture holds a cat and no menu while the screen shows a menu and no cat. Widening
+    // the span is the only way to see a whole cycle. Same fallback-and-announce contract as the cap
+    // below -- this bounds a span, it does not aim one.
+    const uint64_t renderdocPresentsParsed =
+        prosper::frontend::parse_capture_frame(getenv("PROSPER_RENDERDOC_PRESENTS"));
+    const uint64_t renderdocPresents = renderdocPresentsParsed ? renderdocPresentsParsed : 1;
+    if (const char* np = getenv("PROSPER_RENDERDOC_PRESENTS"); np && !renderdocPresentsParsed)
+        std::fprintf(stderr, "[renderdoc] ignoring malformed PROSPER_RENDERDOC_PRESENTS=\"%s\" "
+                             "(expected a positive present count); spanning %llu\n",
+                     np, (unsigned long long)renderdocPresents);
     const uint64_t renderdocMaxItersParsed =
         prosper::frontend::parse_capture_frame(getenv("PROSPER_RENDERDOC_MAX_ITERS"));
     const uint64_t renderdocMaxIterations = renderdocMaxItersParsed ? renderdocMaxItersParsed : 2000;
@@ -2060,6 +2073,9 @@ int main(int argc, char** argv) {
         } else {
             // Never leave this at RenderDoc's default, which is under /tmp -- see the header.
             rdoc.set_path_template(grabDir + "/prosper_frame");
+            if (renderdocPresents != 1)
+                std::fprintf(stderr, "[renderdoc] span set to %llu guest presents\n",
+                             (unsigned long long)renderdocPresents);
             if (scheduledRdocFrame)
                 std::fprintf(stderr, "[renderdoc] capture scheduled at host frame %llu (into %s)\n",
                              (unsigned long long)scheduledRdocFrame, grabDir.c_str());
@@ -2278,7 +2294,8 @@ int main(int argc, char** argv) {
         // by a missing file.
         if (renderdocCaptureOpen) {
             const uint64_t guestNow = gpu::present_count();
-            const bool guestPresented = guestNow > renderdocOpenedAtGuestPresent;
+            const bool guestPresented =
+                guestNow - renderdocOpenedAtGuestPresent >= renderdocPresents;
             const bool hitCap = ++renderdocOpenIterations >= renderdocMaxIterations;
             if (guestPresented || hitCap) {
                 renderdocCaptureOpen = false;


### PR DESCRIPTION
Follow-up to #3322 (which added the triggers). Refs #3321, #3126.

## The default was a guess, and Stray showed it was wrong

#3322 closed the capture span on the **first** guest present. That is right for a title whose frame
is self-contained, and it is wrong for Stray:

- the capture contains a fully rendered 3D **cat** and **no menu**;
- the presented screenshot at the same moment shows a **menu and no cat** (`nonblack=0.0087`, three
  pixel-identical frames — the title screen holding).

A capture that holds half the screen cannot answer where the other half is lost, which is the whole
question in #3126. `PROSPER_RENDERDOC_PRESENTS=N` widens the span. **Default stays 1** — unchanged
behaviour for every existing user of the trigger.

## The measurement, and it contradicts the hypothesis that motivated the change

Stray, `PROSPER_RENDERDOC_PRESENTS=8`, title screen at 175 s:

| | 1 present | 3 presents | ratio |
| --- | ---: | ---: | ---: |
| total chunks | 7,388 | 19,676 | 2.66x |
| `vkCmdBeginRenderPass` | 65 | 192 | **2.95x** |
| `vkCmdDrawIndexed` | 98 | 312 | **3.18x** |
| `vkCmdDispatch` | 89 | 275 | **3.09x** |
| `vkCmdCopyImageToBuffer` | 52 | 168 | 3.23x |

**The ratio table above is NOT what establishes this, and the review was right to say so.** Under an
alternating `cat, UI, cat` sequence the aggregate counts would *also* land near 3x — so the ratio
cannot distinguish `A,B,A` from `A,A,A`. It is a **void discriminator, not a negative one**, and the
conclusion below was reached by a route that does not support it. (It is also not literally true that
"every count scales": roughly a third of the 60 chunk names do not, because RenderDoc serialises some
resources per *capture* rather than per frame — `vkCreateImage` 1.41x, `vkCreateShaderModule` 1.16x,
`vkCreateComputePipelines` 1.05x.)

**The measurement that does establish it**, from the same file: segment the capture by per-render-pass
draw signature. The 192 passes decompose as a 10-pass prefix, then **two complete 66-pass frames that
are identical at all 66 positions — zero differences** — then a 50-pass cap-truncated tail. A full
chunk-name diff of those two frames is 3,905 against 3,900, differing *only* in streaming traffic,
with every draw, dispatch, pass and submit count identical.

So **the frames really are structurally identical**, there is no alternating cat-frame/UI-frame, and
**the multi-frame explanation for the missing menu is withdrawn** — it was the reason I built this,
and the first thing the wider capture did was falsify it. The menu is somewhere in a frame that also
draws the cat; the pipeline map posted to #3126 says the likeliest place is pass 61, a 1920x1080 pass
carrying 10 draws while its neighbours carry 1.

**And a stronger argument for this PR that the original body missed**: the 1-present capture satisfies
`p1 == frame[1:]` exactly, at all 65 positions — so the `N=1` default captures one whole frame *minus
its leading render pass*, which is a real defect in the default rather than merely a limitation.
Confirmed against a frame body taken from a different run.

The widened span is what made any of this measurable.

## Contract

Same fallback-and-announce as `PROSPER_RENDERDOC_MAX_ITERS`, and for the same stated reason: this
**bounds** a span rather than **aiming** one, so a malformed value falls back to the default and says
so — matching `PROSPER_CAPTURE_BUNDLE_MAX_MB` (`main.cpp:1750`), which #3322's review established as
the repo's convention for a malformed bound. Only the two *triggers* disable themselves on a
malformed value, because firing at an unintended moment is worse than not firing.

## The interaction that bit on the first run, and is reported rather than hidden

At `N=8` the **iteration cap closed the span first**, at 3 presents — and the capture was correctly
logged and stamped as `closed by iteration cap` rather than passing as a complete frame. That is
#3322's provenance machinery doing its job on its first real encounter with a truncated span. **A slow
title needs `PROSPER_RENDERDOC_MAX_ITERS` raised alongside `PROSPER_RENDERDOC_PRESENTS`**; the log
line says which of the two closed the span, so the reader is told rather than left to infer it.

## Affected / unaffected

- **Affected:** `prosper-app` only, and only when `PROSPER_RENDERDOC_PRESENTS` is set. The close
  predicate changes from `guestNow > opened` to `guestNow - opened >= presents`, which is identical at
  the default of 1.
- **Unaffected:** every other capture path; all platforms where the trigger already compiles to a
  no-op.
- **Risk:** the close predicate is exactly where #3322's review found a real blocking bug (an open
  capture never closed on exit), so this is worth a second reader despite being 18 lines.

## Verification

```
cmake --build prosper/build-linux --target prosper-app -j6     # clean, no warnings
```

Functional evidence is the table above — one Stray run at `N=8`, converted with
`renderdoccmd convert -c xml` and counted, against the `N=1` capture from #3322.

