### PR TITLE
render: PROSPER_BUFVERIFY re-reads uploaded buffers from device memory

### DIFF
--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -6228,6 +6228,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     const bool share_backend_resources =
         getenv("PROSPER_NO_BACKEND_RESOURCE_SHARE") == nullptr;
     const bool reuse_host_buffers = render_host_buffer_pool_enabled();
+    const bool buffer_verify_enabled = getenv("PROSPER_BUFVERIFY") != nullptr;
     struct SharedBufferKey {
         const uint32_t* words = nullptr;
         size_t count = 0;
@@ -6272,6 +6273,22 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         bool persistent = false;
     };
     std::vector<SharedBufferUpload> shared_buffers;
+    // PROSPER_BUFVERIFY=1 — re-read every uploaded storage buffer from its MAPPED, device-visible
+    // allocation just before the pass is submitted, and compare it byte for byte against the guest
+    // words it was built from. This is the readback that answers "did the bytes the capture proves
+    // correct actually reach the GPU?", which PROSPER_BUFLOG cannot: BUFLOG reports the SOURCE, so a
+    // bad memcpy, a short copy, or a later arena/pool slice reusing the same memory all pass it. The
+    // check is deferred to end-of-pass on purpose — verifying at upload time would miss exactly the
+    // clobber-by-reuse case that motivates it.
+    struct BufferVerifyRecord {
+        const uint32_t* words = nullptr;
+        size_t word_count = 0;
+        uint64_t identity = 0;
+        uint32_t set = 0;
+        uint32_t binding = 0;
+        size_t upload_index = 0;
+    };
+    std::vector<BufferVerifyRecord> buffer_verify_records;
     std::vector<SharedBufferArena> shared_buffer_arenas;
     std::unordered_map<SharedBufferKey, size_t, SharedBufferKeyHash> shared_buffer_indices;
     // Per-call repeat-reference memo (#1268): draws in one pass batch overwhelmingly re-reference
@@ -7290,6 +7307,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                              &res_buffer_index_insert_ms);
                         shared_buffers.push_back(upload);
                         shared_buffer_indices.emplace(buffer_key, buffer_index);
+                        if (buffer_verify_enabled)
+                            buffer_verify_records.push_back(
+                                {words, word_count, identity, set, binding, buffer_index});
                     }
                     ++resource_reuse_stats.unique_buffers;
                     ++backend_hash_stats_totals().unique_buffers;
@@ -9623,6 +9643,84 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     }
     if (timing_enabled && flush_now)
         active_submission.end_gpu_timestamp(cmd);
