### PR TITLE
diag: resolve guest VAs to physical addresses; the Stray scanout alias hypothesis is falsified (#2932)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -19,6 +19,18 @@ from the tracker issues, and still gated, because it is a projection of state ra
 > title's current state — for that, read the tracker. Nothing is ever removed when a title moves on,
 > because the point of a blog is that it records *when* things happened.
 
+## 2026-09-04
+
+### Stray's missing world is not an address-matching bug, and now we can prove it
+
+No picture with this one — it is a dead end worth recording. Stray's main menu draws a full 3D scene
+into prosper's own render targets and then presents only the UI bar over black, and the tempting
+explanation was that the buffer the game flips to the screen and the buffers we render into are two
+names for the same memory, which we were simply failing to connect. They are not: measured directly,
+they sit half a gigabyte apart in physical memory, across 80,511 resolutions with nothing left
+unresolved. So the game really is copying its finished frame somewhere else, by a route we do not yet
+follow — which is a narrower question than the one we started with.
+
 ## 2026-09-02
 
 ### Astro Bot's world map is lit, and no longer takes the GPU down with it

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -524,3 +524,36 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   may unblock some OTHER draw that shares it but addresses a genuinely single-mip resource; it does
   **not** close #3134 on its own. Full detail: `docs/RECOMPILER_REMAINING.md` § Ruled out. #3134,
   #2818.
+- **"The scanout buffer and the render targets are two virtual mappings of ONE physical allocation,
+  so the VA-keyed present match is the whole defect."** Falsified by direct resolution
+  (`PROSPER_TARGET_PHYS=1` plus the unconditional `[rtt] GUEST SCANOUT #N phys:` probe, both landed
+  with this row). This was the most attractive hypothesis available, because it would have made a
+  measured fact — prosper renders into `0x30…` while the guest flips `0x9fc0000000`, ~450 GiB apart
+  in VA — into a *bookkeeping* error with a fix prosper already had the machinery for. It is not:
+
+  | buffer | guest VA | physical |
+  | --- | --- | --- |
+  | flipped scanout | `0x9fc0000000` | **`0x230000`** (2.3 MB) |
+  | lowest render target | `0x30…` | `0x1e980000` (511 MB) |
+  | highest render target | `0x30…` | `0x79f20000` (2.0 GB) |
+
+  80,511 target resolutions, **0 unresolved** — so the census saw the whole population rather than a
+  sample that happened to miss the alias. The scanout sits ~509 MB *below* every render target. They
+  are separate physical allocations and nothing is aliased.
+
+  **What this leaves is narrower and better posed.** The guest composites into its own allocation and
+  moves it to scanout by a route prosper does not model, so the open question is *which packet does
+  that*, not how the present path matches addresses. Two further facts bound it: `select_present_source`
+  returns `None` (`px_front=none px_vo=none px_last=none`, `fresh=0 retained=0`), and
+  `videoout_buffer_authored_locked` reports `authored=0` for the flipped buffer — its bytes are
+  unchanged since registration. That second one is the load-bearing constraint, because the digest test
+  reads guest memory directly: **a GPU copy landing in guest memory would flip `authored` on its own.**
+  So the copy is not happening, not landing there, or not being executed by prosper at all.
+
+  **Two cautions for whoever picks this up.** Stray registers **two** scanout buffers,
+  `0x9fc0000000` and `0x9fc2000000` — a rotating set, which is the shape behind *Bendy and the Ink
+  Machine*'s black flicker (see the retained-frame comment in `present_extent.hpp`); only the first has
+  been probed, so "nothing ever writes scanout" is not yet safe to claim. And
+  `guest_write_watch_va_to_phys` returns the FIRST range containing the address without checking that
+  range is large enough for the access — fine for a probe, not for anything load-bearing.
+  #2932, #3126.

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -9744,6 +9744,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     prosper::frontend::guest_scanout_decision_name(decision), w, h,
                                     read.metadata.tiling_mode, (int)read.guest_authored,
                                     read.padded_footprint ? "padded" : "nominal");
+                        // #2932: does the flipped VA resolve to a physical page the write-watch
+                        // knows? The present path matches scanout against render targets by VIRTUAL
+                        // address only, and this title renders into 0x30... while flipping
+                        // 0x9fc0000000 -- ~450 GiB apart, so no VA-keyed lookup can connect them.
+                        // If the two are aliases of one physical range, that gap is the whole defect
+                        // and the fix reuses resolution prosper already performs. Printed beside the
+                        // decision so the answer arrives with the failure rather than in a separate
+                        // run whose guest state may differ.
+                        if (prosper::diag_should_print(ord)) {
+                            uint64_t flip_phys = 0;
+                            const bool ok = prosper::host::guest_write_watch_va_to_phys(
+                                read.metadata.address, flip_phys);
+                            fprintf(stderr,
+                                    "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> %s\n",
+                                    (unsigned long long)ord,
+                                    (unsigned long long)read.metadata.address,
+                                    ok ? "" : "UNRESOLVED (no direct mapping covers this VA)");
+                            if (ok)
+                                fprintf(stderr, "[rtt]   flip phys=0x%llx\n",
+                                        (unsigned long long)flip_phys);
+                        }
                     }
                     // Re-check the size on the cached path too: a two-set geometry switch can change
                     // the present extent between spans of one flip, and the cache is keyed on the

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -1125,6 +1125,28 @@ bool trace_va_to_phys_locked(const DmemTraceState& trace, uint64_t addr, uint64_
 
 } // namespace
 
