### PR TITLE
perf(gpu,compute): multi-layer writeback, near-full coverage bypass, and bulk maps caching

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -6076,6 +6076,19 @@ program's own first dword** — so a differing prologue cannot explain the miss.
 
 ## Other open defects
 
+- **Prologue cutscene timeline/animation desynchronization at low framerates**: In the opening story mode
+  prologue cutscene (Bank Heist), the scripted sequence consists of six sequential camera angles:
+  1) Robber throws a woman to the floor, camera pans down with her on the floor;
+  2) Camera switches angle, looking up from the floor at the robbers;
+  3) Close-up shot on one robber's face speaking;
+  4) Zoomed-out shot, robber hits the teller window;
+  5) Close-up shot on the robber ordering the clerk to open the door;
+  6) Camera zooms out, robber kicks the security door open.
+  At sub-10 FPS throughput, RAGE cutscene progression (advancing against real process time via
+  `sceKernelGetProcessTimeCounter`) desynchronizes from rendered animation states: the presentation
+  immediately skips the first five camera angles and jumps directly to the robber kicking the door open,
+  with the woman already lying static on the floor. Once throughput reaches real-time targets, animation
+  event triggers align with the script timeline.
 - **#2445** — specific lowercase glyphs (`r`, `s`, `m`) dropped from UI text: "Ente ing Sto y Mode".
   Surrounding text is intact, so it is per-glyph, not a font failure.
 - **#2429** — the world cannot render on 32-wide devices: the EXEC-population-count fix requires

--- a/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute/compute_transfer_gate_census.hpp
@@ -26,7 +26,7 @@ struct ComputeStorageCacheGateInputs {
 
 constexpr bool compute_storage_cache_gate_candidate(
     const ComputeStorageCacheGateInputs& inputs) {
-    return !inputs.renderer_owned && inputs.dcc_cache_safe &&
+    return (!inputs.renderer_owned || inputs.seed_skip) && inputs.dcc_cache_safe &&
            !inputs.poison_verify && (inputs.exact_storage || inputs.seed_skip) &&
            inputs.persistent_enabled;
 }

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -10212,24 +10212,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         w_max_y = std::max(w_max_y, py);
                     }
                 }
-                uint64_t written_layers = 0;
-                bool any_written_partial = false;
-                if (r->depth > 1 && layer_texels > 0 && r->depth <= 64) {
-                    for (uint32_t l = 0; l < r->depth; ++l) {
-                        if (layer_survived[l] < layer_texels) {
-                            written_layers |= (1ULL << l);
-                            if (layer_survived[l] > 0) {
-                                any_written_partial = true;
-                            }
-                        }
-                    }
-                } else {
-                    written_layers = (survived < texels) ? 1ULL : 0ULL;
-                    any_written_partial = (survived > 0 && survived < texels);
-                }
+                // Lifted into seed_reprove.hpp so the >64-layer case is testable in isolation --
+                // it was silently corrupting guest memory here and no test could reach it.
+                const ArrayLayerCoverage layers = classify_array_layer_coverage(
+                    r->depth, layer_survived.data(), layer_texels, survived, texels);
+                const uint64_t written_layers = layers.written_layers;
+                const bool any_written_partial = layers.any_written_partial;
                 SeedCoverage cov = classify_seed_coverage(survived, texels);
-                const bool all_layers_written = (r->depth > 1) &&
-                    (written_layers == ((r->depth >= 64) ? ~0ULL : ((1ULL << r->depth) - 1)));
+                const bool all_layers_written =
+                    array_all_layers_written(r->depth, written_layers, layers.exact);
                 if (r->depth > 1 && all_layers_written && !any_written_partial) {
                     cov = SeedCoverage::Full;
                 }

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3371,6 +3371,8 @@ struct BoundImage {
     bool compute_transfer_seed_borrowed = false;
     std::vector<uint8_t> cache_source_snapshot; // first-use source captured before the transfer
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
+    bool near_full_coverage = false;    // >= 99.8% written post-processing target (cutouts like minimap)
+    uint64_t written_layers_mask = ~0ULL; // bitmask of touched array layers (depth <= 64)
     bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
     bool write_skip = false;            // untouched storage image: unwritten and unread; skip staging, readback, and writeback
     size_t seed_from_imported = SIZE_MAX; // renderer image copied on-device into this partial-write target
@@ -5535,7 +5537,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // window from unbounded to <= interval fast-skips. A genuinely data-independent writer (the
     // exercised full-screen composites or untouched bindings) re-proves each time -- no rendered-output change, ~1
     // extra poison frame per interval. skips counts fast-skips taken since the last (re-)proof.
-    struct SeedVerdict { SeedCoverage cov = SeedCoverage::Partial; uint32_t skips = 0; };
+    struct SeedVerdict {
+        SeedCoverage cov = SeedCoverage::Partial;
+        uint32_t skips = 0;
+        uint64_t written_layers = ~0ULL;
+        bool near_full = false;
+    };
     // key = (shader code_addr, output binding, width, height, depth) -- collision-free by construction.
     using SeedCoverageKey = std::tuple<uint64_t, uint32_t, uint32_t, uint32_t, uint32_t>;
     static std::mutex seed_coverage_mu;
@@ -6691,6 +6698,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         known = true;
                         proven_full = it->second.cov == SeedCoverage::Full;
                         proven_none = it->second.cov == SeedCoverage::None;
+                        bi.written_layers_mask = it->second.written_layers;
+                        bi.near_full_coverage = it->second.near_full;
                         // #1127: periodically re-prove a Full or None verdict so a data-dependent store that
                         // later changes coverage is caught (re-cached Partial, then always seeds). The
                         // helper resets the counter, so concurrent dispatches on this key don't all
@@ -9388,11 +9397,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.write_skip) continue;
-            static const bool no_skip_export_writeback =
-                std::getenv("PROSPER_NO_EXPORTED_STORAGE_WRITEBACK_SKIP") != nullptr;
-            const bool skip_exported_writeback = !no_skip_export_writeback &&
+            static const bool skip_export_writeback_enabled =
+                std::getenv("PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK") != nullptr;
+            const bool skip_exported_writeback = skip_export_writeback_enabled &&
                 bi.graphics_sampled_usage && bi.cache_candidate && bi.persistent &&
-                bi.seed_skip && !bi.poison_verify && !bi.mirror_result_to_imported;
+                (bi.seed_skip || bi.near_full_coverage) &&
+                !bi.poison_verify && !bi.mirror_result_to_imported;
             if (skip_exported_writeback) continue;
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
@@ -10067,11 +10077,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, (unsigned long long)bi.resource->gpu_addr);
                 continue;
             }
-            static const bool no_skip_export_writeback =
-                std::getenv("PROSPER_NO_EXPORTED_STORAGE_WRITEBACK_SKIP") != nullptr;
-            const bool skip_exported_writeback = !no_skip_export_writeback &&
+            static const bool skip_export_writeback_enabled =
+                std::getenv("PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK") != nullptr;
+            const bool skip_exported_writeback = skip_export_writeback_enabled &&
                 bi.graphics_sampled_usage && bi.cache_candidate && bi.persistent &&
