### PR TITLE
gpu: retain export watch registrations across full writebacks

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -2781,7 +2781,8 @@ struct VulkanComputeContext {
                                       const uint8_t* current_source = nullptr,
                                       bool result_unchanged = false,
                                       bool source_snapshot_required = true,
-                                      bool compute_transfer_watch = false) {
+                                      bool compute_transfer_watch = false,
+                                      bool retain_export_watch = false) {
         auto found = image_cache.find(key);
         if (found == image_cache.end()) return;
         CachedComputeImage& cached = found->second;
@@ -2833,9 +2834,14 @@ struct VulkanComputeContext {
             if (!cached.write_watch)
                 cached.write_watch = prosper::host::GuestWriteWatch::create(
                     key.gpu_addr, key.guest_bytes);
-        } else {
+        } else if (!retain_export_watch) {
             cached.write_watch.reset();
         }
+        // Export authority is revoked before dispatch, independently of the watch's lifetime.
+        // A successful exportable full writer can retain its registration until publication rearms
+        // it against the completed guest writeback. Resetting it here only makes publication rebuild
+        // the same page registration. Do not rearm early or restore export authority here; failure
+        // cleanup still invalidates the content and discards the watch.
         if (!source_was_valid) {
             // A failed dispatch/readback may have advanced the retained GPU result while leaving
             // guest memory at the old baseline. The successful repair must replace that invalidated
@@ -10562,7 +10568,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     ctx.validate_cached_image_source(
                         bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
                         bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
-                            native_3d_transfer_enabled());
+                            native_3d_transfer_enabled(),
+                        bi.graphics_sampled_usage && bi.exact_storage_bytes());
                 } else if (bi.image && bi.memory && bi.allocation_bytes &&
                            ctx.retain_image(bi.cache_key, bi.image, bi.memory,
                                             bi.allocation_bytes,

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -626,6 +626,7 @@ struct Registration {
     std::vector<RegistrationPage> pages;
     uint64_t begin = 0, end = 0;
     bool gpu_dirty = false;
+    bool mapping_valid = true;
 };
 
 struct DmemTracePage {
@@ -847,6 +848,15 @@ void invalidate_phys_range_locked(WatchState& w, uint64_t phys_begin, uint64_t p
 // so freeing one here would dangle a live Registration's raw pointer. A page that loses its last alias
 // just lingers, disarmed and Dirty, until its owning registration resets. Called with the lock held.
 void purge_va_range_locked(WatchState& w, uint64_t begin, uint64_t end, bool remove_topology) {
+    // A registration belongs to its requested VA range, not merely to the physical pages that
+    // happened to back it at creation. Keep old pages alive for other aliases/registrations, but
+    // never let rearm bless them after this registration's original mapping has been replaced.
+    // Removing a sibling alias outside the requested range does not invalidate that identity.
+    for (auto& [id, registration] : w.registrations) {
+        (void)id;
+        if (registration.begin < end && registration.end > begin)
+            registration.mapping_valid = false;
+    }
     for (auto& [phys, pageptr] : w.pages_by_phys) {
         (void)phys;
         WatchedPage* page = pageptr.get();
@@ -1349,7 +1359,7 @@ GuestWriteWatchQuery GuestWriteWatch::query() const {
     std::lock_guard lock(w.mutex);
     auto found = w.registrations.find(id_);
     if (found == w.registrations.end()) { bump(stats().unknown); return GuestWriteWatchQuery::Unknown; }
-    if (found->second.gpu_dirty) {
+    if (!found->second.mapping_valid || found->second.gpu_dirty) {
         bump(stats().dirty);
         return GuestWriteWatchQuery::Dirty;
     }
@@ -1368,7 +1378,7 @@ bool GuestWriteWatch::rearm() {
     WatchState& w = state();
     std::lock_guard lock(w.mutex);
     auto found = w.registrations.find(id_);
-    if (found == w.registrations.end()) return false;
+    if (found == w.registrations.end() || !found->second.mapping_valid) return false;
     std::vector<WatchedPage*> pages;
     for (const RegistrationPage& rp : found->second.pages) if (rp.page) pages.push_back(rp.page);
     if (!set_pages_armed(w, pages, true)) return false;   // couldn't re-protect -> caller re-creates
@@ -1761,6 +1771,21 @@ void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t 
         if (a.addr < lo) split_out.push_back({a.addr, lo - a.addr, a.phys, a.prot});
         split_out.push_back({lo, hi - lo, a.phys + (lo - a.addr), protection});
         if (hi < a_end) split_out.push_back({hi, a_end - hi, a.phys + (hi - a.addr), a.prot});
+        // Existing page records may still carry this alias's previous protection. A retained
+        // registration must take the same reset/create path as a fresh watch, including when the
+        // changed alias is outside its original VA range but names the same physical memory.
+        // Ordinary physical writes do not change this registration-lifetime contract.
+        const uint64_t phys_begin = a.phys + (lo - a.addr);
+        const uint64_t phys_end = a.phys + (hi - a.addr);
+        for (auto& [id, registration] : w.registrations) {
+            (void)id;
+            if (std::any_of(registration.pages.begin(), registration.pages.end(),
+                            [&](const RegistrationPage& rp) {
+                                return rp.page && rp.page->phys < phys_end &&
+                                       rp.page->phys + kPage > phys_begin;
+                            }))
+                registration.mapping_valid = false;
+        }
         invalidate_phys_range_locked(w, a.phys + (lo - a.addr), a.phys + (hi - a.addr));
     }
     for (const AliasRange& r : split_out) w.aliases.push_back(r);

--- a/prosper/src/host/memory/guest_write_watch.hpp
+++ b/prosper/src/host/memory/guest_write_watch.hpp
@@ -196,6 +196,8 @@ public:
     static GuestWriteWatch create(uint64_t addr, uint64_t size);
     explicit operator bool() const { return id_ != 0; }
     GuestWriteWatchQuery query() const;
+    // A removed/replaced original mapping or a changed alias protection requires reset/create;
+    // rearm cannot retarget a watch to new physical memory or bless stale protection metadata.
     bool rearm();
     void reset();
 
@@ -207,7 +209,7 @@ private:
 GuestWriteWatchStats guest_write_watch_stats();
 
 // Direct-memory mapping notifications. A topology/protection change invalidates existing watches;
-// their next query is Unknown and the exact path may establish a fresh complete registration.
+// their next query is Dirty/Unknown and the exact path may establish a fresh complete registration.
 void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size, uint64_t phys,
                                                     uint32_t protection);
 void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size);

--- a/prosper/tests/gpu/recompiler/AGENTS.md
+++ b/prosper/tests/gpu/recompiler/AGENTS.md
@@ -1,9 +1,12 @@
-# `tests/gpu/recompiler` — RDNA2 → SPIR-V tests that need no Vulkan device
+# `tests/gpu/recompiler` — translation tests and the legacy compute execution fixture
 
-Everything here asks a question of `src/gpu/recompiler` alone: does this instruction stream decode,
+Most tests here ask a question of `src/gpu/recompiler` alone: does this instruction stream decode,
 does it recompile, does the module it produces have the shape the contract promises, and — just as
 often — does a stream that must NOT compile still reject, and reject *loudly*. No device is created,
 so these run everywhere and are the cheapest place in the project to pin a translator contract.
+The historical exception is `test_game_compute.cpp`: it executes synthetic shaders through the live
+Vulkan backend, including storage writeback, cache authority, and real mapped-page write watches.
+Its existing end-to-end fixtures remain here; new standalone execution tests belong in `execute/`.
 
 **The boundary against its siblings.** `tests/gpu/execute/` runs modules on a real device and
 asserts pixels or buffer contents; anything needing a queue belongs there, not here. Two large

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -6056,9 +6056,30 @@ int main() {
                 alternating_changed.resources = std::make_shared<ShaderResourceTable>(fill_rt);
                 const uint64_t dynamic_snapshots_before =
                     prosper::frontend::live_compute_storage_result_snapshot_bytes();
+                ShaderResource dynamic_sampled = fdst;
+                dynamic_sampled.cls = ResourceClass::Texture;
+                prosper::frontend::LiveComputeImageImport dynamic_import;
+                CHECK(prosper::frontend::import_live_compute_storage_image(
+                          dynamic_sampled, fill_guest_bytes, dynamic_import) &&
+                          dynamic_import.valid(),
+                      "warm changing target has cross-submit watch-backed export authority");
+                dynamic_import = {};
+                const auto dynamic_watch_before = prosper::host::guest_write_watch_stats();
                 CHECK(prosper::frontend::execute_live_compute_items({alternating_changed}) &&
                           prosper::frontend::execute_live_compute_items({it}),
                       "alternating full-coverage storage results execute");
+                const auto dynamic_watch_after = prosper::host::guest_write_watch_stats();
+                CHECK(dynamic_watch_after.create_attempts == dynamic_watch_before.create_attempts,
+                      "warm changing full writers reuse their export watch registration");
+                CHECK(dynamic_watch_after.rearms >= dynamic_watch_before.rearms + 2,
+                      "each changing writer rearms its retained export watch at publication");
+                CHECK(fill_equals(after_prove),
+                      "watch retention preserves exact alternating storage results");
+                CHECK(prosper::frontend::import_live_compute_storage_image(
+                          dynamic_sampled, fill_guest_bytes, dynamic_import) &&
+                          dynamic_import.valid(),
+                      "retained watch authorizes the completed result across submits");
+                dynamic_import = {};
                 const uint64_t dynamic_snapshots_after =
                     prosper::frontend::live_compute_storage_result_snapshot_bytes();
                 if (adaptive_storage_result_validation_enabled) {
@@ -6069,6 +6090,15 @@ int main() {
                               dynamic_snapshots_before + 2 * fill_guest_bytes,
                           "disabled adaptive policy preserves exact dynamic snapshots");
                 }
+                // The installed alternate-stack handler must dirty the retained registration on
+                // a real guest store, without a submit-local journal or an explicit GPU notification.
+                fill_guest[0] ^= 0xff;
+                CHECK(!prosper::frontend::import_live_compute_storage_image(
+                          dynamic_sampled, fill_guest_bytes, dynamic_import),
+                      "CPU write revokes a reused cross-submit export watch");
+                CHECK(prosper::frontend::execute_live_compute_items({it}) &&
+                          fill_equals(after_prove),
+                      "ordinary writeback repairs a guest store after watch reuse");
             }
 #endif
 

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -6099,6 +6099,30 @@ int main() {
                 CHECK(prosper::frontend::execute_live_compute_items({it}) &&
                           fill_equals(after_prove),
                       "ordinary writeback repairs a guest store after watch reuse");
+                prosper::host::guest_write_watch_notify_direct_mapping_removed(
+                    reinterpret_cast<uint64_t>(fill_guest), fill_mapping_bytes);
+                CHECK(mmap(fill_guest, fill_mapping_bytes, PROT_READ | PROT_WRITE,
+                           MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == fill_guest,
+                      "replace warm storage target backing at the same virtual address");
+                prosper::host::guest_write_watch_notify_direct_mapping_added(
+                    reinterpret_cast<uint64_t>(fill_guest), fill_mapping_bytes,
+                    0x33860000, 0x3 /* SCE CPU_READ|CPU_WRITE */);
+                CHECK(prosper::frontend::execute_live_compute_items({alternating_changed}) &&
+                          prosper::frontend::execute_live_compute_items({it}) &&
+                          fill_equals(after_prove),
+                      "full writers rebuild authority after guest target remapping");
+                CHECK(prosper::frontend::import_live_compute_storage_image(
+                          dynamic_sampled, fill_guest_bytes, dynamic_import) &&
+                          dynamic_import.valid(),
+                      "replacement mapping obtains fresh cross-submit export authority");
+                dynamic_import = {};
+                fill_guest[0] ^= 0xff;
+                CHECK(!prosper::frontend::import_live_compute_storage_image(
+                          dynamic_sampled, fill_guest_bytes, dynamic_import),
+                      "CPU store to remapped target revokes the recreated export watch");
+                CHECK(prosper::frontend::execute_live_compute_items({it}) &&
+                          fill_equals(after_prove),
+                      "ordinary writeback repairs the remapped target after its CPU store");
             }
 #endif
 

--- a/prosper/tests/host/memory/AGENTS.md
+++ b/prosper/tests/host/memory/AGENTS.md
@@ -1,0 +1,7 @@
+# Host guest-memory tests
+
+These fixtures exercise the host's mapping/readability caches, direct-memory alias registries,
+write-watch fault handling, and memory search. They model actual mapped pages and mapping lifetimes;
+guest-facing allocation/API behavior belongs to HLE tests, and GPU cache publication belongs to
+the live compute execution fixtures. Linux write-watch tests need a real alternate-stack fault
+handler so direct stores test dirty tracking rather than an explicit-notification substitute.

--- a/prosper/tests/host/memory/test_guest_write_watch.cpp
+++ b/prosper/tests/host/memory/test_guest_write_watch.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstdio>
+#include <initializer_list>
 
 using prosper::host::GuestWriteWatch;
 using prosper::host::GuestWriteWatchQuery;
@@ -202,6 +203,13 @@ int main() {
     prosper::host::guest_write_watch_notify_direct_mapping_protection(
         reinterpret_cast<uint64_t>(a + page), page, kCpuRw);
 
+    // Explicit guest protection changes require fresh alias metadata; ordinary content writes
+    // below still rearm the same registration without recreating it.
+    CHECK(!watch.rearm() && watch.query() == GuestWriteWatchQuery::Dirty,
+          "guest re-protection invalidates the old registration even after restoring permissions");
+    watch.reset();
+    watch = GuestWriteWatch::create(reinterpret_cast<uint64_t>(a), size);
+    CHECK(static_cast<bool>(watch), "recreate the watch after guest re-protection");
     // Re-arm, don't write -> Unchanged again.
     CHECK(watch.rearm(), "rearm succeeds");
     CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "no write since rearm -> Unchanged");
@@ -273,6 +281,119 @@ int main() {
     CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
           "a page still covered by a surviving alias keeps faulting after a sibling alias is removed (B4)");
     munmap(c, size);
+
+    // A partial remap of the ORIGINAL watched VA must force a new registration. Exercise both
+    // an orphaned old page and a surviving old-physical sibling alias: nonempty alias coverage
+    // alone cannot prove that this watch still describes the requested address.
+    for (bool keep_old_alias : {false, true}) {
+        const size_t remap_bytes = page * 3;
+        const uint64_t old_phys = keep_old_alias ? 0xc10000 : 0xc00000;
+        const uint64_t new_phys = old_phys + 0x8000;
+        int old_fd = memfd_create("prosper-ww-remap-old", 0);
+        int new_fd = memfd_create("prosper-ww-remap-new", 0);
+        CHECK(old_fd >= 0 && new_fd >= 0, "remap memfds created");
+        if (old_fd < 0 || new_fd < 0) return 1;
+        CHECK(ftruncate(old_fd, static_cast<off_t>(remap_bytes)) == 0 &&
+                  ftruncate(new_fd, static_cast<off_t>(page)) == 0,
+              "remap memfds sized");
+        auto* original = static_cast<uint8_t*>(mmap(
+            nullptr, remap_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, old_fd, 0));
+        CHECK(original != MAP_FAILED, "original remap range mapped");
+        if (original == MAP_FAILED) return 1;
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(original), remap_bytes, old_phys, kCpuRw);
+        uint8_t* sibling = nullptr;
+        if (keep_old_alias) {
+            sibling = static_cast<uint8_t*>(mmap(
+                nullptr, remap_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, old_fd, 0));
+            CHECK(sibling != MAP_FAILED, "old-physical sibling mapped");
+            if (sibling == MAP_FAILED) return 1;
+            prosper::host::guest_write_watch_notify_direct_mapping_added(
+                reinterpret_cast<uint64_t>(sibling), remap_bytes, old_phys, kCpuRw);
+        }
+        auto original_watch = GuestWriteWatch::create(
+            reinterpret_cast<uint64_t>(original + 8), remap_bytes - 16);
+        CHECK(original_watch && original_watch.query() == GuestWriteWatchQuery::Unchanged,
+              "unaligned original range has a clean watch before middle-page replacement");
+        auto* middle = original + page;
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(middle), page);
+        CHECK(mmap(middle, page, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, new_fd, 0) == middle,
+              "middle page remapped to a different backing section at the same VA");
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(middle), page, new_phys, kCpuRw);
+        CHECK(!original_watch.rearm(), "original-VA remap cannot rearm an old physical registration");
+        CHECK(original_watch.query() == GuestWriteWatchQuery::Dirty,
+              "failed remap rearm never clears the obsolete registration's dirty state");
+        original_watch.reset();
+        auto replacement_watch = GuestWriteWatch::create(reinterpret_cast<uint64_t>(middle + 8), 16);
+        CHECK(replacement_watch && replacement_watch.query() == GuestWriteWatchQuery::Unchanged,
+              "fresh registration resolves the replacement VA backing");
+        middle[12] = 0x5a;
+        CHECK(replacement_watch.query() == GuestWriteWatchQuery::Dirty,
+              "real write to replacement backing dirties the recreated watch");
+        CHECK(!sibling || sibling[page + 12] == 0,
+              "replacement write does not reach the surviving old physical alias");
+        replacement_watch.reset();
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(original), remap_bytes);
+        munmap(original, remap_bytes);
+        if (sibling) {
+            prosper::host::guest_write_watch_notify_direct_mapping_removed(
+                reinterpret_cast<uint64_t>(sibling), remap_bytes);
+            munmap(sibling, remap_bytes);
+        }
+        close(old_fd);
+        close(new_fd);
+    }
+
+    // Protection changes through another VA invalidate the affected PHYSICAL registration only.
+    // A read-only alias becoming writable must not remain invisible to a retained watch.
+    {
+        int protection_fd = memfd_create("prosper-ww-protection", 0);
+        CHECK(protection_fd >= 0 && ftruncate(protection_fd, static_cast<off_t>(page * 3)) == 0,
+              "protection-transition memfd sized");
+        if (protection_fd < 0) return 1;
+        auto* writable = static_cast<uint8_t*>(mmap(
+            nullptr, page * 3, PROT_READ | PROT_WRITE, MAP_SHARED, protection_fd, 0));
+        auto* readonly = static_cast<uint8_t*>(mmap(
+            nullptr, page * 3, PROT_READ, MAP_SHARED, protection_fd, 0));
+        CHECK(writable != MAP_FAILED && readonly != MAP_FAILED,
+              "writable and read-only aliases mapped");
+        if (writable == MAP_FAILED || readonly == MAP_FAILED) return 1;
+        constexpr uint64_t protection_phys = 0xc20000;
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(writable), page * 3, protection_phys, kCpuRw);
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(readonly), page * 3, protection_phys, 0x1);
+        auto affected = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable + page), page);
+        auto unaffected = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable), page);
+        CHECK(affected && unaffected, "affected and disjoint physical ranges watched");
+        CHECK(mprotect(readonly + page, page, PROT_READ | PROT_WRITE) == 0,
+              "middle page of read-only alias becomes writable");
+        prosper::host::guest_write_watch_notify_direct_mapping_protection(
+            reinterpret_cast<uint64_t>(readonly + page), page, kCpuRw);
+        CHECK(!affected.rearm() && affected.query() == GuestWriteWatchQuery::Dirty,
+              "changed sibling-alias protection requires a fresh registration");
+        CHECK(unaffected.rearm() && unaffected.query() == GuestWriteWatchQuery::Unchanged,
+              "partial protection change leaves disjoint physical registration rearmable");
+        affected.reset();
+        affected = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable + page), page);
+        CHECK(affected && affected.query() == GuestWriteWatchQuery::Unchanged,
+              "sole-owner replacement watch uses current sibling-alias protections");
+        readonly[page + 32] = 0x77;
+        CHECK(writable[page + 32] == 0x77 && affected.query() == GuestWriteWatchQuery::Dirty,
+              "real store through newly writable alias dirties recreated watch");
+        affected.reset();
+        unaffected.reset();
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(writable), page * 3);
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(readonly), page * 3);
+        munmap(writable, page * 3);
+        munmap(readonly, page * 3);
+        close(protection_fd);
+    }
 
     // N2: a partial re-protect must record ONLY the re-protected sub-range. Re-protect the MIDDLE page of
     // a fresh 3-page mapping read-only; a watch over the FIRST page must still find it writable, arm it,


