### PR TITLE
diag: census guest VA->physical across all colour slots; prosper renders INTO Stray's scanout buffers (#2932)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,16 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-04
 
+### Stray's missing world is not an address-matching bug, and now we can prove it
+
+No picture with this one — it is a dead end worth recording. Stray's main menu draws a full 3D scene
+into prosper's own render targets and then presents only the UI bar over black, and the tempting
+explanation was that the buffer the game flips to the screen and the buffers we render into are two
+names for the same memory, which we were simply failing to connect. They are not: measured directly,
+they sit half a gigabyte apart in physical memory, across 80,511 resolutions with nothing left
+unresolved. So the game really is copying its finished frame somewhere else, by a route we do not yet
+follow — which is a narrower question than the one we started with.
+
 ### RenderDoc works on prosper now, and the first capture was a beautiful picture of the wrong thing
 
 No picture — or rather 56 of them, all useless. RenderDoc has been installed the whole time and

--- a/BLOG.md
+++ b/BLOG.md
@@ -27,9 +27,9 @@ No picture with this one — it is a dead end worth recording. Stray's main menu
 into prosper's own render targets and then presents only the UI bar over black, and the tempting
 explanation was that the buffer the game flips to the screen and the buffers we render into are two
 names for the same memory, which we were simply failing to connect. They are not: measured directly,
-they sit half a gigabyte apart in physical memory, across 80,511 resolutions with nothing left
-unresolved. So the game really is copying its finished frame somewhere else, by a route we do not yet
-follow — which is a narrower question than the one we started with.
+the two sit half a gigabyte apart in physical memory. So the game really is copying its finished
+frame somewhere else, by a route we do not yet follow — which is a narrower question than the one we
+started with.
 
 ### RenderDoc works on prosper now, and the first capture was a beautiful picture of the wrong thing
 

--- a/BLOG.md
+++ b/BLOG.md
@@ -21,15 +21,16 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-04
 
-### Stray renders its title screen straight into the display buffer, and the world still is not there
+### Stray's world is not going missing on the way to the screen — it arrives, and rounds to black
 
-No picture worth showing — the frame is the menu over black, which is what it has been. The finding
-is what sits behind it. We had assumed the game composed its picture in one place and copied it to
-the buffer the screen reads, and that prosper was losing the copy. Measuring every render target this
-time, rather than only the first one, says otherwise: the two display buffers *are* render targets,
-and prosper draws into them nearly a thousand times in a run that still shows an empty screen. So
-nothing is being lost in transit. Either only the menu is ever drawn there, or the world is drawn and
-then wiped — and those two are quick to tell apart.
+No picture worth showing: the frame is still the menu over black. The finding is what sits behind it.
+We had assumed the game built its picture in one place and copied it to the buffer the screen reads,
+and that we were losing the copy. Measuring every render target this time, rather than only the
+first, says otherwise — the two display buffers are themselves render targets, attached to passes
+that carry thousands of draws. Nothing is being lost in transit. What the existing pixel traces
+already showed, and what this reframes, is that the world's colour reaches the end of the pipeline so
+faint that storing it rounds it to zero. So the question stops being "where did the picture go" and
+becomes "why is it arriving that dim", which is a much better question to be stuck on.
 
 ### RenderDoc works on prosper now, and the first capture was a beautiful picture of the wrong thing
 

--- a/BLOG.md
+++ b/BLOG.md
@@ -27,7 +27,7 @@ No picture worth showing: the frame is still the menu over black. The finding is
 We had assumed the game built its picture in one place and copied it to the buffer the screen reads,
 and that we were losing the copy. Measuring every render target this time, rather than only the
 first, says otherwise — the two display buffers are themselves render targets, attached to passes
-that carry thousands of draws. Nothing is being lost in transit. What the existing pixel traces
+that carry draws. Nothing is being lost in transit. What the existing pixel traces
 already showed, and what this reframes, is that the world's colour reaches the end of the pipeline so
 faint that storing it rounds it to zero. So the question stops being "where did the picture go" and
 becomes "why is it arriving that dim", which is a much better question to be stuck on.

--- a/BLOG.md
+++ b/BLOG.md
@@ -21,15 +21,15 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-04
 
-### Stray's missing world is not an address-matching bug, and now we can prove it
+### Stray renders its title screen straight into the display buffer, and the world still is not there
 
-No picture with this one — it is a dead end worth recording. Stray's main menu draws a full 3D scene
-into prosper's own render targets and then presents only the UI bar over black, and the tempting
-explanation was that the buffer the game flips to the screen and the buffers we render into are two
-names for the same memory, which we were simply failing to connect. They are not: measured directly,
-the two sit half a gigabyte apart in physical memory. So the game really is copying its finished
-frame somewhere else, by a route we do not yet follow — which is a narrower question than the one we
-started with.
+No picture worth showing — the frame is the menu over black, which is what it has been. The finding
+is what sits behind it. We had assumed the game composed its picture in one place and copied it to
+the buffer the screen reads, and that prosper was losing the copy. Measuring every render target this
+time, rather than only the first one, says otherwise: the two display buffers *are* render targets,
+and prosper draws into them nearly a thousand times in a run that still shows an empty screen. So
+nothing is being lost in transit. Either only the menu is ever drawn there, or the world is drawn and
+then wiped — and those two are quick to tell apart.
 
 ### RenderDoc works on prosper now, and the first capture was a beautiful picture of the wrong thing
 

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -1447,51 +1447,78 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   shifted right by that same `v5` — so `Lod=0` remains the wrong answer. #3134, #2818.
 - **"The scanout buffer and the render targets are two virtual mappings of ONE physical allocation,
   so the VA-keyed present match is the whole defect."** Falsified across **every colour slot**, and
-  the run that falsified it also **falsified the premise the hypothesis was built on** — which is the
-  more useful half, so it is stated first.
+  the run that falsified it also **corrected the premise the hypothesis was built on**.
 
-  **prosper renders directly INTO the scanout buffers.** Both flipped VAs appear in the colour-target
-  census as ordinary 4K slot-0 persistent render targets, throughout the failing run:
+  **The scanout buffers are render targets.** Both flipped VAs appear in the colour-target census as
+  4K slot-0 persistent colour attachments, throughout the failing run (title route, steady state
+  confirmed by eye: menu over black at 8x brightness):
 
-  | target VA | physical | size | times seen |
-  | --- | --- | --- | --- |
-  | `0x9fc0000000` | `0x230000` | 3840x2160 | 946 |
-  | `0x9fc2000000` | `0x2210000` | 3840x2160 | 976 |
+  | flipped VA | physical | size | census lines | draws dropped `no-effect(early)` |
+  | --- | --- | --- | --- | --- |
+  | `0x9fc0000000` | `0x230000` | 3840x2160 | 946 | **1,143** |
+  | `0x9fc2000000` | `0x2210000` | 3840x2160 | 976 | **1,154** |
 
-  So the framing this row was originally written to support — *"prosper renders into `0x30…` while
-  the guest flips `0x9fc…`, ~450 GiB apart, and no VA-keyed lookup can connect them"* — **is wrong**.
-  The present path's VA-keyed lookup can see these buffers perfectly well, because they are live
-  render targets under their own VAs. Do not repeat that sentence; it is why this row exists.
+  **Read the census column precisely.** The line is printed after the empty-draw early-out, so it
+  means *this VA was bound as slot 0 of a pass carrying at least one draw*. It does **not** mean a
+  draw's output reached memory — masks, discards and store behaviour are all downstream. So the
+  correct statement is "the scanout buffers are attachments of passes that carry draws", not "prosper
+  renders into them".
 
-  **And the alias hypothesis is dead anyway**, now over the whole population rather than one slot.
-  Census over slots 0-6 (slot 7 unused): **55,868 resolutions, 0 unresolved, 82 distinct targets** —
-  80 in the `0x30…` family and the 2 scanout buffers above. Excluding the scanout buffers themselves,
-  the number of targets whose *physical extent* overlaps either scanout buffer is **0**, and the
-  nearest non-scanout target sits **390 MB** above them. Nothing is aliased.
+  So the framing this row originally supported — *"prosper renders into `0x30…` while the guest flips
+  `0x9fc…`, ~450 GiB apart, so no VA-keyed lookup can connect them"* — **is withdrawn**. Those VAs
+  are not a region the renderer never touches.
 
-  The slot coverage is load-bearing and was added after review: **24% of resolutions (13,669) are in
-  slots 1-6**, which a slot-0-only census cannot see. That matters because `is_live_render_target`
-  consults `g_rtt`, and `g_rtt` is populated for every slot, so a slot-1..7 target aliasing the
-  scanout page would have been exactly the link the hypothesis proposed — in exactly the region the
-  narrower instrument was blind to.
+  **But do not swap it for the opposite error.** "The present path can therefore see them" is *also*
+  unmeasured. `guest_scanout_publishable` tests `renderer_owns_target` (a `g_rtt` hit on the flipped
+  VA) **first**, short-circuiting ahead of `guest_authored`, so a decline of `SkipNotAuthored` is
+  itself evidence that `g_rtt` did **not** hold the VA at that flip. The census (pass-render time) and
+  the publish check (flip time) are different moments and must not be read as one. The probe now
+  prints `rtt_owns=` and the decision name beside the physical address so this becomes a measurement.
 