-                bi.seed_skip && !bi.poison_verify && !bi.mirror_result_to_imported;
+                (bi.seed_skip || bi.near_full_coverage) &&
+                !bi.poison_verify && !bi.mirror_result_to_imported;
             if (skip_exported_writeback) {
                 if (trace || (bi.resource && bi.resource->gpu_addr == 0x204aee0000)) {
                     std::fprintf(stderr,
@@ -10171,12 +10182,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (bi.poison_verify) {
                 size_t survived = 0;
                 poison_texel.assign(texels, 0);
+                const size_t layer_texels = (r->depth > 1) ? (size_t)r->width * r->height : texels;
+                std::vector<size_t> layer_survived(r->depth > 1 ? r->depth : 1, 0);
                 // Stop at the first non-poison unit. The verdict is "every unit is still
                 // poison", so one mismatch settles the texel -- and that is the overwhelmingly
                 // common case: a covering shader writes every texel, so `poison_survived` is 0 and
                 // the mismatch is usually at the first byte. Without the early exit each texel paid
                 // the full guest_texel (or 4-channel) scan to reach a conclusion it already had.
                 // Measured on Astro Bot: 108.4 M texels scanned across one 70 s run.
+                uint32_t s_min_x = UINT32_MAX, s_max_x = 0, s_min_y = UINT32_MAX, s_max_y = 0;
+                uint32_t w_min_x = UINT32_MAX, w_max_x = 0, w_min_y = UINT32_MAX, w_max_y = 0;
                 for (size_t t = 0; t < texels; ++t) {
                     bool all = true;
                     if (bi.exact_storage_bytes()) {
@@ -10187,20 +10202,78 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         for (uint32_t c = 0; c < 4; ++c)
                             if (channels[t * 4 + c] != 0xDEADBEEFu) { all = false; break; }
                     }
-                    if (all) { ++survived; poison_texel[t] = 1; }
+                    const uint32_t px = r->width ? static_cast<uint32_t>(t % r->width) : 0;
+                    const uint32_t py = r->width ? static_cast<uint32_t>(t / r->width) : 0;
+                    const uint32_t l = (r->depth > 1 && layer_texels > 0) ? static_cast<uint32_t>(t / layer_texels) : 0u;
+                    if (all) {
+                        ++survived;
+                        poison_texel[t] = 1;
+                        if (l < layer_survived.size()) ++layer_survived[l];
+                        s_min_x = std::min(s_min_x, px);
+                        s_max_x = std::max(s_max_x, px);
+                        s_min_y = std::min(s_min_y, py);
+                        s_max_y = std::max(s_max_y, py);
+                    } else {
+                        w_min_x = std::min(w_min_x, px);
+                        w_max_x = std::max(w_max_x, px);
+                        w_min_y = std::min(w_min_y, py);
+                        w_max_y = std::max(w_max_y, py);
+                    }
                 }
-                const SeedCoverage cov = classify_seed_coverage(survived, texels);
+                uint64_t written_layers = 0;
+                bool any_written_partial = false;
+                if (r->depth > 1 && layer_texels > 0 && r->depth <= 64) {
+                    for (uint32_t l = 0; l < r->depth; ++l) {
+                        if (layer_survived[l] < layer_texels) {
+                            written_layers |= (1ULL << l);
+                            if (layer_survived[l] > 0) {
+                                any_written_partial = true;
+                            }
+                        }
+                    }
+                } else {
+                    written_layers = (survived < texels) ? 1ULL : 0ULL;
+                    any_written_partial = (survived > 0 && survived < texels);
+                }
+                SeedCoverage cov = classify_seed_coverage(survived, texels);
+                if (r->depth > 1 && written_layers != 0 && !any_written_partial) {
+                    cov = SeedCoverage::Full;
+                }
+                const bool near_full = (survived == 0) || (texels >= 1000 && survived * 500 <= texels);
+                bi.written_layers_mask = written_layers;
+                bi.near_full_coverage = near_full;
                 {
                     const SeedCoverageKey proof_key{item.code_addr, bi.binding,
                                                     r->width, r->height, r->depth};
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                    seed_coverage_proof[proof_key] = SeedVerdict{ cov, 0 };
+                    seed_coverage_proof[proof_key] = SeedVerdict{ cov, 0, written_layers, near_full };
                 }
-                std::fprintf(stderr,
-                             "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
-                             (unsigned long long)item.code_addr, bi.binding, texels, survived,
-                             seed_coverage_name(cov));
+                if (survived == 0) {
+                    std::fprintf(stderr,
+                                 "[seed-skip-verify] code=0x%llx binding=%u addr=0x%llx extent=%ux%ux%u fmt=%u tile=%u "
+                                 "texels=%zu poison_survived=0 %s\n",
+                                 (unsigned long long)item.code_addr, bi.binding,
+                                 (unsigned long long)r->gpu_addr, r->width, r->height, r->depth,
+                                 (unsigned)r->format, r->tile_mode, texels, seed_coverage_name(cov));
+                } else if (survived >= texels) {
+                    std::fprintf(stderr,
+                                 "[seed-skip-verify] code=0x%llx binding=%u addr=0x%llx extent=%ux%ux%u fmt=%u tile=%u "
+                                 "texels=%zu poison_survived=%zu (all) %s\n",
+                                 (unsigned long long)item.code_addr, bi.binding,
+                                 (unsigned long long)r->gpu_addr, r->width, r->height, r->depth,
+                                 (unsigned)r->format, r->tile_mode, texels, survived, seed_coverage_name(cov));
+                } else {
+                    std::fprintf(stderr,
+                                 "[seed-skip-verify] code=0x%llx binding=%u addr=0x%llx extent=%ux%ux%u fmt=%u tile=%u "
+                                 "texels=%zu poison_survived=%zu survived_box=[%u,%u..%u,%u] written_box=[%u,%u..%u,%u] %s\n",
+                                 (unsigned long long)item.code_addr, bi.binding,
+                                 (unsigned long long)r->gpu_addr, r->width, r->height, r->depth,
+                                 (unsigned)r->format, r->tile_mode, texels, survived,
+                                 s_min_x, s_min_y, s_max_x, s_max_y,
+                                 w_min_x, w_min_y, w_max_x, w_max_y,
+                                 seed_coverage_name(cov));
+                }
                 if (cov == SeedCoverage::None) {
                     // Untouched storage target: the shader stored zero texels. Guest memory retains its
                     // clean original contents. Skip guest memory write-watch notification, unpack/pack,
@@ -10249,11 +10322,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                         (end - begin) * guest_texel);
                         });
             } else if (pack_range_enabled) {
-                storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
+                if (array_image && r->depth > 1 && bi.written_layers_mask != ~0ULL) {
+                    const size_t layer_texels = (size_t)r->width * r->height;
+                    for (uint32_t layer = 0; layer < r->depth && layer < 64; ++layer) {
+                        if (bi.written_layers_mask & (1ULL << layer)) {
+                            storage_pack_range(channels + layer * layer_texels * 4,
+                                               r->format, nc, layer_texels,
+                                               packed + layer * layer_texels * guest_texel,
+                                               guest_texel);
+                        }
+                    }
+                } else {
+                    storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
+                }
             } else {
-                for (size_t t = 0; t < texels; t++)
+                for (size_t t = 0; t < texels; t++) {
+                    const uint32_t layer = (array_image && r->depth > 1 && r->width && r->height)
+                        ? static_cast<uint32_t>(t / ((size_t)r->width * r->height)) : 0u;
+                    if (layer < 64 && !(bi.written_layers_mask & (1ULL << layer))) continue;
                     storage_pack_texel(channels + t * 4, r->format, nc,
                                        packed + t * guest_texel);
+                }
             }
             // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
             // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
@@ -10315,6 +10404,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const size_t layer_stride = r->layer_stride_bytes
                     ? r->layer_stride_bytes : selected_slice;
                 for (uint32_t layer = 0; layer < r->depth; ++layer) {
+                    if (layer < 64 && !(bi.written_layers_mask & (1ULL << layer))) {
+                        continue;
+                    }
                     uint8_t* layer_base = destination + layer_stride * layer;
                     if (!r->tile_mode) {
                         const size_t row_pitch = r->layer_stride_bytes
@@ -10360,7 +10452,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // emulator is invalidating its own caches. Everything reaching the DS invalidation path
             // used to report the default `gpu`, which cannot distinguish them.
             set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
-            notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+            if (array_image && r->depth > 1 && bi.written_layers_mask != ~0ULL) {
+                uint32_t max_written_layer = 0;
+                for (uint32_t layer = 0; layer < r->depth && layer < 64; ++layer) {
+                    if (bi.written_layers_mask & (1ULL << layer)) max_written_layer = layer;
+                }
+                const size_t linear_slice = static_cast<size_t>(r->width) * r->height * guest_texel;
+                const size_t selected_slice = r->in_mip_tail
+                    ? r->mip_tail_bytes
+                    : (r->tile_mode
+                           ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0,
+                                                 static_cast<uint32_t>(guest_texel))
+                           : (r->layer_stride_bytes
+                                  ? linear_array_surface_bytes(
+                                        *r, static_cast<uint32_t>(guest_texel))
+                                  : linear_slice));
+                const size_t layer_stride = r->layer_stride_bytes ? r->layer_stride_bytes : selected_slice;
+                const uint64_t written_range = std::min((uint64_t)(max_written_layer + 1) * layer_stride, bi.guest_bytes);
+                notify_guest_gpu_write(r->gpu_addr, written_range);
+            } else {
+                notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+            }
             set_guest_gpu_write_origin(nullptr);
             if (!r->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6700,11 +6700,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         proven_none = it->second.cov == SeedCoverage::None;
                         bi.written_layers_mask = it->second.written_layers;
                         bi.near_full_coverage = it->second.near_full;
-                        // #1127: periodically re-prove a Full or None verdict so a data-dependent store that
-                        // later changes coverage is caught (re-cached Partial, then always seeds). The
-                        // helper resets the counter, so concurrent dispatches on this key don't all
-                        // re-prove at once.
-                        if ((proven_full || proven_none) &&
+                        // #1127: periodically re-prove a Full, None, or layer-masked/near-full Partial verdict
+                        // so a data-dependent store that later changes coverage is caught. The helper resets
+                        // the counter, so concurrent dispatches on this key don't all re-prove at once.
+                        const bool partial_optimised = (it->second.cov == SeedCoverage::Partial) &&
+                            (it->second.written_layers != ~0ULL || it->second.near_full);
+                        if ((proven_full || proven_none || partial_optimised) &&
                             seed_reprove_due(it->second.skips, kSeedReproveInterval))
                             reprove_due = true;
                     }
@@ -7770,18 +7771,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     *r, static_cast<uint32_t>(guest_bytes), image_format);
                 bi.cache_candidate =
                     compute_storage_cache_gate_candidate(storage_cache_gates);
-                if (r->gpu_addr == 0x204aee0000) {
-                    std::fprintf(stderr,
-                        "[diag-0x204aee0000] cache_candidate=%d (r_owned=%d dcc_safe=%d "
-                        "poison=%d exact=%d seed_skip=%d pers_en=%d)\n",
-                        (int)bi.cache_candidate,
-                        (int)storage_cache_gates.renderer_owned,
-                        (int)storage_cache_gates.dcc_cache_safe,
-                        (int)storage_cache_gates.poison_verify,
-                        (int)storage_cache_gates.exact_storage,
-                        (int)storage_cache_gates.seed_skip,
-                        (int)storage_cache_gates.persistent_enabled);
-                }
                 if (storage_gate_census_enabled()) {
                     // Report periodically as well as at exit: a bounded run ends in SIGTERM, whose
                     // default action skips atexit handlers entirely.
@@ -10084,11 +10073,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 (bi.seed_skip || bi.near_full_coverage) &&
                 !bi.poison_verify && !bi.mirror_result_to_imported;
             if (skip_exported_writeback) {
-                if (trace || (bi.resource && bi.resource->gpu_addr == 0x204aee0000)) {
+                if (trace) {
                     std::fprintf(stderr,
                         "[compute]   skipped exported storage writeback binding=%u addr=0x%llx\n",
                         bi.binding, (unsigned long long)bi.resource->gpu_addr);
                 }
+                // Announce write range invalidation without modifying host bytes. Safe because graphics
+                // borrows the device image directly via compute export, and no CPU reader observes these
+                // intermediate post-processing surface bytes.
                 if (bi.resource && bi.resource->gpu_addr) {
                     notify_guest_gpu_write_preserving_bytes(bi.resource->gpu_addr, bi.guest_bytes);
                 }
@@ -10236,9 +10228,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     any_written_partial = (survived > 0 && survived < texels);
                 }
                 SeedCoverage cov = classify_seed_coverage(survived, texels);
-                if (r->depth > 1 && written_layers != 0 && !any_written_partial) {
+                const bool all_layers_written = (r->depth > 1) &&
+                    (written_layers == ((r->depth >= 64) ? ~0ULL : ((1ULL << r->depth) - 1)));
+                if (r->depth > 1 && all_layers_written && !any_written_partial) {
                     cov = SeedCoverage::Full;
                 }
+                // Near-full threshold: permits up to 0.2% (1/500) unwritten texels for targets with >= 1000 texels.
+                // This accounts for small unwritten UI margins or minimap cutouts on 4K post-processing surfaces
+                // (e.g. ~16,000 unwritten margin texels on an ~8.3M 4K target is ~0.19%, just under the 0.2% bound).
                 const bool near_full = (survived == 0) || (texels >= 1000 && survived * 500 <= texels);
                 bi.written_layers_mask = written_layers;
                 bi.near_full_coverage = near_full;
@@ -10468,7 +10465,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                         *r, static_cast<uint32_t>(guest_texel))
                                   : linear_slice));
                 const size_t layer_stride = r->layer_stride_bytes ? r->layer_stride_bytes : selected_slice;
-                const uint64_t written_range = std::min((uint64_t)(max_written_layer + 1) * layer_stride, bi.guest_bytes);
+                const uint64_t written_range =
+                    std::min<uint64_t>((uint64_t)(max_written_layer + 1) * layer_stride, bi.guest_bytes);
                 notify_guest_gpu_write(r->gpu_addr, written_range);
             } else {
                 notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -4998,9 +4998,21 @@ std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item)
     const bool zero_fill = !(pattern[0] | pattern[1] | pattern[2] | pattern[3]);
     if (zero_fill) {
         std::memset(destination, 0, static_cast<size_t>(written_bytes));
-    } else {
+    } else if (records <= 4) {
         for (uint64_t record = 0; record < records; ++record)
             std::memcpy(destination + record * sizeof(pattern), pattern, sizeof(pattern));
+    } else {
+        alignas(64) uint8_t chunk[4096];
+        for (size_t i = 0; i < sizeof(chunk); i += sizeof(pattern))
+            std::memcpy(chunk + i, pattern, sizeof(pattern));
+        size_t offset = 0;
+        const size_t total_bytes = static_cast<size_t>(written_bytes);
+        while (offset + sizeof(chunk) <= total_bytes) {
+            std::memcpy(destination + offset, chunk, sizeof(chunk));
+            offset += sizeof(chunk);
+        }
+        if (offset < total_bytes)
+            std::memcpy(destination + offset, chunk, total_bytes - offset);
     }
     // Match the Vulkan path's conservative invalidation contract: padding beyond the exact launch
     // remains untouched, but every alias of the declared resource must be considered stale.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -2410,6 +2410,11 @@ struct VulkanComputeContext {
         found->second.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         found->second.graphics_export_command_order = producer_command_order;
         found->second.graphics_export_valid = true;
+        if (found->second.write_watch && !found->second.write_watch.rearm())
+            found->second.write_watch.reset();
+        if (!found->second.write_watch)
+            found->second.write_watch = prosper::host::GuestWriteWatch::create(
+                key.gpu_addr, key.guest_bytes);
         return true;
     }
 
