### PR TITLE
gpu: avoid redundant snapshots for exact write-only image aliases

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -52,6 +52,27 @@ that `make_shader_compile_key` computed a provisional hash which all three calle
 overwrote after attaching diagnostic settings. Removing that first calculation preserves the final key,
 equality checks and shader output. End-to-end performance improvement is not yet established.
 
+### Duplicate storage-image preparation (#3065)
+
+On merged `805b49d53`, a later native Performance Story F8 isolated **3.512 ms** in the first
+duplicate storage binding's pre-alias-processing interval, against **3.836 ms** total setup for
+program hash `1d3f91e7f9a30140` (28 fully warm dispatches). Its 3840×2160 RGBA8 output binds one
+canonical storage image and three exact aliases. The interval is not the cost of copying alias
+fields: the backend requests an RTT snapshot before discovering the alias, while only the owner
+publishes a binding-specific coverage proof. The renderer can materialize a full target on that read.
+
+Exact write-only storage aliases now fold before this redundant snapshot/coverage preparation,
+after descriptor, device, shape and DCC validation and the ownership query's pending-write drain.
+Reflected storage representation and complete resource-view identity must match. Canonical seeding,
+partial-write preservation and one writeback remain; sampled and mixed-access bindings retain the
+late path. Synthetic execution checks both aliases' distinct pixels, necessary partial seeds and
+missing-seed rejection; disabling only the early fold fails seven assertions. This establishes the
+mechanism, not an end-to-end speedup. Native comparison evidence remains in #3065.
+
+The phase-report tool's alias records are **not zero work**: this capture has 101.930 ms in aliases
+versus 26.963 ms in real-image records. The report's misleading alias-only wording is tracked in
+#3388. Do not treat its real-image-only decomposition as all image setup.
+
 ## Gameplay framerate optimization: reaching 21+ FPS (2026-09-03)
 
 **Platform**: Measured on **Windows 11 / Intel Core i9 (24 physical cores) / discrete NVIDIA GeForce RTX 4090 (24 GB VRAM, Vulkan 1.4)**.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6334,6 +6334,39 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             image_timing_requested && timing_item_selected &&
             (!timing_capture_only || perf_capture_timing) &&
             (!timing_trace_only || trace);
+        const auto bind_image_alias = [&](size_t i, size_t j, ComputeClock::time_point start) {
+            BoundImage& bi = images[i];
+            bi.alias_of = images[j].alias_of == SIZE_MAX ? j : images[j].alias_of;
+            const BoundImage& owner = images[bi.alias_of];
+            bi.image = owner.image; bi.memory = owner.memory; bi.view = owner.view;
+            bi.sampler = owner.sampler; bi.guest_bytes = owner.guest_bytes;
+            bi.texel_depth = owner.texel_depth;
+            bi.array_layers = owner.array_layers;
+            bi.mip_levels = owner.mip_levels;
+            bi.mip_staging_offsets = owner.mip_staging_offsets;
+            bi.dcc_metadata = owner.dcc_metadata;
+            bi.dcc_metadata_bytes = owner.dcc_metadata_bytes;
+            staging_bytes[i] = staging_bytes[bi.alias_of];
+            const ShaderResource& r = *bi.resource;
+            if (trace)
+                std::fprintf(stderr, "[compute]   image-alias binding=%u -> binding=%u addr=0x%llx\n",
+                             bi.binding, owner.binding, (unsigned long long)r.gpu_addr);
+            if (image_timing)
+                std::fprintf(stderr,
+                             "[compute-image] code=0x%llx hash=0x%016llx "
+                             "binding=%u class=%s alias=1 addr=0x%llx alias_of=%u "
+                             "persistent=%u upload-skipped=%u "
+                             "extent=%ux%ux%u ms=%.3f\n",
+                             (unsigned long long)item.code_addr,
+                             (unsigned long long)timing_program_hash, bi.binding,
+                             bi.storage ? "storage" : "sampled",
+                             (unsigned long long)r.gpu_addr, owner.binding,
+                             owner.persistent ? 1u : 0u,
+                             owner.upload_skipped ? 1u : 0u,
+                             r.width, r.height, r.depth,
+                             std::chrono::duration<double, std::milli>(
+                                 ComputeClock::now() - start).count());
+        };
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
             // Every skip_image call below is inside this loop, so the cursor is always the binding
             // being decided.
