### PR TITLE
gpu: hash finalized shader compile keys once

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -30,6 +30,28 @@ an overall **~34x speedup** (measured across 106 rendered frames in 4.90 s; Run 
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
 
+## Linux windowed baseline (2026-09-06, #3065)
+
+At `a5150495e`, a fresh Release build with `-O3 -DNDEBUG -g1 -fno-omit-frame-pointer`
+reached the bank gameplay scene on the unchanged `reach-performance-story.pad` route. Both save
+roots were fresh. Frontend screenshots confirmed **Graphics Mode: Performance** and subsequently
+the bank interior, characters, radar and walking tutorial. The nine-minute run used native rendering,
+full cadence, immediate presentation, default cache/worker settings and no diagnostic compute skips;
+the app confirmed the renderer's shared present queue. No device-loss signal was recorded.
+
+The native Linux/RADV F8 window measured **5.58 guest flips/s and 5.78 host presents/s** over
+5.02 seconds, with 1.51 process CPU cores. Its 720 renderer and 1,917 compute detail records were
+not truncated. Measured totals were 2,311 ms graphics and 1,547 ms compute; resource preparation
+accounted for 1,179 ms across its frontend/backend layers. These are scoped timing records, not an
+exhaustive GPU frame budget. The later F9 bundle completed with 73 submits and a matching frontend
+gameplay image, outside the timed window. Artifact hashes and capture details belong to #3065.
+
+A separate 20-second CPU profile retained 1,607 samples with zero reported loss. Compiled-key hashing
+was 5.91% of **sampled** CPU; this is not a share of frame time or a promised speedup. Inspection found
+that `make_shader_compile_key` computed a provisional hash which all three callers unconditionally
+overwrote after attaching diagnostic settings. Removing that first calculation preserves the final key,
+equality checks and shader output. End-to-end performance improvement is not yet established.
+
 ## Gameplay framerate optimization: reaching 21+ FPS (2026-09-03)
 
 **Platform**: Measured on **Windows 11 / Intel Core i9 (24 physical cores) / discrete NVIDIA GeForce RTX 4090 (24 GB VRAM, Vulkan 1.4)**.

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -1692,7 +1692,8 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             key.resources.push_back(compiled);
         }
     }
-    key.cached_hash = ShaderCompileKeyHash::compute(key);
+    // All three callers still attach their program's trip-bound settings. Hash only after that
+    // finalization: a provisional hash here is unconditionally overwritten before any cache lookup.
     return key;
 }
 