@@ -2513,7 +2518,7 @@ struct VulkanComputeContext {
             }
             return false;
         }
-        if (exact_unchanged)
+        if (exact_unchanged || watch_unchanged)
             cached.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         cached.last_use = ++image_cache_clock;
         ++cached.pins;
@@ -2822,7 +2827,7 @@ struct VulkanComputeContext {
         // queries walk one record per host page and were slower than memcmp for Plucky's stable
         // post-process targets. A repeated result keeps one collision-free baseline; an identical
         // GPU skip never reaches this function, so that baseline is not recopied.
-        if (compute_transfer_watch) {
+        if (compute_transfer_watch || cached.graphics_export_valid) {
             if (cached.write_watch && !cached.write_watch.rearm())
                 cached.write_watch.reset();
             if (!cached.write_watch)
@@ -7744,6 +7749,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     *r, static_cast<uint32_t>(guest_bytes), image_format);
                 bi.cache_candidate =
                     compute_storage_cache_gate_candidate(storage_cache_gates);
+                if (r->gpu_addr == 0x204aee0000) {
+                    std::fprintf(stderr,
+                        "[diag-0x204aee0000] cache_candidate=%d (r_owned=%d dcc_safe=%d "
+                        "poison=%d exact=%d seed_skip=%d pers_en=%d)\n",
+                        (int)bi.cache_candidate,
+                        (int)storage_cache_gates.renderer_owned,
+                        (int)storage_cache_gates.dcc_cache_safe,
+                        (int)storage_cache_gates.poison_verify,
+                        (int)storage_cache_gates.exact_storage,
+                        (int)storage_cache_gates.seed_skip,
+                        (int)storage_cache_gates.persistent_enabled);
+                }
                 if (storage_gate_census_enabled()) {
                     // Report periodically as well as at exit: a bounded run ends in SIGTERM, whose
                     // default action skips atexit handlers entirely.
@@ -9359,6 +9376,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.write_skip) continue;
+            static const bool no_skip_export_writeback =
+                std::getenv("PROSPER_NO_EXPORTED_STORAGE_WRITEBACK_SKIP") != nullptr;
+            const bool skip_exported_writeback = !no_skip_export_writeback &&
+                bi.graphics_sampled_usage && bi.cache_candidate && bi.persistent &&
+                bi.seed_skip && !bi.poison_verify && !bi.mirror_result_to_imported;
+            if (skip_exported_writeback) continue;
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -10030,6 +10053,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  "[compute]   skipped untouched storage writeback binding=%u "
                                  "addr=0x%llx\n",
                                  bi.binding, (unsigned long long)bi.resource->gpu_addr);
+                continue;
+            }
+            static const bool no_skip_export_writeback =
+                std::getenv("PROSPER_NO_EXPORTED_STORAGE_WRITEBACK_SKIP") != nullptr;
+            const bool skip_exported_writeback = !no_skip_export_writeback &&
+                bi.graphics_sampled_usage && bi.cache_candidate && bi.persistent &&
+                bi.seed_skip && !bi.poison_verify && !bi.mirror_result_to_imported;
+            if (skip_exported_writeback) {
+                if (trace || (bi.resource && bi.resource->gpu_addr == 0x204aee0000)) {
+                    std::fprintf(stderr,
+                        "[compute]   skipped exported storage writeback binding=%u addr=0x%llx\n",
+                        bi.binding, (unsigned long long)bi.resource->gpu_addr);
+                }
+                if (bi.resource && bi.resource->gpu_addr) {
+                    notify_guest_gpu_write_preserving_bytes(bi.resource->gpu_addr, bi.guest_bytes);
+                }
                 continue;
             }
             const auto image_writeback_start = ComputeClock::now();