@@ -6541,6 +6574,45 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
             query_ms = std::chrono::duration<double, std::milli>(
                 ComputeClock::now() - query_start).count();
+            // Exact write-only storage aliases already have a fully prepared canonical image.
+            // Fold before requesting an RTT snapshot or consulting this binding's coverage proof:
+            // only the owner writes back and publishes a proof, so the duplicate would otherwise
+            // keep requesting a snapshot even after the owner has proved a full overwrite.
+            // Keep the ownership query above: the live renderer also drains pending guest writes.
+            // Sampled/imported representations and mixed-access bindings retain the late path.
+            const auto& decl = image_descriptors[i];
+            if (bi.storage && decl.writable && !decl.readable && !decl.atomic_access) {
+                for (size_t j = 0; j < i; ++j) {
+                    const BoundImage& owner = images[j];
+                    const auto& owner_decl = image_descriptors[j];
+                    if (!owner.storage || owner.alias_of != SIZE_MAX || !owner.resource ||
+                        !owner_decl.writable || owner_decl.readable || owner_decl.atomic_access)
+                        continue;
+                    const bool same_representation =
+                        decl.image_numeric_class == owner_decl.image_numeric_class &&
+                        decl.storage_image_format == owner_decl.storage_image_format &&
+                        decl.image_dim == owner_decl.image_dim &&
+                        decl.image_arrayed == owner_decl.image_arrayed &&
+                        decl.image_multisampled == owner_decl.image_multisampled &&
+                        decl.image_depth == owner_decl.image_depth &&
+                        bi.native_float_storage == owner.native_float_storage &&
+                        bi.native_uint_storage == owner.native_uint_storage &&
+                        bi.packed_r11_storage == owner.packed_r11_storage &&
+                        bi.graphics_sampled_usage == owner.graphics_sampled_usage &&
+                        !owner.imported && !owner.depth_bits_source &&
+                        !owner.unorm_rtt_value_reuse;
+                    const prosper::gpu::ComputeImageViewShape owner_shape{
+                        owner.storage, owner.texel_depth, owner.array_layers};
+                    const prosper::gpu::ComputeImageViewShape this_shape{
+                        bi.storage, bi.texel_depth, bi.array_layers};
+                    if (!prosper::gpu::shader_resource_same_view(
+                            *owner.resource, *r, owner_shape, this_shape, same_representation))
+                        continue;
+                    bind_image_alias(i, j, image_start);
+                    break;
+                }
+                if (bi.alias_of != SIZE_MAX) continue;
+            }
             static const uint32_t render_scale = [] {
                 const char* e = std::getenv("PROSPER_RENDER_SCALE");
                 const long v = e ? std::strtol(e, nullptr, 10) : 1;
@@ -6959,41 +7031,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (!bi.storage && same_view)
                     same_sampler = prosper::gpu::shader_resource_same_sampler(*p, *r);
                 if (!same_view || !same_sampler) continue;
-                bi.alias_of = prior.alias_of == SIZE_MAX ? j : prior.alias_of;
-                const BoundImage& owner = images[bi.alias_of];
-                bi.image = owner.image; bi.memory = owner.memory; bi.view = owner.view;
-                bi.sampler = owner.sampler; bi.guest_bytes = owner.guest_bytes;
-                bi.texel_depth = owner.texel_depth;
-                bi.array_layers = owner.array_layers;
-                bi.mip_levels = owner.mip_levels;
-                bi.mip_staging_offsets = owner.mip_staging_offsets;
-                bi.dcc_metadata = owner.dcc_metadata;
-                bi.dcc_metadata_bytes = owner.dcc_metadata_bytes;
-                staging_bytes[i] = staging_bytes[bi.alias_of];
-                if (trace)
-                    std::fprintf(stderr, "[compute]   image-alias binding=%u -> binding=%u addr=0x%llx\n",
-                                 bi.binding, owner.binding, (unsigned long long)r->gpu_addr);
+                bind_image_alias(i, j, image_start);
                 break;
             }