+    if (buffer_verify_enabled) {
+        // Compare the mapped allocation against the source words. A mismatch names the first
+        // differing BYTE, because the question this exists to answer -- "which range computation
+        // truncated the upload?" -- is answered by an offset, not by a boolean.
+        // A clean zero from this check is only worth as much as its ability to report a dirty one,
+        // and nothing in the normal path ever exercises the mismatch branch. PROSPER_BUFVERIFY_MUTATE
+        // corrupts one byte of the FIRST verified buffer's device copy at the given offset, so the
+        // very next lines must name that exact offset. Run it once beside any run whose zero you
+        // intend to quote; without it "0 mismatched" and "the comparison never ran" print the same.
+        size_t mutate_offset = SIZE_MAX;
+        if (const char* mut = getenv("PROSPER_BUFVERIFY_MUTATE")) {
+            char* end = nullptr;
+            errno = 0;
+            const unsigned long long want = std::strtoull(mut, &end, 0);
+            if (!errno && end != mut && end && !*end) mutate_offset = static_cast<size_t>(want);
+        }
+        // Which record to corrupt. The default (the first) proves only that the comparison runs at
+        // all — on a small UBO. A null about a 7 KiB vertex buffer is not validated by a control on a
+        // 128-byte one, so PROSPER_BUFVERIFY_MUTATE_BINDING aims the mutation at the binding whose
+        // zero you actually want to believe, and PROSPER_BUFVERIFY_MUTATE_MINBYTES at the size class.
+        long long mutate_binding = -1;
+        if (const char* mb = getenv("PROSPER_BUFVERIFY_MUTATE_BINDING")) mutate_binding = atoll(mb);
+        size_t mutate_min_bytes = 0;
+        if (const char* mm = getenv("PROSPER_BUFVERIFY_MUTATE_MINBYTES"))
+            mutate_min_bytes = static_cast<size_t>(atoll(mm));
+        const BufferVerifyRecord* mutate_target = nullptr;
+        for (const BufferVerifyRecord& cand : buffer_verify_records) {
+            if (mutate_binding >= 0 && cand.binding != static_cast<uint32_t>(mutate_binding)) continue;
+            if (cand.word_count * sizeof(uint32_t) < mutate_min_bytes) continue;
+            mutate_target = &cand;
+            break;
+        }
+        if (mutate_offset != SIZE_MAX && mutate_target) {
+            const BufferVerifyRecord& rec = *mutate_target;
+            if (rec.upload_index < shared_buffers.size()) {
+                const SharedBufferUpload& up = shared_buffers[rec.upload_index];
+                if (up.mapped && mutate_offset < static_cast<size_t>(up.range)) {
+                    uint8_t* device =
+                        static_cast<uint8_t*>(up.mapped) + static_cast<size_t>(up.offset);
+                    device[mutate_offset] = static_cast<uint8_t>(device[mutate_offset] ^ 0xFF);
+                    std::fprintf(stderr,
+                                 "[bufverify] MUTATED device byte %zu of set=%u binding=%u -- the "
+                                 "next line must report a mismatch at exactly that offset\n",
+                                 mutate_offset, rec.set, rec.binding);
+                }
+            }
+        }
+        size_t checked = 0, mismatched = 0;
+        for (const BufferVerifyRecord& rec : buffer_verify_records) {
+            if (rec.upload_index >= shared_buffers.size()) continue;
+            const SharedBufferUpload& up = shared_buffers[rec.upload_index];
+            if (!up.mapped || !rec.words || !rec.word_count) continue;
+            const size_t source_bytes = rec.word_count * sizeof(uint32_t);
+            const size_t device_bytes = static_cast<size_t>(up.range);
+            const uint8_t* device =
+                static_cast<const uint8_t*>(up.mapped) + static_cast<size_t>(up.offset);
+            const uint8_t* source = reinterpret_cast<const uint8_t*>(rec.words);
+            ++checked;
+            size_t first_bad = SIZE_MAX;
+            const size_t common = source_bytes < device_bytes ? source_bytes : device_bytes;
+            for (size_t b = 0; b < common; ++b)
+                if (device[b] != source[b]) { first_bad = b; break; }
+            if (first_bad == SIZE_MAX && source_bytes == device_bytes) continue;
+            ++mismatched;
+            if (mismatched <= 32)
+                std::fprintf(stderr,
+                             "[bufverify] MISMATCH set=%u binding=%u id=%llx source_bytes=%zu "
+                             "device_bytes=%zu first_differing_byte=%s (vertex %s at stride 32)\n",
+                             rec.set, rec.binding, (unsigned long long)rec.identity,
+                             source_bytes, device_bytes,
+                             first_bad == SIZE_MAX ? "none (size differs only)"
+                                                   : std::to_string(first_bad).c_str(),
+                             first_bad == SIZE_MAX ? "-" : std::to_string(first_bad / 32).c_str());
+        }
+        std::fprintf(stderr, "[bufverify] %zu buffer(s) re-read from device memory, %zu mismatched\n",
+                     checked, mismatched);
+        buffer_verify_records.clear();
+    }
     vkEndCommandBuffer(cmd);
 
     // Publish newly uploaded exact-version textures before a later command buffer in the same batch

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -6275,11 +6275,15 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     std::vector<SharedBufferUpload> shared_buffers;
     // PROSPER_BUFVERIFY=1 — re-read every uploaded storage buffer from its MAPPED, device-visible
     // allocation just before the pass is submitted, and compare it byte for byte against the guest