@@ -10959,7 +10998,7 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
     gates.single_mip_level = sampled_resource.declared_mip_levels == 1;
     gates.in_mip_tail = sampled_resource.in_mip_tail;
     gates.srgb = sampled_resource.srgb;
-    gates.depth_compare = sampled_resource.depth_compare;
+    gates.depth_compare = sampled_resource.depth_compare && !cube_array_alias;
     gates.native_format_defined = sampled_native_format != VK_FORMAT_UNDEFINED;
     const prosper::frontend::ComputeImageImportDecline decline =
         prosper::frontend::classify_compute_image_import(gates);

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5530,7 +5530,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // cached Partial and always seeds (safe).
     using prosper::frontend::SeedCoverage;
     using prosper::frontend::classify_seed_coverage;
+    using prosper::frontend::classify_near_full_coverage;
     using prosper::frontend::seed_coverage_name;
+    using prosper::frontend::seed_verdict_reprove_eligible;
     // #1127: 'prove once, trust forever' is unsound for a DATA-DEPENDENT store (full on the proving
     // frame, partial later). Re-prove a Full or None verdict every kSeedReproveInterval fast-skips: a shader
     // that ever covers partially is then re-cached Partial and always seeds, bounding the corruption
@@ -6701,11 +6703,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         bi.written_layers_mask = it->second.written_layers;
                         bi.near_full_coverage = it->second.near_full;
                         // #1127: periodically re-prove a Full, None, or layer-masked/near-full Partial verdict
-                        // so a data-dependent store that later changes coverage is caught. The helper resets
-                        // the counter, so concurrent dispatches on this key don't all re-prove at once.
-                        const bool partial_optimised = (it->second.cov == SeedCoverage::Partial) &&
-                            (it->second.written_layers != ~0ULL || it->second.near_full);
-                        if ((proven_full || proven_none || partial_optimised) &&
+                        // so a data-dependent store that later changes coverage is caught (#3328 B1/N2). The helper
+                        // resets the counter, so concurrent dispatches on this key don't all re-prove at once.
+                        if (seed_verdict_reprove_eligible(it->second.cov, it->second.written_layers, it->second.near_full) &&
                             seed_reprove_due(it->second.skips, kSeedReproveInterval))
                             reprove_due = true;
                     }
@@ -10233,10 +10233,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (r->depth > 1 && all_layers_written && !any_written_partial) {
                     cov = SeedCoverage::Full;
                 }
-                // Near-full threshold: permits up to 0.2% (1/500) unwritten texels for targets with >= 1000 texels.
-                // This accounts for small unwritten UI margins or minimap cutouts on 4K post-processing surfaces
-                // (e.g. ~16,000 unwritten margin texels on an ~8.3M 4K target is ~0.19%, just under the 0.2% bound).
-                const bool near_full = (survived == 0) || (texels >= 1000 && survived * 500 <= texels);
+                const bool near_full = classify_near_full_coverage(survived, texels);
                 bi.written_layers_mask = written_layers;
                 bi.near_full_coverage = near_full;
                 {

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -3876,25 +3876,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 resource_compute_image_hit);
                             if (!resource_compute_image_hit) compute_image_import = {};
                         }
-                        if (r.gpu_addr == 0x204aee0000) {
-                            const prosper::test::RenderVkCtx& render_context =
-                                prosper::test::render_vk_ctx();
-                            std::fprintf(stderr,
-                                "[diag-0x204aee0000] renderer candidate=%d import_ok=%d valid=%d "
-                                "fmt_match=%d (%u vs %u) size_match=%d (%ux%u vs %ux%u) "
-                                "depth_match=%d (%u vs %u) dev_match=%d hit=%d\n",
-                                (int)compute_image_candidate,
-                                compute_image_import.valid(),
-                                compute_image_import.valid() ? 1 : 0,
-                                compute_image_import.native_format == static_cast<uint32_t>(compute_image_format),
-                                compute_image_import.native_format, (unsigned)compute_image_format,
-                                (compute_image_import.width == tw && compute_image_import.height == th),
-                                compute_image_import.width, compute_image_import.height, tw, th,
-                                compute_image_import.depth == r.depth,
-                                compute_image_import.depth, r.depth,
-                                (render_context.ok && compute_image_import.device == static_cast<void*>(render_context.dev)),
-                                (int)resource_compute_image_hit);
-                        }
                         if (resource_compute_image_hit &&
                             compute_image_import.vertical_stack_layers == 6u) {
                             // The compute image is the exact five-face copy result. A later graphics

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -3448,11 +3448,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 prosper::test::select_persistent_ds_cube_depth(
                                     r.gpu_addr, tw, th);
                             retained_depth_cube_cache_candidate =
-                                retained_depth_cube.present_mask == 0x3fu &&
+                                retained_depth_cube.present_mask != 0 &&
                                 retained_depth_cube.overlay_version != 0;
                             if (retained_depth_cube_cache_candidate)
                                 decode_key.renderer_overlay_version =
-                                    retained_depth_cube.overlay_version;
+                                    (static_cast<uint64_t>(retained_depth_cube.present_mask) << 56) |
+                                    (retained_depth_cube.overlay_version & 0x00ffffffffffffffull);
                         }
                         const uint32_t persistent_pitch = PROSPER_ENV_VALUE("PROSPER_PITCH")
                             ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
@@ -3850,7 +3851,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             !has_live_rtt && !has_ds_live && r.cls == RC::Texture &&
                             compute_image_shape && !r.in_mip_tail &&
                             r.declared_mip_levels == 1u && !r.srgb &&
-                            !r.depth_compare && !r.host_data &&
+                            (!r.depth_compare || (r.img_dim == 3u && r.depth == 6u)) &&
+                            !r.host_data &&
                             compute_image_guest_bytes &&
                             (!r.compression_enabled || persistent_dcc_uncompressed) &&
                             compute_image_format != VK_FORMAT_UNDEFINED;
@@ -3873,6 +3875,25 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             prosper::frontend::live_compute_record_image_borrow_renderer_verdict(
                                 resource_compute_image_hit);
                             if (!resource_compute_image_hit) compute_image_import = {};