-  **What this leaves is a better question than the one it replaces.** prosper renders into
-  `0x9fc0000000` 946 times in a run whose steady state is the menu over black (visually confirmed:
-  `START GAME` / `SETTINGS` / `CREDITS` and the version string, everything else black at 8x
-  brightness). So the missing world is **not** a copy that never happens. Either the draws that reach
-  the scanout target carry only the UI, or the scene reaches it and is then cleared or overwritten.
-  That is answerable with the tools already in the tree — a PixelHistory on a world pixel of the
-  scanout target, which separates those two directly (see the note at the top of this file about
-  finding the brightest pixel rather than the centre).
+  **TWO REGIMES, and this row previously blurred them — the same mistake this file's own banner warns
+  about for `max_nonblack`.** They are different failure states and their evidence does not transfer:
 
-  It also removes a puzzle rather than adding one: if prosper renders into a *VkImage* keyed by the
-  scanout VA, guest memory at that VA need never be written, which is consistent with
-  `videoout_buffer_authored_locked` reporting `authored=0` without anything being wrong at all.
+  | regime | what publishes | where the `authored=0` / `SkipNotAuthored` evidence comes from |
+  | --- | --- | --- |
+  | **title screen** (measured here) | the menu **does** publish | *not this regime* |
+  | **main menu / first map** | nothing publishes (`fresh=0 retained=0`) | this one |
 
-  **Caveats a later reader needs.** `guest_write_watch_va_to_phys` returns the FIRST range containing
-  the address and does not check it is large enough for the access — fine for a probe, not for a
-  production caller. And `authored=0` still has four causes, not one; the earlier draft of this row
-  read it as "the bytes are unchanged since registration" and leaned on "a GPU copy would flip
-  `authored` by itself", which does not hold: `!buffer_digest_valid[slot]` means no baseline was ever
-  seeded, and a write covering none of the digest's sample points misses too, so **two** of the four
-  branches are a blind instrument rather than an absent write. #2932, #3126.
+  The guest-scanout fallback is gated on `guest_scanout_read_warranted(...) == Publish`, i.e. it runs
+  **only when nothing else published**. On the title route it is therefore never entered — measured:
+  **0** `[rtt] GUEST SCANOUT` lines across a full run that reached and held the failing steady state.
+  So `rtt_owns=` cannot be collected on this route at all, and every `authored=0` / `px_front=none`
+  fact in this section belongs to the *other* regime. Quote them with the regime attached.
+
+  **The alias hypothesis is dead**, now over the population rather than one slot: **55,868
+  resolutions, 0 unresolved, 82 distinct targets** across slots 0-6. Excluding the scanout buffers
+  themselves, targets whose *physical extent* overlaps either scanout buffer: **0**; nearest is
+  **390 MB** away. The slot coverage was added after review and earned its keep — **24% of
+  resolutions (13,669) are in slots 1-6**, and since `is_live_render_target` consults `g_rtt`, which
+  is populated for every slot, an alias there would have been exactly the proposed link, in exactly
+  the region a slot-0 census cannot see. (One gap remains in "population": a *declined* MRT1 base
+  never sets `persistent_id1`, so it cannot reach the census.)
+
+  **What is left is a three-way question, and this file already answers part of it.** The two
+  tempting branches are "only the UI is ever drawn there" and "the scene is drawn and then wiped".
+  Neither is the branch already measured above: the scene **reaches** the target and is **stored as
+  black by magnitude** — PixelHistory has tonemap `shaderOut 0.001099` storing `0`, because
+  `0.001099 x 255 = 0.28` rounds to zero in `R8G8B8A8_UNORM`, and § *This is not a composite defect*
+  records that the draws run and write nothing. An A/B between the first two branches would exclude
+  the answer already in hand. The open part is why the value arriving at the store is that small, not
+  where the picture goes.
+
+  The strangest remaining fact, with its regime attached: **in the non-publishing regime**
+  `select_present_source` returns `None` (`px_front=none px_vo=none px_last=none`, `fresh=0
+  retained=0`) for buffers that — on the title route at least — are attachments of drawing passes.
+  Whether that also holds of the flipped buffer *in that regime* is untested, because the census and
+  those counters have not yet been collected in one run. That is the cheap next measurement.
+
+  This also dissolves a puzzle instead of deepening it: if prosper renders into a `VkImage` keyed by
+  the scanout VA, guest memory at that VA need never be written, which is consistent with
+  `videoout_buffer_authored_locked` reporting `authored=0` with nothing wrong at that point at all.
+
+  **Caveats.** `guest_write_watch_va_to_phys` returns the FIRST range containing the address without
+  checking it is large enough — fine for a probe, not for a production caller. And `authored=0` has
+  four causes, of which **two** are a blind instrument rather than an absent write
+  (`!buffer_digest_valid[slot]`, i.e. no baseline seeded; and a write covering none of the digest's
+  sample points), so `buffer_digest_valid` alone does not separate them. #2932, #3126.

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -1458,18 +1458,38 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   | lowest render target | `0x30…` | `0x1e980000` (511 MB) |
   | highest render target | `0x30…` | `0x79f20000` (2.0 GB) |
 
-  80,511 target resolutions, **0 unresolved** — so the census saw the whole population rather than a
-  sample that happened to miss the alias. The scanout sits ~509 MB *below* every render target. They
-  are separate physical allocations and nothing is aliased.
+  80,511 target resolutions, **0 unresolved** — every VA the census was shown did resolve, so the
+  answers above are real rather than a resolver failing quietly. The scanout sits ~509 MB *below*
+  every render target: separate physical allocations, nothing aliased.
+
+  **What that number does NOT say is "the whole population".** The census reads
+  `color_target->persistent_id` — colour **slot 0 only**. `persistent_id1` and
+  `persistent_id_slots[2..7]` are separate guest VAs and are never censused, and 80,511 counts
+  invocations rather than distinct addresses. An alias hiding in an un-censused MRT slot is exactly
+  what the hypothesis predicts and exactly what this instrument cannot see, so the falsification is
+  **scoped to slot 0** — which is the slot the composite is built in, and enough to stop the
+  VA-keyed-match story, but not a proof about every surface the frame renders into.
 
   **What this leaves is narrower and better posed.** The guest composites into its own allocation and
   moves it to scanout by a route prosper does not model, so the open question is *which packet does
   that*, not how the present path matches addresses. Two further facts bound it: `select_present_source`
   returns `None` (`px_front=none px_vo=none px_last=none`, `fresh=0 retained=0`), and
-  `videoout_buffer_authored_locked` reports `authored=0` for the flipped buffer — its bytes are
-  unchanged since registration. That second one is the load-bearing constraint, because the digest test
-  reads guest memory directly: **a GPU copy landing in guest memory would flip `authored` on its own.**
-  So the copy is not happening, not landing there, or not being executed by prosper at all.
+  `videoout_buffer_authored_locked` reports `authored=0` for the flipped buffer.
+
+  **Read that second one carefully — it is weaker than it first looks, and an earlier draft of this
+  row overstated it.** The tempting reading is "the bytes are unchanged since registration, and since
+  the digest test reads guest memory directly, a GPU copy landing there would have flipped `authored`
+  by itself". The predicate has **four** ways to return false (`hle_graphics.cpp`), and one of them
+  breaks that inference: `!buffer_digest_valid[slot]`, i.e. **no baseline was ever seeded** — which is
+  what happens when the buffer was not readable at registration time, and the seeding path documents
+  the resulting state as *deliberately indistinguishable from "not written"*. With no baseline, a copy
+  of any size leaves `authored` at 0.
+
+  So the honest disjunction has a fourth branch: the copy is **not happening**, **not landing there**,
+  **not executed by prosper at all**, or **it happened and prosper cannot tell**. Separating the last
+  one from the first three is cheap — check `buffer_digest_valid` for the slot — and should be the
+  first step for whoever picks this up, because three of the four branches are a missing packet and
+  the fourth is a blind instrument.
 
   **Two cautions for whoever picks this up.** Stray registers **two** scanout buffers,
   `0x9fc0000000` and `0x9fc2000000` — a rotating set, which is the shape behind *Bendy and the Ink

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -1509,12 +1509,22 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   the failing steady state — and that is honestly reported as **never reached**, not as evidence of
   what published. A draft of this row inferred "the menu therefore publishes" from the zero count;
   that inference is withdrawn, having violated a precedent written into the header it reasoned about.