-    // words it was built from. This is the readback that answers "did the bytes the capture proves
-    // correct actually reach the GPU?", which PROSPER_BUFLOG cannot: BUFLOG reports the SOURCE, so a
-    // bad memcpy, a short copy, or a later arena/pool slice reusing the same memory all pass it. The
-    // check is deferred to end-of-pass on purpose — verifying at upload time would miss exactly the
-    // clobber-by-reuse case that motivates it.
+    // words it was built from. PROSPER_BUFLOG reports only the SOURCE words, so it cannot see the
+    // destination at all; this closes that half.
+    //
+    // Scope, stated narrowly on purpose. The destination `range` is assigned the same byte count the
+    // memcpy used, so a SHORT upload is structurally inexpressible here and a zero from this check
+    // says nothing about truncation — that is `[buffer-truncated]`'s and BUFLOG's question. What it
+    // does detect is the destination being clobbered after the memcpy and before submission: an
+    // overlapping arena slice, a stray write, a pooled buffer handed out twice. End-of-pass placement
+    // is what makes that case visible; verifying at upload time would miss all of it.
     struct BufferVerifyRecord {
         const uint32_t* words = nullptr;
         size_t word_count = 0;
@@ -9645,67 +9649,94 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         active_submission.end_gpu_timestamp(cmd);
     if (buffer_verify_enabled) {
         // Compare the mapped allocation against the source words. A mismatch names the first
-        // differing BYTE, because the question this exists to answer -- "which range computation
-        // truncated the upload?" -- is answered by an offset, not by a boolean.
-        // A clean zero from this check is only worth as much as its ability to report a dirty one,
-        // and nothing in the normal path ever exercises the mismatch branch. PROSPER_BUFVERIFY_MUTATE
-        // corrupts one byte of the FIRST verified buffer's device copy at the given offset, so the
-        // very next lines must name that exact offset. Run it once beside any run whose zero you
-        // intend to quote; without it "0 mismatched" and "the comparison never ran" print the same.
-        size_t mutate_offset = SIZE_MAX;
-        if (const char* mut = getenv("PROSPER_BUFVERIFY_MUTATE")) {
-            char* end = nullptr;
-            errno = 0;
-            const unsigned long long want = std::strtoull(mut, &end, 0);
-            if (!errno && end != mut && end && !*end) mutate_offset = static_cast<size_t>(want);
-        }
-        // Which record to corrupt. The default (the first) proves only that the comparison runs at
-        // all — on a small UBO. A null about a 7 KiB vertex buffer is not validated by a control on a
-        // 128-byte one, so PROSPER_BUFVERIFY_MUTATE_BINDING aims the mutation at the binding whose
-        // zero you actually want to believe, and PROSPER_BUFVERIFY_MUTATE_MINBYTES at the size class.
-        long long mutate_binding = -1;
-        if (const char* mb = getenv("PROSPER_BUFVERIFY_MUTATE_BINDING")) mutate_binding = atoll(mb);
-        size_t mutate_min_bytes = 0;
-        if (const char* mm = getenv("PROSPER_BUFVERIFY_MUTATE_MINBYTES"))
-            mutate_min_bytes = static_cast<size_t>(atoll(mm));
+        // differing BYTE, because what this is used to localize is an offset, not a boolean.
+        //
+        // WHAT IT CAN AND CANNOT SEE, precisely, because the difference decides what a zero from it
+        // is allowed to retire. On the branch this examines, `upload.range` is assigned the same
+        // `bytes` that drove the memcpy and that `word_count` describes, so `source_bytes` and
+        // `device_bytes` are equal BY CONSTRUCTION: a short upload is structurally inexpressible
+        // here and this check can never observe one. What it does observe is the destination range
+        // being CLOBBERED after the memcpy and before the pass is submitted -- an overlapping arena
+        // slice, a stray write, a pooled buffer handed out twice. Truncation is BUFLOG's and
+        // `[buffer-truncated]`'s question; do not quote a zero from here against it.
+        //
+        // The other direction is a false POSITIVE: `#1268` above deliberately tolerates cross-thread
+        // guest writes to the source words, so a guest that rewrites them after the memcpy produces
+        // a MISMATCH that is not a prosper defect. Check the guest before blaming the upload.
+        uint64_t parsed = 0;
+        bool arming_rejected = false;
+        auto strict = [&](const char* name, size_t& out, size_t unset) {
+            const char* text = getenv(name);
+            if (!text || !*text) { out = unset; return; }
+            if (prosper::diag::parse_u64_auto_base(text, &parsed)) { out = (size_t)parsed; return; }
+            std::fprintf(stderr,
+                         "[bufverify] %s=\"%s\" is not a number (decimal or 0x hex); the control is "
+                         "DISARMED rather than aimed somewhere unintended\n", name, text);
+            arming_rejected = true;
+            out = unset;
+        };
+        size_t mutate_offset = SIZE_MAX, mutate_min_bytes = 0, mutate_binding = SIZE_MAX;
+        strict("PROSPER_BUFVERIFY_MUTATE", mutate_offset, SIZE_MAX);
+        strict("PROSPER_BUFVERIFY_MUTATE_BINDING", mutate_binding, SIZE_MAX);
+        strict("PROSPER_BUFVERIFY_MUTATE_MINBYTES", mutate_min_bytes, 0);
+        if (arming_rejected) mutate_offset = SIZE_MAX;
+
+        // The control. A clean zero from the comparison is worth exactly what its ability to report a
+        // dirty one is worth, and nothing in the normal path ever exercises the mismatch branch.
+        // PROSPER_BUFVERIFY_MUTATE corrupts one byte of a device copy so the very next line must name
+        // that offset. It is AIMABLE because a control on a 128-byte uniform buffer says nothing
+        // about a 7 KiB vertex buffer: a control drawn from a different size class than the null
+        // tests the discriminator, not the domain.
         const BufferVerifyRecord* mutate_target = nullptr;
         for (const BufferVerifyRecord& cand : buffer_verify_records) {
-            if (mutate_binding >= 0 && cand.binding != static_cast<uint32_t>(mutate_binding)) continue;
+            if (mutate_binding != SIZE_MAX && cand.binding != (uint32_t)mutate_binding) continue;
             if (cand.word_count * sizeof(uint32_t) < mutate_min_bytes) continue;
+            if (cand.upload_index >= shared_buffers.size()) continue;
+            if (!shared_buffers[cand.upload_index].mapped) continue;
+            if (mutate_offset >= (size_t)shared_buffers[cand.upload_index].range) continue;
             mutate_target = &cand;
             break;
         }
         if (mutate_offset != SIZE_MAX && mutate_target) {
-            const BufferVerifyRecord& rec = *mutate_target;
-            if (rec.upload_index < shared_buffers.size()) {
-                const SharedBufferUpload& up = shared_buffers[rec.upload_index];
-                if (up.mapped && mutate_offset < static_cast<size_t>(up.range)) {
-                    uint8_t* device =
-                        static_cast<uint8_t*>(up.mapped) + static_cast<size_t>(up.offset);
-                    device[mutate_offset] = static_cast<uint8_t>(device[mutate_offset] ^ 0xFF);
-                    std::fprintf(stderr,
-                                 "[bufverify] MUTATED device byte %zu of set=%u binding=%u -- the "
-                                 "next line must report a mismatch at exactly that offset\n",
-                                 mutate_offset, rec.set, rec.binding);
-                }
-            }
+            const SharedBufferUpload& up = shared_buffers[mutate_target->upload_index];
+            uint8_t* device = static_cast<uint8_t*>(up.mapped) + (size_t)up.offset;
+            device[mutate_offset] = (uint8_t)(device[mutate_offset] ^ 0xFF);
+            std::fprintf(stderr,
+                         "[bufverify] MUTATED device byte %zu of set=%u binding=%u source_bytes=%zu "
+                         "-- the next line must report a mismatch at exactly that offset\n",
+                         mutate_offset, mutate_target->set, mutate_target->binding,
+                         mutate_target->word_count * sizeof(uint32_t));
+        } else if (mutate_offset != SIZE_MAX) {
+            // Silence here is indistinguishable from a clean run, which is the whole failure this
+            // control exists to prevent. Say so.
+            std::fprintf(stderr,
+                         "[bufverify] CONTROL DID NOT FIRE: no recorded buffer matched "
+                         "binding=%s minbytes=%zu with a host mapping and offset %zu in range. "
+                         "The \"0 mismatched\" below is UNVALIDATED\n",
+                         mutate_binding == SIZE_MAX ? "any" : std::to_string(mutate_binding).c_str(),
+                         mutate_min_bytes, mutate_offset);
         }
-        size_t checked = 0, mismatched = 0;
+
+        size_t checked = 0, mismatched = 0, skipped_unmapped = 0;
         for (const BufferVerifyRecord& rec : buffer_verify_records) {
-            if (rec.upload_index >= shared_buffers.size()) continue;
+            if (rec.upload_index >= shared_buffers.size()) { ++skipped_unmapped; continue; }
             const SharedBufferUpload& up = shared_buffers[rec.upload_index];
-            if (!up.mapped || !rec.words || !rec.word_count) continue;
+            // A transient (non-arena, non-pooled) upload unmaps its memory before returning, so it
+            // has no host mapping to re-read and is skipped. That is a WHOLE CLASS, not an oddity:
+            // PROSPER_NO_BACKEND_BUFFER_POOL sends every upload down that path, and without the
+            // count below such a run would print an authoritative-looking "0 mismatched" having
+            // verified nothing at all.
+            if (!up.mapped || !rec.words || !rec.word_count) { ++skipped_unmapped; continue; }
             const size_t source_bytes = rec.word_count * sizeof(uint32_t);
-            const size_t device_bytes = static_cast<size_t>(up.range);
-            const uint8_t* device =
-                static_cast<const uint8_t*>(up.mapped) + static_cast<size_t>(up.offset);
+            const size_t device_bytes = (size_t)up.range;
+            const uint8_t* device = static_cast<const uint8_t*>(up.mapped) + (size_t)up.offset;
             const uint8_t* source = reinterpret_cast<const uint8_t*>(rec.words);
             ++checked;
-            size_t first_bad = SIZE_MAX;
             const size_t common = source_bytes < device_bytes ? source_bytes : device_bytes;
+            if (std::memcmp(device, source, common) == 0 && source_bytes == device_bytes) continue;
+            size_t first_bad = SIZE_MAX;
             for (size_t b = 0; b < common; ++b)
                 if (device[b] != source[b]) { first_bad = b; break; }
-            if (first_bad == SIZE_MAX && source_bytes == device_bytes) continue;
             ++mismatched;
             if (mismatched <= 32)
                 std::fprintf(stderr,
@@ -9717,10 +9748,17 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                    : std::to_string(first_bad).c_str(),
                              first_bad == SIZE_MAX ? "-" : std::to_string(first_bad / 32).c_str());
         }
-        std::fprintf(stderr, "[bufverify] %zu buffer(s) re-read from device memory, %zu mismatched\n",
-                     checked, mismatched);
-        buffer_verify_records.clear();
+        if (!checked && !buffer_verify_records.empty())
+            std::fprintf(stderr,
+                         "[bufverify] NOTHING WAS VERIFIED: all %zu recorded buffer(s) lack a host "
+                         "mapping (transient uploads). A zero from this run means the check never "
+                         "ran, not that the uploads are correct\n",
+                         buffer_verify_records.size());
+        std::fprintf(stderr,
+                     "[bufverify] %zu buffer(s) re-read from device memory, %zu mismatched, "
+                     "%zu skipped (no host mapping)\n", checked, mismatched, skipped_unmapped);
     }
+
     vkEndCommandBuffer(cmd);
 
     // Publish newly uploaded exact-version textures before a later command buffer in the same batch

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -9668,10 +9668,18 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         auto strict = [&](const char* name, size_t& out, size_t unset) {
             const char* text = getenv(name);
             if (!text || !*text) { out = unset; return; }
-            if (prosper::diag::parse_u64_auto_base(text, &parsed)) { out = (size_t)parsed; return; }
+            // The UINT32_MAX bound is not pedantry: `binding` is compared as uint32_t below, so a
+            // value above it would truncate and aim the control at a DIFFERENT binding while still
+            // printing a confident MUTATED line -- the same silent-misaim this strict parse exists
+            // to prevent, one range check further out.
+            if (prosper::diag::parse_u64_auto_base(text, &parsed) && parsed <= UINT32_MAX) {
+                out = (size_t)parsed;
+                return;
+            }
             std::fprintf(stderr,
-                         "[bufverify] %s=\"%s\" is not a number (decimal or 0x hex); the control is "
-                         "DISARMED rather than aimed somewhere unintended\n", name, text);
+                         "[bufverify] %s=\"%s\" is not a number in [0, 4294967295] (decimal or 0x "
+                         "hex); the control is DISARMED rather than aimed somewhere unintended\n",
+                         name, text);
             arming_rejected = true;
             out = unset;
         };

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -99,6 +99,59 @@ guest pitch while retaining their historical tight byte span.
 The `vs=` and `fs=` summaries identify whether each recompiled shader is retained as `owned` or
 `shared`; their size and hash always describe the accessor-selected words the renderer consumes.
 