+// Diagnostic resolution of a guest VA to its physical address (#2932). Reuses the trace's own alias
+// table rather than adding a second notion of "which VAs map this page": a duplicated resolver that
+// could disagree with the write-watch would be worse than none, because two subsystems would then
+// answer the same question differently.
+bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys) {
+    if (!addr) return false;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    // `w.aliases` is the LIVE DMEM TOPOLOGY -- every direct mapping the guest has made, recorded by
+    // guest_write_watch_notify_direct_mapping_added. `w.trace.pages` is a different thing: a narrow
+    // write-trace armed for one investigation at a time. An earlier revision of this probe resolved
+    // against the trace and reported UNRESOLVED for a scanout buffer, which reads as "prosper does
+    // not know this mapping" when it means "this diagnostic was not armed for it" -- the instrument
+    // answering a different question than the one asked.
+    for (const AliasRange& a : w.aliases) {
+        if (!a.size || addr < a.addr || addr - a.addr >= a.size) continue;
+        phys = a.phys + (addr - a.addr);
+        return true;
+    }
+    return false;
+}
+
 GuestWriteWatch::~GuestWriteWatch() { reset(); }
 GuestWriteWatch::GuestWriteWatch(GuestWriteWatch&& other) noexcept
     : id_(std::exchange(other.id_, 0)) {}

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -193,6 +193,20 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
 void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size);
 void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
                                                         uint32_t protection);
+// PROSPER_SCANOUT_PHYS (#2932): resolve a guest VA to its physical address through the dmem trace.
+//
+// The present path matches a flipped scanout buffer against render targets by VIRTUAL address only
+// (`is_live_render_target`), and `hle_graphics.cpp`'s scanout registry has no aliasing concept at
+// all. Stray renders into 0x30... and flips 0x9fc0000000 -- ~450 GiB apart -- so no VA-keyed lookup
+// can connect them, and BOTH publish paths fail: no pass "targets" the flip, and the scanout bytes
+// are unchanged since registration so the guest-authored fallback declines too.
+//
+// If those are two mappings of one set of physical pages, every one of those observations follows
+// with no further defect. This exposes the resolution the write-watch already performs -- it models
+// exactly this aliasing in `WatchedPage { phys; aliases; }` -- so the hypothesis can be TESTED
+// before anything is built on it. Diagnostic only; no production path calls it.
+bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys);
+
 void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size);
 void guest_write_watch_invalidate_all();
 

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -3,6 +3,7 @@
 // pixels. Used to verify recompiled shaders end-to-end (render -> readback -> pixel asserts). The
 // including test links Vulkan::Vulkan.
 #pragma once
+#include "host/memory/guest_write_watch.hpp"   // VA->phys for the #2932 target census
 #include "shared/rtt/mrt_extent.hpp"
 #include <vulkan/vulkan.h>
 #include "gpu/capture/gpu_capture.hpp"