### PR DESCRIPTION
## Problem and contract

Refs #3065. A detailed native Linux Performance Story capture places about 2.03 ms in cache maintenance and 1.77 ms in publication per selected 4K packed-image writeback ([measurement and population limits](https://github.com/mattias800/prosper/issues/3065#issuecomment-5555623073)). These are inclusive attribution buckets, not an established saving.

Before storage dispatch, compute correctly revokes graphics export authority. Successful ordinary full-overwrite validation then treats that revoked flag as a reason to destroy its existing guest write-watch registration. Publication immediately rebuilds that same registration.

Keep registration lifetime separate from export permission: a successful, native-exact, sampled full writer retains an existing watch through validation. Publication still rearms it, or resets/recreates on failure, at the existing authority boundary. This changes no guest bytes, shader, format, launch, render cadence, journal snapshot, or notification. Pre-dispatch revocation and failed-dispatch cleanup remain intact.

Review found that existing rearming could accept obsolete physical pages after the original VA was remapped, or stale alias protections after a guest permission change. The follow-up adds a sticky registration-validity guard under the existing watch lock: original-range replacement or a covered physical alias's explicit protection change requires reset/create. Ordinary writes, new same-physical aliases, and removal of a sibling alias outside the original range remain rearmable. The initial `1cbee0d` approval was withdrawn; only review of the corrected head can authorize merge.