+## Verifying what reached the GPU — `PROSPER_BUFVERIFY`
+
+`PROSPER_BUFLOG=1` prints the **source** words of every storage-buffer upload, which answers "what did
+prosper believe it was uploading". It cannot answer "did that arrive", because it never looks at the
+destination.
+
+`PROSPER_BUFVERIFY=1` closes that half. Every uploaded storage buffer is recorded and, just before the
+pass's command buffer is closed, re-read from its mapped device-visible allocation and compared byte
+for byte against the words it was built from:
+
+```
+[bufverify] 91 buffer(s) re-read from device memory, 0 mismatched, 0 skipped (no host mapping)
+[bufverify] MISMATCH set=0 binding=7 id=2079b49510 source_bytes=11520 device_bytes=11520
+            first_differing_byte=6528 (vertex 204 at stride 32)
+```
+
+**What a zero from it does and does not retire.** The destination `range` is assigned the same byte
+count the memcpy used, so a *short* upload is structurally inexpressible here — truncation is
+`[buffer-truncated]`'s and BUFLOG's question, not this one. What this detects is the destination being
+**clobbered between the memcpy and submission**: an overlapping arena slice, a stray write, a pooled
+buffer handed out twice. End-of-pass placement is what makes that visible.
+
+A mismatch can also be a false positive: the `#1268` dedup path deliberately tolerates cross-thread
+guest writes to the source words, so a guest that rewrites them after the memcpy trips this without any
+prosper defect being involved.
+
+**`skipped (no host mapping)` is load-bearing.** A transient upload (neither arena nor pool) unmaps its
+memory before returning and cannot be re-read. `PROSPER_NO_BACKEND_BUFFER_POOL=1` sends *every* upload
+down that path, so that arm verifies nothing — and says so, loudly, rather than printing a
+confident-looking zero.
+
+### The control, and aiming it
+
+This check exists to report a zero, and nothing in a normal run exercises its mismatch branch, so it
+ships with a deliberate-corruption control. `PROSPER_BUFVERIFY_MUTATE=N` flips one byte of a device copy
+and the next line must name that offset:
+
+```
+[bufverify] MUTATED device byte 6528 of set=0 binding=7 source_bytes=11520 -- the next line must
+            report a mismatch at exactly that offset
+```
+
+`PROSPER_BUFVERIFY_MUTATE_BINDING` and `PROSPER_BUFVERIFY_MUTATE_MINBYTES` aim it. **Aim it at the
+binding and size class whose zero you intend to quote.** The first version of this control always took
+whichever buffer was recorded first — a 128-byte uniform buffer — and fired perfectly, which proves the
+comparison runs and says nothing about the 7 KiB vertex buffer the null was about. A control drawn from
+a different size class than the null tests the discriminator, not the domain.
+
+If nothing matches the aim, the run prints `CONTROL DID NOT FIRE ... UNVALIDATED` instead of falling
+silent, because silence there is indistinguishable from a clean verified run. All three values parse
+strictly (decimal or `0x` hex); a malformed one disarms the control loudly rather than aiming it
+somewhere unintended.
+
 ## Draw-time resource provenance
 
 Set `PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE=DRAW:vs|ps:BINDING` while taking a capsule with