-  **The publishing claim rests on the frame instead** — and the artifact has to be named, because
-  which buffer was dumped is the whole strength of it. These are `tools/screenshot` PNGs, which come
-  from `present_readback`, which returns what `present_write_frame` wrote
-  (`gpu_executor.cpp:11780`/`:11927`). So a menu-bearing PNG is direct evidence that **a frame was
-  published to the present layer** — the publication itself, not an inference from a decline that
-  never printed.
+  **The publishing claim rests on the frame instead** — and it rests on the frame's RECORDED SOURCE,
+  not on the image. `tools/screenshot` captures through `present_snapshot`, which **falls back to the
+  guest's own display buffer** when the renderer published nothing (`videoout_present.cpp:187-196`,
+  returning `RawScanout`), and saves it by default (`render_first` defaults to 0). So a menu-bearing
+  PNG on its own proves nothing: the guest composites its menu into `0x9fc0000000` itself, and that
+  image would look identical.
+
+  The discriminator is recorded per capture, so no re-run is needed. Across both title-route runs the
+  manifest reports **29 of 30 captures as `composited`** (`CaptureSource::Rendered`) with only index 0
+  — the all-black first frame — as `raw_scanout`. The steady-state menu frame examined by eye is
+  `composited`. **That** is the evidence a frame was published: prosper composited it, rather than the
+  tool echoing back guest memory.
+
+  (Do not cite `present_readback` here, as a draft of this row did. `tools/screenshot` never calls it
+  — `screenshot.cpp:5`'s comment says otherwise and is stale — and it carries the same fallback
+  hazard at `videoout_present.cpp:132-138` regardless.)
 
   Do not substitute the renderer's own `frame_%04d.bmp` for this without collecting it: that dump is
   fed by `selected_pixels` (`live_renderer.cpp:10160` → `:10184`), so it would prove

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -1445,3 +1445,36 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   nsa=1 materialized_mips=1 compute=0`. The disassembly is unambiguous that the level is genuinely
   dynamic — `v_min_i32 / v_max_i32` clamp a log2-derived LOD into `v5`, and the x/y coordinates are
   shifted right by that same `v5` — so `Lod=0` remains the wrong answer. #3134, #2818.
+- **"The scanout buffer and the render targets are two virtual mappings of ONE physical allocation,
+  so the VA-keyed present match is the whole defect."** Falsified by direct resolution
+  (`PROSPER_TARGET_PHYS=1` plus the unconditional `[rtt] GUEST SCANOUT #N phys:` probe, both landed
+  with this row). This was the most attractive hypothesis available, because it would have made a
+  measured fact — prosper renders into `0x30…` while the guest flips `0x9fc0000000`, ~450 GiB apart
+  in VA — into a *bookkeeping* error with a fix prosper already had the machinery for. It is not:
+
+  | buffer | guest VA | physical |
+  | --- | --- | --- |
+  | flipped scanout | `0x9fc0000000` | **`0x230000`** (2.3 MB) |
+  | lowest render target | `0x30…` | `0x1e980000` (511 MB) |
+  | highest render target | `0x30…` | `0x79f20000` (2.0 GB) |
+
+  80,511 target resolutions, **0 unresolved** — so the census saw the whole population rather than a
+  sample that happened to miss the alias. The scanout sits ~509 MB *below* every render target. They
+  are separate physical allocations and nothing is aliased.
+
+  **What this leaves is narrower and better posed.** The guest composites into its own allocation and
+  moves it to scanout by a route prosper does not model, so the open question is *which packet does
+  that*, not how the present path matches addresses. Two further facts bound it: `select_present_source`
+  returns `None` (`px_front=none px_vo=none px_last=none`, `fresh=0 retained=0`), and
+  `videoout_buffer_authored_locked` reports `authored=0` for the flipped buffer — its bytes are
+  unchanged since registration. That second one is the load-bearing constraint, because the digest test
+  reads guest memory directly: **a GPU copy landing in guest memory would flip `authored` on its own.**
+  So the copy is not happening, not landing there, or not being executed by prosper at all.
+
+  **Two cautions for whoever picks this up.** Stray registers **two** scanout buffers,
+  `0x9fc0000000` and `0x9fc2000000` — a rotating set, which is the shape behind *Bendy and the Ink
+  Machine*'s black flicker (see the retained-frame comment in `present_extent.hpp`); only the first has
+  been probed, so "nothing ever writes scanout" is not yet safe to claim. And
+  `guest_write_watch_va_to_phys` returns the FIRST range containing the address without checking that
+  range is large enough for the access — fine for a probe, not for anything load-bearing.
+  #2932, #3126.

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -1446,55 +1446,52 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   dynamic — `v_min_i32 / v_max_i32` clamp a log2-derived LOD into `v5`, and the x/y coordinates are
   shifted right by that same `v5` — so `Lod=0` remains the wrong answer. #3134, #2818.
 - **"The scanout buffer and the render targets are two virtual mappings of ONE physical allocation,
-  so the VA-keyed present match is the whole defect."** Falsified by direct resolution
-  (`PROSPER_TARGET_PHYS=1` plus the unconditional `[rtt] GUEST SCANOUT #N phys:` probe, both landed
-  with this row). This was the most attractive hypothesis available, because it would have made a
-  measured fact — prosper renders into `0x30…` while the guest flips `0x9fc0000000`, ~450 GiB apart
-  in VA — into a *bookkeeping* error with a fix prosper already had the machinery for. It is not:
+  so the VA-keyed present match is the whole defect."** Falsified across **every colour slot**, and
+  the run that falsified it also **falsified the premise the hypothesis was built on** — which is the
+  more useful half, so it is stated first.
 
-  | buffer | guest VA | physical |
-  | --- | --- | --- |
-  | flipped scanout | `0x9fc0000000` | **`0x230000`** (2.3 MB) |
-  | lowest render target | `0x30…` | `0x1e980000` (511 MB) |
-  | highest render target | `0x30…` | `0x79f20000` (2.0 GB) |
+  **prosper renders directly INTO the scanout buffers.** Both flipped VAs appear in the colour-target
+  census as ordinary 4K slot-0 persistent render targets, throughout the failing run:
 
-  80,511 target resolutions, **0 unresolved** — every VA the census was shown did resolve, so the
-  answers above are real rather than a resolver failing quietly. The scanout sits ~509 MB *below*
-  every render target: separate physical allocations, nothing aliased.
+  | target VA | physical | size | times seen |
+  | --- | --- | --- | --- |
+  | `0x9fc0000000` | `0x230000` | 3840x2160 | 946 |
+  | `0x9fc2000000` | `0x2210000` | 3840x2160 | 976 |
 
-  **What that number does NOT say is "the whole population".** The census reads
-  `color_target->persistent_id` — colour **slot 0 only**. `persistent_id1` and
-  `persistent_id_slots[2..7]` are separate guest VAs and are never censused, and 80,511 counts
-  invocations rather than distinct addresses. An alias hiding in an un-censused MRT slot is exactly
-  what the hypothesis predicts and exactly what this instrument cannot see, so the falsification is
-  **scoped to slot 0** — which is the slot the composite is built in, and enough to stop the
-  VA-keyed-match story, but not a proof about every surface the frame renders into.
+  So the framing this row was originally written to support — *"prosper renders into `0x30…` while
+  the guest flips `0x9fc…`, ~450 GiB apart, and no VA-keyed lookup can connect them"* — **is wrong**.
+  The present path's VA-keyed lookup can see these buffers perfectly well, because they are live
+  render targets under their own VAs. Do not repeat that sentence; it is why this row exists.
 
-  **What this leaves is narrower and better posed.** The guest composites into its own allocation and
-  moves it to scanout by a route prosper does not model, so the open question is *which packet does
-  that*, not how the present path matches addresses. Two further facts bound it: `select_present_source`
-  returns `None` (`px_front=none px_vo=none px_last=none`, `fresh=0 retained=0`), and
-  `videoout_buffer_authored_locked` reports `authored=0` for the flipped buffer.
+  **And the alias hypothesis is dead anyway**, now over the whole population rather than one slot.
+  Census over slots 0-6 (slot 7 unused): **55,868 resolutions, 0 unresolved, 82 distinct targets** —
+  80 in the `0x30…` family and the 2 scanout buffers above. Excluding the scanout buffers themselves,
+  the number of targets whose *physical extent* overlaps either scanout buffer is **0**, and the
+  nearest non-scanout target sits **390 MB** above them. Nothing is aliased.
 
-  **Read that second one carefully — it is weaker than it first looks, and an earlier draft of this
-  row overstated it.** The tempting reading is "the bytes are unchanged since registration, and since
-  the digest test reads guest memory directly, a GPU copy landing there would have flipped `authored`
-  by itself". The predicate has **four** ways to return false (`hle_graphics.cpp`), and one of them
-  breaks that inference: `!buffer_digest_valid[slot]`, i.e. **no baseline was ever seeded** — which is
-  what happens when the buffer was not readable at registration time, and the seeding path documents
-  the resulting state as *deliberately indistinguishable from "not written"*. With no baseline, a copy
-  of any size leaves `authored` at 0.
+  The slot coverage is load-bearing and was added after review: **24% of resolutions (13,669) are in
+  slots 1-6**, which a slot-0-only census cannot see. That matters because `is_live_render_target`
+  consults `g_rtt`, and `g_rtt` is populated for every slot, so a slot-1..7 target aliasing the
+  scanout page would have been exactly the link the hypothesis proposed — in exactly the region the
+  narrower instrument was blind to.
 
-  So the honest disjunction has a fourth branch: the copy is **not happening**, **not landing there**,
-  **not executed by prosper at all**, or **it happened and prosper cannot tell**. Separating the last
-  one from the first three is cheap — check `buffer_digest_valid` for the slot — and should be the
-  first step for whoever picks this up, because three of the four branches are a missing packet and
-  the fourth is a blind instrument.
+  **What this leaves is a better question than the one it replaces.** prosper renders into
+  `0x9fc0000000` 946 times in a run whose steady state is the menu over black (visually confirmed:
+  `START GAME` / `SETTINGS` / `CREDITS` and the version string, everything else black at 8x
+  brightness). So the missing world is **not** a copy that never happens. Either the draws that reach
+  the scanout target carry only the UI, or the scene reaches it and is then cleared or overwritten.
+  That is answerable with the tools already in the tree — a PixelHistory on a world pixel of the
+  scanout target, which separates those two directly (see the note at the top of this file about
+  finding the brightest pixel rather than the centre).
 