Host-backed replay, adaptive-disabled validation, partial/read-modify-write targets, and the existing 3D-transfer-watch branch keep their previous behavior. Cold/missing watches are still established at publication. This is not deferred writeback or a new cross-submit visibility contract. The main risk is accidentally publishing stale cached content; the retained watch is never used to bypass existing authorization checks.

## Verification

Configured inside the development container with Vulkan and the app enabled:

```sh
export PROSPER_GAME_ROOT=<DUMP_ROOT>
export TMPDIR=<WORKTREE>/prosper/build-linux/tmpdir
cmake -S prosper -B prosper/build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DPROSPER_APP=ON -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 \
  "-DCMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG -g1 -fno-omit-frame-pointer"
cmake --build prosper/build-linux --target prosper-app test_game_compute \
  test_guest_write_watch test_live_compute_host_read_barrier -j6
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure \
  -R '^(game_compute_exec.*|guest_write_watch|live_compute_host_read_barrier)$' -j1
```

- Author working-tree run: **5/5 passed**, exit 0, real RADV hardware after a 301-second quiet gate. Compute variants executed 526/512/526 assertions (default/no-adaptive/scratch-poison). The intentional child fault is the existing unarmed-page rejection control, not an unexpected test crash.
- New fixture alternates two proven full writers on one mapped target; checks no new registration attempts, publication rearming, exact bytes, positive cross-submit imports, rejection after a real CPU store, and ordinary repair. Existing fixture coverage includes cold publication, GPU-notified invalidation, failed readback/retry, partial and untouched outputs.
- Initial mutation: restore the old unconditional reset branch with the new test unchanged. **1/1 failed**, CTest exit 8, exactly the registration-reuse and publication-rearm assertions fail; all 526 assertions execute. Restoring the fix passed all five tests on exact `1cbee0d`.
- Topology follow-up: **5/5 passed** on the corrected working tree, including 531/517/531 compute assertions. Host controls replace the middle page of an unaligned watched range using real section mappings, both with and without a surviving old-physical sibling; another case changes a read-only alias to writable while checking an unaffected physical page. Compute exercises remapping of a warm full-writer target, cross-submit export, a real store, and repair.
- Topology mutation: remove the validity checks from `query`/`rearm` while retaining the optimization and tests. **2/2 failed**, exit 8: six host checks reject stale remap/protection authority, and compute fails actual remapped-target CPU invalidation and repair. All 531 compute assertions execute. Guards restored; the exact `8c48fcf999ed2392add35abb71df9d177bad9e38` rebuild and **5/5** test rerun passed, exit 0, with 531/517/531 compute assertions.
- Additional exact-head host targets `test_dmem_write_trace` and `test_watch_mapping_generation` built successfully; `ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure -R '^(dmem_write_trace|watch_mapping_generation)$' -j1` passed **2/2**, exit 0. Together with the main run, seven tests executed and passed.
- Markdown tables, `git diff --check`, contribution-shape (7 changed paths), usage-text (44 modules), and CTest-gate (10 invocations) checks pass.
- [Independent registered review APPROVED the corrected exact head](https://github.com/mattias800/prosper/pull/3386#pullrequestreview-5123541189), resolving the initial rejection. [Exact-head author evidence](https://github.com/mattias800/prosper/pull/3386#issuecomment-5555735220).
- No full snapshot matrix required for this scoped change. The first native prototype completed Performance Story F8/F9 without device loss, but it is rejected for the topology hole and is **not** safe implementation evidence. Corrected native validation is below.

## Corrected native GTA validation

Exact head `8c48fcf999ed2392add35abb71df9d177bad9e38`, verified clean source and executable SHA-256 `0e4bea34d387576a94966d73c8e6f7d42590dca954df03a0556f7caac7e17c3c`: native Linux `prosper-app`, Wayland/RADV, fresh save, `scripts/gta5/reach-performance-story.pad`, default tiling workers, full resolution and render cadence, no compute skip. Scheduled F8 after 300 seconds and F9 after 380 seconds. Existing phase/image diagnostics were restricted to the F8 capture and hash `9d2f1fa81873e9a9`. Exclusive GPU ownership and host process/DRM censuses covered the run; no CPU profiler ran alongside it.

The bounded 451-second run exited normally with no device-loss/reset/fault signature. Direct captures visibly show the Performance setting and the rendered bank interior, characters, radar and tutorial. F9 completed all 73 submits outside the timed window. This verifies the existing checkpoint, not a new progression rung or pixel equivalence to PS5 hardware.

For the same selected 3840x2160 packed R11G11B10 output (tile 27, 33,423,360 guest bytes), warm cache-hit/seed-skipped/non-poisoned writebacks changed as follows:

| Mean host time (ms) | Baseline (30 warm samples) | Corrected (29 warm samples) |
| --- | ---: | ---: |
| Whole selected writeback phase | 5.709 | 2.351 |
| Publication | 1.775 | 0.450 |
| Image cache maintenance | 2.027 | 0.000586 |
| Image watch | 0.546 | 0.523 |
| Image layout | 1.305 | 1.326 |

The corrected capture also contains one cold/proving writeback at 18.24 ms; **all 30**, including cold, average 2.881 ms. Requiring setup-upload-skipped as well leaves 28 fully warm samples averaging 2.353 ms. Both arms used the same diagnostic configuration; these are inclusive host attribution buckets, not additive independent savings.

Corrected F8 has 768 renderer and 2,030 compute records, zero drops; its post counters give 30 guest frames over 5.016 seconds, about **5.98 guest frames/s**. Sustained host presentation counters were 6.18/s baseline and 6.66/s corrected, but these are upper bounds without a distinct-content sampler, from one pilot pair rather than repeated statistical trials. **This establishes a selected-path reduction, not a demonstrated end-to-end framerate speedup or full-speed gameplay.** Raw captures remain local.

Known separate limitation: [#3387](https://github.com/mattias800/prosper/issues/3387) tracks stale per-page protection metadata when another registration retains the same physical page through reconstruction. The protection guard here restores the previous reset/create lifecycle; it does not claim to repair that pre-existing shared-owner case.

The tests folder map now identifies the existing legacy Vulkan fixture accurately; no source relocation is mixed into this behavior change.