-            if (bi.alias_of != SIZE_MAX) {
-                const BoundImage& alias_owner = images[bi.alias_of];
-                if (image_timing)
-                    std::fprintf(stderr,
-                                 "[compute-image] code=0x%llx hash=0x%016llx "
-                                 "binding=%u class=%s alias=1 addr=0x%llx alias_of=%u "
-                                 "persistent=%u upload-skipped=%u "
-                                 "extent=%ux%ux%u ms=%.3f\n",
-                                 (unsigned long long)item.code_addr,
-                                 (unsigned long long)timing_program_hash, bi.binding,
-                                 bi.storage ? "storage" : "sampled",
-                                 (unsigned long long)r->gpu_addr, alias_owner.binding,
-                                 alias_owner.persistent ? 1u : 0u,
-                                 alias_owner.upload_skipped ? 1u : 0u,
-                                 r->width, r->height, r->depth,
-                                 std::chrono::duration<double, std::milli>(
-                                     ComputeClock::now() - image_start).count());
-                continue;
-            }
+            if (bi.alias_of != SIZE_MAX) continue;
             const uint32_t sampled_layers = dim_cube_stacked ? 6u
                                             : dim_2d_array ? r->depth : 1u;
             const VkDeviceSize volume_texels = static_cast<VkDeviceSize>(r->width) * r->height *

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -5001,6 +5001,153 @@ int main() {
     set_live_target_reader({});
     set_live_target_query({});
 
+    // Exact write-only storage aliases must fold before their independent RTT seed preparation.
+    // The two stores cover different rows through different bindings: losing either store or
+    // splitting the Vulkan image cannot satisfy the byte oracle. Only the canonical owner proves
+    // coverage, so an alias must not repeatedly request a snapshot for its never-published proof.
+    auto check_write_only_rtt_alias = [&](uint32_t height, uint64_t code_addr) {
+        const bool full = height == 2;
+        const bool allow_warm_seed_skip =
+            std::getenv("PROSPER_NO_SKIP_SEED") == nullptr &&
+            std::getenv("PROSPER_VERIFY_SEED_SKIP") == nullptr &&
+            prosper::frontend::seed_reprove_interval_from_env(
+                std::getenv("PROSPER_SEED_REPROVE"), 256u) != 1;
+        static const uint32_t alias_rows[] = {
+            0x7E080300u,              // v4 = x from the local ID
+            0x7E0A0280u,              // v5 = 0: owner writes row zero
+            0x7E0002F2u,              // v0 = 1.0f (red)
+            0x7E020280u,              // v1 = 0
+            0x7E040280u,              // v2 = 0
+            0x7E0602F2u,              // v3 = 1.0f (alpha)
+            0xF0200F08u, 0x00020004u, // IMAGE_STORE through s[8:15], binding 5
+            0x7E0A0281u,              // v5 = 1: alias writes row one
+            0x7E000280u,              // v0 = 0
+            0x7E0202F2u,              // v1 = 1.0f (green)
+            0xF0200F08u, 0x00040004u, // IMAGE_STORE through s[16:23], binding 6
+            0xBF810000u,
+        };
+        std::vector<uint8_t> destination(static_cast<size_t>(W) * height * 4, 0xC7);
+        auto snapshot_bytes = std::make_shared<std::vector<uint8_t>>(destination.size());
+        for (size_t byte = 0; byte < snapshot_bytes->size(); ++byte)
+            (*snapshot_bytes)[byte] = static_cast<uint8_t>(byte * 13 + 29);
+        const uint64_t address = reinterpret_cast<uint64_t>(destination.data());
+        ShaderResourceTable table;
+        for (uint32_t binding = 5; binding <= 6; ++binding) {
+            ShaderResource resource{};
+            resource.cls = ResourceClass::StorageImage;
+            resource.img_dim = 1;
+            resource.binding = binding;
+            resource.sgpr_base = binding == 5 ? 8 : 16;
+            resource.format = DataFormat::Unorm8;
+            resource.num_components = 4;
+            resource.width = W;
+            resource.height = height;
+            resource.depth = 1;
+            resource.gpu_addr = address;
+            resource.size = static_cast<uint32_t>(destination.size());
+            table.resources.push_back(resource);
+        }
+        ComputeShaderConfig config;
+        config.user_sgprs.resize(24);
+        config.local_x = W;
+        config.local_y = config.local_z = 1;
+        config.tidig_comp_cnt = 0;
+        config.native_storage_format_support =
+            native_storage_format_support_bit(DataFormat::Unorm8, 4);
+        const std::vector<uint32_t> spirv =
+            recompile_compute(alias_rows, std::size(alias_rows), &table, config);
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const bool write_only_aliases = !spirv.empty() && report.ok() &&
+            report.descriptors.size() == 2 &&
+            std::all_of(report.descriptors.begin(), report.descriptors.end(),
+                [](const SpirvDescriptorBinding& descriptor) {
+                    return descriptor.kind == SpirvDescriptorKind::StorageImage &&
+                           descriptor.writable && !descriptor.readable &&
+                           descriptor.storage_float;
+                });
+        CHECK(write_only_aliases,
+              "RTT alias fixture reflects two native write-only storage bindings");
+        if (!write_only_aliases) return;
+
+        ComputeItem item;
+        item.spirv = spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(table);
+        item.launch.threads_x = item.launch.local_x = W;
+        item.launch.groups_x = 1;
+        item.launch.threads_y = item.launch.threads_z = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = code_addr;
+        uint32_t queries = 0, reads = 0, notifications = 0;
+        bool fail_reader = false;
+        set_live_target_query([&](uint64_t candidate) {
+            if (candidate != address) return false;
+            ++queries;
+            return true;
+        });
+        set_live_target_reader([&](uint64_t candidate, LiveTargetSnapshot& snapshot) {
+            if (candidate != address) return false;
+            ++reads;
+            if (fail_reader) return false;
+            snapshot.width = W;
+            snapshot.height = height;
+            snapshot.format = LiveTargetPixelFormat::Rgba8Unorm;
+            snapshot.pixels = snapshot_bytes;
+            return true;
+        });
+        set_guest_gpu_write_observer([&](uint64_t written_addr, uint64_t bytes, const char*) {
+            if (written_addr == address && bytes == destination.size()) ++notifications;
+        });
+        for (uint32_t run = 0; run < 2; ++run) {
+            const bool unused_reader = full && run != 0 && allow_warm_seed_skip;
+            queries = reads = notifications = 0;
+            // A fresh guest mirror must not satisfy the result oracle without actual writeback.
+            std::fill(destination.begin(), destination.end(), 0xC7);
+            if (run) {
+                for (uint8_t& byte : *snapshot_bytes) byte ^= 0x6D;
+            }
+            fail_reader = unused_reader;
+            std::vector<uint8_t> expected = *snapshot_bytes;
+            for (uint32_t x = 0; x < W; ++x) {
+                const size_t first = static_cast<size_t>(x) * 4;
+                const size_t second = (static_cast<size_t>(W) + x) * 4;
+                expected[first] = 255; expected[first + 1] = expected[first + 2] = 0;
+                expected[first + 3] = 255;
+                expected[second] = expected[second + 2] = 0;
+                expected[second + 1] = expected[second + 3] = 255;
+            }
+            const bool executed = prosper::frontend::execute_live_compute_items({item});
+            CHECK(executed, unused_reader
+                  ? "warm full RTT aliases execute even when an unused snapshot reader would fail"
+                  : "RTT aliases execute with the required canonical snapshot seed");
+            CHECK(destination == expected, full
+                  ? "both write-only aliases contribute their exact distinct output rows"
+                  : "partial write-only aliases preserve the untouched row from the current RTT seed");
+            CHECK(reads == (unused_reader ? 0u : 1u), unused_reader
+                  ? "warm full RTT aliases request no discarded CPU snapshot"
+                  : "RTT alias proving or partial run requests exactly one owner snapshot");
+            CHECK(queries == 2,
+                  "both RTT storage bindings retain their ownership query and pending-write drain");
+            CHECK(notifications == 1,
+                  "exact RTT storage aliases publish one canonical guest-write notification");
+        }
+        if (!full) {
+            const std::vector<uint8_t> before_failure = destination;
+            reads = notifications = 0;
+            fail_reader = true;
+            CHECK(!prosper::frontend::execute_live_compute_items({item}),
+                  "partial RTT alias dispatch still rejects a missing authoritative seed");
+            CHECK(reads == 1 && notifications == 0 && destination == before_failure,
+                  "failed partial RTT alias seed leaves guest bytes and write notifications untouched");
+        }
+        set_guest_gpu_write_observer({});
+        set_live_target_reader({});
+        set_live_target_query({});
+    };
+    check_write_only_rtt_alias(2, 0x590EA10u);
+    check_write_only_rtt_alias(3, 0x590EA11u);
+
     // The exact packed fallback must obey the same authority rule. Keep stale zeroes in guest RAM,
     // publish distinct R11G11B10 renderer pixels, overwrite only row zero, and require every other
     // row to survive from the snapshot rather than the stale allocation.


### PR DESCRIPTION
Refs #3065. This is a shared compute resource-preparation optimization, not a title-specific workaround or a rendering milestone.

### Failure scenario and contract

An exact write-only storage alias currently requests a renderer-owned image snapshot before discovering its already-prepared canonical image. Coverage proofs are binding-specific, and only the canonical owner publishes them. A duplicate can therefore materialize a full RTT every dispatch even after its owner proves a complete overwrite. The duplicate's snapshot is discarded by the later alias fold.

On the native Performance Story attribution described in #3065, the first duplicate of a 3840×2160 RGBA8 output averages 3.512 ms against 3.836 ms whole setup (28 fully warm dispatches). This measures pre-alias processing, not the field-copy operation. No end-to-end speedup is claimed yet.

### Change and invariants

- Fold exact write-only, non-atomic storage aliases before duplicate coverage/snapshot preparation.
- Retain per-binding descriptor, device, dimensionality and DCC validation; retain the ownership query, which drains pending guest writes.
- Require complete resource-view identity and matching reflected storage representation, not merely the same address.
- Use the already-prepared canonical image, one staging allocation, canonical coverage proof, and one writeback/publication. Partial writes retain the required authoritative seed.
- Sampled/imported and mixed-access bindings keep their existing late path. No game-speed, frame-pacing, resolution, draw-skipping or shader-output policy changes.

Risk is silently widening alias identity or suppressing a necessary seed. The fast path deliberately excludes mixed access and atomic images; the existing identity predicate retains mip/tail/layer, capture-backing and DCC distinctions. Failure to obtain an unused duplicate snapshot is intentionally no longer a dispatch failure; failure to obtain a necessary canonical seed still is.

### Verification

Container build, Release `-O3 -DNDEBUG -g1 -fno-omit-frame-pointer`, Vulkan RADV:

```sh
cmake -S prosper -B prosper/build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CXX_FLAGS_RELEASE='-O3 -DNDEBUG -g1 -fno-omit-frame-pointer' \
  -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 -DPROSPER_APP=ON
cmake --build prosper/build-linux -j6 --target prosper-app test_game_compute \
  test_image_identity test_spirv_storage_match test_live_compute_descriptor_array \
  test_live_compute_host_read_barrier
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure \
  -R '^(game_compute_exec|game_compute_exec_no_adaptive_storage_result|game_compute_exec_scratch_poison|image_identity|spirv_storage_match|live_compute_descriptor_array|live_compute_host_read_barrier)$'
```

Initial and restored-source runs: **7/7 pass**, game compute **555 / 541 / 555 assertions**. New synthetic fixtures require both aliases' distinct output rows, exactly two ownership queries, one required proving/partial snapshot and zero unused warm-full snapshots, plus one canonical write notification. Partial missing-seed rejection leaves guest bytes unchanged.

Mutation disabling only the new early fold: **7 assertions fail** in the added fixture, including snapshot count, warm execution and exact pixels; restoring it returns all seven tests to green.

Additional whole-fixture `PROSPER_VERIFY_SEED_SKIP=1` / `PROSPER_NO_SKIP_SEED=1` runs are **not green**: existing cache/proof-dependent assertions fail (44 / 6 respectively), outside the new fixture. Disabling only the early fold retains those exact failure-message multisets plus four added alias snapshot-count failures per mode. Tracked separately in #3390; do not count those optional diagnostic runs as acceptance passes.

Exact-commit author rerun on **d4bb56bf6eff43b7aa088a8cf9bc191cd98adc8c: 7/7 pass, exit 0**, with 555 / 541 / 555 compute assertions. Independent registered review 5123624487 states **APPROVED** on that exact head. Applicable CI remains a merge gate. No snapshot-matrix run or new PS5-oracle comparison. Raw captures and local paths remain private.

### Native acceptance and measured scope

The exact-head candidate completed the same fresh-save `scripts/gta5/reach-performance-story.pad` route using native Wayland/RADV, immediate presentation, full resolution/cadence and default workers. Both runs used identical selected-program F8 phase/image timing and capped frontend texture detail, no compute skip, a continuously clear 300-second gate and a dedicated GPU lease with pre/mid/post process/DRM monitoring. No competing GPU consumer or build/profiler was observed.

Candidate completed the 450-second bound normally (451.010 seconds including shutdown, exit 0), with no device-loss signature, complete F8 and a complete 73-submit F9. All three retained native images were inspected: explicit **Performance** settings, the early masked-character bank scene, and the final bank interior with characters, radar, walking tutorial and “Go to the guard.” The known gameplay checkpoint remains recognizable; no new rung, pixel-equivalence or PS5-oracle claim.

| Mean milliseconds | Baseline fully warm (28) | Candidate fully warm (31) |
|---|---:|---:|
| First duplicate storage interval (binding 26) | 3.512357 | 0.001000 |
| Complete selected-program setup | 3.835714 | 0.304839 |
| Setup excluding that interval | 0.323357 | 0.303839 |

The measured benefit is approximately **3.5 ms removed per warm dispatch** of this program; **not a whole-game FPS claim**. Candidate alias rows all print 0.001 ms, so their precision is limited by the existing timer format. Full-warm strata require writeback cache-hit=1, seed-skip=1, poison=0 and canonical setup upload-skipped=1. Baseline also contains one cold/proving record and one setup-seeded transition, excluded here; this candidate F8 contains neither. Geometry, code/hash and resource identity match, and all 31 selected detail phases pair sequentially with F8 records.

Candidate F8: pre=20/post=21, 779 renderer / 2,120 compute records, zero drops. Its 5.02-second window reports 6.17 guest flips/s and 6.17 host presentations/s with 1.60 process CPU cores, versus 5.78/s in the earlier attribution window. These are single instrumented windows with different cold-event populations, not an established end-to-end throughput improvement. The selector hashes programs outside F8 and the F9 operation is outside the timed window.

Executable SHA256: baseline `0e4bea34d387576a94966d73c8e6f7d42590dca954df03a0556f7caac7e17c3c` (8c48fcf source tree equals main 805b49d53); candidate `c5f3cb7a0efe086f14ee44ee2ec7f6af00b6e4a6fba4187e047ba0415eeb72d7` (d4bb56bf6).

Separate existing source-derived mixed-read/write alias coverage risk is tracked in #3391; this PR neither widens its eligibility nor claims to repair it. The report's misleading “no work” alias label is tracked in #3388.