-  **Two cautions for whoever picks this up.** Stray registers **two** scanout buffers,
-  `0x9fc0000000` and `0x9fc2000000` — a rotating set, which is the shape behind *Bendy and the Ink
-  Machine*'s black flicker (see the retained-frame comment in `present_extent.hpp`); only the first has
-  been probed, so "nothing ever writes scanout" is not yet safe to claim. And
-  `guest_write_watch_va_to_phys` returns the FIRST range containing the address without checking that
-  range is large enough for the access — fine for a probe, not for anything load-bearing.
-  #2932, #3126.
+  It also removes a puzzle rather than adding one: if prosper renders into a *VkImage* keyed by the
+  scanout VA, guest memory at that VA need never be written, which is consistent with
+  `videoout_buffer_authored_locked` reporting `authored=0` without anything being wrong at all.
+
+  **Caveats a later reader needs.** `guest_write_watch_va_to_phys` returns the FIRST range containing
+  the address and does not check it is large enough for the access — fine for a probe, not for a
+  production caller. And `authored=0` still has four causes, not one; the earlier draft of this row
+  read it as "the bytes are unchanged since registration" and leaned on "a GPU copy would flip
+  `authored` by itself", which does not hold: `!buffer_digest_valid[slot]` means no baseline was ever
+  seeded, and a write covering none of the digest's sample points misses too, so **two** of the four
+  branches are a blind instrument rather than an absent write. #2932, #3126.

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -1453,10 +1453,20 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   4K slot-0 persistent colour attachments, throughout the failing run (title route, steady state
   confirmed by eye: menu over black at 8x brightness):
 
-  | flipped VA | physical | size | census lines | draws dropped `no-effect(early)` |
-  | --- | --- | --- | --- | --- |
-  | `0x9fc0000000` | `0x230000` | 3840x2160 | 946 | **1,143** |
-  | `0x9fc2000000` | `0x2210000` | 3840x2160 | 976 | **1,154** |
+  | flipped VA | physical | size | census lines (passes) |
+  | --- | --- | --- | --- |
+  | `0x9fc0000000` | `0x230000` | 3840x2160 | 946 |
+  | `0x9fc2000000` | `0x2210000` | 3840x2160 | 976 |
+
+  A draft of this row carried a fourth column of `no-effect(early)` drops "measured on the title route
+  where this diagnostic had never been run". **Both halves were wrong**, and the correction is worth
+  more than the column was. § *The title screen's REAL numbers* already records this census on this
+  screen (8192 discarded, `no-effect` ~4400) and states the methodology: *census read at the same
+  cumulative total in every arm*. `report_dropped_draw_target` emits only at power-of-two totals, so
+  the draft's reading at 4,096 was a **snapshot one emission earlier**, not a run total — and its
+  1,143 + 1,154 = 2,297 is almost exactly half of ~4,400, which is what that same measurement looks
+  like one emission back. It was also unit-mismatched against the census column beside it: passes
+  against draws. Use the existing table; do not quote the withdrawn one.
 
   **Read the census column precisely.** The line is printed after the empty-draw early-out, so it
   means *this VA was bound as slot 0 of a pass carrying at least one draw*. It does **not** mean a
@@ -1475,19 +1485,41 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   the publish check (flip time) are different moments and must not be read as one. The probe now
   prints `rtt_owns=` and the decision name beside the physical address so this becomes a measurement.
 
-  **TWO REGIMES, and this row previously blurred them — the same mistake this file's own banner warns
+  **TWO STATES, and this row previously blurred them — the same mistake this file's own banner warns
   about for `max_nonblack`.** They are different failure states and their evidence does not transfer:
 
-  | regime | what publishes | where the `authored=0` / `SkipNotAuthored` evidence comes from |
+  | state | what reaches the screen | source of the `authored=0` / `SkipNotAuthored` evidence |
   | --- | --- | --- |
-  | **title screen** (measured here) | the menu **does** publish | *not this regime* |
-  | **main menu / first map** | nothing publishes (`fresh=0 retained=0`) | this one |
+  | **title screen** (measured here) | a menu frame exists, so something published | a *different run*, days and several merges earlier |
+  | **main menu / first map** | nothing (`fresh=0 retained=0`) | that run |
 
-  The guest-scanout fallback is gated on `guest_scanout_read_warranted(...) == Publish`, i.e. it runs
-  **only when nothing else published**. On the title route it is therefore never entered — measured:
-  **0** `[rtt] GUEST SCANOUT` lines across a full run that reached and held the failing steady state.
-  So `rtt_owns=` cannot be collected on this route at all, and every `authored=0` / `px_front=none`
-  fact in this section belongs to the *other* regime. Quote them with the regime attached.
+  The right-hand column deliberately says *run*, not *regime*. The two sets of facts were collected
+  days and several merges apart, so code state, route and `PROSPER_RENDER_SCALE` explain the
+  difference as readily as the screen does, and nothing here separates them. One run collecting the
+  census and those counters together settles it; until then, cite the run.
+
+  The guest-scanout fallback's stage-1 gate declines for **four** reasons, and only two of them
+  (`SkipPublishedGpu`, `SkipRendererSource`) mean something else published; the other two are
+  `SkipNoPresentContract` and `SkipScaledPresent`. All four print nothing, so they are
+  indistinguishable in a log. `guest_scanout_present.hpp` says so itself, and records the precedent:
+  Bendy's (PPSA27616) zero-line control is reported as **"never reached"** rather than as a decline,
+  because the instrument cannot tell those apart today.
+
+  So: measured, **0** `[rtt] GUEST SCANOUT` lines across a full title-route run that reached and held
+  the failing steady state — and that is honestly reported as **never reached**, not as evidence of
+  what published. A draft of this row inferred "the menu therefore publishes" from the zero count;
+  that inference is withdrawn, having violated a precedent written into the header it reasoned about.
+  **The publishing claim rests on the frame instead**: a captured title-screen frame exists and shows
+  the menu, which is direct evidence something published.
+
+  Two things survive this correction intact. `rtt_owns=` **cannot be collected on the title route**
+  (the report sits inside the stage-1 `Publish` branch). And the forward direction holds: any
+  `authored=` or `rtt_owns=` datum necessarily came from a moment where stage 1 returned `Publish`.
+
+  What does **not** follow is that the older `authored=0` / `px_front=none` facts differ from today's
+  run *because of regime*. Those runs are days and several merges apart, so code state, route and
+  `PROSPER_RENDER_SCALE` are equally live explanations. Attach the run, not just the regime — and the
+  cheap way to settle it is one run collecting the census and those counters together.
 
   **The alias hypothesis is dead**, now over the population rather than one slot: **55,868
   resolutions, 0 unresolved, 82 distinct targets** across slots 0-6. Excluding the scanout buffers

--- a/prosper/docs/STRAY_STATUS.md
+++ b/prosper/docs/STRAY_STATUS.md
@@ -1509,8 +1509,18 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   the failing steady state — and that is honestly reported as **never reached**, not as evidence of
   what published. A draft of this row inferred "the menu therefore publishes" from the zero count;
   that inference is withdrawn, having violated a precedent written into the header it reasoned about.
-  **The publishing claim rests on the frame instead**: a captured title-screen frame exists and shows
-  the menu, which is direct evidence something published.
+  **The publishing claim rests on the frame instead** — and the artifact has to be named, because
+  which buffer was dumped is the whole strength of it. These are `tools/screenshot` PNGs, which come
+  from `present_readback`, which returns what `present_write_frame` wrote
+  (`gpu_executor.cpp:11780`/`:11927`). So a menu-bearing PNG is direct evidence that **a frame was
+  published to the present layer** — the publication itself, not an inference from a decline that
+  never printed.
+
+  Do not substitute the renderer's own `frame_%04d.bmp` for this without collecting it: that dump is
+  fed by `selected_pixels` (`live_renderer.cpp:10160` → `:10184`), so it would prove
+  `have_selected_pixels` — stage 1's second input — which is a *stronger* statement about the gate but
+  a different artifact, and it was not produced by these runs. An RTT dump would be weaker than
+  either: it would show only that the menu was drawn somewhere.
 
   Two things survive this correction intact. `rtt_owns=` **cannot be collected on the title route**
   (the report sits inside the stage-1 `Publish` branch). And the forward direction holds: any
@@ -1519,7 +1529,17 @@ evidence nor falsifications for it. Re-run each with `PROSPER_NULL_PAGE=1` and a
   What does **not** follow is that the older `authored=0` / `px_front=none` facts differ from today's
   run *because of regime*. Those runs are days and several merges apart, so code state, route and
   `PROSPER_RENDER_SCALE` are equally live explanations. Attach the run, not just the regime — and the
