### PR TITLE
gpu: make storage-image seed proofs alias-group aware

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1339,6 +1339,13 @@ if(TARGET prosper_core)
   target_include_directories(test_compute_image_borrow_census PRIVATE frontends)
   add_test(NAME compute_image_borrow_census COMMAND test_compute_image_borrow_census)
 
+  # Storage-image alias access union is metadata-only and must run without Vulkan on every platform.
+  add_executable(test_storage_image_alias_plan
+                 frontends/shared/tests/test_storage_image_alias_plan.cpp)
+  target_include_directories(test_storage_image_alias_plan PRIVATE frontends src)
+  target_link_libraries(test_storage_image_alias_plan PRIVATE prosper_core)
+  add_test(NAME storage_image_alias_plan COMMAND test_storage_image_alias_plan)
+
   add_executable(test_texture_decode_diagnostic
                  frontends/shared/tests/test_texture_decode_diagnostic.cpp)
   target_include_directories(test_texture_decode_diagnostic PRIVATE frontends src)

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -129,6 +129,31 @@ used by the instruction. It then makes the referenced guest bytes or image avail
 and passes the resulting `ShaderResourceTable` into recompilation. Runtime-selected arrays extend this
 same contract with reflected descriptor count and dynamic-index metadata; they are not a parallel path.
 