+                        }
+                        if (r.gpu_addr == 0x204aee0000) {
+                            const prosper::test::RenderVkCtx& render_context =
+                                prosper::test::render_vk_ctx();
+                            std::fprintf(stderr,
+                                "[diag-0x204aee0000] renderer candidate=%d import_ok=%d valid=%d "
+                                "fmt_match=%d (%u vs %u) size_match=%d (%ux%u vs %ux%u) "
+                                "depth_match=%d (%u vs %u) dev_match=%d hit=%d\n",
+                                (int)compute_image_candidate,
+                                compute_image_import.valid(),
+                                compute_image_import.valid() ? 1 : 0,
+                                compute_image_import.native_format == static_cast<uint32_t>(compute_image_format),
+                                compute_image_import.native_format, (unsigned)compute_image_format,
+                                (compute_image_import.width == tw && compute_image_import.height == th),
+                                compute_image_import.width, compute_image_import.height, tw, th,
+                                compute_image_import.depth == r.depth,
+                                compute_image_import.depth, r.depth,
+                                (render_context.ok && compute_image_import.device == static_cast<void*>(render_context.dev)),
+                                (int)resource_compute_image_hit);
                         }
                         if (resource_compute_image_hit &&
                             compute_image_import.vertical_stack_layers == 6u) {
@@ -5504,19 +5525,61 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             (void)cube_error;
                             if (complete && texture_pixels.size() >=
                                     static_cast<size_t>(tw) * th * 6u * 4u) {
+                                const bool ctiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) &&
+                                    !PROSPER_ENV_VALUE("PROSPER_NODETILE");
+                                auto face_base = [&](uint32_t face, size_t selected_span) {
+                                    const uint64_t stride = r.layer_stride_bytes
+                                        ? r.layer_stride_bytes : selected_span;
+                                    return r.gpu_addr + static_cast<uint64_t>(face) * stride;
+                                };
                                 for (uint32_t face = 0; face < 6u; ++face) {
                                     const std::vector<float>& src = faces[face];
                                     uint8_t* dst = texture_pixels.data() +
                                         static_cast<size_t>(face) * tw * th * 4u;
-                                    for (size_t i = 0; i < static_cast<size_t>(tw) * th &&
-                                                       i < src.size(); ++i) {
-                                        float d = src[i];
-                                        d = d < 0.0f ? 0.0f : (d > 1.0f ? 1.0f : d);
-                                        const uint8_t q = static_cast<uint8_t>(d * 255.0f + 0.5f);
-                                        dst[i * 4 + 0] = q;
-                                        dst[i * 4 + 1] = q;
-                                        dst[i * 4 + 2] = q;
-                                        dst[i * 4 + 3] = 0xffu;
+                                    if (!src.empty()) {
+                                        for (size_t i = 0; i < static_cast<size_t>(tw) * th &&
+                                                           i < src.size(); ++i) {
+                                            float d = src[i];
+                                            d = d < 0.0f ? 0.0f : (d > 1.0f ? 1.0f : d);
+                                            const uint8_t q = static_cast<uint8_t>(d * 255.0f + 0.5f);
+                                            dst[i * 4 + 0] = q;
+                                            dst[i * 4 + 1] = q;
+                                            dst[i * 4 + 2] = q;
+                                            dst[i * 4 + 3] = 0xffu;
+                                        }
+                                    } else {
+                                        const uint32_t source_bpt = bpt ? bpt : 2u;
+                                        const size_t linear_bytes = static_cast<size_t>(tw) * th * source_bpt;
+                                        const size_t surface_bytes = ctiled
+                                            ? prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, source_bpt)
+                                            : linear_bytes;
+                                        const uint64_t selected_addr = face_base(face, surface_bytes);
+                                        std::vector<uint8_t> traw(surface_bytes, 0);
+                                        const size_t got = copy_resource(traw.data(), selected_addr, surface_bytes);
+                                        std::vector<uint8_t> linear(linear_bytes, 0);
+                                        if (got >= linear.size() && ctiled) {
+                                            prosper::gpu::detile_surface(
+                                                linear.data(), traw.data(), tw, th, r.tile_mode, 0, source_bpt);
+                                        } else if (got >= linear.size()) {
+                                            std::memcpy(linear.data(), traw.data(), linear.size());
+                                        }
+                                        if (got >= linear.size()) {
+                                            const uint16_t* u16 = reinterpret_cast<const uint16_t*>(linear.data());
+                                            for (size_t i = 0; i < static_cast<size_t>(tw) * th; ++i) {
+                                                const uint8_t q = static_cast<uint8_t>((u16[i] >> 8) & 0xffu);
+                                                dst[i * 4 + 0] = q;
+                                                dst[i * 4 + 1] = q;
+                                                dst[i * 4 + 2] = q;
+                                                dst[i * 4 + 3] = 0xffu;
+                                            }
+                                        } else {
+                                            for (size_t i = 0; i < static_cast<size_t>(tw) * th; ++i) {
+                                                dst[i * 4 + 0] = 0xffu;
+                                                dst[i * 4 + 1] = 0xffu;
+                                                dst[i * 4 + 2] = 0xffu;
+                                                dst[i * 4 + 3] = 0xffu;
+                                            }
+                                        }
                                     }
                                 }
                                 cube_depth_bridged = true;

--- a/prosper/frontends/shared/texture/seed_reprove.hpp
+++ b/prosper/frontends/shared/texture/seed_reprove.hpp
@@ -68,4 +68,22 @@ constexpr const char* seed_coverage_name(SeedCoverage cov) {
     return "unknown";
 }
 
+// Near-full coverage classification: permits up to 0.2% (1/500) unwritten texels for targets with >= 1000 texels.
+// This accounts for small unwritten UI margins or minimap cutouts on 4K post-processing surfaces
+// (e.g. ~16,000 unwritten margin texels on an ~8.3M 4K target is ~0.19%, just under the 0.2% bound).
+constexpr bool classify_near_full_coverage(size_t survived, size_t texels) {
+    return (survived == 0) || (texels >= 1000 && survived * 500 <= texels);
+}
+
+// Determines whether a cached seed verdict should participate in periodic re-proving.
+// In addition to Full and None, any Partial verdict that carries an active optimization
+// (a non-default layer mask or near-full coverage bypass) must periodically re-prove so
+// that data-dependent stores changing which layers/texels are written do not remain stale
+// beyond one reprove interval (#3328 B1/N2).
+constexpr bool seed_verdict_reprove_eligible(SeedCoverage cov, uint64_t written_layers, bool near_full) {
+    if (cov == SeedCoverage::Full || cov == SeedCoverage::None) return true;
+    if (cov == SeedCoverage::Partial && (written_layers != ~0ULL || near_full)) return true;
+    return false;
+}
+
 }  // namespace prosper::frontend

--- a/prosper/frontends/shared/texture/seed_reprove.hpp
+++ b/prosper/frontends/shared/texture/seed_reprove.hpp
@@ -86,4 +86,61 @@ constexpr bool seed_verdict_reprove_eligible(SeedCoverage cov, uint64_t written_
     return false;
 }
 
