### PR TITLE
fault reports: label a guest rip by its own module, not as an unbounded eboot offset

### DIFF
--- a/prosper/src/host/image/boot_program.hpp
+++ b/prosper/src/host/image/boot_program.hpp
@@ -6,6 +6,8 @@
 // then installs its own frontends (renderer / audio sink / pad backend) and calls run_entry().
 #pragma once
 #include "loader/linker.hpp"   // Program
+#include <cstdio>    // format_guest_module_label
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <functional>
@@ -138,6 +140,21 @@ inline bool guest_va_in_module(uint64_t a) {
 // covering the runtime-module aperture the moment it was placed ABOVE the stubs (#639).
 inline bool guest_va_in_module_code(uint64_t a) {
     return guest_va_in_module(a) && !(a >= BOOT_STUB && a < BOOT_STUB_END);
+}
+
+// Render "<module>+0x<rva>" for a guest address into `buf`, using the SAME lookup every other
+// diagnostic uses. This exists so a fault reporter cannot grow its own arithmetic: three fault
+// sites in exec_image_linux.cpp printed a hard-coded "image+0x%llx" computed as `rip - eboot_base`,
+// which labels an address in ANY other module as an eboot offset. On PPSA20447 that rendered a
+// libc.prx address as `image+0x1b0004a20` -- 6.75 GiB past the end of a 250 MiB image -- and the
+// nonsense offset read as a wild jump, which is what produced (and cost a session on) a
+// null-pointer hypothesis for what is really `abort()`'s `int $0x45` trap at libc.prx+0x4a20.
+//
+// Signal-safe: `snprintf` into a caller-owned buffer plus the two pure lookups above. No
+// allocation, no locks, no libc TLS -- callers in fault handlers pair it with raw_write().
+inline void format_guest_module_label(char* buf, size_t n, uint64_t a) {
+    std::snprintf(buf, n, "%s+0x%llx", guest_module_name(a),
+                  (unsigned long long)guest_module_offset(a));
 }
 
 // Boot the title rooted at `dump_root` (the app0 directory): link the fixed module set (dropping any

--- a/prosper/src/host/image/exec_image_linux.cpp
+++ b/prosper/src/host/image/exec_image_linux.cpp
@@ -2418,13 +2418,13 @@ namespace {
             static std::atomic<long> dump_owner{0};
             long expected = 0;
             if (!prosper::host::claim_fault_report(dump_owner, fc.tid, &expected)) {
-                char cb2[224];
+                char cb2[224], where2[64];
+                prosper::format_guest_module_label(where2, sizeof where2, fc.rip);
                 int cn2 = snprintf(cb2, sizeof cb2,
                     "[prosper] CONCURRENT WORKER-THREAD FAULT: tid=%ld sig=%d addr=%p rip=0x%llx "
-                    "(image+0x%llx) -- full dump suppressed, tid=%ld is already reporting\n",
+                    "(%s) -- full dump suppressed, tid=%ld is already reporting\n",
                     fc.tid, fc.sig, (void*)(uintptr_t)fc.addr, (unsigned long long)fc.rip,
-                    (unsigned long long)(g_base && fc.rip >= g_base ? fc.rip - g_base : fc.rip),
-                    expected);
+                    where2, expected);
                 raw_write_fmt(2, cb2, sizeof cb2, cn2);
                 // Wait for the owner to finish before ending the process — `_exit` here would
                 // truncate the very report this gate exists to keep whole (measured: the header
@@ -2449,11 +2449,11 @@ namespace {
                 if (getenv("PROSPER_WORKER_PARK")) { for (;;) pause(); }
                 _exit(90);
             }
-            char b[200];
-            int n = snprintf(b, sizeof b, "[prosper] WORKER-THREAD FAULT: sig=%d addr=%p rip=0x%llx (image+0x%llx) rbp=0x%llx tid=%ld\n",
+            char b[200], where3[64];
+            prosper::format_guest_module_label(where3, sizeof where3, fc.rip);
+            int n = snprintf(b, sizeof b, "[prosper] WORKER-THREAD FAULT: sig=%d addr=%p rip=0x%llx (%s) rbp=0x%llx tid=%ld\n",
                              fc.sig, (void*)(uintptr_t)fc.addr, (unsigned long long)fc.rip,
-                             (unsigned long long)(g_base && fc.rip >= g_base ? fc.rip - g_base : fc.rip),
-                             (unsigned long long)fc.rbp, fc.tid);
+                             where3, (unsigned long long)fc.rbp, fc.tid);
             raw_write_fmt(2, b, sizeof b, n);   /* raw syscall: no libc TLS access */
             // Classify the fault rip + fault-addr regions (which mapping / module) and dump the instruction
             // bytes at rip — turns the ASLR-relocated "rip=0x...48b" into an identifiable location.
@@ -2896,9 +2896,14 @@ namespace {
         const char* sn = g_trap_sig == SIGILL ? "SIGILL"
                        : g_trap_sig == SIGBUS ? "SIGBUS"
                        : g_trap_sig == SIGFPE ? "SIGFPE" : "SIGSEGV";
-        uint64_t off = (g_base && g_fault_rip >= g_base) ? g_fault_rip - g_base : 0;
-        snprintf(buf, sizeof buf, "%s at addr=%p  rip=0x%llx (image+0x%llx)",
-                 sn, g_fault_addr, (unsigned long long)g_fault_rip, (unsigned long long)off);
+        // Label the rip with the SHARED module lookup (#1659), not `rip - eboot_base`. The old
+        // arithmetic printed "image+<rip - g_base>" for EVERY rip, so a fault in any module other
+        // than the eboot rendered as a nonsense eboot offset -- on PPSA20447 a libc.prx address
+        // came out as image+0x1b0004a20, 6.75 GiB past the end of a 250 MiB image.
+        char where[64];
+        prosper::format_guest_module_label(where, sizeof where, g_fault_rip);
+        snprintf(buf, sizeof buf, "%s at addr=%p  rip=0x%llx (%s)",
+                 sn, g_fault_addr, (unsigned long long)g_fault_rip, where);
         return buf;
     }
 

--- a/prosper/tests/host/image/test_guest_module_label.cpp
+++ b/prosper/tests/host/image/test_guest_module_label.cpp
@@ -100,6 +100,48 @@ int main() {
               "an Il2Cpp address never renders as eboot+");
     }
 
+    // ---- the FAULT REPORTER's own formatter, and the exact address that misled a session -------
+    // The three fault sites in exec_image_linux.cpp (trap_detail, WORKER-THREAD FAULT, CONCURRENT
+    // WORKER-THREAD FAULT) each computed `rip - eboot_base` and printed a hard-coded "image+0x%llx".
+    // That is correct only for an eboot rip; for any other module it renders a number that lands
+    // nowhere. Measured on PPSA20447 (The First Berserker: Khazan): the guest calls abort(), whose
+    // PS5 implementation is `int $0x45` at libc.prx+0x4a20, and the fault line read
+    //     SIGSEGV at addr=(nil)  rip=0x5c0004a20 (image+0x1b0004a20)
+    // -- 6.75 GiB past the end of a 250 MiB image. The offset read as a wild jump into nothing, and
+    // that appearance is what produced a null-pointer-dereference hypothesis for a deliberate abort.
+    //
+    // These arms drive `format_guest_module_label`, which is the function those sites now call, so a
+    // site that stops calling it is a visible edit rather than a silent arithmetic change.
+    {
+        char line[64];
+        const uint64_t abort_trap = BOOT_LIBC + 0x4a20;      // the real faulting rip
+        format_guest_module_label(line, sizeof line, abort_trap);
+        CHECK(std::strcmp(line, "libc.prx+0x4a20") == 0,
+              "the fault reporter's formatter names libc.prx and offsets from ITS base");
+        // The mutation this arm exists to catch, spelled out: reverting a site to
+        // `snprintf(..., "image+0x%llx", rip - BOOT_EBOOT)` renders exactly this string.
+        char stale[64];
+        std::snprintf(stale, sizeof stale, "image+0x%llx",
+                      (unsigned long long)(abort_trap - BOOT_EBOOT));
+        CHECK(std::strcmp(line, stale) != 0,
+              "it does NOT render the eboot-relative offset the old fault sites printed");
+        // ...and that offset really is outside the image, which is why it looked like a wild jump.
+        constexpr uint64_t kKhazanEbootBytes = 0xf9ae768ull;   // the flattened PPSA20447 eboot
+        CHECK(abort_trap - BOOT_EBOOT > kKhazanEbootBytes &&
+              guest_module_offset(abort_trap) < kKhazanEbootBytes,
+              "the stale offset is past the end of the eboot while the correct one is a real RVA");
+    }
+
+    // A host/unmapped rip must not be dressed up as a module offset either: it reports verbatim.
+    {
+        char line[64];
+        const uint64_t host_rip = 0x7f2a98dfed30ull;
+        format_guest_module_label(line, sizeof line, host_rip);
+        CHECK(std::strncmp(line, "mapped/host+0x", 14) == 0 &&
+              std::strstr(line, "7f2a98dfed30") != nullptr,
+              "a non-guest rip renders as mapped/host+<the address>, not a fabricated RVA");
+    }
+
     std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
     return fails ? 1 : 0;
 }