@@ -2183,7 +2184,7 @@ std::vector<uint32_t> recompile_compute_shader_cached(
     // Only meaningful while the trip-bound diagnostic is armed; disarmed it leaves the key exactly as
     // it was. The program address is carried on the diagnostic context because nothing else in the
     // key identifies WHICH program these code bytes belong to, and that is precisely the distinction
-    // the selector makes. Recompute the hash: make_shader_compile_key already cached one.
+    // the selector makes. Finalize the hash only after attaching those diagnostic settings.
     key.trip_bound = compute_trip_bound_settings();
     if (key.trip_bound.bound) key.trip_bound_program_address = diagnostic.program_address;
     key.cached_hash = ShaderCompileKeyHash::compute(key);

--- a/prosper/tests/gpu/execute/AGENTS.md
+++ b/prosper/tests/gpu/execute/AGENTS.md
@@ -1,0 +1,9 @@
+# Execution-layer tests
+
+These tests cover the contracts that turn decoded GPU work into executable operations: dependency
+ordering, draw realization, index interpretation, and compiled-shader cache identity. The cache tests
+compare emitted modules and warm-cache behavior without running a game; they are not visual or
+performance oracles. Vulkan execution coverage is separate, including tests under `tests/shared/`.
+
+When changing a cache key, exercise both a reusable identical key and a changed code-generation
+input. Diagnostic selectors are code-generation inputs too, even when normal launches leave them off.

--- a/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
+++ b/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
@@ -1885,6 +1885,51 @@ int main() {
               stats.misses == 1 && stats.hits == 1,
           "identical vertex prolog/main pairs share one compiled cache entry");
 
+    // The factory returns an unfinished key: chained vertices, like ordinary graphics and compute,
+    // attach the diagnostic address before hashing it. Relocated identical prologs must separate
+    // while a selector is armed, and each finalized key must remain reusable in either call order.
+    {
+        const std::vector<uint32_t> relocated_prolog(
+            vertex_prolog, vertex_prolog + std::size(vertex_prolog));
+        char selector[32];
+        std::snprintf(selector, sizeof selector, "0x%llx",
+                      static_cast<unsigned long long>(
+                          reinterpret_cast<uintptr_t>(vertex_prolog)));
+        set_test_env("PROSPER_CFG_TRIP_BOUND", "4");
+        set_test_env("PROSPER_CFG_TRIP_BOUND_PROGRAM", selector);
+        set_test_env("PROSPER_CFG_TRIP_BOUND_PHASE", "0");
+        for (bool relocated_first : {false, true}) {
+            clear_shader_recompile_cache();
+            const uint32_t* first = relocated_first ? relocated_prolog.data() : vertex_prolog;
+            const uint32_t* second = relocated_first ? vertex_prolog : relocated_prolog.data();
+            uint64_t first_id = 0, second_id = 0, repeated_id = 0;
+            const auto first_words = recompile_vertex_chain_cached_shared(
+                first, std::size(vertex_prolog), chain_main.data(), chain_main.size(),
+                &table, nullptr, &first_id);
+            const auto second_words = recompile_vertex_chain_cached_shared(
+                second, std::size(vertex_prolog), chain_main.data(), chain_main.size(),
+                &table, nullptr, &second_id);
+            const auto repeated_words = recompile_vertex_chain_cached_shared(
+                first, std::size(vertex_prolog), chain_main.data(), chain_main.size(),
+                &table, nullptr, &repeated_id);
+            const auto selected_stats = shader_recompile_cache_stats();
+            CHECK(first_words && second_words && !first_words->empty() && !second_words->empty() &&
+                      first_id != 0 && second_id != 0 && first_id != second_id &&
+                      repeated_words == first_words && repeated_id == first_id &&
+                      selected_stats.misses == 2 && selected_stats.hits == 1,
+                  "armed chained-vertex keys separate addresses and hit after finalization");
+        }
+        set_test_env("PROSPER_CFG_TRIP_BOUND", nullptr);
+        set_test_env("PROSPER_CFG_TRIP_BOUND_PROGRAM", nullptr);
+        set_test_env("PROSPER_CFG_TRIP_BOUND_PHASE", nullptr);
+        // Restore the ordinary pair for the LDS and code-mutation arms below.
+        clear_shader_recompile_cache();
+        (void)recompile_vertex_chain_cached_shared(
+            vertex_prolog, std::size(vertex_prolog), chain_main.data(), chain_main.size(),
+            &table, nullptr, &chain_first_identity);
+        stats = shader_recompile_cache_stats();
+    }
+
     const uint64_t pre_lds_misses = stats.misses;
     uint64_t chain_lds_identity = 0;
     const SharedShaderWords chain_with_lds = recompile_vertex_chain_cached_shared(


### PR DESCRIPTION
## Change

Refs #3065; does not close the broader gameplay-performance investigation.

Remove the provisional full shader-key hash from `make_shader_compile_key`. All three callers already attach diagnostic settings and unconditionally calculate the final hash before any cache lookup. The hash algorithm, complete-key equality, shader inputs and final cache identities are unchanged.

Add chained-vertex coverage for address-sensitive diagnostic selectors and reusable finalized keys in both lookup orders. Existing graphics/compute tests cover the sibling paths. These are behavior guards, not a timing benchmark; source inspection establishes the eliminated redundant call.

## Evidence and limits

[Current native windowed bank-gameplay baseline and retained artifact hashes](https://github.com/mattias800/prosper/issues/3065#issuecomment-5555267500): Performance mode visually confirmed, fresh save roots, full rendering cadence, shared GPU presentation, no compute skips or device loss. The clean CPU recording attributes 5.91% of sampled CPU to compiled-key hashing. This is not a share of frame time and does not predict an equivalent FPS improvement.

The status document now separates this Linux baseline from the existing Windows result. No end-to-end speedup is claimed. Compute writeback/resource handling and short-lived worker granularity remain larger investigation areas; scheduler tooling compatibility is tracked separately in #3384.

## Author verification

Head: `35d4e8375579d9254af2c8235f0fbf9b7c5ab1ef`; base: `a5150495e389deace1814db3322185e43b889e74`.

- Fresh isolated Release build with optimized symbols/frame pointers; built `prosper-app`, `test_shader_recompile_cache`, `test_cfg_trip_bound` through the development container.
- Exact-head CTest: `shader_recompile_cache` and `cfg_trip_bound_exec`, **2/2 passed**, including real Vulkan execution for the latter. Used `--no-tests=error`.
- Existing performance-report Python tests: **26 passed**.
- Touched Markdown table checks and `git diff --check`: passed.
- Full rendering snapshot matrix not run; compiled-module/cache contracts are the focused guard for this unchanged-output optimization.

Independent registered review approved this exact head. Its separate 300-second candidate live smoke
run reached the bank scene, retained a completed F9 bundle and frontend screenshot, and exited cleanly
without a device-loss signature. This is qualitative verification only: candidate CPU sampling overlapped
part of its F8 timing window, so it is not used for an end-to-end speedup claim. Details and artifact
hashes are in the author-verification comment. Applicable CI is still required before merge.