+// Per-layer written mask for an array storage image, and whether that mask is EXACT.
+//
+// The mask is a 64-bit bitmap, so it cannot name a layer above 63. The first version of this
+// computation fell back to `written_layers = (survived < texels) ? 1 : 0` for such resources -- bit 0
+// used as a boolean -- and that is not a conservative approximation, it is a wrong mask: the retile
+// and pack consumers read bit `layer`, so a fully-written 100-layer array had layers 1..63 skipped as
+// "untouched" while layers 64..99 fell through the `layer < 64` guard and were written from scratch
+// that is deliberately allocated without zero-fill. Silent guest-memory corruption, default-on.
+//
+// There is no honest per-layer answer above 64 layers, so this returns the NO-MASKING sentinel
+// `~0ULL` -- the value every consumer already understands as "the optimization is off" -- and marks
+// the result inexact. `exact` exists because a sentinel mask must never be mistaken for a proof:
+// `~0ULL` would otherwise compare equal to "every layer written" and promote coverage to Full on a
+// surface nothing was known about. The same applies when per-layer counts are unavailable
+// (`layer_texels == 0`), which had the identical defect for any depth.
+struct ArrayLayerCoverage {
+    uint64_t written_layers = ~0ULL;   // ~0ULL == no masking
+    bool any_written_partial = false;
+    bool exact = false;                // false => the bits are a sentinel, not a measurement
+};
+
+inline ArrayLayerCoverage classify_array_layer_coverage(uint32_t depth,
+                                                        const size_t* layer_survived,
+                                                        size_t layer_texels,
+                                                        size_t survived, size_t texels) {
+    ArrayLayerCoverage out{};
+    if (depth > 1 && depth <= 64 && layer_texels > 0 && layer_survived) {
+        out.written_layers = 0;
+        for (uint32_t l = 0; l < depth; ++l) {
+            if (layer_survived[l] < layer_texels) {
+                out.written_layers |= (1ULL << l);
+                if (layer_survived[l] > 0) out.any_written_partial = true;
+            }
+        }
+        out.exact = true;
+        return out;
+    }
+    out.any_written_partial = (survived > 0 && survived < texels);
+    if (depth > 1) {          // > 64 layers, or no per-layer counts: disable the optimization
+        out.written_layers = ~0ULL;
+        out.exact = false;
+        return out;
+    }
+    out.written_layers = (survived < texels) ? 1ULL : 0ULL;   // depth == 1: one bit IS the truth
+    out.exact = true;
+    return out;
+}
+
+// Whether every layer of an array is known written. Requires an EXACT mask: an inexact one is the
+// `~0ULL` sentinel, which would otherwise satisfy the all-ones comparison and promote a surface that
+// was never measured per layer. `depth == 64` needs the explicit all-ones constant because
+// `1ULL << 64` is undefined.
+constexpr bool array_all_layers_written(uint32_t depth, uint64_t written_layers, bool exact) {
+    if (!exact || depth <= 1 || depth > 64) return false;
+    return written_layers == ((depth == 64) ? ~0ULL : ((1ULL << depth) - 1));
+}
+
 }  // namespace prosper::frontend

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -2728,31 +2728,76 @@ bool guest_writable(uint64_t a, uint32_t n) {
     return true;
 #else
     // #2387: this is the arm the cache above exists for. Windows and macOS answer with a syscall
-    // per region; only here is the answer a text parse of the process's entire mapping table --
-    // fopen, then fgets + sscanf per line, per call. Uncached, that made guest_writable the
-    // dominant stdio cost on the render thread.
+    // per region; here on Linux the answer is /proc/self/maps. Parsing all writable ranges in one
+    // fast pass and assigning them to the range cache populates the cache for the entire generation,
+    // converting hundreds of stdio opens into nanosecond cache hits.
+    const uint64_t gen = host::guest_mapping_generation();
     ++g_guest_writable_cache.os_probes;
-    FILE* maps = fopen("/proc/self/maps", "re");
-    if (!maps) return false;
-    uint64_t cursor = a;
-    char line[512];
-    while (cursor < end && fgets(line, sizeof line, maps)) {
-        unsigned long long begin = 0, finish = 0;
-        char perms[5] = {};
-        if (sscanf(line, "%llx-%llx %4s", &begin, &finish, perms) != 3 || finish <= cursor)
-            continue;
-        if (begin > cursor || perms[1] != 'w' || finish <= begin) {
-            fclose(maps);
-            return false;
+    int fd = open("/proc/self/maps", O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return false;
+
+    std::vector<host::GuestReadableRange> writable_ranges;
+    writable_ranges.reserve(256);
+    char buf[16384];
+    char line[4096];
+    size_t line_len = 0;
+    ssize_t bytes_read = 0;
+
+    while ((bytes_read = read(fd, buf, sizeof(buf))) > 0) {
+        for (ssize_t i = 0; i < bytes_read; ++i) {
+            char c = buf[i];
+            if (c == '\n') {
+                line[line_len] = '\0';
+                const char* p = line;
+                uint64_t begin = 0, finish = 0;
+                while (*p && *p != '-') {
+                    char h = *p++;
+                    uint64_t v = (h >= '0' && h <= '9') ? (h - '0') : (h >= 'a' && h <= 'f') ? (h - 'a' + 10) : 0;
+                    begin = (begin << 4) | v;
+                }
+                if (*p == '-') {
+                    ++p;
+                    while (*p && *p != ' ') {
+                        char h = *p++;
+                        uint64_t v = (h >= '0' && h <= '9') ? (h - '0') : (h >= 'a' && h <= 'f') ? (h - 'a' + 10) : 0;
+                        finish = (finish << 4) | v;
+                    }
+                    if (*p == ' ') {
+                        ++p;
+                        if (p[0] && p[1] == 'w' && finish > begin) {
+                            begin = std::max(begin, (uint64_t)0x1000);
+                            if (finish > begin) {
+                                if (!writable_ranges.empty() && writable_ranges.back().end == begin) {
+                                    writable_ranges.back().end = finish;
+                                } else {
+                                    writable_ranges.push_back({begin, finish});
+                                }
+                            }
+                        }
+                    }
+                }
+                line_len = 0;
+            } else {
+                if (line_len < sizeof(line) - 1) {
+                    line[line_len++] = c;
+                }
+            }
         }
-        if (cursor == a) span_lo = std::max((uint64_t)begin, (uint64_t)0x1000);
-        span_hi = finish;
-        cursor = std::min(end, static_cast<uint64_t>(finish));
     }
-    fclose(maps);
-    if (cursor != end) return false;
-    cache_guest_writable_range(span_lo, span_hi);   // #2387
-    return true;
+    close(fd);
+
+    bool found = false;
+    for (const auto& r : writable_ranges) {
+        if (r.begin <= a && end <= r.end) {
+            found = true;
+            break;
+        }
+    }
+
+    if (found && g_guest_writable_cache.enabled) {
+        g_guest_writable_cache.ranges.assign_sorted_ranges(std::move(writable_ranges), gen);
+    }
+    return found;
 #endif
 }
 

--- a/prosper/src/host/memory/guest_memory_map.hpp
+++ b/prosper/src/host/memory/guest_memory_map.hpp
@@ -84,6 +84,13 @@ public:
     size_t range_count() const { return ranges_.size(); }
     uint64_t generation() const { return generation_; }
 
+    void assign_sorted_ranges(std::vector<GuestReadableRange> ranges, uint64_t generation) {
+        ranges_ = std::move(ranges);
+        generation_ = generation;
+        last_hit_ = {};
+        have_last_hit_ = false;
+    }
+
 private:
     std::vector<GuestReadableRange> ranges_;
     GuestReadableRange last_hit_;

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2257,6 +2257,7 @@ inline size_t persistent_color_target_count_ceiling(bool eviction_deferred) {
 inline PersistentColorTargetImage* find_persistent_color_target(
     uint64_t id, uint32_t width, uint32_t height, VkFormat format, bool require_valid = true) {
     if (!id) return nullptr;
+    format = backend_color_format(format);
     auto& cache = persistent_color_target_cache();
     auto found = cache.find({id, width, height, format});
     if (found == cache.end() || (require_valid && !found->second.valid)) return nullptr;
@@ -4421,6 +4422,7 @@ inline bool copy_persistent_color_target(uint64_t src_id, uint64_t dst_id, uint3
         VkMemoryRequirements ir{}; vkGetImageMemoryRequirements(ctx.dev, img, &ir);
         const VkDeviceSize limit = persistent_color_target_limit();
         const size_t count_limit = persistent_color_target_count_limit();
+        const size_t count_ceiling = persistent_color_target_count_ceiling(true);
         if (ir.size <= limit) {
             ++src->pin_count;
             while ((persistent_color_target_cache().size() > count_limit ||
@@ -4433,11 +4435,19 @@ inline bool copy_persistent_color_target(uint64_t src_id, uint64_t dst_id, uint3
         iai.allocationSize = ir.size;
         iai.memoryTypeIndex = render_memory_type(ctx.phys, ir.memoryTypeBits, 0);
         if (ir.size > limit || persistent_color_target_bytes() > limit - ir.size ||
-            persistent_color_target_cache().size() > count_limit ||
+            persistent_color_target_cache().size() > count_ceiling ||
             vkAllocateMemory(ctx.dev, &iai, nullptr, &imem) != VK_SUCCESS || !imem) {
             vkDestroyImage(ctx.dev, img, nullptr);
             persistent_color_target_cache().erase(dst_key);
-            error = "resolve destination exceeds the persistent target budget";
+            char buf[256];
+            snprintf(buf, sizeof(buf),
+                     "resolve destination exceeds budget (ir=%llu limit=%llu cur_bytes=%llu "
+                     "cache_size=%zu ceiling=%zu mem_type=%u)",
+                     (unsigned long long)ir.size, (unsigned long long)limit,
+                     (unsigned long long)persistent_color_target_bytes(),
+                     persistent_color_target_cache().size(), count_ceiling,
+                     iai.memoryTypeIndex);
+            error = buf;
             return false;
         }
         if (vkBindImageMemory(ctx.dev, img, imem, 0) != VK_SUCCESS) {
@@ -4680,7 +4690,7 @@ inline bool read_persistent_ds_cube_depth(uint64_t base, uint32_t width, uint32_
         if (!read_persistent_ds_depth(*found, width, height, faces[slice], error)) return false;
         ++slices_found;
     }
-    return slices_found == 6u;
+    return slices_found != 0;
 }
 
 // Retained depth faces produced after a compute image. GTA V builds each shadow cube by copying

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -806,6 +806,15 @@ int main() {
                   "per-layer mask is exact below 64 layers");
             CHECK(!array_all_layers_written(4, part.written_layers, part.exact),
                   "partially written array is not promoted");
+
+            // The ONE input where `exact` decides the answer. Below 64 the comparison is against
+            // (1<<depth)-1, which ~0ULL fails anyway; above 64 the depth guard returns first. So
+            // depth==64 with no per-layer counts is the only case that can catch a future edit
+            // deleting the `!exact ||` guard -- and without this arm, deleting it passes everything.
+            const auto d64_nocounts = classify_array_layer_coverage(64, nullptr, 0,
+                                                                    /*survived=*/10, /*texels=*/1024);
+            CHECK(!array_all_layers_written(64, d64_nocounts.written_layers, d64_nocounts.exact),
+                  "a depth-64 sentinel mask must not promote an unmeasured surface to Full");
         }
     }
 

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -702,6 +702,61 @@ int main() {
               "None coverage name contains NONE-COVERAGE");
         CHECK(std::string(seed_coverage_name(SeedCoverage::Partial)).find("PARTIAL-COVERAGE") != std::string::npos,
               "Partial coverage name contains PARTIAL-COVERAGE");
+
+        // #3328 B1/N2/N3: near-full coverage classification and reprove eligibility.
+        using prosper::frontend::classify_near_full_coverage;
+        using prosper::frontend::seed_verdict_reprove_eligible;
+
+        // classify_near_full_coverage:
+        CHECK(classify_near_full_coverage(0, 8294400),
+              "zero survivors classifies as near-full coverage");
+        CHECK(classify_near_full_coverage(0, 100),
+              "zero survivors on small target classifies as near-full coverage");
+        // Target < 1000 texels cannot be near-full unless 0 survived
+        CHECK(!classify_near_full_coverage(1, 999),
+              "sub-1000 texel target with 1 survivor is not near-full");
+        // 1000 texel target: 0.2% threshold is 2 texels (2 * 500 <= 1000)
+        CHECK(classify_near_full_coverage(2, 1000),
+              "1000 texels with 2 survivors clears 0.2% near-full bound");
+        CHECK(!classify_near_full_coverage(3, 1000),
+              "1000 texels with 3 survivors exceeds 0.2% near-full bound");
+        // 4K target (3840x2160 = 8,294,400 texels): minimap/cutout tolerance
+        CHECK(classify_near_full_coverage(16000, 8294400),
+              "4K target with 16000 unwritten texels (minimap cutout ~0.19%) classifies as near-full");
+        CHECK(!classify_near_full_coverage(17000, 8294400),
+              "4K target with 17000 unwritten texels (>0.2%) rejects near-full");
+
+        // seed_verdict_reprove_eligible (#3328 B1/N2):
+        // Full and None verdicts are always eligible for periodic re-proving
+        CHECK(seed_verdict_reprove_eligible(SeedCoverage::Full, ~0ULL, false),
+              "Full coverage verdict is reprove-eligible");
+        CHECK(seed_verdict_reprove_eligible(SeedCoverage::None, ~0ULL, false),
+              "None coverage verdict is reprove-eligible");
+        // Default Partial verdict (untouched, no active optimization) seeds every time, no re-proving needed
+        CHECK(!seed_verdict_reprove_eligible(SeedCoverage::Partial, ~0ULL, false),
+              "unoptimized Partial verdict does not re-prove (always seeds)");
+        // Partial verdict with active layer mask optimization MUST periodically re-prove (B1)
+        constexpr uint64_t kLayer0Only = 0x1ULL;
+        CHECK(seed_verdict_reprove_eligible(SeedCoverage::Partial, kLayer0Only, false),
+              "Partial verdict with layer mask is reprove-eligible (B1 bounds staleness)");
+        // Partial verdict with active near-full coverage bypass MUST periodically re-prove (N2)
+        CHECK(seed_verdict_reprove_eligible(SeedCoverage::Partial, ~0ULL, true),
+              "Partial verdict with near-full coverage is reprove-eligible (N2 bounds staleness)");
+        CHECK(seed_verdict_reprove_eligible(SeedCoverage::Partial, kLayer0Only, true),
+              "Partial verdict with both layer mask and near-full is reprove-eligible");
+
+        // B1 cycle verification: Partial with layer mask fires on interval and resets
+        {
+            uint32_t partial_skips = 0;
+            const bool eligible = seed_verdict_reprove_eligible(SeedCoverage::Partial, kLayer0Only, false);
+            CHECK(eligible, "layer-masked partial is eligible");
+            bool fired = false;
+            for (uint32_t i = 0; i < 3; ++i) {
+                if (eligible && seed_reprove_due(partial_skips, 3)) fired = true;
+            }
+            CHECK(fired && partial_skips == 0,
+                  "reprove_eligible Partial verdict fires re-proving at interval and resets counter");
+        }
     }
 
     // MinGW's lround dominates full-HD storage-image writeback. Prove the bounded integer path is

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -757,6 +757,56 @@ int main() {
             CHECK(fired && partial_skips == 0,
                   "reprove_eligible Partial verdict fires re-proving at interval and resets counter");
         }
+
+        // #3328 B2: the >64-layer array mask. Each arm below FAILS on the previous revision, which
+        // set `written_layers = (survived < texels) ? 1 : 0` for these resources -- bit 0 as a
+        // boolean. That is not a conservative approximation: the retile/pack consumers read bit
+        // `layer`, so layers 1..63 were skipped as untouched while layers >= 64 fell through the
+        // `layer < 64` guard and were written from non-zero-filled scratch.
+        {
+            using prosper::frontend::classify_array_layer_coverage;
+            using prosper::frontend::array_all_layers_written;
+
+            // A fully-written 100-layer array. Old code: written_layers == 1 (bit 0 only).
+            std::vector<size_t> none_survived(100, 0);
+            const auto deep_full = classify_array_layer_coverage(100, none_survived.data(), 64,
+                                                                 /*survived=*/0, /*texels=*/6400);
+            CHECK(deep_full.written_layers == ~0ULL,
+                  "depth>64 publishes the no-masking sentinel, never a bit-0 boolean");
+            CHECK(!deep_full.exact, "depth>64 mask is marked inexact");
+            CHECK(!array_all_layers_written(100, deep_full.written_layers, deep_full.exact),
+                  "an inexact sentinel mask must not promote coverage to Full");
+
+            // The dangerous direction: NOTHING written on a >64-layer array. A sentinel that were
+            // trusted would compare all-ones and promote an untouched surface to Full.
+            std::vector<size_t> all_survived(100, 64);
+            const auto deep_none = classify_array_layer_coverage(100, all_survived.data(), 64,
+                                                                 /*survived=*/6400, /*texels=*/6400);
+            CHECK(!array_all_layers_written(100, deep_none.written_layers, deep_none.exact),
+                  "untouched depth>64 array is never promoted to Full");
+            CHECK(!deep_none.any_written_partial, "untouched array reports no partial write");
+
+            // No per-layer counts (layer_texels == 0) had the identical defect at ANY depth.
+            const auto no_counts = classify_array_layer_coverage(8, nullptr, 0, 10, 100);
+            CHECK(no_counts.written_layers == ~0ULL && !no_counts.exact,
+                  "missing per-layer counts disable masking rather than approximate it");
+
+            // Exactly 64 layers still works and must not use the UB `1ULL << 64`.
+            std::vector<size_t> s64(64, 0);
+            const auto d64 = classify_array_layer_coverage(64, s64.data(), 16, 0, 1024);
+            CHECK(d64.exact && d64.written_layers == ~0ULL,
+                  "depth==64 computes a real all-ones mask");
+            CHECK(array_all_layers_written(64, d64.written_layers, d64.exact),
+                  "depth==64 fully written is promoted");
+
+            // Ordinary masked case still behaves: layers 0 and 2 of 4 written.
+            std::vector<size_t> mixed{0, 16, 0, 16};
+            const auto part = classify_array_layer_coverage(4, mixed.data(), 16, 32, 64);
+            CHECK(part.exact && part.written_layers == 0b0101ULL,
+                  "per-layer mask is exact below 64 layers");
+            CHECK(!array_all_layers_written(4, part.written_layers, part.exact),
+                  "partially written array is not promoted");
+        }
     }
 
     // MinGW's lround dominates full-HD storage-image writeback. Prove the bounded integer path is

--- a/prosper/tests/render/test_ds_layer_stride.cpp
+++ b/prosper/tests/render/test_ds_layer_stride.cpp
@@ -314,6 +314,33 @@ int main() {
               "a preserving write outside every plane of this surface invalidates nothing");
     }
 
+    // ---- 10. Cube depth selection accepts partial cubes (e.g. 5 faces in GTA V) ----------------
+    {
+        constexpr uint64_t kCubeBase = 0x2094ec0000ull;
+        constexpr uint32_t kW = 512, kH = 512;
+        auto& ds_cache = prosper::test::persistent_ds_cache();
+        for (uint32_t slice = 0; slice < 5u; ++slice) {
+            PersistentDsKey key{};
+            key.dr = kCubeBase;
+            key.dw = kCubeBase;
+            key.w = kW;
+            key.h = kH;
+            key.slice = slice;
+            auto& img = ds_cache[key];
+            img.depth_valid = true;
+            img.layout_initialized = true;
+            img.image = reinterpret_cast<VkImage>(static_cast<uintptr_t>(0x1234 + slice));
+            img.last_depth_write = 100 + slice;
+        }
+        const auto sel = prosper::test::select_persistent_ds_cube_depth(kCubeBase, kW, kH);
+        check(sel.present_mask == 0x1fu, "5-face cube reports present_mask 0x1f");
+        check(sel.overlay_version == 104, "overlay_version matches newest face last_depth_write");
+        for (uint32_t slice = 0; slice < 5u; ++slice) {
+            check(sel.faces[slice] != nullptr, "face 0..4 is populated");
+        }
+        check(sel.faces[5] == nullptr, "face 5 is null");
+    }
+
     if (failures) { std::fprintf(stderr, "== FAIL: %d ==\n", failures); return 1; }
     std::fprintf(stderr, "== PASS ==\n");
     return 0;

--- a/prosper/tests/shared/compute/test_compute_timing_selector.cpp
+++ b/prosper/tests/shared/compute/test_compute_timing_selector.cpp
@@ -126,6 +126,9 @@ int main() {
     cache_gates.renderer_owned = true;
     CHECK(!compute_storage_cache_gate_candidate(cache_gates),
           "renderer ownership blocks storage cache candidate");
+    cache_gates.seed_skip = true;
+    CHECK(compute_storage_cache_gate_candidate(cache_gates),
+          "seed skip overrides renderer ownership for storage cache candidate");
     cache_gates = cache_eligible;
     cache_gates.dcc_cache_safe = false;
     CHECK(!compute_storage_cache_gate_candidate(cache_gates),

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -245,12 +245,19 @@ def _compute_program_groups(records, limit=10, address_limit=8):
             continue
         group = groups.setdefault(program_hash, {
             "records": 0, "dispatches": 0, "total_ms": 0.0, "max_ms": 0.0,
+            "setup_ms": 0.0, "writeback_ms": 0.0, "dispatch_wait_ms": 0.0,
+            "gpu_device_ms": 0.0, "gpu_shader_ms": 0.0,
             "addresses": set(),
         })
         group["records"] += 1
         group["dispatches"] += dispatches
         group["total_ms"] += total_ms
         group["max_ms"] = max(group["max_ms"], total_ms)
+        group["setup_ms"] += float(record.get("setup_ms", 0.0))
+        group["writeback_ms"] += float(record.get("writeback_ms", 0.0))
+        group["dispatch_wait_ms"] += float(record.get("dispatch_wait_ms", 0.0))
+        group["gpu_device_ms"] += float(record.get("gpu_device_ms", 0.0))
+        group["gpu_shader_ms"] += float(record.get("gpu_shader_ms", 0.0))
         group["addresses"].add(address)
 
     ranked = []
@@ -560,9 +567,21 @@ def print_summary(summary):
         addresses = ",".join(group["addresses"])
         if group["address_count"] > len(group["addresses"]):
             addresses += f",+{group['address_count'] - len(group['addresses'])}"
+        parts = []
+        if group.get("setup_ms", 0.0) >= 0.05:
+            parts.append(f"setup={group['setup_ms']:.1f}ms")
+        if group.get("writeback_ms", 0.0) >= 0.05:
+            parts.append(f"wb={group['writeback_ms']:.1f}ms")
+        if group.get("dispatch_wait_ms", 0.0) >= 0.05:
+            parts.append(f"wait={group['dispatch_wait_ms']:.1f}ms")
+        if group.get("gpu_device_ms", 0.0) >= 0.05:
+            parts.append(f"dev={group['gpu_device_ms']:.1f}ms")
+        if group.get("gpu_shader_ms", 0.0) >= 0.05 and abs(group.get("gpu_shader_ms", 0.0) - group.get("gpu_device_ms", 0.0)) >= 0.05:
+            parts.append(f"shader={group['gpu_shader_ms']:.1f}ms")
+        breakdown_str = f" ({' '.join(parts)})" if parts else ""
         print(f"  {group['program_hash']} records={group['records']} "
               f"dispatches={group['dispatches']} total={group['total_ms']:.1f} ms "
-              f"mean={group['mean_ms']:.2f} ms max={group['max_ms']:.2f} ms "
+              f"mean={group['mean_ms']:.2f} ms max={group['max_ms']:.2f} ms{breakdown_str} "
               f"addresses={addresses}")
     if programs["groups_omitted"]:
         print(f"  ... {programs['groups_omitted']} lower-cost groups omitted")


### PR DESCRIPTION
## Summary

Optimizes compute writeback, multi-layer array handling, and memory tracking in GTA V (`PPSA04263`, RAGE engine) on Linux/AMD RADV:

1. **Multi-Layer / Cubemap Array Writeback & Seed Optimization** (Default):
   - For multi-layer storage images (`r->depth > 1`, such as Scaleform/glyph UI rasterizer `0x2042f4a600` targeting a 6-layer `512x512x6` cubemap array), track per-layer write coverage during proving frames.
   - For write-only shaders storing strictly to a subset of layers (layer 0 in `0x2042f4a600`), recognize unwritten layers as untouched.
   - In setup: skip redundant detiling and staging uploads for untouched layers.
   - In writeback: restrict packing, retiling (`tile_surface`), and dirty range notifications strictly to touched layers, eliminating 83.3% of redundant CPU tiling overhead across 50+ dispatches/sec.
   - Re-proving protection extends to Partial verdicts that carry non-`~0ULL` masks on `kSeedReproveInterval`.

2. **Near-Full Coverage & Cutout Writeback Bypass** (`PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1`):
   - Shaders with $\ge 99.8\%$ coverage (such as post-processing shaders `0x205b557400` and `0x205b574e00` that intentionally skip the static minimap/radar UI cutout) are classified as `near_full_coverage`.
   - With `PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1`, persistent targets sampled by graphics bypass CPU staging readback, packing, and retiling, allowing graphics to borrow the device `VkImage` directly.

3. **Bulk `/proc/self/maps` Range Caching & Chunked Memory Fill** (Default):
   - Bulk-cache writable memory mappings to avoid per-page `/proc/self/maps` parsing.
   - Fast AVX2 chunked fills for guest writable memory queries.

## Performance Impact

Measured on Linux AMD Radeon 8060S (RADV STRIX_HALO APU) with 5.0s bounded F8 `.prperf` captures in GTA V story mode prologue:

| Metric / Component | Baseline | After Changes | Delta | Configuration |
| :--- | :--- | :--- | :--- | :--- |
| **Guest Flips (FPS)** | 4.78 FPS | **6.92 FPS** | **+45%** | `PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1` |
| **Compute Execution Time** | 2,122.6 ms (51% of frame) | **765.8 ms** (22% of frame) | **-64% (-1,357 ms)** | `PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1` |
| **Shader `0x2042f4a600` (UI/Glyphs)** | 265.5 ms (wb: 205.0 ms) | **85.2 ms** (wb: **9.1 ms**) | **-95.6% writeback** | **Default** (layer-aware writeback) |
| **Shader `0x205b574e00` (SSAO/Post)** | 113.1 ms (wb: 77.7 ms) | **45.2 ms** (wb: **1.0 ms**) | **-98.7% writeback** | `PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1` |
| **Shader `0x205b557400` (Post)** | 78.7 ms (wb: 63.5 ms) | *Dropped from top 10* | **~-98% writeback** | `PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1` |

## Verification
- `test_game_compute`: 491/491 assertions PASS
- CTest suite (`decode_scratch`, `compute_image_borrow_census`, `guest_writable_cache`, `watch_mapping_generation`, `ds_layer_stride`, `compute_timing_selector_policy`): 100% PASS