### PR DESCRIPTION
`area:infra`. Produced by the overnight orchestrated run (Khazan lane), split out because it helps
every title and should not wait on title work.

## The defect

A guest fault report printed the faulting `rip` as an **eboot offset, with no upper bound**:

```
[app] guest thread ended: kind=2 detail=SIGSEGV at addr=(nil) rip=0x5c0004a20 (image+0x1b0004a20)
```

`image+0x1b0004a20` is **6.75 GiB past the end of a 250 MiB image**. The address is not in the eboot
at all — `BOOT_LIBC = 0x5c0000000`, so it is `libc.prx + 0x4a20`, in a module prosper preloads
itself.

## What it cost

A session. That line, plus `addr=(nil)`, reads as a null-pointer dereference in guest code — the same
shape as *Beneath* (`PPSA27640`), which needs `PROSPER_NULL_PAGE=1` to boot at all. So the Khazan lane
was sent to test exactly that, and burned three arms falsifying it.

The real answer, once the address was labelled correctly: `libc.prx+0x4a20` disassembles to

```
4a10: push %rbp ; mov %rsp,%rbp ; movl $0xa002000b,%fs:0x28
4a20: int $0x45 ; nop ; ud2
```

`int $0x45` is the PS5's deliberate-abort trap, which raises `SIGSEGV` with `si_addr = 0` from user
space. **The guest called `abort()`.** Not a null dereference, and not even in the eboot. The fault
report's own `rbp == rsp` matches that two-instruction prologue, so the attribution is pinned by
register state as well as by address.