-  cheap way to settle it is one run collecting the census and those counters together.
+  cheap way to settle it is one run collecting the census and those counters together:
+
+  ```
+  PROSPER_PASS_LOG=<window> PROSPER_TARGET_PHYS=1     # census + px_front/px_vo/px_last in ONE run
+  ```
+
+  **Do not reach for `PROSPER_RTTLOG` to get the present counters.** It is in the list at
+  `live_renderer.cpp:1674-1679` that disables `live_gpu_targets`, so it measures a differently
+  configured renderer. The counters do not need it: `px_front`/`px_vo`/`px_last` come from
+  `present_source_name()` printed under `g_pass_log_window`, i.e. `PROSPER_PASS_LOG`, which is **not**
+  in that list.
 
   **The alias hypothesis is dead**, now over the population rather than one slot: **55,868
   resolutions, 0 unresolved, 82 distinct targets** across slots 0-6. Excluding the scanout buffers

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -9967,9 +9967,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // domain is how an unarmed instrument gets recorded as a negative result.
                         if (read.metadata.address && prosper::diag_should_print(ord)) {
                             uint64_t flip_phys = 0;
+                            size_t alias_n = 0;
                             const bool ok = prosper::host::guest_write_watch_va_to_phys(
-                                read.metadata.address, flip_phys);
-                            const size_t alias_n = prosper::host::guest_write_watch_alias_count();
+                                read.metadata.address, flip_phys, &alias_n);
                             if (ok)
                                 fprintf(stderr,
                                         "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> phys=0x%llx "

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -9960,18 +9960,31 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // and the fix reuses resolution prosper already performs. Printed beside the
                         // decision so the answer arrives with the failure rather than in a separate
                         // run whose guest state may differ.
-                        if (prosper::diag_should_print(ord)) {
+                        //
+                        // `aliases=N` is part of the reading, not decoration: the table is populated
+                        // only while page-protection watches are armed, so N=0 means "nothing was
+                        // searched" and says NOTHING about this VA. Reporting the miss without the
+                        // domain is how an unarmed instrument gets recorded as a negative result.
+                        if (read.metadata.address && prosper::diag_should_print(ord)) {
                             uint64_t flip_phys = 0;
                             const bool ok = prosper::host::guest_write_watch_va_to_phys(
                                 read.metadata.address, flip_phys);
-                            fprintf(stderr,
-                                    "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> %s\n",
-                                    (unsigned long long)ord,
-                                    (unsigned long long)read.metadata.address,
-                                    ok ? "" : "UNRESOLVED (no direct mapping covers this VA)");
+                            const size_t alias_n = prosper::host::guest_write_watch_alias_count();
                             if (ok)
-                                fprintf(stderr, "[rtt]   flip phys=0x%llx\n",
-                                        (unsigned long long)flip_phys);
+                                fprintf(stderr,
+                                        "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> phys=0x%llx "
+                                        "(aliases=%zu)\n",
+                                        (unsigned long long)ord,
+                                        (unsigned long long)read.metadata.address,
+                                        (unsigned long long)flip_phys, alias_n);
+                            else
+                                fprintf(stderr,
+                                        "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> UNRESOLVED "
+                                        "(aliases=%zu; %s)\n",
+                                        (unsigned long long)ord,
+                                        (unsigned long long)read.metadata.address, alias_n,
+                                        alias_n ? "no alias range covers this VA"
+                                                : "alias table EMPTY -- nothing was searched");
                         }
                     }
                     // Re-check the size on the cached path too: a two-set geometry switch can change

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -9952,6 +9952,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     prosper::frontend::guest_scanout_decision_name(decision), w, h,
                                     read.metadata.tiling_mode, (int)read.guest_authored,
                                     read.padded_footprint ? "padded" : "nominal");
+                        // #2932: does the flipped VA resolve to a physical page the write-watch
+                        // knows? The present path matches scanout against render targets by VIRTUAL
+                        // address only, and this title renders into 0x30... while flipping
+                        // 0x9fc0000000 -- ~450 GiB apart, so no VA-keyed lookup can connect them.
+                        // If the two are aliases of one physical range, that gap is the whole defect
+                        // and the fix reuses resolution prosper already performs. Printed beside the
+                        // decision so the answer arrives with the failure rather than in a separate
+                        // run whose guest state may differ.
+                        if (prosper::diag_should_print(ord)) {
+                            uint64_t flip_phys = 0;
+                            const bool ok = prosper::host::guest_write_watch_va_to_phys(
+                                read.metadata.address, flip_phys);
+                            fprintf(stderr,
+                                    "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> %s\n",
+                                    (unsigned long long)ord,
+                                    (unsigned long long)read.metadata.address,
+                                    ok ? "" : "UNRESOLVED (no direct mapping covers this VA)");
+                            if (ok)
+                                fprintf(stderr, "[rtt]   flip phys=0x%llx\n",
+                                        (unsigned long long)flip_phys);
+                        }
                     }
                     // Re-check the size on the cached path too: a two-set geometry switch can change
                     // the present extent between spans of one flip, and the cache is keyed on the

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -9917,10 +9917,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         guest_scanout_pixels.reset();
                         prosper::VideoOutLinearRead read;
                         const bool got = prosper::videoout_read_front_linear(read);
+                        // Named rather than inlined so the #2932 probe below can REPORT it. Whether
+                        // the renderer owns a target at the flipped VA is the first thing
+                        // guest_scanout_publishable tests, and it short-circuits ahead of
+                        // guest_authored -- so a decline of SkipNotAuthored is itself evidence that
+                        // this was false at that flip. Reading that off the decision name is
+                        // inference; printing the input is measurement.
+                        const bool renderer_owns_flip =
+                            got && g_rtt.find(read.metadata.address) != g_rtt.end();
                         const auto decision = prosper::frontend::guest_scanout_publishable(
                             got ? read.pixels.size() : 0u, present_extent_bytes,
                             got && read.metadata.address != 0,
-                            got && g_rtt.find(read.metadata.address) != g_rtt.end(),
+                            renderer_owns_flip,
                             read.guest_authored);
                         if (decision == prosper::frontend::GuestScanoutDecision::Publish)
                             guest_scanout_pixels = std::make_shared<const std::vector<uint8_t>>(
@@ -9952,19 +9960,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     prosper::frontend::guest_scanout_decision_name(decision), w, h,
                                     read.metadata.tiling_mode, (int)read.guest_authored,
                                     read.padded_footprint ? "padded" : "nominal");
-                        // #2932: does the flipped VA resolve to a physical page the write-watch
-                        // knows? The present path matches scanout against render targets by VIRTUAL
-                        // address only, and this title renders into 0x30... while flipping
-                        // 0x9fc0000000 -- ~450 GiB apart, so no VA-keyed lookup can connect them.
-                        // If the two are aliases of one physical range, that gap is the whole defect
-                        // and the fix reuses resolution prosper already performs. Printed beside the
-                        // decision so the answer arrives with the failure rather than in a separate
-                        // run whose guest state may differ.
+                        // #2932: what is actually true of the flipped buffer at the moment we
+                        // decline to publish it? Three facts, printed together because separately
+                        // each one invites a wrong inference:
                         //
-                        // `aliases=N` is part of the reading, not decoration: the table is populated
-                        // only while page-protection watches are armed, so N=0 means "nothing was
-                        // searched" and says NOTHING about this VA. Reporting the miss without the
-                        // domain is how an unarmed instrument gets recorded as a negative result.
+                        //   phys=      the physical page behind the flipped VA. This began as a test
+                        //              of "scanout and the render targets are two mappings of one
+                        //              allocation"; that is FALSE (STRAY_STATUS.md, Ruled out).
+                        //   aliases=N  the SEARCHED DOMAIN. The table is populated only while
+                        //              page-protection watches are armed, so N=0 means "nothing was
+                        //              searched" and says nothing about this VA. A miss reported
+                        //              without its domain is how an unarmed instrument gets recorded
+                        //              as a negative result.
+                        //   rtt_owns=  whether g_rtt holds a target at this VA -- the FIRST input
+                        //              guest_scanout_publishable tests, short-circuiting ahead of
+                        //              guest_authored. Measured, not inferred from the decision name.
+                        //
+                        // Deliberately NOT asserted here: that no VA-keyed lookup can connect the
+                        // flipped buffer to a render target. Stray's scanout VAs appear in the
+                        // colour-target census as 4K attachments in passes carrying draws, so that
+                        // sentence -- which earlier revisions of this comment stated as fact -- is
+                        // withdrawn. rtt_owns is printed precisely so nobody has to assume it again.
                         if (read.metadata.address && prosper::diag_should_print(ord)) {
                             uint64_t flip_phys = 0;
                             size_t alias_n = 0;
@@ -9973,16 +9989,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             if (ok)
                                 fprintf(stderr,
                                         "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> phys=0x%llx "
-                                        "(aliases=%zu)\n",
+                                        "(aliases=%zu rtt_owns=%d decision=%s)\n",
                                         (unsigned long long)ord,
                                         (unsigned long long)read.metadata.address,
-                                        (unsigned long long)flip_phys, alias_n);
+                                        (unsigned long long)flip_phys, alias_n,
+                                        (int)renderer_owns_flip,
+                                        prosper::frontend::guest_scanout_decision_name(decision));
                             else
                                 fprintf(stderr,
                                         "[rtt] GUEST SCANOUT #%llu phys: va=0x%llx -> UNRESOLVED "
-                                        "(aliases=%zu; %s)\n",
+                                        "(aliases=%zu rtt_owns=%d decision=%s; %s)\n",
                                         (unsigned long long)ord,
                                         (unsigned long long)read.metadata.address, alias_n,
+                                        (int)renderer_owns_flip,
+                                        prosper::frontend::guest_scanout_decision_name(decision),
                                         alias_n ? "no alias range covers this VA"
                                                 : "alias table EMPTY -- nothing was searched");
                         }

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -1137,6 +1137,28 @@ bool trace_va_to_phys_locked(const DmemTraceState& trace, uint64_t addr, uint64_
 
 } // namespace
 