### PR DESCRIPTION
## Why

Investigating #3364 needed a measurement the renderer could not make: **do the bytes a capture proves
correct still hold in the memory the GPU is about to read?**

`PROSPER_BUFLOG` reports the *source* words of each storage-buffer upload. It never looks at the
destination, so it cannot see the destination being clobbered between the memcpy and submission — an
overlapping arena slice, a stray write, a pooled buffer handed out twice. Cobra's symptom (a contiguous
range of a text mesh's vertices producing nothing while the rest of the same buffer renders) is that
family's signature, and without a readback it could only be argued about.

## What

`PROSPER_BUFVERIFY=1` records every uploaded storage buffer and, **just before the pass's command buffer
is closed**, re-reads it from its mapped device-visible allocation and compares it byte for byte against
the guest words it was built from:

```
[bufverify] 91 buffer(s) re-read from device memory, 0 mismatched, 0 skipped (no host mapping)
[bufverify] MISMATCH set=0 binding=7 id=2079b49510 source_bytes=11520 device_bytes=11520
            first_differing_byte=6528 (vertex 204 at stride 32)
```

End-of-pass placement is the point: verifying right after the memcpy would miss every clobber-by-reuse
case, which is the class worth suspecting.

### What a zero from it does NOT retire

**It cannot observe a truncation.** The destination `range` is assigned the same byte count that drove
the memcpy and that the recorded word count describes, so source and device sizes are equal *by
construction* on every buffer it checks. A short upload is structurally inexpressible here; that is
`[buffer-truncated]`'s and `PROSPER_BUFLOG`'s question. The comments, the README and the #3364 record all
say so — an earlier revision of this PR claimed otherwise and that over-claim is corrected on the issue.