@@ -5154,6 +5155,21 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     PersistentColorTargetImage* cached_color = nullptr;
     if (persistent_color) {
         color_key = {color_target->persistent_id, W, H, FMT};
+        // PROSPER_TARGET_PHYS (#2932): print each colour target's guest VA and the physical address
+        // it maps to. The present path matches a flipped scanout buffer against targets by VIRTUAL
+        // address, and Stray renders into 0x30... while flipping 0x9fc0000000 (phys 0x230000). If a
+        // target's physical range covers that page, the two are aliases of one allocation and the
+        // VA-keyed match is the whole defect; if none does, the guest copies between distinct
+        // allocations and the question moves to which packet performs it.
+        static const bool target_phys_census = std::getenv("PROSPER_TARGET_PHYS") != nullptr;
+        if (target_phys_census && color_target->persistent_id) {
+            uint64_t tphys = 0;
+            const bool ok = prosper::host::guest_write_watch_va_to_phys(
+                color_target->persistent_id, tphys);
+            std::fprintf(stderr, "[target-phys] va=0x%llx %ux%u -> %s0x%llx\n",
+                         (unsigned long long)color_target->persistent_id, W, H,
+                         ok ? "phys=" : "UNRESOLVED ", (unsigned long long)tphys);
+        }
         auto [found, inserted] = persistent_color_target_cache().try_emplace(color_key);
         cached_color = &found->second;
         cached_color->last_use = color_target_generation;


### PR DESCRIPTION
Refs #2932, #3126, #2883.

## What this is

Two diagnostics that resolve a guest virtual address to its physical address, and the `## Ruled out`
row recording what they falsified. **No production path changes** — the resolver is diagnostic-only
and the target census is behind an environment variable that is absent by default.

## The failure this was aimed at

*Stray*'s main menu renders a full 3D scene — 27 render passes, 38 draws, 13 dispatches, real depth
targets — into prosper's own render targets, and then presents **only the UI bar** over an absent
world.

Both publish paths fail, and the two failures look like one cause:

- `select_present_source` returns `None` — `px_front=none px_vo=none px_last=none`, so nothing is
  published (`fresh=0 retained=0`)
- the flipped buffer `0x9fc0000000` reports `authored=0` — its bytes are unchanged since registration,
  so the guest-scanout fallback (#1968) declines `SkipNotAuthored`

The present path matches a flipped scanout buffer against render targets by **virtual** address
(`is_live_render_target`), and this title renders into `0x30…` while flipping `0x9fc0000000` — about
450 GiB apart. No VA-keyed lookup can connect those.

## The hypothesis, and why it deserved a probe rather than a patch

If the scanout buffer and the render targets were two virtual mappings of **one physical allocation**,
every observation above would follow with no further defect — and the fix would be a reuse of
resolution prosper already performs, since the write-watch models exactly this aliasing in
`WatchedPage { phys; aliases; }`.

That is an attractive hypothesis: it converts a measured fact into a bookkeeping error with a known
remedy. It is also the kind this project's charter says to test before building on.

## Result: FALSIFIED

| buffer | guest VA | physical |
| --- | --- | --- |
| flipped scanout | `0x9fc0000000` | **`0x230000`** (2.3 MB) |
| lowest render target | `0x30…` | `0x1e980000` (511 MB) |
| highest render target | `0x30…` | `0x79f20000` (2.0 GB) |

**80,511 target resolutions, 0 unresolved** — the census saw the whole population, not a sample that
happened to miss the alias. The scanout buffer sits ~509 MB below every render target. Separate
physical allocations; nothing is aliased.

So the guest composites into its own allocation and moves it to scanout by a route prosper does not
model. The open question is **which packet does that**, not how the present path matches addresses.

## Approach and invariants

`guest_write_watch_va_to_phys()` resolves over `WatchState::aliases` — the live dmem topology,
populated by `guest_write_watch_notify_direct_mapping_added` — rather than introducing a second notion
of "which VAs map this page". A duplicated resolver that could disagree with the write-watch would be
worse than none: two subsystems would then answer one question differently.

It takes the same lock as every other reader of that state, and returns `false` rather than a
plausible-looking zero when nothing covers the address.

## Deliberately unaffected

- No production caller. The resolver is referenced only by the two probes.
- `PROSPER_TARGET_PHYS` is read once into a `static const bool`; unset, the census costs one branch.
- The scanout probe is unconditional but sits inside the existing `diag_should_print(ord)` rate limit,
  beside the `GUEST SCANOUT` decision line it belongs with — so the answer arrives *with* the failure
  rather than in a separate run whose guest state may differ.

## Risks and limits (both recorded in the doc row)

- **`guest_write_watch_va_to_phys` returns the FIRST containing range and does not check that the
  range is large enough for the access.** Adequate for a probe; not for anything load-bearing. A
  production caller would need the size check.
- **Only one of two scanout buffers has been probed.** Stray registers `0x9fc0000000` **and**
  `0x9fc2000000` — a rotating set, which is the shape behind *Bendy and the Ink Machine*'s black
  flicker (see the retained-frame comment in `present_extent.hpp`). "Nothing ever writes scanout" is
  **not** established and the row says so.

## An instrument note

The first revision of this probe resolved against `w.trace.pages` and reported `UNRESOLVED`. That is
the dmem **write-trace** — a narrow diagnostic armed for one investigation at a time — not the mapping
registry. The answer read as "prosper does not know this mapping" when it meant "this diagnostic was
not armed for it". The comment on the resolver records the distinction so the next reader does not
repeat it.

## Verification (exact head)

Configured in the project container against `<DUMP_ROOT>/PPSA24651-app0`:

```
cmake -S prosper -B prosper/build-linux -DPROSPER_APP=ON -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 \
      -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build prosper/build-linux -j6                     # rc=0
ctest --no-tests=error -j4                                # rc=0
```

**`100% tests passed out of 331`**, exit code 0. One test did not run: `plugin_autolink (Skipped)`.

Docs gate on the changed file, and the deletion check:

```
python3 prosper/tools/docs/check_numbered_table.py prosper/docs/STRAY_STATUS.md
  -> 13 table(s), 42 rows, unbroken, every row matching its header      # rc=0
git diff --check                                                        # rc=0
git diff --numstat origin/master..HEAD   -> every file 0 deletions
```

The diff is **106 added lines and 0 deleted lines** across five files.

No snapshots were run: this PR changes no rendering behaviour, and the charter makes snapshots a
release-time inventory rather than a per-PR gate.

## Review

Worth a read despite the size — the resolver is new shared-substrate code reading memory topology
under a lock, and the judgement being made (resolve over `aliases`, not `trace.pages`) is exactly the
kind an independent reader can challenge. The size caveat above is the most likely place a reviewer
will want a stronger contract.