A correct line would have read `libc.prx+0x4a20`, and nobody would have hypothesised a null page.

## The fix

`format_guest_module_label()` in `boot_program.hpp`, next to the **existing** `guest_module_name` /
`guest_module_offset` that #1659 added for exactly this "every diagnostic labels guest addresses one
way" reason. One `snprintf` over two pure lookups, so it stays signal-handler-safe beside `raw_write`.
**No second labeller and no new address arithmetic** — a duplicate that could disagree with the first
would be worse than the bug.

Converted: the three sites in `exec_image_linux.cpp` that printed a hard-coded `image+0x%llx` with no
bound — `trap_detail()`, `WORKER-THREAD FAULT`, `CONCURRENT WORKER-THREAD FAULT`.

**Windows is not affected**: `exec_image_win.cpp:423` already bounds its eboot branch by `g_image_end`
and falls through to `GetModuleHandleExA`. Checked rather than assumed; no parity work attempted.

## Tests, and their honest limit

Arms in `tests/host/image/test_guest_module_label.cpp` assert the real faulting address renders
`libc.prx+0x4a20`, that the stale rendering lands past the end of the `PPSA20447` eboot while the
correct offset is inside it, and that a host `rip` reports `mapped/host+<address>` rather than a
fabricated RVA.

**Mutation, run rather than asserted:** reverting `format_guest_module_label` to
`snprintf(..., "image+0x%llx", a - BOOT_EBOOT)` turns **3 arms red** (`== FAIL: 3 ==`). One arm stays
green under that mutation because it exercises `guest_module_offset` directly rather than the
formatter — it is a supporting fact, not a discriminator, and it is not counted.

**The limit, stated plainly:** the arms cover the shared function the sites now call, so a site that
**re-inlined** the arithmetic would still pass. That is a visible edit rather than a silent one, which
is the improvement — it is not full call-site coverage, and a reviewer should not have to discover
that.

## Verification

Build RC=0, zero `error:` lines (two pre-existing warnings in `exec_image_linux.cpp`, on lines this
does not touch). `ctest --no-tests=error -R guest_module_label`: **1/1 passed, 100%, exit 0**;
mutation red as above; reverted and re-verified green. `git diff --check` clean; session-trailer gate
**0**.