A mismatch also has a false-positive direction: the `#1268` dedup path deliberately tolerates
cross-thread guest writes to the source words, so a guest that rewrites them after the memcpy trips this
without any prosper defect.

**`skipped (no host mapping)` is load-bearing.** A transient upload (neither arena nor pool) unmaps its
memory before returning and cannot be re-read. `PROSPER_NO_BACKEND_BUFFER_POOL=1` sends *every* upload
down that path, so that arm verifies nothing — and now says so rather than printing a vacuous zero:

```
[bufverify] 0 buffer(s) re-read from device memory, 0 mismatched, 91 skipped (no host mapping)
[bufverify] NOTHING WAS VERIFIED: all 2 recorded buffer(s) lack a host mapping (transient uploads).
            A zero from this run means the check never ran, not that the uploads are correct
```

## The control ships with it, and is aimable

Nothing in a normal run exercises the mismatch branch, so a deliberate-corruption control comes with the
check. `PROSPER_BUFVERIFY_MUTATE=N` flips one byte of a device copy and the next line must name that
offset:

```
[bufverify] MUTATED device byte 6528 of set=0 binding=7 source_bytes=11520 -- the next line must
            report a mismatch at exactly that offset
[bufverify] MISMATCH set=0 binding=7 id=2079b49510 source_bytes=11520 device_bytes=11520
            first_differing_byte=6528 (vertex 204 at stride 32)
```