+## Storage-image alias seed authority
+
+Live compute resolves each dispatch's exact storage-image alias groups before preparing their
+canonical images (`frontends/shared/compute/storage_image_alias_plan.hpp`). Access is a group
+property: any readable or atomic member prohibits seed omission and destructive poison proving.
+The plan follows the existing late-fold identity, including view shape, capture backing and DCC;
+it does not change which descriptors actually share a Vulkan image. Sampled images remain separate.
+
+Cached coverage verdicts include the sorted group binding set. Moving an intact group does not
+change that identity, but joining or splitting does: two writers may cover an entire image together
+while neither does alone, and a previously inactive owner may gain a writer. Both proof lookup and
+publication use the same member-aware key. These are seed-safety constraints, not a static proof
+that a shader's coverage is invariant under arbitrary input changes (#3391).
+
+### Ruled out: per-binding seed safety
+
+- **A write-only owner's reflection is sufficient to omit seed data, provided untouched image
+  texels are restored afterwards:** falsified by a race-free storage-image read into an independent
+  SSBO. Restoring the image cannot repair values already consumed by another output. Reverting
+  only the access union produces seven exact-read failures in cold, warm and newly joined cases;
+  reader-first controls pass (#3391).
+- **Code, owner binding and extents identify a reusable coverage verdict regardless of alias
+  membership:** falsified by fixed-code, fixed-extent split/join fixtures. Reverting only membership
+  in the proof key produces two stale-Full and two stale-None failures (#3391).
+
 ## Ruled out
 
 Cross-title falsifications about **how the user-data / SH register block reaches a stage**. One line

--- a/prosper/frontends/shared/compute/AGENTS.md
+++ b/prosper/frontends/shared/compute/AGENTS.md
@@ -3,7 +3,7 @@
 Header-only, Vulkan-free, dependency-light decision logic and instrumentation for the live compute
 backend (`live/live_compute.cpp`) and for the one boundary it shares with the renderer
 (`live/live_renderer.cpp`). Nothing here touches a device, guest memory, or the write-watch
-mechanism: every file answers a question from plain integers and booleans, so it is unit-testable
+mechanism: every file answers a question from plain metadata, so it is unit-testable
 without a GPU. The tests live in `frontends/shared/tests/`.
 
 **Why the decisions live here and not beside their call sites.** `live_compute.cpp` is eleven

--- a/prosper/frontends/shared/compute/storage_image_alias_plan.hpp
+++ b/prosper/frontends/shared/compute/storage_image_alias_plan.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "gpu/resources/image_identity.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace prosper::frontend {
+
+// Metadata only: this is the shape used by live compute before allocating an image. Validation
+// still belongs to the materializer; an invalid descriptor must not become valid by joining a group.
+inline prosper::gpu::ComputeImageViewShape compute_image_alias_shape(
+    const prosper::gpu::ShaderResource& resource,
+    const prosper::gpu::SpirvDescriptorBinding& descriptor) {
+    return {
+        descriptor.kind == prosper::gpu::SpirvDescriptorKind::StorageImage,
+        resource.img_dim == 2 ? resource.depth : 1u,
+        resource.img_dim == 5 && descriptor.image_dim == 1u && descriptor.image_arrayed
+            ? resource.depth : 1u,
+    };
+}
+
+struct StorageImageAliasGroup {
+    size_t owner_index = SIZE_MAX;
+    std::vector<uint32_t> bindings;
+    bool readable = false;
+    bool writable = false;
+    bool atomic = false;
+
+    bool can_discard_seed() const { return writable && !readable && !atomic; }
+};
+
+struct StorageImageAliasPlan {
+    bool valid = true;
+    // Non-storage descriptors have no group. Indices refer to the supplied descriptor order.
+    std::vector<size_t> group_for_image;
+    std::vector<StorageImageAliasGroup> groups;
+};
+
+// Seeding must account for EVERY descriptor that will share the canonical image, before that
+// image is uploaded or poisoned. This follows the existing late storage-alias identity, not the
+// narrower early-fold optimization: storage never imports renderer/depth/value-reuse images, so
+// its late same_backing_representation is true. Reflection-format differences must not hide a
+// reader here when the late path can still fold it. This plan does not change actual folding.
+inline StorageImageAliasPlan plan_storage_image_aliases(
+    std::span<const prosper::gpu::SpirvDescriptorBinding> descriptors,
+    const prosper::gpu::ShaderResourceTable& resources) {
+    StorageImageAliasPlan plan;
+    plan.group_for_image.assign(descriptors.size(), SIZE_MAX);
+    std::vector<const prosper::gpu::ShaderResource*> resolved(descriptors.size(), nullptr);
+    for (size_t i = 0; i < descriptors.size(); ++i) {
+        const auto& descriptor = descriptors[i];
+        if (descriptor.kind != prosper::gpu::SpirvDescriptorKind::StorageImage) continue;
+        const auto* resource = resources.by_binding(descriptor.binding);
+        if (!resource) {
+            plan.valid = false;
+            continue;
+        }
+        resolved[i] = resource;
+        const auto shape = compute_image_alias_shape(*resource, descriptor);
+        size_t group_index = 0;
+        for (; group_index < plan.groups.size(); ++group_index) {
+            const size_t owner = plan.groups[group_index].owner_index;
+            if (prosper::gpu::shader_resource_same_view(
+                    *resolved[owner], *resource,
+                    compute_image_alias_shape(*resolved[owner], descriptors[owner]), shape, true))
+                break;
+        }
+        if (group_index == plan.groups.size()) {
+            plan.groups.emplace_back();
+            plan.groups.back().owner_index = i;
+        }
+        plan.group_for_image[i] = group_index;
+        auto& group = plan.groups[group_index];
+        group.bindings.push_back(descriptor.binding);
+        group.readable |= descriptor.readable;
+        group.writable |= descriptor.writable;
+        group.atomic |= descriptor.atomic_access;
+    }
+    // Coverage is a property of this member set, not of transient guest addresses. Removing a
+    // writer can turn Full into Partial/None, and adding a writer can invalidate a None verdict.
+    for (auto& group : plan.groups) std::sort(group.bindings.begin(), group.bindings.end());
+    return plan;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -4,6 +4,7 @@
 #include "shared/compute/compute_image_borrow_census.hpp"
 #include "shared/compute/compute_timing_selector.hpp"
 #include "shared/compute/compute_transfer_gate_census.hpp"
+#include "shared/compute/storage_image_alias_plan.hpp"
 #include "shared/live/decode_scratch.hpp"  // pooled full-surface intermediates (#3309's mechanism)
 #include "shared/live/live_target_format.hpp"
 #include "shared/rtt/rtt_scale.hpp"
@@ -5551,8 +5552,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         uint64_t written_layers = ~0ULL;
         bool near_full = false;
     };
-    // key = (shader code_addr, output binding, width, height, depth) -- collision-free by construction.
-    using SeedCoverageKey = std::tuple<uint64_t, uint32_t, uint32_t, uint32_t, uint32_t>;
+    // Coverage was observed over the shared image, so its writer membership is part of the proof.
+    // Splitting a previously full-coverage alias group can leave the owner only partially written.
+    using SeedCoverageKey = std::tuple<uint64_t, uint32_t, uint32_t, uint32_t, uint32_t,
+                                       std::vector<uint32_t>>;
     static std::mutex seed_coverage_mu;
     static std::map<SeedCoverageKey, SeedVerdict> seed_coverage_proof;
     // PROSPER_SEED_REPROVE=N: re-prove every N fast-skips (default 256; explicit 0 disables = old
@@ -5778,6 +5781,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     std::sort(image_descriptors.begin(), image_descriptors.end(), [](const auto& a, const auto& b) {
         return a.binding < b.binding;
     });
+    const auto image_alias_plan = item.resources
+        ? prosper::frontend::plan_storage_image_aliases(image_descriptors, *item.resources)
+        : prosper::frontend::StorageImageAliasPlan{};
+    if (!image_alias_plan.valid) return decline("storage-alias-resource-missing");
+    const auto image_seed_coverage_key = [&](size_t i, const ShaderResource& resource) {
+        return SeedCoverageKey{
+            item.code_addr, image_descriptors[i].binding,
+            resource.width, resource.height, resource.depth,
+            image_alias_plan.groups[image_alias_plan.group_for_image[i]].bindings};
+    };
 
     const LiveComputeBufferDescriptorPlan buffer_plan =
         plan_live_compute_buffer_descriptors(
@@ -6533,8 +6546,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (dim_cube_stacked && (r->depth < 6 || r->height > UINT32_MAX / 6u)) {
                 skip_image(r, "cube image does not contain six valid faces"); break;
             }
-            bi.texel_depth = dim_3d ? r->depth : 1u;
-            bi.array_layers = dim_2d_array ? r->depth : 1u;
+            const auto alias_shape = prosper::frontend::compute_image_alias_shape(
+                *r, image_descriptors[i]);
+            bi.texel_depth = alias_shape.texel_depth;
+            bi.array_layers = alias_shape.array_layers;
             if (cube_face_as_2d && trace)
                 std::fprintf(stderr,
                              "[compute]   binding cube face zero as shader-declared 2D image "
@@ -6766,10 +6781,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 r->width, r->height, r->depth, 16);
             // Diagnostic: force the proving (poison) path on every eligible dispatch, never fast-skip.
             static const bool force_verify = std::getenv("PROSPER_VERIFY_SEED_SKIP") != nullptr;
-            if (bi.storage && seed_skip_enabled && !image_descriptors[i].readable &&
-                image_descriptors[i].writable && enough_threads) {
-                const SeedCoverageKey proof_key{item.code_addr, bi.binding,
-                                                r->width, r->height, r->depth};
+            // A write-only descriptor can share this image with a readable sibling. Poisoning
+            // would corrupt values consumed during execution even if writeback later restored the
+            // untouched image texels. Decide from the whole group before consulting ANY proof.
+            if (bi.storage && seed_skip_enabled &&
+                image_alias_plan.groups[image_alias_plan.group_for_image[i]].can_discard_seed() &&
+                enough_threads) {
+                const SeedCoverageKey proof_key = image_seed_coverage_key(i, *r);
                 bool proven_full = false, proven_none = false, known = false, reprove_due = false;
                 {
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
@@ -10275,8 +10293,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.written_layers_mask = written_layers;
                 bi.near_full_coverage = near_full;
                 {
-                    const SeedCoverageKey proof_key{item.code_addr, bi.binding,
-                                                    r->width, r->height, r->depth};
+                    const SeedCoverageKey proof_key = image_seed_coverage_key(i, *r);
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
                     seed_coverage_proof[proof_key] = SeedVerdict{ cov, 0, written_layers, near_full };

--- a/prosper/frontends/shared/tests/AGENTS.md
+++ b/prosper/frontends/shared/tests/AGENTS.md
@@ -1,0 +1,22 @@
+# `frontends/shared/tests` — shared frontend policy and metadata checks
+
+Small CPU-side tests for the decisions shared by the app, screenshot tool and live backends:
+texture/write-watch policies, compute alias plans and censuses, render-target/present extents,
+capture windows and performance records, and scratch-buffer lifetime rules. Put a test here when
+hand-built descriptors, counters, byte arrays or policy inputs can establish the contract without
+running a guest or submitting Vulkan work. Include positive and negative cases; an alias-plan test
+proves metadata grouping and access union, not that the live caller seeds, binds or executes correctly.
+
+Device-backed integration belongs with the existing harnesses in `tests/shared/live/`,
+`tests/shared/present/` or the relevant `tests/gpu/` family. Some neighboring tests also have CPU
+arms, so navigate by the contract rather than assuming the directory name guarantees GPU use.
+`tests/fixtures/render_runner.h` is the real graphics backend used by those harnesses, not a mock;
+the compute backend is separate. Do not pull either into a metadata-only test just to exercise a
+decision that already has a device-free interface.
+
+Register CPU-only tests in the platform-independent test section of `prosper/CMakeLists.txt`, with
+`frontends` for `shared/...` includes and `src` plus `prosper_core` only where needed. Do not gate
+them on the live-renderer target or Vulkan availability. The present-blit policy check is a narrow
+exception requiring Vulkan headers/types but no device; its CMake guard is not a template for
+ordinary policy tests. Environment-controlled variants need their own CTest environment when the
+implementation reads a setting once per process.

--- a/prosper/frontends/shared/tests/test_storage_image_alias_plan.cpp
+++ b/prosper/frontends/shared/tests/test_storage_image_alias_plan.cpp
@@ -1,0 +1,258 @@
+// Metadata-only storage alias access union. Expectations are hand-built member sets and access
+// verdicts, never calls to the same identity helper used by the planner as a second oracle.
+#include "shared/compute/storage_image_alias_plan.hpp"
+
+#include <array>
+#include <cstdio>
+#include <initializer_list>
+#include <vector>
+
+using namespace prosper::gpu;
+using prosper::frontend::StorageImageAliasPlan;
+using prosper::frontend::plan_storage_image_aliases;
+
+static int failures = 0;
+static const char* context = "initial";
+#define CHECK(condition) do { if (!(condition)) { \
+    std::fprintf(stderr, "FAIL %s:%d [%s]: %s\n", __FILE__, __LINE__, context, #condition); \
+    ++failures; } } while (0)
+
+static ShaderResource resource(uint32_t binding, uint64_t address = 0x10000) {
+    ShaderResource r;
+    r.cls = ResourceClass::StorageImage;
+    r.binding = binding;
+    r.gpu_addr = address;
+    r.size = 256;
+    r.width = r.height = 8;
+    r.depth = 1;
+    r.img_dim = 1;
+    r.format = DataFormat::Unorm8;
+    r.num_components = 4;
+    r.tile_mode = 27;
+    return r;
+}
+
+static SpirvDescriptorBinding descriptor(uint32_t binding, bool read, bool write) {
+    SpirvDescriptorBinding d;
+    d.binding = binding;
+    d.kind = SpirvDescriptorKind::StorageImage;
+    d.stage = SpirvShaderStage::Compute;
+    d.image_dim = 1;
+    d.storage_float = true;
+    d.image_numeric_class = SpirvImageNumericClass::Float;
+    d.readable = read;
+    d.writable = write;
+    return d;
+}
+
+static void group(const StorageImageAliasPlan& plan, size_t index, size_t owner,
+                  std::initializer_list<uint32_t> members,
+                  bool read, bool write, bool atomic, bool discard) {
+    CHECK(index < plan.groups.size());
+    if (index >= plan.groups.size()) return;
+    const auto& g = plan.groups[index];
+    CHECK(g.owner_index == owner);
+    CHECK(g.bindings == std::vector<uint32_t>(members));
+    CHECK(g.readable == read);
+    CHECK(g.writable == write);
+    CHECK(g.atomic == atomic);
+    CHECK(g.can_discard_seed() == discard);
+}
+
+static ShaderResourceTable pair_resources() {
+    ShaderResourceTable table;
+    table.resources = {resource(5), resource(26)};
+    return table;
+}
+
+template<class Mutate>
+static void resource_split(const char* label, Mutate mutate) {
+    context = label;
+    auto table = pair_resources();
+    mutate(table.resources[1]);
+    const std::array ds{descriptor(5, false, true), descriptor(26, true, false)};
+    const auto plan = plan_storage_image_aliases(ds, table);
+    CHECK(plan.valid);
+    CHECK(plan.groups.size() == 2);
+    CHECK((plan.group_for_image == std::vector<size_t>{0, 1}));
+    group(plan, 0, 0, {5}, false, true, false, true);
+    group(plan, 1, 1, {26}, true, false, false, false);
+}
+
+int main() {
+    auto table = pair_resources();
+    // Reverse descriptor visitation, but not the resource-table order: lookup is by binding.
+    for (bool reverse : {false, true}) {
+        context = reverse ? "reader then writer" : "writer then reader";
+        std::array ds{descriptor(5, false, true), descriptor(26, true, false)};
+        if (reverse) std::swap(ds[0], ds[1]);
+        auto plan = plan_storage_image_aliases(ds, table);
+        CHECK(plan.valid);
+        CHECK(plan.groups.size() == 1);
+        CHECK((plan.group_for_image == std::vector<size_t>{0, 0}));
+        group(plan, 0, 0, {5, 26}, true, true, false, false);
+
+        context = reverse ? "atomic then writer" : "writer then atomic";
+        ds = {descriptor(5, false, true), descriptor(26, false, true)};
+        ds[1].atomic_access = true;
+        if (reverse) std::swap(ds[0], ds[1]);
+        plan = plan_storage_image_aliases(ds, table);
+        CHECK(plan.groups.size() == 1);
+        group(plan, 0, 0, {5, 26}, false, true, true, false);
+    }
+
+    context = "write-only union and distinct reader";
+    table.resources.push_back(resource(42, 0x20000));
+    std::array ds{descriptor(26, false, true), descriptor(5, false, true),
+                  descriptor(42, true, false)};
+    auto plan = plan_storage_image_aliases(ds, table);
+    CHECK(plan.valid);
+    CHECK((plan.group_for_image == std::vector<size_t>{0, 0, 1}));
+    group(plan, 0, 0, {5, 26}, false, true, false, true);
+    group(plan, 1, 2, {42}, true, false, false, false);
+
+    context = "sampled image is not a storage-group reader";
+    ds[2].kind = SpirvDescriptorKind::CombinedImageSampler;
+    table.resources[2].gpu_addr = 0x10000;
+    plan = plan_storage_image_aliases(ds, table);
+    CHECK(plan.valid);
+    CHECK(plan.groups.size() == 1);
+    CHECK((plan.group_for_image == std::vector<size_t>{0, 0, SIZE_MAX}));
+    group(plan, 0, 0, {5, 26}, false, true, false, true);
+
+    context = "read-only and inactive groups cannot discard";
+    std::array only{descriptor(5, true, false)};
+    group(plan_storage_image_aliases(only, table), 0, 0, {5}, true, false, false, false);
+    only[0].readable = false;
+    group(plan_storage_image_aliases(only, table), 0, 0, {5}, false, false, false, false);
+
+    // Distinct full-view fields must not turn a separate reader into this writer's alias.
+#define SPLIT(field, value) resource_split(#field, [](ShaderResource& r) { r.field = value; })
+    SPLIT(gpu_addr, 0x20000);
+    SPLIT(size, 512);
+    SPLIT(width, 16);
+    SPLIT(height, 16);
+    SPLIT(depth, 2);
+    SPLIT(format, DataFormat::Float32);
+    SPLIT(num_components, 2);
+    SPLIT(tile_mode, 0);
+    SPLIT(img_dim, 2);
+    SPLIT(layer_stride_bytes, 1024);
+    SPLIT(layer_mip_offset_bytes, 128);
+    SPLIT(in_mip_tail, true);
+    SPLIT(mip_tail_x, 1);
+    SPLIT(mip_tail_y, 1);
+    SPLIT(declared_mip_levels, 2);
+    SPLIT(srgb, true);
+    SPLIT(host_data_size, 256);
+    SPLIT(host_data_prefix_bytes, 64);
+    SPLIT(max_uncompressed_block_size, 1);
+    SPLIT(max_compressed_block_size, 1);
+    SPLIT(meta_pipe_aligned, true);
+    SPLIT(write_compress_enabled, true);
+    SPLIT(compression_enabled, true);
+    SPLIT(alpha_is_on_msb, true);
+    SPLIT(color_transform, true);
+    SPLIT(metadata_addr, 0x40000);
+    SPLIT(dcc_metadata_size, 64);
+    SPLIT(dcc_metadata_host_data_size, 64);
+#undef SPLIT
+    std::array<uint8_t, 512> blob_a{}, blob_b{};
+    resource_split("DCC host backing identity", [&](ShaderResource& r) {
+        r.dcc_metadata_host_data = blob_a.data();
+    });
+
+    context = "same guest range in independently owned capture blobs";
+    table = pair_resources();
+    table.resources[0].host_data = blob_a.data() + 64;
+    table.resources[1].host_data = blob_b.data() + 64;
+    for (auto& r : table.resources) { r.host_data_size = 256; r.host_data_prefix_bytes = 64; }
+    const std::array pair{descriptor(5, false, true), descriptor(26, true, false)};
+    plan = plan_storage_image_aliases(pair, table);
+    CHECK(plan.groups.size() == 1);
+    group(plan, 0, 0, {5, 26}, true, true, false, false);
+    context = "capture replacement owns a different prefix";
+    table.resources[1].host_data_prefix_bytes = 0;
+    plan = plan_storage_image_aliases(pair, table);
+    CHECK(plan.groups.size() == 2);
+    CHECK((plan.group_for_image == std::vector<size_t>{0, 1}));
+
+    context = "arrayed reflection changes realized layers";
+    table = pair_resources();
+    for (auto& r : table.resources) { r.img_dim = 5; r.depth = 3; }
+    auto shape_pair = pair;
+    shape_pair[1].image_arrayed = true;
+    plan = plan_storage_image_aliases(shape_pair, table);
+    CHECK(plan.groups.size() == 2);
+    CHECK((plan.group_for_image == std::vector<size_t>{0, 1}));
+    shape_pair[0].image_arrayed = true;
+    CHECK(plan_storage_image_aliases(shape_pair, table).groups.size() == 1);
+
+    context = "3D shape is metadata, not allocation validation";
+    auto volume = resource(5);
+    volume.img_dim = 2; volume.depth = 3;
+    const auto shape = prosper::frontend::compute_image_alias_shape(volume, pair[0]);
+    CHECK(shape.storage && shape.texel_depth == 3 && shape.array_layers == 1);
+
+    // Single-level provenance is deliberately irrelevant; a real mip chain makes it identity.
+    for (bool multilevel : {false, true}) {
+        context = multilevel ? "mip-chain provenance splits" : "single-level provenance ignored";
+        table = pair_resources();
+        for (auto& r : table.resources) r.declared_mip_levels = multilevel ? 2 : 1;
+        table.resources[1].mip_chain_element_width = 32;
+        plan = plan_storage_image_aliases(pair, table);
+        CHECK(plan.groups.size() == (multilevel ? 2u : 1u));
+    }
+
+    context = "reflected format must not hide a late-folded reader";
+    table = pair_resources();
+    auto reflected_pair = pair;
+    reflected_pair[1].storage_image_format = 33; // R32ui versus the first binding's Unknown.
+    reflected_pair[1].storage_float = false;
+    reflected_pair[1].image_numeric_class = SpirvImageNumericClass::Uint;
+    plan = plan_storage_image_aliases(reflected_pair, table);
+    CHECK(plan.groups.size() == 1);
+    group(plan, 0, 0, {5, 26}, true, true, false, false);
+
+    context = "member set survives address movement, changes on join and split";
+    table.resources.push_back(resource(42, 0x20000));
+    ds = {descriptor(26, false, true), descriptor(5, false, true), descriptor(42, false, true)};
+    plan = plan_storage_image_aliases(ds, table);
+    group(plan, 0, 0, {5, 26}, false, true, false, true);
+    group(plan, 1, 2, {42}, false, true, false, true);
+    for (auto& r : table.resources) r.gpu_addr += 0x80000;
+    plan = plan_storage_image_aliases(ds, table);
+    group(plan, 0, 0, {5, 26}, false, true, false, true);
+    group(plan, 1, 2, {42}, false, true, false, true);
+    table.resources[2].gpu_addr = table.resources[0].gpu_addr;
+    plan = plan_storage_image_aliases(ds, table);
+    CHECK(plan.groups.size() == 1);
+    group(plan, 0, 0, {5, 26, 42}, false, true, false, true);
+    table.resources[1].gpu_addr += 0x10000;
+    plan = plan_storage_image_aliases(ds, table);
+    CHECK((plan.group_for_image == std::vector<size_t>{0, 1, 1}));
+    group(plan, 0, 0, {26}, false, true, false, true);
+    group(plan, 1, 1, {5, 42}, false, true, false, true);
+
+    context = "missing storage resource fails closed without hiding valid groups";
+    table = pair_resources();
+    table.resources.pop_back();
+    plan = plan_storage_image_aliases(pair, table);
+    CHECK(!plan.valid);
+    CHECK((plan.group_for_image == std::vector<size_t>{0, SIZE_MAX}));
+    group(plan, 0, 0, {5}, false, true, false, true);
+    auto missing_first = pair;
+    std::swap(missing_first[0], missing_first[1]);
+    plan = plan_storage_image_aliases(missing_first, table);
+    CHECK(!plan.valid);
+    CHECK((plan.group_for_image == std::vector<size_t>{SIZE_MAX, 0}));
+    group(plan, 0, 1, {5}, false, true, false, true);
+    missing_first[0].kind = SpirvDescriptorKind::CombinedImageSampler;
+    CHECK(plan_storage_image_aliases(missing_first, table).valid);
+    const std::array<SpirvDescriptorBinding, 0> empty{};
+    plan = plan_storage_image_aliases(empty, table);
+    CHECK(plan.valid && plan.groups.empty() && plan.group_for_image.empty());
+
+    std::printf("storage_image_alias_plan: %d failure(s)\n", failures);
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -5,6 +5,7 @@
 #include "gpu/capture/gpu_capture.hpp"
 #include "gpu/execute/gpu_execute.hpp"
 #include "gpu/resources/shader_resources.hpp"
+#include "gpu/resources/image_identity.hpp"
 #include "gpu/resources/mip_chain_plan.hpp"
 #include "gpu/texture/tile.hpp"
 #include "host/memory/guest_write_watch.hpp"
@@ -5147,6 +5148,243 @@ int main() {
     };
     check_write_only_rtt_alias(2, 0x590EA10u);
     check_write_only_rtt_alias(3, 0x590EA11u);
+
+    // #3391: an exact storage view is one image even when its bindings have different access.
+    // Each invocation owns one column, so reads of the untouched row (partial) or reads before
+    // that invocation's own stores (full) have no cross-invocation race. The SSBO independently
+    // observes the input: restoring poisoned pixels at writeback cannot repair a wrong shader read.
+    auto check_mixed_storage_alias = [&](bool reader_first, bool full, bool join_after_proof) {
+        const uint32_t writer_binding = reader_first ? 6u : 5u;
+        const uint32_t reader_binding = reader_first ? 5u : 6u;
+        constexpr uint32_t stored = 0x13579BDFu;
+        std::vector<uint32_t> shader = {
+            0x7E080300u, // v4 = local x, preserved across image loads
+        };
+        auto read_row = [&](uint32_t row, uint32_t buffer_offset) {
+            shader.insert(shader.end(), {
+                row ? 0x7E0A0281u : 0x7E0A0280u, // v5 = row
+                0xF0000108u, 0x00040804u,       // IMAGE_LOAD x -> v8, s[16:23]
+                0xBF8C3F70u,                    // s_waitcnt vmcnt(0)
+                0xE0702000u | buffer_offset, 0x80000804u, // store v8 at v4, s[0:3]
+            });
+        };
+        auto write_row = [&](uint32_t row) {
+            shader.insert(shader.end(), {
+                row ? 0x7E0A0281u : 0x7E0A0280u, // v5 = row
+                0x7E0002FFu, stored,             // v0 = exact integer literal
+                0xF0200108u, 0x00020004u,        // IMAGE_STORE x, s[8:15]
+            });
+        };
+        if (full) {
+            read_row(0, 0);
+            write_row(0);
+            read_row(1, W * sizeof(uint32_t));
+            write_row(1);
+        } else {
+            read_row(1, 0);
+            write_row(0);
+        }
+        shader.push_back(0xBF810000u);
+        std::vector<uint32_t> image_words(W * 2);
+        std::vector<uint32_t> separate_reader(W * 2);
+        std::vector<uint32_t> observed(W * (full ? 2u : 1u), 0xCCCCCCCCu);
+        ShaderResourceTable table;
+        ShaderResource buffer{};
+        buffer.cls = ResourceClass::ConstantBuffer;
+        buffer.binding = 2;
+        buffer.sgpr_base = 0;
+        buffer.format = DataFormat::Uint32;
+        buffer.num_components = 1;
+        buffer.stride = sizeof(uint32_t);
+        buffer.gpu_addr = reinterpret_cast<uint64_t>(observed.data());
+        buffer.size = static_cast<uint32_t>(observed.size() * sizeof(uint32_t));
+        table.resources.push_back(buffer);
+        for (uint32_t binding = 5; binding <= 6; ++binding) {
+            ShaderResource image{};
+            image.cls = ResourceClass::StorageImage;
+            image.binding = binding;
+            image.sgpr_base = binding == writer_binding ? 8 : 16;
+            image.img_dim = 1;
+            image.format = DataFormat::Uint32;
+            image.num_components = 1;
+            image.width = W;
+            image.height = 2;
+            image.depth = 1;
+            image.gpu_addr = reinterpret_cast<uint64_t>(image_words.data());
+            image.size = static_cast<uint32_t>(image_words.size() * sizeof(uint32_t));
+            table.resources.push_back(image);
+        }
+        ComputeShaderConfig config;
+        config.user_sgprs.resize(24);
+        config.local_x = W;
+        config.local_y = config.local_z = 1;
+        config.tidig_comp_cnt = 0;
+        config.native_storage_format_support =
+            native_storage_format_support_bit(DataFormat::Uint32, 1);
+        const std::vector<uint32_t> spirv =
+            recompile_compute(shader.data(), shader.size(), &table, config);
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const auto* writer = find_spirv_descriptor_binding(report, 0, writer_binding);
+        const auto* reader = find_spirv_descriptor_binding(report, 0, reader_binding);
+        const auto* output = find_spirv_descriptor_binding(report, 0, buffer.binding);
+        const auto exact_r32 = [](const SpirvDescriptorBinding* descriptor) {
+            return descriptor && descriptor->kind == SpirvDescriptorKind::StorageImage &&
+                   descriptor->image_numeric_class == SpirvImageNumericClass::Uint &&
+                   descriptor->storage_image_format == kSpirvImageFormatR32ui &&
+                   descriptor->image_dim == 1 && !descriptor->image_arrayed &&
+                   !descriptor->image_multisampled;
+        };
+        const bool access_ok = !spirv.empty() && report.ok() && report.descriptors.size() == 3 &&
+            exact_r32(writer) && writer->writable && !writer->readable &&
+            exact_r32(reader) && reader->readable && !reader->writable &&
+            output && output->kind == SpirvDescriptorKind::StorageBuffer && output->writable;
+        CHECK(access_ok, "mixed storage fixture reflects distinct write-only/read-only R32_UINT bindings and SSBO");
+        if (!access_ok) return;
+        const ComputeImageViewShape shape{true, 1, 1};
+        CHECK(shader_resource_same_view(table.resources[1], table.resources[2], shape, shape, true),
+              "mixed storage fixture begins with exact storage-view identity");
+        ComputeItem item;
+        item.spirv = spirv;
+        item.launch.threads_x = item.launch.local_x = W;
+        item.launch.threads_y = item.launch.threads_z = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_x = item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = 0x33910000u + (reader_first ? 0x100u : 0u) +
+                         (full ? 0x10u : 0u) + (join_after_proof ? 1u : 0u);
+        for (uint32_t run = 0; run < 4; ++run) {
+            const bool aliased = !join_after_proof || run >= 2;
+            for (uint32_t texel = 0; texel < W * 2; ++texel) {
+                image_words[texel] = 0x24680000u + run * 0x1000u + texel * 17u;
+                separate_reader[texel] = 0xABCD0000u + run * 0x1000u + texel * 19u;
+            }
+            std::fill(observed.begin(), observed.end(), 0xCCCCCCCCu);
+            for (ShaderResource& resource : table.resources) {
+                if (resource.binding == reader_binding)
+                    resource.gpu_addr = reinterpret_cast<uint64_t>(
+                        aliased ? image_words.data() : separate_reader.data());
+            }
+            CHECK(shader_resource_same_view(table.resources[1], table.resources[2], shape, shape, true) == aliased,
+                  "mixed storage dispatch pins exact alias identity or deliberate separate-view control");
+            const std::vector<uint32_t>& input = aliased ? image_words : separate_reader;
+            const std::vector<uint32_t> expected_observed(
+                input.begin() + (full ? 0u : W), input.end());
+            std::vector<uint32_t> expected_image = image_words;
+            std::fill_n(expected_image.begin(), full ? W * 2 : W, stored);
+            item.resources = std::make_shared<ShaderResourceTable>(table);
+            const bool executed = prosper::frontend::execute_live_compute_items({item});
+            if (!executed || image_words != expected_image || observed != expected_observed)
+                std::printf("  mixed storage alias reader_first=%u full=%u join_after_proof=%u run=%u aliased=%u\n",
+                            reader_first, full, join_after_proof, run, aliased);
+            CHECK(executed, "mixed storage alias dispatch executes in both binding orders");
+            CHECK(image_words == expected_image,
+                  "mixed storage alias writes exact output and preserves every untouched image texel");
+            CHECK(observed == expected_observed,
+                  "mixed storage alias reader observes current exact input, including warm and newly joined views");
+        }
+    };
+    for (bool reader_first : {false, true}) {
+        check_mixed_storage_alias(reader_first, false, false);
+        check_mixed_storage_alias(reader_first, true, false);
+        check_mixed_storage_alias(reader_first, true, true);
+    }
+
+    // A Full proof established jointly by two write-only aliases is not a proof for either
+    // binding alone. Keep code and extents fixed while the group splits, then joins again.
+    // Conversely, an isolated owner's None proof cannot suppress a newly joined writer.
+    auto check_write_only_group_membership = [&](bool none_owner) {
+        std::vector<uint32_t> split_writer_code = {
+            0x7E080300u,                         // v4 = x
+            0x7E0A0280u,                         // row zero through binding 5
+            0x7E0002FFu, 0x13579BDFu,
+            0xF0200108u, 0x00020004u,
+            0x7E0A0281u,                         // row one through binding 6
+            0x7E0002FFu, 0x2468ACE0u,
+            0xF0200108u, 0x00040004u,
+            0xBF810000u,
+        };
+        if (none_owner) {
+            // Keep the store reflected, but put the owner's row outside the image. Binding 6
+            // still writes row one, so separate -> joined changes owner coverage None -> Partial.
+            split_writer_code[1] = 0x7E0A02FFu;
+            split_writer_code.insert(split_writer_code.begin() + 2, 9999u);
+        }
+        std::vector<uint32_t> first(W * 2), second(W * 2);
+        ShaderResourceTable table;
+        for (uint32_t binding = 5; binding <= 6; ++binding) {
+            ShaderResource image{};
+            image.cls = ResourceClass::StorageImage;
+            image.binding = binding;
+            image.sgpr_base = binding == 5 ? 8 : 16;
+            image.img_dim = 1;
+            image.format = DataFormat::Uint32;
+            image.num_components = 1;
+            image.width = W;
+            image.height = 2;
+            image.depth = 1;
+            image.gpu_addr = reinterpret_cast<uint64_t>(first.data());
+            image.size = static_cast<uint32_t>(first.size() * sizeof(uint32_t));
+            table.resources.push_back(image);
+        }
+        ComputeShaderConfig config;
+        config.user_sgprs.resize(24);
+        config.local_x = W;
+        config.local_y = config.local_z = 1;
+        config.tidig_comp_cnt = 0;
+        config.native_storage_format_support =
+            native_storage_format_support_bit(DataFormat::Uint32, 1);
+        const std::vector<uint32_t> spirv = recompile_compute(
+            split_writer_code.data(), split_writer_code.size(), &table, config);
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const bool shape_ok = !spirv.empty() && report.ok() && report.descriptors.size() == 2 &&
+            std::all_of(report.descriptors.begin(), report.descriptors.end(),
+                [](const SpirvDescriptorBinding& descriptor) {
+                    return descriptor.kind == SpirvDescriptorKind::StorageImage &&
+                           descriptor.writable && !descriptor.readable &&
+                           descriptor.image_numeric_class == SpirvImageNumericClass::Uint &&
+                           descriptor.storage_image_format == kSpirvImageFormatR32ui &&
+                           descriptor.image_dim == 1 && !descriptor.image_arrayed &&
+                           !descriptor.image_multisampled;
+                });
+        CHECK(shape_ok, "alias split/rejoin fixture reflects two exact write-only R32_UINT images");
+        if (shape_ok) {
+            ComputeItem item;
+            item.spirv = spirv;
+            item.code_addr = none_owner ? 0x3391A11Bu : 0x3391A11Au;
+            item.launch.threads_x = item.launch.local_x = W;
+            item.launch.threads_y = item.launch.threads_z = 1;
+            item.launch.local_y = item.launch.local_z = 1;
+            item.launch.groups_x = item.launch.groups_y = item.launch.groups_z = 1;
+            const ComputeImageViewShape shape{true, 1, 1};
+            for (uint32_t run = 0; run < 6; ++run) {
+                const bool aliased = none_owner ? run >= 2 && run < 4 : run < 2 || run >= 4;
+                for (uint32_t texel = 0; texel < W * 2; ++texel) {
+                    first[texel] = 0xAAAA0000u + run * 0x1000u + texel * 23u;
+                    second[texel] = 0xBBBB0000u + run * 0x1000u + texel * 29u;
+                }
+                table.resources[1].gpu_addr = reinterpret_cast<uint64_t>(
+                    aliased ? first.data() : second.data());
+                CHECK(shader_resource_same_view(table.resources[0], table.resources[1], shape, shape, true) == aliased,
+                      "write-only group membership follows the explicit alias/split/rejoin sequence");
+                std::vector<uint32_t> expected_first = first, expected_second = second;
+                if (!none_owner) std::fill_n(expected_first.begin(), W, 0x13579BDFu);
+                std::fill_n((aliased ? expected_first : expected_second).begin() + W, W, 0x2468ACE0u);
+                item.resources = std::make_shared<ShaderResourceTable>(table);
+                const bool executed = prosper::frontend::execute_live_compute_items({item});
+                if (!executed || first != expected_first || second != expected_second)
+                    std::printf("  write-only alias split/rejoin none_owner=%u run=%u aliased=%u\n",
+                                none_owner, run, aliased);
+                CHECK(executed, "write-only storage group executes through alias/split/rejoin transitions");
+                CHECK(first == expected_first && second == expected_second,
+                      none_owner
+                          ? "write-only group None proof never suppresses a newly joined writer"
+                          : "write-only group Full proof never discards fresh untouched rows after a split");
+            }
+        }
+    };
+    check_write_only_group_membership(false);
+    check_write_only_group_membership(true);
 
     // The exact packed fallback must obey the same authority rule. Keep stale zeroes in guest RAM,
     // publish distinct R11G11B10 renderer pixels, overwrite only row zero, and require every other


### PR DESCRIPTION
Fixes #3391.

## Failure and contract

Two exact storage-image descriptors can have different reflected access. If the first is write-only, per-binding eligibility can poison its seed before a later readable descriptor aliases it. Restoring untouched image pixels after dispatch cannot repair values already read into another output. Coverage also belongs to the current group: splitting jointly Full writers or joining a writer to a previously None owner invalidates the old verdict even when code, binding and extents are unchanged.

## Change

- Plan exact storage alias groups before canonical image preparation; union readable, writable and atomic access. Any reader/atomic member prevents destructive proving and seed omission.
- Use the existing late-fold view/capture/DCC identity and shared realized shape. The plan does not perform or broaden folding. Reflected-format differences cannot hide a reader that the existing late fold still shares.
- Add sorted group bindings to both coverage lookup and publication. Intact groups may move addresses without changing membership; joins/splits select distinct proofs.
- Add metadata-only coverage plus race-free live-backend regressions with exact image and independent SSBO oracles. Record the falsifications and folder boundaries.

Unchanged: actual early/late alias binding, descriptor validation, renderer ownership ordering, sampled-image behavior, canonical writeback/publication and synchronization barriers. All-write-only groups remain eligible for the existing optimization. This does not make coverage a static proof against arbitrary shader input changes or redesign the existing reproving policy.

## Verification

Linux Release build inside the development container, RADV STRIX_HALO; configure uses `-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 -DPROSPER_APP=ON`.

```sh
cmake --build prosper/build-linux -j6 --target prosper-app test_game_compute test_storage_image_alias_plan test_image_identity test_spirv_storage_match test_live_compute_descriptor_array test_live_compute_host_read_barrier
ctest --test-dir prosper/build-linux --no-tests=error -V -R '^(storage_image_alias_plan|image_identity|spirv_storage_match|game_compute_exec.*|live_compute_descriptor_array|live_compute_host_read_barrier)$'
```

- Eight selected cases pass, exit 0. Compute default/scratch-poison: 701 assertions each; no-adaptive-storage-result: 687. Device creation is confirmed on RADV, not inferred from CI.
- Unchanged `a5ed0687f` backend, initial 682-assertion fixture: nine failures (seven mixed reads, two stale Full); reader-first controls pass. This predates the additional None fixture.
- Isolated access mutation, retaining member-aware keys: seven exact SSBO failures / 701 assertions, exit 8.
- Isolated membership mutation, retaining group access but substituting empty membership in the key: four failures / 701 assertions, two stale Full and two stale None, exit 8.
- Complete fix restored: eight cases pass again. Mutation logs are retained privately.
- `PROSPER_NO_SKIP_SEED=1` on the unchanged-backend initial fixture clears all new failures but retains six pre-existing optimization-specific failures tracked in #3390; the complete diagnostic run is not green.
- `git diff --check` and Markdown table checks pass.

No title milestone, visible rendering improvement or whole-game FPS gain is claimed. Full snapshot matrix not run. Exact-head author verification on `6a10714b43a2c9796d396e72a291b796672d735d` passed all eight selected cases; independent APPROVED review #5123756137 covers that commit. Final CI gate: nine passing checks, two intentional skips, no failures or pending checks; branch tip matches the PR head.

The exact-head native GTA Performance Story guard also passed: 300.568-second idle gate, 450.931-second bounded run, launcher exit 0, no device loss, full-resolution/cadence immediate presentation and fresh saves. All three native images were inspected: explicit Performance settings, rendered bank character/tutorial scene, then playable bank interior with radar and the guard objective. F8 contains 789 renderer / 2134 compute records with zero drops; F9 contains 73 submits. The previously optimized alias interval stays at 0.001 ms at printed precision across 31 fully warm dispatches, with setup averaging 0.329 ms versus 0.305 ms in the previous guard. This is a scoped regression check, not an isolated overhead measurement or whole-game FPS claim. Captures stay private; the GPU lease is released.
