### PR TITLE
memory: reconcile shared write-watch alias protections

### DIFF
--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -143,6 +143,35 @@ while neither does alone, and a previously inactive owner may gain a writer. Bot
 publication use the same member-aware key. These are seed-safety constraints, not a static proof
 that a shader's coverage is invariant under arbitrary input changes (#3391).
 
+### Write-watch alias protection
+
+Storage-result and texture caches may reuse a physical-page watch while other registrations still
+reference it. A guest permission change must update every retained alias's permissions before the
+production watch or diagnostic trace restores pages; recreating one registration does not recreate
+that shared page record. Late read-only aliases are retained so a later write upgrade cannot escape
+coverage. Trace invalidation follows physical topology, including aliases omitted from its original
+writable-only set (#3387).
+
+Failed production protection transitions explicitly invalidate page coverage. Neither a replacement watch nor
+a same-state rearm may publish Unchanged without a complete protection pass. Last-owner cleanup
+retains fault-recovery metadata if restoration fails; mapping removal can later reclaim it. A fault
+on a guest-revoked alias remains unhandled, and a trace's already-owned single-step still completes
+as invalid without restoring revoked permissions. Windows/macOS keep their existing safe fallback.
+This does not establish complete recovery after diagnostic-only partial protection failures.
+
+### Ruled out: shared watch reconstruction
+
+- **Reset/create repairs stale alias protections even when another registration survives:** falsified
+  by real shared mappings, a fresh Unchanged control and a raw upgraded-alias store that failed to
+  dirty the replacement. Updating only the mapping registry leaves the shared page stale (#3387).
+- **Disarming cannot undo an already-successful permission downgrade:** falsified by actual read/write
+  probes immediately after notification and last-owner release, for both RO and PROT_NONE. Production
+  and Armed diagnostic owners both restored old permissions; metadata reconciliation precedes either
+  restoration now (#3387).
+- **An armed bit plus a fresh generation proves complete coverage after a failed protection call:**
+  falsified by an inaccessible sibling alias. Forced reprotection and an explicit incomplete-coverage
+  state are required; attempted restoration is not proof that a faulting store can resume (#3387).
+
 ### Ruled out: per-binding seed safety
 
 - **A write-only owner's reflection is sufficient to omit seed data, provided untouched image

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -619,6 +619,9 @@ struct WatchedPage {
     uint64_t phys = 0, generation = 0;
     uint32_t references = 0;
     bool armed = false;
+    // A failed transition can leave some aliases protected and others writable. Keep the fault
+    // recovery record, but never publish Unchanged or skip the next complete protection pass.
+    bool coverage_incomplete = false;
     std::vector<PageAlias> aliases;
 };
 struct RegistrationPage { WatchedPage* page = nullptr; uint64_t generation = 0; };
@@ -757,7 +760,7 @@ std::vector<ProtectionRun> protection_runs(const WatchState& w,
         if (!page) continue;
         const bool prior_read_only = page_requires_read_only_locked(w, *page, page->armed);
         const bool wanted_read_only = page_requires_read_only_locked(w, *page, arm);
-        if (prior_read_only == wanted_read_only) continue;
+        if (prior_read_only == wanted_read_only && !page->coverage_incomplete) continue;
         for (const PageAlias& alias : page->aliases) {
             if (!cpu_writable(alias.prot)) continue;
             const int full = host_prot(alias.prot);
@@ -786,7 +789,8 @@ std::vector<ProtectionRun> protection_runs(const WatchState& w,
 
 // mprotect every writable alias of `pages` to read-only (arm) or back to its guest prot (disarm).
 // Read-only / PROT_NONE aliases are left untouched (a CPU store can't dirty them). Returns false and
-// rolls back on the first mprotect failure so the guest is never left with a wrong protection.
+// attempts rollback on the first mprotect failure. Failed/partial coverage remains explicit until
+// a complete pass succeeds; rollback itself can fail and is not proof that all aliases are restored.
 bool set_pages_armed(WatchState& w, const std::vector<WatchedPage*>& pages, bool arm) {
     if (arm && w.trace.status == GuestDmemWriteTraceStatus::Stepping &&
         std::any_of(pages.begin(), pages.end(), [&](const WatchedPage* page) {
@@ -798,6 +802,7 @@ bool set_pages_armed(WatchState& w, const std::vector<WatchedPage*>& pages, bool
     for (const ProtectionRun& run : runs) {
         if (watch_mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(run.addr)),
                            static_cast<size_t>(run.size), run.to) != 0) {
+            for (WatchedPage* page : pages) if (page) page->coverage_incomplete = true;
             while (changed) {
                 const ProtectionRun& prior = runs[--changed];
                 watch_mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(prior.addr)),
@@ -807,8 +812,21 @@ bool set_pages_armed(WatchState& w, const std::vector<WatchedPage*>& pages, bool
         }
         ++changed;
     }
-    for (WatchedPage* page : pages) if (page && page->armed != arm) page->armed = arm;
+    for (WatchedPage* page : pages) if (page) {
+        page->armed = arm;
+        page->coverage_incomplete = false;
+    }
     return true;
+}
+
+void erase_released_pages_locked(WatchState& w, const std::vector<WatchedPage*>& pages) {
+    for (WatchedPage* page : pages) {
+        // Failed restoration may leave real guest-writable VAs read-only. Retain their fault index
+        // even after the last registration goes away; normal mapping removal retries cleanup.
+        if (page->references || page->armed || page->coverage_incomplete) continue;
+        for (const PageAlias& alias : page->aliases) w.pages_by_addr.erase(alias.addr);
+        w.pages_by_phys.erase(page->phys);
+    }
 }
 
 void release_registration_locked(WatchState& w,
@@ -821,16 +839,12 @@ void release_registration_locked(WatchState& w,
         released.push_back(page);
     }
     set_pages_armed(w, released, false);
-    for (WatchedPage* page : released) {
-        for (const PageAlias& al : page->aliases) w.pages_by_addr.erase(al.addr);
-        w.pages_by_phys.erase(page->phys);
-    }
+    erase_released_pages_locked(w, released);
     w.registrations.erase(reg);
 }
 
-// A dmem topology/protection change makes every currently-watched page overlapping the changed range
-// Dirty (bump generation) and unmapped from the address index; the next query reads Dirty/Unknown and
-// the renderer re-establishes a fresh watch. Called with the lock held.
+// A dmem topology/protection change disarms and dirties overlapping physical pages. Keep their
+// address index while registrations or failed-restoration recovery still need it. Called locked.
 void invalidate_phys_range_locked(WatchState& w, uint64_t phys_begin, uint64_t phys_end) {
     std::vector<WatchedPage*> hit;
     for (auto& [phys, page] : w.pages_by_phys)
@@ -844,9 +858,9 @@ void invalidate_phys_range_locked(WatchState& w, uint64_t phys_begin, uint64_t p
 // next query reads Dirty). This is what resolves review B4: no stale VA survives in pages_by_addr for a
 // later handle_fault to mprotect after the VA has been unmapped/reused. Does NOT mprotect the vanishing
 // VAs (the caller is unmapping/remapping them; the kernel drops their protection) and — critically — does
-// NOT free the WatchedPage: page lifetime is reference-counted and owned by release_registration_locked,
-// so freeing one here would dangle a live Registration's raw pointer. A page that loses its last alias
-// just lingers, disarmed and Dirty, until its owning registration resets. Called with the lock held.
+// NOT free a referenced WatchedPage, which would dangle a live Registration's raw pointer. A page
+// that loses its last alias lingers until its owning registration resets. Unreferenced recovery-only
+// records can be reclaimed once their remaining aliases are safely restored. Called locked.
 void purge_va_range_locked(WatchState& w, uint64_t begin, uint64_t end, bool remove_topology) {
     // A registration belongs to its requested VA range, not merely to the physical pages that
     // happened to back it at creation. Keep old pages alive for other aliases/registrations, but
@@ -857,6 +871,7 @@ void purge_va_range_locked(WatchState& w, uint64_t begin, uint64_t end, bool rem
         if (registration.begin < end && registration.end > begin)
             registration.mapping_valid = false;
     }
+    std::vector<WatchedPage*> recovery;
     for (auto& [phys, pageptr] : w.pages_by_phys) {
         (void)phys;
         WatchedPage* page = pageptr.get();
@@ -871,8 +886,13 @@ void purge_va_range_locked(WatchState& w, uint64_t begin, uint64_t end, bool rem
                 ++ai;
             }
         }
-        if (changed) page->generation++;
+        if (changed) {
+            page->generation++;
+            if (!page->references) recovery.push_back(page);
+        }
     }
+    set_pages_armed(w, recovery, false);
+    erase_released_pages_locked(w, recovery);
     if (remove_topology)
         w.aliases.erase(std::remove_if(w.aliases.begin(), w.aliases.end(),
                                        [&](const AliasRange& a) {
@@ -1336,13 +1356,12 @@ GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
         reg.pages.push_back({page, page->generation});
     }
     if (!set_pages_armed(w, to_arm, true)) {
-        // Undo references + any pages we just created; report protect failure -> Unknown.
+        // Undo references and restore newly created pages; retain recovery metadata if restoration
+        // also fails. The attempted registration still reports protect failure -> Unknown.
         for (const RegistrationPage& rp : reg.pages)
             if (rp.page && rp.page->references) rp.page->references--;
-        for (WatchedPage* page : to_arm) {
-            for (const PageAlias& al : page->aliases) w.pages_by_addr.erase(al.addr & ~(kPage - 1));
-            w.pages_by_phys.erase(page->phys);
-        }
+        set_pages_armed(w, to_arm, false);
+        erase_released_pages_locked(w, to_arm);
         bump(stats().create_protect_failures);
         return {};
     }
@@ -1364,7 +1383,8 @@ GuestWriteWatchQuery GuestWriteWatch::query() const {
         return GuestWriteWatchQuery::Dirty;
     }
     for (const RegistrationPage& rp : found->second.pages) {
-        if (!rp.page || !rp.page->armed || rp.page->generation != rp.generation) {
+        if (!rp.page || !rp.page->armed || rp.page->coverage_incomplete ||
+            rp.page->generation != rp.generation) {
             bump(stats().dirty);
             return GuestWriteWatchQuery::Dirty;
         }
@@ -1698,8 +1718,9 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
 
     // A new alias to an already-watched physical page must be armed too, or a write through it would not
     // fault and the renderer would trust a stale texture (review B2). Same-phys aliasing does not change
-    // content, so we do NOT bump generation — we extend the page's alias set and arm the new VA in place.
-    if (!cpu_writable(protection) || w.pages_by_phys.empty()) return;   // nothing armed to extend
+    // content, so we do NOT bump generation on success. Retain even RO aliases so a later protection
+    // upgrade can update this shared record; only writable aliases need arming now.
+    if (w.pages_by_phys.empty()) return;   // nothing armed to extend
     for (uint64_t off = 0; off < size; off += kPage) {
         auto it = w.pages_by_phys.find(phys + off);
         if (it == w.pages_by_phys.end()) continue;
@@ -1707,10 +1728,12 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
         const uint64_t va = (addr + off) & ~(kPage - 1);
         page->aliases.push_back({va, protection});
         w.pages_by_addr[va] = page;
-        if (page->armed &&
+        if (page->armed && cpu_writable(protection) &&
             watch_mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(va)), kPage,
-                           host_prot(protection) & ~PROT_WRITE) != 0)
-            page->generation++;   // couldn't arm the new alias -> mark Dirty so the renderer re-creates
+                           host_prot(protection) & ~PROT_WRITE) != 0) {
+            page->generation++;
+            page->coverage_incomplete = true;
+        }
     }
 }
 
@@ -1745,12 +1768,33 @@ void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t 
     if (!w.fault_onstack.load(std::memory_order_acquire)) return;   // feature off -> nothing tracked
     std::lock_guard lock(w.mutex);
     const uint64_t end = addr + size;
+    // POSIX has already applied the new guest permissions. Both owners must use those permissions
+    // before any disarm restores aliases; stale RW metadata would undo a successful RO/NONE change.
+    for (auto& [phys, page] : w.pages_by_phys) {
+        (void)phys;
+        for (PageAlias& alias : page->aliases)
+            if (alias.addr < end && alias.addr + kPage > addr) {
+                alias.prot = protection;
+                page->coverage_incomplete = true;
+            }
+    }
+    for (DmemTracePage& page : w.trace.pages)
+        for (PageAlias& alias : page.aliases)
+            if (alias.addr < end && alias.addr + kPage > addr) alias.prot = protection;
     if (w.trace.status == GuestDmemWriteTraceStatus::Armed ||
         w.trace.status == GuestDmemWriteTraceStatus::Stepping) {
         bool overlap = false;
-        for (const DmemTracePage& page : w.trace.pages)
-            for (const PageAlias& alias : page.aliases)
-                if (alias.addr < end && alias.addr + kPage > addr) overlap = true;
+        // A RO alias was not in the trace's writable-only arm set. Resolve through live physical
+        // topology so upgrading that previously invisible sibling also invalidates trace coverage.
+        for (const AliasRange& alias : w.aliases) {
+            const uint64_t lo = std::max(addr, alias.addr);
+            const uint64_t hi = std::min(end, alias.addr + alias.size);
+            if (lo >= hi) continue;
+            const uint64_t first = alias.phys + (lo - alias.addr);
+            const uint64_t last = alias.phys + (hi - alias.addr);
+            for (const DmemTracePage& page : w.trace.pages)
+                if (page.phys < last && page.phys + kPage > first) overlap = true;
+        }
         if (overlap)
             trace_invalidate_locked(w, GuestDmemWriteTraceInvalidReason::MappingProtectionChanged,
                                     w.trace.status == GuestDmemWriteTraceStatus::Stepping);
@@ -1771,7 +1815,7 @@ void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t 
         if (a.addr < lo) split_out.push_back({a.addr, lo - a.addr, a.phys, a.prot});
         split_out.push_back({lo, hi - lo, a.phys + (lo - a.addr), protection});
         if (hi < a_end) split_out.push_back({hi, a_end - hi, a.phys + (hi - a.addr), a.prot});
-        // Existing page records may still carry this alias's previous protection. A retained
+        // Existing registrations were established under this alias's previous protection. A retained
         // registration must take the same reset/create path as a fresh watch, including when the
         // changed alias is outside its original VA range but names the same physical memory.
         // Ordinary physical writes do not change this registration-lifetime contract.
@@ -2111,10 +2155,24 @@ static GuestWriteWatchFaultAction guest_write_watch_handle_fault_impl(
         trace_va_to_phys_locked(w.trace, addr, trace_fault_phys);
     if (!production_page && !trace_page) return GuestWriteWatchFaultAction::NotHandled;
 
+    // Retained alias permissions are reconciled before protection-change invalidation. Check the
+    // faulting VA, not just physical-page membership: a revoked sibling is a genuine guest fault,
+    // including while another thread still owns the trace's pending single-step window.
+    const auto writable_alias = [&](const std::vector<PageAlias>& aliases) {
+        return std::any_of(aliases.begin(), aliases.end(), [&](const PageAlias& alias) {
+            return alias.addr == fault_page && cpu_writable(alias.prot);
+        });
+    };
+    const bool fault_writable = production_page ? writable_alias(production_page->aliases)
+        : std::any_of(w.trace.pages.begin(), w.trace.pages.end(), [&](const DmemTracePage& page) {
+              return writable_alias(page.aliases);
+          });
+    if (!fault_writable) return GuestWriteWatchFaultAction::NotHandled;
+
     bool production_handled = false;
     bool production_faulting_alias_restored = false;
     auto disarm_production_page = [&](WatchedPage* page) {
-        if (!page || !page->armed) return;
+        if (!page || (!page->armed && !page->coverage_incomplete)) return;
         bool restored = true;
         bool page_faulting_alias_restored = page != production_page;
         for (const PageAlias& alias : page->aliases) {
@@ -2128,6 +2186,7 @@ static GuestWriteWatchFaultAction guest_write_watch_handle_fault_impl(
                 page_faulting_alias_restored = true;
         }
         page->generation++;
+        page->coverage_incomplete = !restored;
         // Preserve #1144's stale-alias contract: a failure on a non-faulting alias must not leave the
         // successfully restored faulting VA logically armed. For diagnostic-only sibling pages there
         // is no faulting VA, so require the complete restore instead.
@@ -2137,7 +2196,8 @@ static GuestWriteWatchFaultAction guest_write_watch_handle_fault_impl(
         production_handled = true;
     };
 
-    if (production_page && !production_page->armed && !trace_page) {
+    if (production_page && !production_page->armed && !production_page->coverage_incomplete &&
+        !trace_page) {
         // Two guest workers can take the same RO-page fault before either signal handler runs. The
         // first handler restores RW and clears `armed`; the second delivery is already queued and used
         // to fall through as a fatal guest fault despite the store now being safe to retry (Cobra's
@@ -2203,8 +2263,8 @@ static GuestWriteWatchFaultAction guest_write_watch_handle_fault_impl(
     if (!trace_page) {
         disarm_production_page(production_page);
         if (production_handled) bump(stats().faults);
-        return production_handled ? GuestWriteWatchFaultAction::Resume
-                                  : GuestWriteWatchFaultAction::NotHandled;
+        return production_faulting_alias_restored ? GuestWriteWatchFaultAction::Resume
+                                                 : GuestWriteWatchFaultAction::NotHandled;
     }
 
     // The diagnostic opens every selected physical page for the one stepped instruction. Mark any
@@ -2284,8 +2344,8 @@ static GuestWriteWatchFaultAction guest_write_watch_handle_fault_impl(
         w.trace.armed = false;
         w.trace.status = GuestDmemWriteTraceStatus::Invalid;
         w.trace.invalid_reason = GuestDmemWriteTraceInvalidReason::ProtectFailed;
-        return production_handled ? GuestWriteWatchFaultAction::Resume
-                                  : GuestWriteWatchFaultAction::NotHandled;
+        return production_faulting_alias_restored ? GuestWriteWatchFaultAction::Resume
+                                                 : GuestWriteWatchFaultAction::NotHandled;
     }
     if (!all_restored) {
         w.trace.invalid_reason = GuestDmemWriteTraceInvalidReason::ProtectFailed;

--- a/prosper/tests/host/memory/test_dmem_write_trace.cpp
+++ b/prosper/tests/host/memory/test_dmem_write_trace.cpp
@@ -67,6 +67,29 @@ void dynamic_protection_hook() {
     dynamic_protection_helper_entries.fetch_add(1, std::memory_order_relaxed);
 }
 
+// Kernel copies obey the real VMA permissions without entering our SIGSEGV handler. Probe both
+// directions: rejecting a write alone cannot distinguish the requested RO from accidental NONE.
+void check_kernel_permissions(uint8_t* address, bool readable, bool writable) {
+    int probe[2] = {-1, -1};
+    const int opened = pipe(probe);
+    CHECK(opened == 0, "permission probe pipe created");
+    if (opened != 0) return;
+    const uint8_t payload = 0x31;
+    CHECK(write(probe[1], &payload, 1) == 1, "permission probe payload queued");
+    errno = 0;
+    const ssize_t copied_to_page = read(probe[0], address, 1);
+    const int write_error = errno;
+    CHECK(writable ? copied_to_page == 1 : copied_to_page == -1 && write_error == EFAULT,
+          "kernel write probe matches requested alias permission");
+    errno = 0;
+    const ssize_t copied_from_page = write(probe[1], address, 1);
+    const int read_error = errno;
+    CHECK(readable ? copied_from_page == 1 : copied_from_page == -1 && read_error == EFAULT,
+          "kernel read probe distinguishes requested RO from NONE");
+    close(probe[0]);
+    close(probe[1]);
+}
+
 void trace_signal_handler(int sig, siginfo_t* info, void* raw_context) {
     auto* context = static_cast<ucontext_t*>(raw_context);
     const int64_t tid = static_cast<int64_t>(syscall(SYS_gettid));
@@ -780,6 +803,211 @@ int main() {
             reinterpret_cast<uint64_t>(occurrence_two_mapping), allocation_size);
         munmap(occurrence_two_mapping, allocation_size);
     }
+    // #3387: a successful guest mprotect precedes the notification on POSIX. Neither the diagnostic
+    // nor a co-owning production watch may restore the changed alias's OLD writable protection.
+    // Real shared backing, not merely equal registry IDs, also makes the stepping store meaningful.
+    for (const bool stepping : {false, true}) {
+        for (const bool with_production : {false, true}) {
+            for (const int downgraded_prot : {PROT_READ, PROT_NONE}) {
+                std::fprintf(stderr, "[trace-protection] stepping=%d production=%d protection=%d\n",
+                             stepping, with_production, downgraded_prot);
+                const int backing = static_cast<int>(syscall(SYS_memfd_create,
+                                                             "trace-protection", 0));
+                CHECK(backing >= 0, "create shared trace-protection backing");
+                if (backing < 0) continue;
+                const int sized = ftruncate(backing, allocation_size);
+                CHECK(sized == 0, "size shared trace-protection backing");
+                if (sized != 0) { close(backing); continue; }
+                auto* writer_alias = static_cast<uint8_t*>(mmap(
+                    nullptr, allocation_size, PROT_READ | PROT_WRITE, MAP_SHARED, backing, 0));
+                auto* changed_alias = static_cast<uint8_t*>(mmap(
+                    nullptr, allocation_size, PROT_READ | PROT_WRITE, MAP_SHARED, backing, 0));
+                close(backing);
+                CHECK(writer_alias != MAP_FAILED && changed_alias != MAP_FAILED,
+                      "map two actual shared aliases for protection control");
+                if (writer_alias == MAP_FAILED || changed_alias == MAP_FAILED) {
+                    if (writer_alias != MAP_FAILED) munmap(writer_alias, allocation_size);
+                    if (changed_alias != MAP_FAILED) munmap(changed_alias, allocation_size);
+                    continue;
+                }
+                std::memset(writer_alias, 0x31, allocation_size);
+                CHECK(changed_alias[offset] == 0x31, "protection control aliases share bytes");
+                CHECK(prosper::host::guest_dmem_write_trace_configure(config),
+                      "reset selector for alias-protection control");
+                // Record both aliases before selecting the allocation, avoiding a late-map gap.
+                constexpr uint64_t protection_physical = 0x980000;
+                prosper::host::guest_write_watch_notify_direct_mapping_added(
+                    reinterpret_cast<uint64_t>(writer_alias), allocation_size,
+                    protection_physical, 0x3);
+                prosper::host::guest_write_watch_notify_direct_mapping_added(
+                    reinterpret_cast<uint64_t>(changed_alias), allocation_size,
+                    protection_physical, 0x3);
+                prosper::host::guest_dmem_write_trace_notify_allocation(
+                    protection_physical, allocation_size, chain);
+                CHECK(prosper::host::guest_dmem_write_trace_snapshot().status ==
+                          prosper::host::GuestDmemWriteTraceStatus::Armed,
+                      "complete alias set arms protection-control trace");
+                prosper::host::GuestWriteWatch shared_owner;
+                if (with_production) {
+                    shared_owner = prosper::host::GuestWriteWatch::create(
+                        reinterpret_cast<uint64_t>(writer_alias + offset), bytes);
+                    CHECK(static_cast<bool>(shared_owner),
+                          "production owner shares the diagnostic physical page");
+                }
+                std::thread pending_writer;
+                std::atomic<int64_t> pending_tid{0};
+                volatile sig_atomic_t protection_marker = 0;
+                if (stepping) {
+                    pause_invalidation_step.store(true, std::memory_order_release);
+                    invalidation_step_ready.store(false, std::memory_order_release);
+                    release_invalidation_step.store(false, std::memory_order_release);
+                    invalidation_canary_active.store(true, std::memory_order_release);
+                    last_step_action.store(-1, std::memory_order_release);
+                    pending_writer = std::thread([&] {
+                        install_altstack();
+                        pending_tid.store(static_cast<int64_t>(syscall(SYS_gettid)),
+                                          std::memory_order_release);
+                        store_byte_then_mark(writer_alias + offset, 0x67, &protection_marker);
+                    });
+                    while (!invalidation_step_ready.load(std::memory_order_acquire)) sched_yield();
+                }
+                // Downgrade only the NON-faulting sibling. The pending writer's original store
+                // remains legal; revoking its own VA would test a different guest protection fault.
+                const int protected_result = mprotect(changed_alias + page, page, downgraded_prot);
+                CHECK(protected_result == 0, "apply actual sibling alias permission downgrade");
+                if (protected_result == 0)
+                    prosper::host::guest_write_watch_notify_direct_mapping_protection(
+                        reinterpret_cast<uint64_t>(changed_alias + page), page,
+                        downgraded_prot == PROT_READ ? 0x1 : 0x0);
+                const auto pending = prosper::host::guest_dmem_write_trace_snapshot();
+                CHECK(pending.status == (stepping ? prosper::host::GuestDmemWriteTraceStatus::Stepping
+                                                 : prosper::host::GuestDmemWriteTraceStatus::Invalid) &&
+                          pending.invalid_reason ==
+                              prosper::host::GuestDmemWriteTraceInvalidReason::MappingProtectionChanged &&
+                          pending.event_count == 0,
+                      "protection change invalidates trace without losing a pending TF owner");
+                check_kernel_permissions(changed_alias + offset, downgraded_prot == PROT_READ, false);
+                if (stepping) {
+                    // The retained trace alias must not turn a new, genuine permission fault into
+                    // a stale queued-fault Resume while another thread owns the original TF window.
+                    const auto revoked_fault = prosper::host::guest_write_watch_handle_fault_ex(
+                        reinterpret_cast<uint64_t>(changed_alias + offset), 0,
+                        static_cast<int64_t>(syscall(SYS_gettid)), false);
+                    const auto after_revoked_fault = prosper::host::guest_dmem_write_trace_snapshot();
+                    CHECK(revoked_fault == prosper::host::GuestWriteWatchFaultAction::NotHandled &&
+                              after_revoked_fault.status ==
+                                  prosper::host::GuestDmemWriteTraceStatus::Stepping &&
+                              after_revoked_fault.invalid_reason ==
+                                  prosper::host::GuestDmemWriteTraceInvalidReason::MappingProtectionChanged &&
+                              after_revoked_fault.event_count == 0,
+                          "revoked sibling fault is rejected without consuming the pending TF owner");
+                    check_kernel_permissions(changed_alias + offset,
+                                             downgraded_prot == PROT_READ, false);
+                    release_invalidation_step.store(true, std::memory_order_release);
+                    pending_writer.join();
+                    invalidation_canary_active.store(false, std::memory_order_release);
+                    const auto completed = prosper::host::guest_dmem_write_trace_snapshot();
+                    CHECK(last_step_action.load(std::memory_order_acquire) == static_cast<int>(
+                              prosper::host::GuestDmemWriteTraceStepAction::CompleteInvalid) &&
+                              protection_marker == 1 && writer_alias[offset] == 0x67 &&
+                              completed.status == prosper::host::GuestDmemWriteTraceStatus::Invalid &&
+                              completed.invalid_reason ==
+                                  prosper::host::GuestDmemWriteTraceInvalidReason::MappingProtectionChanged &&
+                              completed.completed_steps == 1 && completed.event_count == 1 &&
+                              completed.events[0].tid == pending_tid.load(std::memory_order_acquire) &&
+                              !completed.events[0].rearmed && !completed.events[0].post_available &&
+                              completed.rearms == 0,
+                          "downgraded sibling preserves exact TF owner and completes without rearm");
+                    check_kernel_permissions(changed_alias + offset,
+                                             downgraded_prot == PROT_READ, false);
+                }
+                shared_owner.reset();
+                check_kernel_permissions(changed_alias + offset, downgraded_prot == PROT_READ, false);
+                check_kernel_permissions(writer_alias + offset, true, true);
+                check_kernel_permissions(changed_alias, true, true);
+                check_kernel_permissions(changed_alias + 2 * page, true, true);
+                prosper::host::guest_write_watch_notify_direct_mapping_removed(
+                    reinterpret_cast<uint64_t>(writer_alias), allocation_size);
+                prosper::host::guest_write_watch_notify_direct_mapping_removed(
+                    reinterpret_cast<uint64_t>(changed_alias), allocation_size);
+                munmap(writer_alias, allocation_size);
+                munmap(changed_alias, allocation_size);
+            }
+        }
+    }
+
+    // An initially RO alias never enters the trace's writable-only page vectors. Its upgrade still
+    // breaks physical-page coverage, so invalidation must consult live mapping topology as well.
+    for (const bool with_production : {false, true}) {
+        std::fprintf(stderr, "[trace-protection-upgrade] production=%d\n", with_production);
+        const int backing = static_cast<int>(syscall(SYS_memfd_create, "trace-upgrade", 0));
+        CHECK(backing >= 0, "create shared trace-upgrade backing");
+        if (backing < 0) continue;
+        const int sized = ftruncate(backing, allocation_size);
+        CHECK(sized == 0, "size shared trace-upgrade backing");
+        if (sized != 0) { close(backing); continue; }
+        auto* writable_alias = static_cast<uint8_t*>(mmap(
+            nullptr, allocation_size, PROT_READ | PROT_WRITE, MAP_SHARED, backing, 0));
+        auto* readonly_alias = static_cast<uint8_t*>(mmap(
+            nullptr, allocation_size, PROT_READ, MAP_SHARED, backing, 0));
+        close(backing);
+        CHECK(writable_alias != MAP_FAILED && readonly_alias != MAP_FAILED,
+              "map pre-existing RW and RO aliases for upgrade control");
+        if (writable_alias == MAP_FAILED || readonly_alias == MAP_FAILED) {
+            if (writable_alias != MAP_FAILED) munmap(writable_alias, allocation_size);
+            if (readonly_alias != MAP_FAILED) munmap(readonly_alias, allocation_size);
+            continue;
+        }
+        std::memset(writable_alias, 0x31, allocation_size);
+        CHECK(readonly_alias[offset] == 0x31, "upgrade aliases share actual backing bytes");
+        CHECK(prosper::host::guest_dmem_write_trace_configure(config),
+              "reset selector for pre-existing RO alias upgrade");
+        constexpr uint64_t upgrade_physical = 0x9c0000;
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(writable_alias), allocation_size, upgrade_physical, 0x3);
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(readonly_alias), allocation_size, upgrade_physical, 0x1);
+        prosper::host::guest_dmem_write_trace_notify_allocation(
+            upgrade_physical, allocation_size, chain);
+        CHECK(prosper::host::guest_dmem_write_trace_snapshot().status ==
+                  prosper::host::GuestDmemWriteTraceStatus::Armed,
+              "trace arms with a pre-existing non-writable sibling");
+        prosper::host::GuestWriteWatch shared_owner;
+        if (with_production) {
+            shared_owner = prosper::host::GuestWriteWatch::create(
+                reinterpret_cast<uint64_t>(writable_alias + offset), bytes);
+            CHECK(static_cast<bool>(shared_owner), "production owner shares upgrade-control page");
+        }
+        check_kernel_permissions(readonly_alias + offset, true, false);
+        const int upgraded = mprotect(readonly_alias + page, page, PROT_READ | PROT_WRITE);
+        CHECK(upgraded == 0, "apply actual pre-existing sibling RO-to-RW upgrade");
+        if (upgraded == 0) {
+            prosper::host::guest_write_watch_notify_direct_mapping_protection(
+                reinterpret_cast<uint64_t>(readonly_alias + page), page, 0x3);
+            const auto invalidated = prosper::host::guest_dmem_write_trace_snapshot();
+            CHECK(invalidated.status == prosper::host::GuestDmemWriteTraceStatus::Invalid &&
+                      invalidated.invalid_reason ==
+                          prosper::host::GuestDmemWriteTraceInvalidReason::MappingProtectionChanged,
+                  "physical coverage invalidates even when changed RO alias was absent from trace pages");
+            store_byte(readonly_alias + offset, 0x6a);
+            const auto after_store = prosper::host::guest_dmem_write_trace_snapshot();
+            CHECK(writable_alias[offset] == 0x6a &&
+                      after_store.status == prosper::host::GuestDmemWriteTraceStatus::Invalid &&
+                      after_store.invalid_reason ==
+                          prosper::host::GuestDmemWriteTraceInvalidReason::MappingProtectionChanged &&
+                      after_store.event_count == 0 && after_store.completed_steps == 0 &&
+                      after_store.result != prosper::host::GuestDmemWriteTraceResult::NoSelectedWriteObserved,
+                  "upgraded alias accepts a real store without claiming negative diagnostic coverage");
+        }
+        shared_owner.reset();
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(writable_alias), allocation_size);
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(readonly_alias), allocation_size);
+        munmap(writable_alias, allocation_size);
+        munmap(readonly_alias, allocation_size);
+    }
+
     // ---- host-write rebaseline (#3146) --------------------------------------------------------
     //
     // Three review rounds found three defects in this feature and no test could reach any of them,

--- a/prosper/tests/host/memory/test_guest_write_watch.cpp
+++ b/prosper/tests/host/memory/test_guest_write_watch.cpp
@@ -86,14 +86,65 @@ int main() {
 #else   // ---- Linux: exercise the real mprotect + SIGSEGV dirty-tracking (#1144) ------------------
 
 #include <cerrno>
+#include <csignal>
 #include <cstring>
 #include <sys/mman.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 namespace {
 // dmem is section-backed (one memfd, MAP_SHARED at multiple VAs) — mirror that so the alias handling
 // is exercised, not just a single mapping.
 constexpr uint32_t kCpuRw = 0x3;   // SCE CPU_READ|CPU_WRITE (see host_prot in guest_write_watch.cpp)
+
+enum class AccessProbe { Allowed, Faulted, Failed };
+
+// Fault in a child, never the test runner. Ordinary probes deliberately bypass prosper's handler:
+// they measure actual host permissions, not whether a stale watch could restore permission later.
+// The tracked-store arm instead keeps the production handler and checks the child's copied watch
+// state there; a fork cannot make the parent's private dirty counters observe the child's store.
+AccessProbe probe_access(uint8_t* address, bool write, GuestWriteWatch* tracked = nullptr,
+                         GuestWriteWatch* obsolete = nullptr, bool keep_fault_handler = false) {
+    const pid_t child = fork();
+    if (child < 0) return AccessProbe::Failed;
+    if (child == 0) {
+        const rlimit no_core{0, 0};
+        if (setrlimit(RLIMIT_CORE, &no_core) != 0) _exit(120);
+        struct sigaction action{};
+        action.sa_handler = SIG_DFL;
+        sigemptyset(&action.sa_mask);
+        if (sigaction(SIGALRM, &action, nullptr) != 0 ||
+            sigaction(SIGBUS, &action, nullptr) != 0 ||
+            (!tracked && !keep_fault_handler &&
+             sigaction(SIGSEGV, &action, nullptr) != 0)) _exit(121);
+        sigset_t unblock;
+        sigemptyset(&unblock);
+        sigaddset(&unblock, SIGALRM);
+        sigaddset(&unblock, SIGBUS);
+        sigaddset(&unblock, SIGSEGV);
+        if (sigprocmask(SIG_UNBLOCK, &unblock, nullptr) != 0) _exit(122);
+        alarm(3); // A stale alias protection must fail, not loop forever in the fault handler.
+        if (tracked && tracked->query() != GuestWriteWatchQuery::Unchanged) _exit(123);
+        if (obsolete && (obsolete->rearm() ||
+                         obsolete->query() != GuestWriteWatchQuery::Dirty)) _exit(124);
+        auto* byte = reinterpret_cast<volatile uint8_t*>(address);
+        if (write) *byte = 0x77;
+        else { const uint8_t value = *byte; (void)value; }
+        if (tracked && tracked->query() != GuestWriteWatchQuery::Dirty) _exit(125);
+        if (obsolete && (obsolete->rearm() ||
+                         obsolete->query() != GuestWriteWatchQuery::Dirty)) _exit(126);
+        _exit(0);
+    }
+    int status = 0;
+    pid_t waited;
+    do { waited = waitpid(child, &status, 0); } while (waited < 0 && errno == EINTR);
+    if (waited != child) return AccessProbe::Failed;
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) return AccessProbe::Allowed;
+    if (WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS))
+        return AccessProbe::Faulted;
+    return AccessProbe::Failed;
+}
 
 } // namespace
 
@@ -349,42 +400,81 @@ int main() {
 
     // Protection changes through another VA invalidate the affected PHYSICAL registration only.
     // A read-only alias becoming writable must not remain invisible to a retained watch.
-    {
+    for (bool failed_reconciliation : {false, true}) for (bool late_readonly : {false, true}) {
         int protection_fd = memfd_create("prosper-ww-protection", 0);
         CHECK(protection_fd >= 0 && ftruncate(protection_fd, static_cast<off_t>(page * 3)) == 0,
               "protection-transition memfd sized");
         if (protection_fd < 0) return 1;
         auto* writable = static_cast<uint8_t*>(mmap(
             nullptr, page * 3, PROT_READ | PROT_WRITE, MAP_SHARED, protection_fd, 0));
-        auto* readonly = static_cast<uint8_t*>(mmap(
-            nullptr, page * 3, PROT_READ, MAP_SHARED, protection_fd, 0));
-        CHECK(writable != MAP_FAILED && readonly != MAP_FAILED,
-              "writable and read-only aliases mapped");
-        if (writable == MAP_FAILED || readonly == MAP_FAILED) return 1;
-        constexpr uint64_t protection_phys = 0xc20000;
+        CHECK(writable != MAP_FAILED, "protection-transition writable alias mapped");
+        if (writable == MAP_FAILED) return 1;
+        uint8_t* readonly = nullptr;
+        const uint64_t protection_phys = (late_readonly ? 0xc30000 : 0xc20000) +
+                                         (failed_reconciliation ? 0x20000 : 0);
+        constexpr uint64_t stale_alias = 0x700000008000ull;
         prosper::host::guest_write_watch_notify_direct_mapping_added(
             reinterpret_cast<uint64_t>(writable), page * 3, protection_phys, kCpuRw);
-        prosper::host::guest_write_watch_notify_direct_mapping_added(
-            reinterpret_cast<uint64_t>(readonly), page * 3, protection_phys, 0x1);
+        auto add_readonly = [&] {
+            readonly = static_cast<uint8_t*>(mmap(
+                nullptr, page * 3, PROT_READ, MAP_SHARED, protection_fd, 0));
+            CHECK(readonly != MAP_FAILED, "protection-transition read-only alias mapped");
+            if (readonly == MAP_FAILED) return false;
+            prosper::host::guest_write_watch_notify_direct_mapping_added(
+                reinterpret_cast<uint64_t>(readonly), page * 3, protection_phys, 0x1);
+            return true;
+        };
+        if (!late_readonly && !add_readonly()) return 1;
         auto affected = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable + page), page);
+        auto retained = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable + page + 8), 16);
         auto unaffected = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable), page);
-        CHECK(affected && unaffected, "affected and disjoint physical ranges watched");
+        CHECK(affected && retained && unaffected, "two middle-page owners and disjoint physical range watched");
+        if (late_readonly && !add_readonly()) return 1;
+        CHECK(affected.query() == GuestWriteWatchQuery::Unchanged &&
+                  retained.query() == GuestWriteWatchQuery::Unchanged,
+              "early or late read-only alias leaves both middle-page watches initially clean");
+        CHECK(probe_access(readonly + page + 32, false) == AccessProbe::Allowed &&
+                  probe_access(readonly + page + 32, true) == AccessProbe::Faulted,
+              "read-only alias probe can read but cannot write before upgrade");
+        if (failed_reconciliation) {
+            CHECK(probe_access(reinterpret_cast<uint8_t*>(stale_alias), false) == AccessProbe::Faulted,
+                  "failed-reconciliation control address is inaccessible");
+            prosper::host::guest_write_watch_notify_direct_mapping_added(
+                stale_alias, page, protection_phys + page, kCpuRw);
+        }
         CHECK(mprotect(readonly + page, page, PROT_READ | PROT_WRITE) == 0,
               "middle page of read-only alias becomes writable");
         prosper::host::guest_write_watch_notify_direct_mapping_protection(
             reinterpret_cast<uint64_t>(readonly + page), page, kCpuRw);
         CHECK(!affected.rearm() && affected.query() == GuestWriteWatchQuery::Dirty,
               "changed sibling-alias protection requires a fresh registration");
+        CHECK(!retained.rearm() && retained.query() == GuestWriteWatchQuery::Dirty,
+              "protection upgrade invalidates every existing owner of the middle physical page");
         CHECK(unaffected.rearm() && unaffected.query() == GuestWriteWatchQuery::Unchanged,
               "partial protection change leaves disjoint physical registration rearmable");
         affected.reset();
         affected = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable + page), page);
-        CHECK(affected && affected.query() == GuestWriteWatchQuery::Unchanged,
-              "sole-owner replacement watch uses current sibling-alias protections");
-        readonly[page + 32] = 0x77;
-        CHECK(writable[page + 32] == 0x77 && affected.query() == GuestWriteWatchQuery::Dirty,
-              "real store through newly writable alias dirties recreated watch");
+        if (failed_reconciliation) {
+            CHECK(!affected.rearm() && affected.query() != GuestWriteWatchQuery::Unchanged,
+                  "failed sibling protection reconciliation cannot publish a clean replacement watch");
+            prosper::host::guest_write_watch_notify_direct_mapping_removed(stale_alias, page);
+            if (!affected)
+                affected = GuestWriteWatch::create(reinterpret_cast<uint64_t>(writable + page), page);
+        }
+        CHECK(affected && affected.rearm() && affected.query() == GuestWriteWatchQuery::Unchanged,
+              "replacement starts clean with current alias permissions while another owner retains the page");
+        CHECK(probe_access(readonly + page + 32, true, &affected, &retained) == AccessProbe::Allowed &&
+                  writable[page + 32] == 0x77,
+              "raw upgraded-alias store dirties the fresh child watch and leaves the retained owner invalid");
+        CHECK(!retained.rearm() && retained.query() == GuestWriteWatchQuery::Dirty,
+              "recreating one owner never revives the other obsolete registration");
+        CHECK(unaffected.query() == GuestWriteWatchQuery::Unchanged &&
+                  probe_access(readonly + 32, true) == AccessProbe::Faulted &&
+                  probe_access(readonly + page * 2 + 32, true) == AccessProbe::Faulted &&
+                  probe_access(writable + page * 2 + 32, true) == AccessProbe::Allowed,
+              "middle-page upgrade preserves neighboring permissions and the disjoint watch");
         affected.reset();
+        retained.reset();
         unaffected.reset();
         prosper::host::guest_write_watch_notify_direct_mapping_removed(
             reinterpret_cast<uint64_t>(writable), page * 3);
@@ -393,6 +483,83 @@ int main() {
         munmap(writable, page * 3);
         munmap(readonly, page * 3);
         close(protection_fd);
+    }
+
+    // A permission downgrade must survive disarming, shared-owner replacement, and last release.
+    // The writable sibling still supports a watch; it must not grant B permissions the guest revoked.
+    for (int requested : {PROT_READ, PROT_NONE}) {
+        int downgrade_fd = memfd_create("prosper-ww-downgrade", 0);
+        CHECK(downgrade_fd >= 0 && ftruncate(downgrade_fd, static_cast<off_t>(page * 3)) == 0,
+              "downgrade memfd sized");
+        if (downgrade_fd < 0) return 1;
+        auto* first = static_cast<uint8_t*>(mmap(
+            nullptr, page * 3, PROT_READ | PROT_WRITE, MAP_SHARED, downgrade_fd, 0));
+        auto* second = static_cast<uint8_t*>(mmap(
+            nullptr, page * 3, PROT_READ | PROT_WRITE, MAP_SHARED, downgrade_fd, 0));
+        CHECK(first != MAP_FAILED && second != MAP_FAILED, "downgrade aliases mapped");
+        if (first == MAP_FAILED || second == MAP_FAILED) return 1;
+        const uint64_t phys = requested == PROT_READ ? 0xc60000 : 0xc70000;
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(first), page * 3, phys, kCpuRw);
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(second), page * 3, phys, kCpuRw);
+        CHECK(probe_access(second + page + 32, true) == AccessProbe::Allowed,
+              "downgrade write probe succeeds on the initial writable alias");
+        auto replaced = GuestWriteWatch::create(reinterpret_cast<uint64_t>(first + page), page);
+        auto retained = GuestWriteWatch::create(reinterpret_cast<uint64_t>(first + page + 8), 16);
+        auto outer = GuestWriteWatch::create(reinterpret_cast<uint64_t>(first), page);
+        CHECK(replaced && retained && outer &&
+                  replaced.query() == GuestWriteWatchQuery::Unchanged &&
+                  retained.query() == GuestWriteWatchQuery::Unchanged,
+              "downgrade starts with two clean middle owners and a disjoint outer owner");
+        auto check_permissions = [&](const char* stage) {
+            const AccessProbe read_result = probe_access(second + page + 32, false);
+            const AccessProbe write_result = probe_access(second + page + 32, true);
+            const bool correct = read_result == (requested == PROT_READ
+                ? AccessProbe::Allowed : AccessProbe::Faulted) && write_result == AccessProbe::Faulted;
+            if (!correct) std::fprintf(stderr, "  downgrade prot=%d stage=%s\n", requested, stage);
+            CHECK(correct, "downgraded alias retains exact actual read/write permissions");
+            CHECK(outer.query() == GuestWriteWatchQuery::Unchanged &&
+                      probe_access(second + 32, false) == AccessProbe::Allowed &&
+                      probe_access(second + 32, true) == AccessProbe::Faulted &&
+                      probe_access(second + page * 2 + 32, true) == AccessProbe::Allowed,
+                  "middle-page downgrade preserves the armed left neighbor and writable right neighbor");
+        };
+        CHECK(mprotect(second + page, page, requested) == 0, "guest downgrades only the middle alias page");
+        check_permissions("before notification");
+        prosper::host::guest_write_watch_notify_direct_mapping_protection(
+            reinterpret_cast<uint64_t>(second + page), page, requested == PROT_READ ? 0x1 : 0x0);
+        check_permissions("after notification");
+        CHECK(!replaced.rearm() && !retained.rearm() &&
+                  replaced.query() == GuestWriteWatchQuery::Dirty &&
+                  retained.query() == GuestWriteWatchQuery::Dirty,
+              "downgrade invalidates both old middle registrations");
+        replaced.reset();
+        replaced = GuestWriteWatch::create(reinterpret_cast<uint64_t>(first + page), page);
+        if (requested == PROT_NONE) {
+            CHECK(!replaced && !replaced.rearm() &&
+                      replaced.query() == GuestWriteWatchQuery::Unknown,
+                  "an inaccessible physical alias keeps replacement watches on the exact fallback");
+        } else {
+            CHECK(replaced && replaced.rearm() && replaced.query() == GuestWriteWatchQuery::Unchanged,
+                  "fresh middle watch can arm through the still-writable sibling");
+        }
+        check_permissions("after one-owner replacement");
+        replaced.reset();
+        retained.reset();
+        check_permissions("after last middle owner release");
+        CHECK(probe_access(first + page + 32, true) == AccessProbe::Allowed,
+              "last middle owner release restores the sibling's legitimate write permission");
+        outer.reset();
+        CHECK(probe_access(second + 32, true) == AccessProbe::Allowed,
+              "outer owner release restores its unchanged writable alias");
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(first), page * 3);
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(second), page * 3);
+        munmap(first, page * 3);
+        munmap(second, page * 3);
+        close(downgrade_fd);
     }
 
     // N2: a partial re-protect must record ONLY the re-protected sub-range. Re-protect the MIDDLE page of
@@ -427,6 +594,58 @@ int main() {
     GuestWriteWatch none = GuestWriteWatch::create(0x9000000000ULL, page);
     CHECK(!static_cast<bool>(none), "create over an unmapped range yields Unknown");
 
+    // Last-owner release can fail to restore RW when one recorded sibling no longer maps. Its
+    // transactional rollback leaves the real alias RO: zero references must not erase the only
+    // fault-recovery metadata while that protection remains installed.
+    {
+        int recovery_fd = memfd_create("prosper-ww-release-recovery", 0);
+        CHECK(recovery_fd >= 0 && ftruncate(recovery_fd, static_cast<off_t>(page)) == 0,
+              "last-release recovery memfd sized");
+        if (recovery_fd < 0) return 1;
+        auto* real = static_cast<uint8_t*>(mmap(
+            nullptr, page, PROT_READ | PROT_WRITE, MAP_SHARED, recovery_fd, 0));
+        CHECK(real != MAP_FAILED, "last-release recovery alias mapped");
+        if (real == MAP_FAILED) return 1;
+        constexpr uint64_t recovery_phys = 0xc80000;
+        constexpr uint64_t missing_alias = 0x700000010000ull;
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(real), page, recovery_phys, kCpuRw);
+        CHECK(probe_access(real + 32, true) == AccessProbe::Allowed,
+              "last-release recovery alias is initially writable without a fault handler");
+        auto released = GuestWriteWatch::create(reinterpret_cast<uint64_t>(real), page);
+        CHECK(released && released.query() == GuestWriteWatchQuery::Unchanged,
+              "last-release recovery watch begins clean");
+        CHECK(probe_access(real + 32, true) == AccessProbe::Faulted,
+              "last-release recovery control proves the watch actually armed the real page");
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            missing_alias, page, recovery_phys, kCpuRw);
+        CHECK(!released.rearm() && released.query() == GuestWriteWatchQuery::Dirty,
+              "missing sibling makes the release-recovery watch fail closed");
+        released.reset();
+        CHECK(!released && released.query() == GuestWriteWatchQuery::Unknown,
+              "last-release recovery handle relinquishes its registration");
+        CHECK(probe_access(real + 40, true) == AccessProbe::Faulted,
+              "failed last-owner disarm leaves a real RO page requiring fault recovery");
+        CHECK(probe_access(real + 40, true, nullptr, nullptr, true) == AccessProbe::Allowed &&
+                  real[40] == 0x77,
+              "production fault handler recovers a raw store after failed last-owner release");
+        // The child handled its own copied protection state. Repair the parent's topology too,
+        // then require a genuinely fresh clean watch and another raw-store dirty witness.
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(missing_alias, page);
+        auto repaired = GuestWriteWatch::create(reinterpret_cast<uint64_t>(real), page);
+        CHECK(repaired && repaired.rearm() && repaired.query() == GuestWriteWatchQuery::Unchanged,
+              "removing the missing sibling permits a fresh exact watch after failed release");
+        CHECK(probe_access(real + 48, true, &repaired) == AccessProbe::Allowed && real[48] == 0x77,
+              "fresh watch after release recovery catches a real store from an Unchanged baseline");
+        repaired.reset();
+        CHECK(probe_access(real + 56, true) == AccessProbe::Allowed,
+              "successful final release restores actual RW permission after recovery");
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(real), page);
+        munmap(real, page);
+        close(recovery_fd);
+    }
+
     // A title's Job.Worker executes guest code with %fs pointing at its guest TCB. The production
     // SIGSEGV handler must temporarily restore host %fs before GuestWriteWatch enters std::mutex and
     // glibc mprotect, then restore guest %fs before the faulting store resumes. Make that boundary
@@ -450,15 +669,13 @@ int main() {
                 reinterpret_cast<uint64_t>(guest_page), page);
             CHECK(static_cast<bool>(guest_watch), "guest-FS watch armed");
 
-            // The fake VA is intentionally not mapped. Adding it after the page is armed records the
-            // stale alias and makes its immediate mprotect fail without preventing the real alias from
-            // remaining armed. Rearm accepts the updated generation because the physical page itself
-            // is still armed.
+            // The fake VA is intentionally not mapped. Its failed protection update must prevent a
+            // clean verdict, even though the real alias remains armed and can still fault below.
             prosper::host::guest_write_watch_notify_direct_mapping_added(
                 kStaleAlias, page, kGuestFsPhys, kCpuRw);
-            CHECK(guest_watch.rearm(), "guest-FS watch rearmed after stale-alias injection");
-            CHECK(guest_watch.query() == GuestWriteWatchQuery::Unchanged,
-                  "guest-FS watch clean before the fault");
+            CHECK(!guest_watch.rearm(), "guest-FS watch refuses incomplete stale-alias coverage");
+            CHECK(guest_watch.query() == GuestWriteWatchQuery::Dirty,
+                  "guest-FS watch fails closed before the real alias fault");
 
             uint64_t host_fs = 0;
             __asm__ volatile("rdfsbase %0" : "=r"(host_fs));


### PR DESCRIPTION
## Contract and repair

Fixes #3387.

Shared physical-page watch records outlive individual registrations. After a sibling alias changes permissions, reset/create could reuse stale per-alias protection metadata and miss raw writes through an upgraded alias. Conversely, disarming either a production watch or a diagnostic trace could undo an already-successful guest RO/PROT_NONE downgrade.

Reconcile retained permissions before either restoration owner runs, retain late read-only aliases, and invalidate diagnostic coverage by physical topology (including initially read-only aliases omitted from its writable arm set). Existing registrations remain invalid after a protection change.

Track incomplete production protection coverage explicitly. Same-state rearm must retry the complete protection pass; failed transitions cannot publish Unchanged. Failed last-owner/create cleanup retains fault-recovery records until restoration or mapping removal makes reclamation safe. A genuine fault on a revoked alias remains unhandled; production Resume requires the faulting alias to have been restored. Pending diagnostic single-step ownership remains intact. Signal-time changes do not allocate or destroy page records.

Windows/macOS retain their existing safe fallback. This does not change shader semantics, rendering cadence, game settings, or the HLE syscall/notification ordering. Diagnostic-only partial protection failure recovery remains a separate source-derived issue (#3393); no complete diagnostic recovery guarantee is claimed here.

## Verification

Real memfd aliases and raw volatile stores exercise early/late RO-to-RW upgrades with two owners on the same physical page, RO/NONE downgrades, partial ranges, failed reconciliation, and failed final release. Permission probes bypass prosper's handler; tracked fork-child stores require Unchanged before the store and Dirty in that same child afterwards. Trace tests cover Armed/Stepping, with/without a production owner, RO/NONE, pending TF ownership, and initially invisible RO aliases.

Expanded tests against unchanged runtime `c5eb785c0facded58390312beec33515d8a4659e`: 2/2 fail, exit 8, 35 failed assertions. Isolated runtime mutations against the full fix:

| Disabled safeguard | Result |
| --- | --- |
| Forced same-state reconciliation | Production test fails 7 assertions; trace passes |
| Last-owner recovery retention | Production raw-store recovery fails 1 assertion; trace passes |
| Revoked-alias fault rejection | Trace fails 4 assertions; production passes |
| Physical-topology trace invalidation | Trace-only upgrade fails 2 assertions; co-owner upgrade fails its invalidation assertion then times out at 60 s; production passes |

All mutations were restored. Full implementation has passed all 8 related cases (exit 0), including RADV compute execution with 701/687/701 assertions. Exact-head author verification will be posted separately after publication.

Build/test commands (Linux distrobox, Release, frame pointers and line tables):

```sh
export TMPDIR="$PWD/prosper/build-linux/tmpdir"
export PROSPER_GAME_ROOT=<DUMP_ROOT>
cmake -S prosper -B prosper/build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG -g1 -fno-omit-frame-pointer" \
  -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 -DPROSPER_APP=ON
cmake --build prosper/build-linux -j6 --target test_guest_write_watch test_dmem_write_trace \
  test_watch_mapping_generation test_guest_writable_cache test_guest_memory_map \
  test_game_compute prosper-app
ctest --test-dir prosper/build-linux --no-tests=error --timeout 60 -V \
  -R '^(guest_write_watch|dmem_write_trace|watch_mapping_generation|guest_writable_cache|guest_memory_map|game_compute_exec.*)$'
```

Risk is Linux page-protection/fault lifecycle behavior; focused memory tests and compute consumers are the relevant guards. No snapshots or new live-game run for this PR, and no game-specific rendering or FPS improvement is attributed to this fix. Raw test artifacts remain local. RESOURCE_BINDING records the contract and falsifications.