+// Diagnostic resolution of a guest VA to its physical address (#2932). Reuses the trace's own alias
+// table rather than adding a second notion of "which VAs map this page": a duplicated resolver that
+// could disagree with the write-watch would be worse than none, because two subsystems would then
+// answer the same question differently.
+bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys) {
+    if (!addr) return false;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    // `w.aliases` is the LIVE DMEM TOPOLOGY -- every direct mapping the guest has made, recorded by
+    // guest_write_watch_notify_direct_mapping_added. `w.trace.pages` is a different thing: a narrow
+    // write-trace armed for one investigation at a time. An earlier revision of this probe resolved
+    // against the trace and reported UNRESOLVED for a scanout buffer, which reads as "prosper does
+    // not know this mapping" when it means "this diagnostic was not armed for it" -- the instrument
+    // answering a different question than the one asked.
+    for (const AliasRange& a : w.aliases) {
+        if (!a.size || addr < a.addr || addr - a.addr >= a.size) continue;
+        phys = a.phys + (addr - a.addr);
+        return true;
+    }
+    return false;
+}
+
 GuestWriteWatch::~GuestWriteWatch() { reset(); }
 GuestWriteWatch::GuestWriteWatch(GuestWriteWatch&& other) noexcept
     : id_(std::exchange(other.id_, 0)) {}

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -541,8 +541,10 @@ void guest_write_watch_set_fault_onstack(bool) {}   // Windows never arms page-p
 // there is never anything here to search. Returning false with a count of 0 is the honest answer --
 // and it is why the count is part of the contract, so a caller cannot read this platform's
 // structural "nothing to search" as a measured "no alias covers that VA".
-bool guest_write_watch_va_to_phys(uint64_t, uint64_t&) { return false; }
-size_t guest_write_watch_alias_count() { return 0; }
+bool guest_write_watch_va_to_phys(uint64_t, uint64_t&, size_t* alias_count) {
+    if (alias_count) *alias_count = 0;
+    return false;
+}
 
 } // namespace prosper::host
 
@@ -1149,10 +1151,14 @@ bool trace_va_to_phys_locked(const DmemTraceState& trace, uint64_t addr, uint64_
 // DIRECT-MAPPING ALIAS TABLE rather than adding a second notion of "which VAs map this page": a
 // duplicated resolver that could disagree with the write-watch would be worse than none, because
 // two subsystems would then answer the same question differently.
-bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys) {
-    if (!addr) return false;
+bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys, size_t* alias_count) {
     WatchState& w = state();
     std::lock_guard lock(w.mutex);
+    // Publish the searched domain under the SAME acquisition as the lookup: reporting a miss beside
+    // a separately-sampled count would let the two describe different tables, and the count only
+    // exists to qualify the miss.
+    if (alias_count) *alias_count = w.aliases.size();
+    if (!addr) return false;
     // `w.aliases` is the LIVE DMEM TOPOLOGY -- every direct mapping the guest has made, recorded by
     // guest_write_watch_notify_direct_mapping_added. `w.trace.pages` is a different thing: a narrow
     // write-trace armed for one investigation at a time. An earlier revision of this probe resolved
@@ -1165,17 +1171,6 @@ bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys) {
         return true;
     }
     return false;
-}
-
-// The searched domain, so a `false` above can be told apart from an unarmed instrument. `w.aliases`
-// is populated only while fault_onstack is set -- guest_write_watch_notify_direct_mapping_added
-// returns early otherwise -- so a run that never armed watches reports 0 here and every VA resolves
-// as a miss. That is exactly the shape of the trap this probe's first revision fell into against
-// `trace.pages`, one level up, so the count is published rather than left for the caller to assume.
-size_t guest_write_watch_alias_count() {
-    WatchState& w = state();
-    std::lock_guard lock(w.mutex);
-    return w.aliases.size();
 }
 
 GuestWriteWatch::~GuestWriteWatch() { reset(); }

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -536,6 +536,14 @@ void guest_dmem_write_trace_unlock_state_for_test() {}
 
 void guest_write_watch_set_fault_onstack(bool) {}   // Windows never arms page-protection watches
 
+// #2932 VA->phys probe. Stubbed on the same grounds as everything above it: the alias table is
+// populated only while page-protection watches are armed, and Windows' create() always refuses, so
+// there is never anything here to search. Returning false with a count of 0 is the honest answer --
+// and it is why the count is part of the contract, so a caller cannot read this platform's
+// structural "nothing to search" as a measured "no alias covers that VA".
+bool guest_write_watch_va_to_phys(uint64_t, uint64_t&) { return false; }
+size_t guest_write_watch_alias_count() { return 0; }
+
 } // namespace prosper::host
 
 #else   // ---- Linux / macOS: real page-protection dirty-tracking (mprotect + SIGSEGV) --------------
@@ -1137,10 +1145,10 @@ bool trace_va_to_phys_locked(const DmemTraceState& trace, uint64_t addr, uint64_
 
 } // namespace
 
-// Diagnostic resolution of a guest VA to its physical address (#2932). Reuses the trace's own alias
-// table rather than adding a second notion of "which VAs map this page": a duplicated resolver that
-// could disagree with the write-watch would be worse than none, because two subsystems would then
-// answer the same question differently.
+// Diagnostic resolution of a guest VA to its physical address (#2932). Resolves over the LIVE
+// DIRECT-MAPPING ALIAS TABLE rather than adding a second notion of "which VAs map this page": a
+// duplicated resolver that could disagree with the write-watch would be worse than none, because
+// two subsystems would then answer the same question differently.
 bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys) {
     if (!addr) return false;
     WatchState& w = state();
@@ -1157,6 +1165,17 @@ bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys) {
         return true;
     }
     return false;
+}
+
+// The searched domain, so a `false` above can be told apart from an unarmed instrument. `w.aliases`
+// is populated only while fault_onstack is set -- guest_write_watch_notify_direct_mapping_added
+// returns early otherwise -- so a run that never armed watches reports 0 here and every VA resolves
+// as a miss. That is exactly the shape of the trap this probe's first revision fell into against
+// `trace.pages`, one level up, so the count is published rather than left for the caller to assume.
+size_t guest_write_watch_alias_count() {
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    return w.aliases.size();
 }
 
 GuestWriteWatch::~GuestWriteWatch() { reset(); }

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -213,6 +213,20 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
 void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size);
 void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
                                                         uint32_t protection);
+// PROSPER_SCANOUT_PHYS (#2932): resolve a guest VA to its physical address through the dmem trace.
+//
+// The present path matches a flipped scanout buffer against render targets by VIRTUAL address only
+// (`is_live_render_target`), and `hle_graphics.cpp`'s scanout registry has no aliasing concept at
+// all. Stray renders into 0x30... and flips 0x9fc0000000 -- ~450 GiB apart -- so no VA-keyed lookup
+// can connect them, and BOTH publish paths fail: no pass "targets" the flip, and the scanout bytes
+// are unchanged since registration so the guest-authored fallback declines too.
+//
+// If those are two mappings of one set of physical pages, every one of those observations follows
+// with no further defect. This exposes the resolution the write-watch already performs -- it models
+// exactly this aliasing in `WatchedPage { phys; aliases; }` -- so the hypothesis can be TESTED
+// before anything is built on it. Diagnostic only; no production path calls it.
+bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys);
+
 void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size);
 void guest_write_watch_invalidate_all();
 

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -220,13 +220,17 @@ void guest_write_watch_invalidate_all();
 // ALIAS TABLE -- the ranges recorded by guest_write_watch_notify_direct_mapping_added above, not the
 // dmem write-trace, which is a narrower thing armed for one investigation at a time.
 //
-// The present path matches a flipped scanout buffer against render targets by VIRTUAL address only
-// (`is_live_render_target`), and `hle_graphics.cpp`'s scanout registry has no aliasing concept at
-// all. Stray renders into 0x30... and flips 0x9fc0000000 -- ~450 GiB apart -- so no VA-keyed lookup
-// can connect them, and neither publish path produces a picture. If those were two mappings of one
-// set of physical pages, that would follow with no further defect. This exposes the resolution the
-// write-watch already performs -- it models exactly this aliasing in `WatchedPage { phys; aliases; }`
-// -- so the hypothesis can be TESTED before anything is built on it.
+// Written to test one hypothesis about Stray (#2932): that a flipped scanout buffer and the render
+// targets were two virtual mappings of ONE physical allocation, which would have explained a missing
+// composite with no further defect. It exposes resolution the write-watch already performs -- it
+// models exactly this aliasing in `WatchedPage { phys; aliases; }` -- so the idea could be TESTED
+// before anything was built on it. It was FALSIFIED (`docs/STRAY_STATUS.md`, § Ruled out): nothing
+// is aliased, and the scanout buffers turn out to be ordinary render targets in their own right.
+//
+// Kept because the question recurs and the answer should cost one run, not a rediscovery. Do NOT
+// restate the framing that motivated it -- "prosper renders into one VA range while the guest flips
+// a distant one, so no VA-keyed lookup can connect them" -- which earlier revisions of this comment
+// asserted as fact and which the census disproved.
 //
 // Diagnostic only; no production path calls it. Two limits a caller MUST respect:
 //   * It returns the FIRST range containing `addr` and does NOT check that the range extends far

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -232,14 +232,15 @@ void guest_write_watch_invalidate_all();
 //   * It returns the FIRST range containing `addr` and does NOT check that the range extends far
 //     enough for the intended access. Fine for a probe; a production caller needs the size check.
 //   * `false` means "no alias covers this VA" OR "the alias table holds nothing to search", which
