### PR TITLE
gpu_replay: let --inspect-only print the whole index list, not just 16

### DIFF
--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -904,7 +904,18 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay, uint32_t format_v
                     d.ps.db_depth_info, d.ps.db_z_info, d.ps.db_stencil_info,
                     d.ps.db_dfsm_control, d.ps.db_rmi_l2_cache_control);
         if (!d.indices.empty()) {
-            const size_t preview_count = std::min<size_t>(d.indices.size(), 16);
+            // The default 16 answers "is this a quad list?"; a corruption that starts later in the
+            // stream is invisible at that length, so allow the whole list to be printed on request.
+            // Malformed values keep the default rather than silently printing an unintended amount.
+            size_t preview_limit = 16;
+            if (const char* env = std::getenv("PROSPER_REPLAY_INDEX_PREVIEW")) {
+                char* end = nullptr;
+                errno = 0;
+                const unsigned long long wanted = std::strtoull(env, &end, 0);
+                if (!errno && end != env && end && !*end && wanted > 0)
+                    preview_limit = static_cast<size_t>(wanted);
+            }
+            const size_t preview_count = std::min<size_t>(d.indices.size(), preview_limit);
             std::printf("  indices first[%zu/%zu]=", preview_count, d.indices.size());
             for (size_t index = 0; index < preview_count; ++index)
                 std::printf("%s%u", index ? "," : "", d.indices[index]);


### PR DESCRIPTION
## Why

Investigating #3364 (Space Adventure Cobra's mangled UI text) required ruling the index buffer in or
out as the source of the corruption. `gpu_replay --inspect-only` prints the index list, but hard-capped
at 16 entries:

```
indices first[16/348]=0,1,2,2,3,0,4,5,6,6,7,4,8,9,10,10
```

Sixteen entries answers "is this a quad list?" and nothing else. The draw under investigation has 348
indices, its output degrades along the string, and its last seven quads render nothing at all - so the
whole question was whether the index stream stays regular past the preview. At 16 entries that is
unanswerable, and clearing the suspect meant patching the tool.

## What

`PROSPER_REPLAY_INDEX_PREVIEW=N` raises the cap. Unset, behaviour is unchanged at 16. A malformed
value (empty, non-numeric, trailing text, zero) keeps the default rather than silently printing an
unintended amount, matching the strict-parse convention the other capture tunables follow - a typo
costs you detail, never a wrong reading.

Diagnostic only: it changes what is printed, never what is decoded, realized or rendered.

## What it established

With the cap raised, `draw[29]`'s full 348-entry list follows the standard quad pattern
`(4q, 4q+1, 4q+2, 4q+2, 4q+3, 4q)` for all 58 quads with **zero** deviating quads and a maximum index
of 231 against 232 realized vertices. The index buffer is exonerated, and that is recorded in #3364's
`## Ruled out` list alongside the atlas, the UVs, the UV fetch stride, the UV byte offset, the vertex
index drift and the vertex colours.

## Verification

```
cmake --build prosper/build-linux -j6 --target gpu_replay     # clean
```

Behavioural check on a real capsule (one submit from a Cobra frame bundle, 24 indexed draws):

- unset: every draw prints `indices first[16/N]` as before, and short draws print their full length
  (`first[6/6]`, `first[12/12]`) exactly as they did.
- `PROSPER_REPLAY_INDEX_PREVIEW=400`: the 348- and 360-index draws print in full; nothing else changes.

No behavioural code is touched, so no snapshots were run.

Refs #3364