**Aiming it is not a convenience.** The first version always mutated whichever buffer was recorded first
— a 128-byte uniform buffer — and fired perfectly. That proves the compare loop runs and says nothing
about the 7 KiB vertex buffer whose zero was about to be quoted: a control drawn from a different size
class than the null tests the discriminator, not the domain. `PROSPER_BUFVERIFY_MUTATE_BINDING` and
`PROSPER_BUFVERIFY_MUTATE_MINBYTES` aim it at the binding and size class you intend to believe.

If nothing matches, the run prints `CONTROL DID NOT FIRE … UNVALIDATED` rather than falling silent,
because silence there is indistinguishable from a clean verified run. All three values parse strictly
(decimal or `0x` hex, bounded at `UINT32_MAX`); a malformed one disarms the control loudly.

## Verification

```
cmake --build prosper/build-linux -j6                 # clean
ctest --no-tests=error -j4                            # 363 tests discovered
```

**363 tests, 358 passed, 5 failed**, and all five (`recompiled_shaders_render`, `multidraw_render`,
`indexed_render`, `descriptor_array_render`, `gpu_execute`) fail **identically on unmodified
`origin/main`** in the same worktree — established by stashing this diff, rebuilding and re-running.
They are flaky on this AMD/RADV box: repeated `test_indexed_render` runs on clean main give 4, 5, 4, 2,
3 and once **0** failures. Filed separately as #3371. CI does not see them because its Linux job renders
on a software implementation.

Observational by construction: unset, nothing is recorded and no comparison runs; enabled, the rendered
frame is byte-identical to the untouched run (same MD5).

## What it established on #3364

133 buffers re-read across one *Space Adventure Cobra* frame, **0 mismatched**, with the control fired at
byte 6528 of the same binding and size class — the exact offset where that frame's text stops rendering.
Together with `PROSPER_BUFLOG` showing full, correctly-addressed uploads with zero `[buffer-truncated]`
lines, and a four-arm arena/pool/share A/B producing byte-identical output, that retires the upload,
truncation, dirty-range and buffer-reuse families for the defect and points it downstream of resource
realization.

## Review

Independently reviewed. First round **REJECTED** with four blocking findings — a silently skipped upload
class that made a whole A/B arm vacuous, an over-claim about truncation, a control that could decline to
fire in silence, and non-strict parsing of the aiming values. All four fixed in `39c3efad6`; re-reviewed
and **APPROVED**. `933daba3a` adds one further guard the re-review raised as non-blocking (bounding the
aiming values at `UINT32_MAX`, since the binding filter compares as `uint32_t`); the whole delta from the
approved head is that guard.

Refs #3364