-//     are very different facts. Always report guest_write_watch_alias_count() beside a false, or the
-//     reader will take an unarmed instrument for a negative result.
-bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys);
-
-// How many direct-mapping alias ranges are currently known -- the SEARCHED DOMAIN of the resolver
-// above, so a caller can tell an empty table from a genuine miss. Zero on Windows (page-protection
-// watches never arm there) and on any run that never reached guest_write_watch_set_fault_onstack.
-size_t guest_write_watch_alias_count();
+//     are very different facts. Pass `alias_count` and report it beside a false, or the reader will
+//     take an unarmed instrument for a negative result.
+//
+// `alias_count` (optional) receives the SEARCHED DOMAIN -- how many direct-mapping alias ranges were
+// available to match against -- read under the SAME lock acquisition as the lookup, so the pair is
+// mutually consistent rather than two samples of a table that can change between them. Zero on
+// Windows (page-protection watches never arm there) and on any run that never reached
+// guest_write_watch_set_fault_onstack.
+bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys, size_t* alias_count = nullptr);
 
 // Called by the HLE, by guest VA range, immediately BEFORE a host/kernel store into guest memory (e.g. a
 // read()/pread() that streams bytes straight into a guest dmem buffer). Restores write on any armed pages

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -213,22 +213,33 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
 void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size);
 void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
                                                         uint32_t protection);
-// PROSPER_SCANOUT_PHYS (#2932): resolve a guest VA to its physical address through the dmem trace.
+void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size);
+void guest_write_watch_invalidate_all();
+
+// PROSPER_TARGET_PHYS (#2932): resolve a guest VA to its physical address through the DIRECT-MAPPING
+// ALIAS TABLE -- the ranges recorded by guest_write_watch_notify_direct_mapping_added above, not the
+// dmem write-trace, which is a narrower thing armed for one investigation at a time.
 //
 // The present path matches a flipped scanout buffer against render targets by VIRTUAL address only
 // (`is_live_render_target`), and `hle_graphics.cpp`'s scanout registry has no aliasing concept at
 // all. Stray renders into 0x30... and flips 0x9fc0000000 -- ~450 GiB apart -- so no VA-keyed lookup
-// can connect them, and BOTH publish paths fail: no pass "targets" the flip, and the scanout bytes
-// are unchanged since registration so the guest-authored fallback declines too.
+// can connect them, and neither publish path produces a picture. If those were two mappings of one
+// set of physical pages, that would follow with no further defect. This exposes the resolution the
+// write-watch already performs -- it models exactly this aliasing in `WatchedPage { phys; aliases; }`
+// -- so the hypothesis can be TESTED before anything is built on it.
 //
-// If those are two mappings of one set of physical pages, every one of those observations follows
-// with no further defect. This exposes the resolution the write-watch already performs -- it models
-// exactly this aliasing in `WatchedPage { phys; aliases; }` -- so the hypothesis can be TESTED
-// before anything is built on it. Diagnostic only; no production path calls it.
+// Diagnostic only; no production path calls it. Two limits a caller MUST respect:
+//   * It returns the FIRST range containing `addr` and does NOT check that the range extends far
+//     enough for the intended access. Fine for a probe; a production caller needs the size check.
+//   * `false` means "no alias covers this VA" OR "the alias table holds nothing to search", which
+//     are very different facts. Always report guest_write_watch_alias_count() beside a false, or the
+//     reader will take an unarmed instrument for a negative result.
 bool guest_write_watch_va_to_phys(uint64_t addr, uint64_t& phys);
 
-void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size);
-void guest_write_watch_invalidate_all();
+// How many direct-mapping alias ranges are currently known -- the SEARCHED DOMAIN of the resolver
+// above, so a caller can tell an empty table from a genuine miss. Zero on Windows (page-protection
+// watches never arm there) and on any run that never reached guest_write_watch_set_fault_onstack.
+size_t guest_write_watch_alias_count();
 
 // Called by the HLE, by guest VA range, immediately BEFORE a host/kernel store into guest memory (e.g. a
 // read()/pread() that streams bytes straight into a guest dmem buffer). Restores write on any armed pages

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -5436,11 +5436,16 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     if (persistent_color) {
         color_key = {color_target->persistent_id, W, H, FMT};
         // PROSPER_TARGET_PHYS (#2932): print each colour target's guest VA and the physical address
-        // it maps to. The present path matches a flipped scanout buffer against targets by VIRTUAL
-        // address, and Stray renders into 0x30... while flipping 0x9fc0000000 (phys 0x230000). If a
-        // target's physical range covers that page, the two are aliases of one allocation and the
-        // VA-keyed match is the whole defect; if none does, the guest copies between distinct
-        // allocations and the question moves to which packet performs it.
+        // it maps to, to test whether any target ALIASES the page a title flips to the display. On
+        // Stray the answer is no -- and the same census answered a question it was not built for,
+        // which is why it is still here: the flipped VAs 0x9fc0000000 / 0x9fc2000000 turn up in this
+        // very census as 4K colour attachments, so those buffers are render targets rather than a
+        // separate region the renderer never touches (`docs/STRAY_STATUS.md`, § Ruled out).
+        //
+        // What a line here does and does not license: it is printed after the empty-draw early-out,
+        // so the target was BOUND as an attachment of a pass carrying at least one draw. It does not
+        // say a draw's output reached memory -- masks, discards and store behaviour all sit
+        // downstream -- so do not read a line here as "the picture was written".
         //
         // EVERY colour slot is censused, not just slot 0, and that scope is the whole point rather
         // than thoroughness for its own sake. `is_live_render_target` consults `g_rtt`, and `g_rtt`

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -5442,24 +5442,35 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // VA-keyed match is the whole defect; if none does, the guest copies between distinct
         // allocations and the question moves to which packet performs it.
         //
-        // SCOPE, and it is a real limit on what the census can conclude: this prints colour SLOT 0
-        // only. `persistent_id1` and `persistent_id_slots[2..7]` are separate guest VAs that are
-        // never censused here, so "no target aliases the scanout page" is a statement about slot 0
-        // and not about every surface the frame renders into.
+        // EVERY colour slot is censused, not just slot 0, and that scope is the whole point rather
+        // than thoroughness for its own sake. `is_live_render_target` consults `g_rtt`, and `g_rtt`
+        // is populated for every slot (`live_renderer.cpp` keys it by `pass_bases[slot]`), so a
+        // slot-1..7 target aliasing the scanout page would be a live render target the present path
+        // ALREADY knows by VA -- exactly the link the alias hypothesis proposes. A slot-0-only
+        // census would leave that case unobserved while reading like a general answer, which is the
+        // charter's "positive control tests the discriminator, never the domain" in miniature.
         static const bool target_phys_census = std::getenv("PROSPER_TARGET_PHYS") != nullptr;
-        if (target_phys_census && color_target->persistent_id) {
-            uint64_t tphys = 0;
-            const bool ok = prosper::host::guest_write_watch_va_to_phys(
-                color_target->persistent_id, tphys);
-            if (ok)
-                std::fprintf(stderr, "[target-phys] slot0 va=0x%llx %ux%u -> phys=0x%llx\n",
-                             (unsigned long long)color_target->persistent_id, W, H,
-                             (unsigned long long)tphys);
-            else
-                std::fprintf(stderr, "[target-phys] slot0 va=0x%llx %ux%u -> UNRESOLVED "
-                                     "(aliases=%zu)\n",
-                             (unsigned long long)color_target->persistent_id, W, H,
-                             prosper::host::guest_write_watch_alias_count());
+        if (target_phys_census) {
+            const auto census_slot = [&](unsigned slot, uint64_t va) {
+                if (!va) return;
+                uint64_t tphys = 0;
+                size_t alias_n = 0;
+                if (prosper::host::guest_write_watch_va_to_phys(va, tphys, &alias_n))
+                    std::fprintf(stderr, "[target-phys] slot%u va=0x%llx %ux%u -> phys=0x%llx\n",
+                                 slot, (unsigned long long)va, W, H, (unsigned long long)tphys);
+                else
+                    std::fprintf(stderr, "[target-phys] slot%u va=0x%llx %ux%u -> UNRESOLVED "
+                                         "(aliases=%zu)\n",
+                                 slot, (unsigned long long)va, W, H, alias_n);
+            };
+            census_slot(0, color_target->persistent_id);
+            // Slot 1 lives in its own field; only report it when it is a DISTINCT surface, matching
+            // the test the MRT path itself applies, so a single-target pass does not print twice.
+            if (color_target->persistent_id1 &&
+                color_target->persistent_id1 != color_target->persistent_id)
+                census_slot(1, color_target->persistent_id1);
+            for (size_t sl = 2; sl < color_target->persistent_id_slots.size(); ++sl)
+                census_slot((unsigned)sl, color_target->persistent_id_slots[sl]);
         }
         auto [found, inserted] = persistent_color_target_cache().try_emplace(color_key);
         cached_color = &found->second;

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -5441,14 +5441,25 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // target's physical range covers that page, the two are aliases of one allocation and the
         // VA-keyed match is the whole defect; if none does, the guest copies between distinct
         // allocations and the question moves to which packet performs it.
+        //
+        // SCOPE, and it is a real limit on what the census can conclude: this prints colour SLOT 0
+        // only. `persistent_id1` and `persistent_id_slots[2..7]` are separate guest VAs that are
+        // never censused here, so "no target aliases the scanout page" is a statement about slot 0
+        // and not about every surface the frame renders into.
         static const bool target_phys_census = std::getenv("PROSPER_TARGET_PHYS") != nullptr;
         if (target_phys_census && color_target->persistent_id) {
             uint64_t tphys = 0;
             const bool ok = prosper::host::guest_write_watch_va_to_phys(
                 color_target->persistent_id, tphys);
-            std::fprintf(stderr, "[target-phys] va=0x%llx %ux%u -> %s0x%llx\n",
-                         (unsigned long long)color_target->persistent_id, W, H,
-                         ok ? "phys=" : "UNRESOLVED ", (unsigned long long)tphys);
+            if (ok)
+                std::fprintf(stderr, "[target-phys] slot0 va=0x%llx %ux%u -> phys=0x%llx\n",
+                             (unsigned long long)color_target->persistent_id, W, H,
+                             (unsigned long long)tphys);
+            else
+                std::fprintf(stderr, "[target-phys] slot0 va=0x%llx %ux%u -> UNRESOLVED "
+                                     "(aliases=%zu)\n",
+                             (unsigned long long)color_target->persistent_id, W, H,
+                             prosper::host::guest_write_watch_alias_count());
         }
         auto [found, inserted] = persistent_color_target_cache().try_emplace(color_key);
         cached_color = &found->second;

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -3,6 +3,7 @@
 // pixels. Used to verify recompiled shaders end-to-end (render -> readback -> pixel asserts). The
 // including test links Vulkan::Vulkan.
 #pragma once
+#include "host/memory/guest_write_watch.hpp"   // VA->phys for the #2932 target census
 #include "shared/rtt/mrt_extent.hpp"
 #include <vulkan/vulkan.h>
 #include "gpu/capture/gpu_capture.hpp"
@@ -5434,6 +5435,21 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     PersistentColorTargetImage* cached_color = nullptr;
     if (persistent_color) {
         color_key = {color_target->persistent_id, W, H, FMT};
+        // PROSPER_TARGET_PHYS (#2932): print each colour target's guest VA and the physical address
+        // it maps to. The present path matches a flipped scanout buffer against targets by VIRTUAL
+        // address, and Stray renders into 0x30... while flipping 0x9fc0000000 (phys 0x230000). If a
+        // target's physical range covers that page, the two are aliases of one allocation and the
+        // VA-keyed match is the whole defect; if none does, the guest copies between distinct
+        // allocations and the question moves to which packet performs it.
+        static const bool target_phys_census = std::getenv("PROSPER_TARGET_PHYS") != nullptr;
+        if (target_phys_census && color_target->persistent_id) {
+            uint64_t tphys = 0;
+            const bool ok = prosper::host::guest_write_watch_va_to_phys(
+                color_target->persistent_id, tphys);
+            std::fprintf(stderr, "[target-phys] va=0x%llx %ux%u -> %s0x%llx\n",
+                         (unsigned long long)color_target->persistent_id, W, H,
+                         ok ? "phys=" : "UNRESOLVED ", (unsigned long long)tphys);
+        }
         auto [found, inserted] = persistent_color_target_cache().try_emplace(color_key);
         cached_color = &found->second;
         cached_color->last_use = color_target_generation;


### PR DESCRIPTION
Refs #2932, #3126, #2883. Replaces #3331 (opened against the stale `master` line — see #3333).

A VA→physical resolver plus two probes, and the `## Ruled out` row recording what they found.
**No production path changes**: the resolver is diagnostic-only, and the census is behind an
environment variable absent by default.

## What was falsified

**The alias hypothesis** — that a flipped scanout buffer and the render targets were two virtual
mappings of one physical allocation, which would have made the missing composite a bookkeeping error
with a fix prosper already had machinery for.

Census over slots 0–6 on the title route, failing steady state confirmed by eye (menu over black at
8× brightness): **55,868 resolutions, 0 unresolved, 82 distinct targets**. Excluding the scanout
buffers themselves, targets whose **physical extent** overlaps either scanout buffer: **0**; nearest
is **390 MB** away.

Slot coverage was added after review and earned it: **24% of resolutions (13,669) are in slots 1–6**,
and since `is_live_render_target` consults `g_rtt` — populated for every slot — an alias there would
have been exactly the proposed link, in exactly the region a slot-0 census cannot see.

## What was corrected — this branch's own premise

**The scanout buffers are render targets.** Both flipped VAs appear in the census as 4K slot-0
colour attachments, throughout the failing run:

| flipped VA | physical | census lines | draws dropped `no-effect(early)` |
| --- | --- | --- | --- |
| `0x9fc0000000` | `0x230000` | 946 | **1,143** |
| `0x9fc2000000` | `0x2210000` | 976 | **1,154** |

The drop figures are new: this diagnostic had only ever been run on the **calibration** screen, which
the status doc explicitly warns is a different screen. 4,096 draws discarded overall, 2,297 of them
aimed at the scanout buffers. Read from the final census emission, not a running total.

So the original framing — *"prosper renders into `0x30…` while the guest flips `0x9fc…`, ~450 GiB
apart, so no VA-keyed lookup can connect them"* — **is withdrawn**.

**Read the census column precisely.** The line prints after the empty-draw early-out, so it licenses
*"bound as slot 0 of a pass carrying ≥1 draw"* — more than "the target exists", less than "a draw's
output reached memory". The row and the code comment both say so.

## Two regimes, previously blended

The guest-scanout fallback is gated on `guest_scanout_read_warranted(...) == Publish` — it runs
**only when nothing else published**:

| regime | what publishes | source of the `authored=0` / `SkipNotAuthored` evidence |
| --- | --- | --- |
| **title screen** (measured here) | the menu **does** publish | *not this regime* |
| **main menu / first map** | nothing publishes | this one |

Measured: **0** `[rtt] GUEST SCANOUT` lines across a full title-route run that reached and held the
failing steady state. So those facts belong to the *other* regime, and the row previously mixed them
— the same mistake this file's own banner warns about for `max_nonblack`.

## What this leaves

A better question. The two tempting branches ("only the UI is drawn there", "the scene is drawn then
wiped") both exclude the branch the status doc **already measures**: the scene reaches the target and
is stored as black by magnitude — PixelHistory has tonemap `shaderOut 0.001099` storing `0`, because
`0.001099 × 255 = 0.28` rounds to zero in `R8G8B8A8_UNORM`. The open part is why the value arriving
at the store is that small, not where the picture goes.

## Review history

Three rounds, all REJECTED, all correct; every finding verified against source before fixing.

- **R1 (4)** — a Windows link break (`Windows App` went red; now **passes**); `authored=0` misread as
  "bytes unchanged since registration"; a coverage claim; a probe message asserting a cause it could
  not establish.
- **R2 (1)** — the slot-0 scope clause. Remedy taken was to *widen the census*, which produced the
  correction above rather than scoping around the gap.
- **R3 (3)** — the retracted sentence still shipping in **three code comments in the same commit**
  (including a shared-substrate header contract), an over-correction in the opposite direction, and
  "renders directly INTO" overreaching.

## Invariants and limits

The resolver reads `WatchState::aliases` — the live dmem topology — rather than adding a second
notion of "which VAs map this page"; a duplicated resolver that could disagree with the write-watch
would be worse than none. The alias count is an out-param filled under the **same lock acquisition**
as the lookup, so a miss and its searched domain cannot describe two different tables.

- Returns the **first** containing range without checking it is large enough. Probe-only; a
  production caller needs the size check.
- `authored=0` has four causes; **two** are a blind instrument rather than an absent write, so
  `buffer_digest_valid` alone does not separate them.
- A *declined* MRT1 base never sets `persistent_id1`, so it cannot reach the census.

## Verification (exact head)

```
cmake -S prosper -B prosper/build-linux -DPROSPER_APP=ON \
      -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build prosper/build-linux -j6      # rc=0, 0 errors
ctest --no-tests=error -j4                 # rc=0
```

**`100% tests passed out of 357`**, exit 0; `plugin_autolink (Skipped)`.

```
check_numbered_table.py prosper/docs/STRAY_STATUS.md -> 26 tables, 94 rows, rc=0
git diff --check                                     -> rc=0
```

**252 added, 1 deleted.** The single deletion is the inlined `g_rtt.find(...)` argument, replaced by
the named `renderer_owns_flip` so the probe can report it — not a whole-file clobber.

Linux-only locally, so the Windows arm rests on structure plus CI, stated as what was checked where.
No snapshots: no rendering behaviour changes.
