### PR TITLE
gpu: stream per-draw shader property scans

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1931,6 +1931,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_vertex_fetch_reject_diagnostic PRIVATE prosper_core)
   add_test(NAME vertex_fetch_reject_diagnostic COMMAND test_vertex_fetch_reject_diagnostic)
 
+  # CPU-only streaming shader properties: exact legacy semantics without per-query vectors.
+  add_executable(test_shader_property_scans tests/gpu/recompiler/test_shader_property_scans.cpp)
+  target_link_libraries(test_shader_property_scans PRIVATE prosper_core)
+  add_test(NAME shader_property_scans COMMAND test_shader_property_scans)
+
   add_executable(test_gta5_selected_sbuffer tests/gpu/recompiler/test_gta5_selected_sbuffer.cpp)
   target_link_libraries(test_gta5_selected_sbuffer PRIVATE prosper_core)
   add_test(NAME gta5_selected_sbuffer COMMAND test_gta5_selected_sbuffer)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1934,7 +1934,8 @@ if(TARGET prosper_core)
   # CPU-only streaming shader properties: exact legacy semantics without per-query vectors.
   add_executable(test_shader_property_scans tests/gpu/recompiler/test_shader_property_scans.cpp)
   target_link_libraries(test_shader_property_scans PRIVATE prosper_core)
-  add_test(NAME shader_property_scans COMMAND test_shader_property_scans)
+  add_test(NAME shader_property_scans COMMAND ${CMAKE_COMMAND} -E env
+           --unset=PROSPER_PROLOGLOG $<TARGET_FILE:test_shader_property_scans>)
 
   add_executable(test_gta5_selected_sbuffer tests/gpu/recompiler/test_gta5_selected_sbuffer.cpp)
   target_link_libraries(test_gta5_selected_sbuffer PRIVATE prosper_core)

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -44,6 +44,10 @@ this document is the map that helps the next orchestrator find and interpret tha
   This paragraph is a handoff, not a lock: live `in-progress` labels, claim comments and remote fix
   branches are authoritative for ownership.
 - GPU state: sharing is the default; see the scheduling rules below.
+- **GTA V native Linux performance (2026-09-06):** #3065 owns the current CPU/resource-budget
+  investigation. The Performance Story route renders the bank; its latest instrumented baseline
+  is about 6 guest flips/s, not the separate Windows throughput figure. See `GTA5_STATUS.md` for
+  the bounded shader-property scan experiment and the issue for native comparison evidence.
 
 ### The standing objective, in the user's words
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -73,6 +73,31 @@ The phase-report tool's alias records are **not zero work**: this capture has 10
 versus 26.963 ms in real-image records. The report's misleading alias-only wording is tracked in
 #3388. Do not treat its real-image-only decomposition as all image setup.
 
+### Streaming per-draw shader properties (#3065)
+
+A fresh native Performance Story baseline on `7dfcc038` (source tree equal to main `5974d41b5`)
+again rendered the bank at “Go to the guard,” without a device-loss signal. Its complete F8 window
+contained 779 renderer and 2,120 compute records with zero drops and measured 5.98 guest/host
+flips per second over 5.016 seconds. This is an instrumented attribution window, not a new
+progression milestone or an untouched throughput comparison.
+
+The separate userspace CPU profile identified repeated instruction-vector construction in
+`fragment_color_export_mask` and `rdna2_vertex_prolog_info`. These queries now decode directly
+without retaining a full vector: first nonzero export per MRT is unchanged, and prolog branches
+must still target the retained prefix or its exact transfer instruction. Shader translation,
+resource resolution, cache validation and emitted instructions are unchanged. The existing
+dynamic-fetch decode cache is not absent and is not modified by this change.
+
+CPU-only comparison against the previous vector algorithms covered 139 fragment and 88 vertex
+streams extracted from the native F9 frame, with identical property results throughout. Across
+six alternating trials, summing each unique stream's median one-call time gave 1.368 → 0.224 ms
+for fragment masks and 0.215 → 0.00681 ms for vertex-prolog queries. These unweighted corpus totals
+are **not per-frame costs or FPS gains**. All retained vertex streams reject as split prologs;
+accepted transfers, signed branch boundaries, truncated inputs and same-address mutations are
+covered separately by the CPU regression. Its allocation controls fail with the old vector
+implementations while the property-equivalence checks remain green. Native comparison and exact
+verification evidence are tracked in #3065.
+
 ## Gameplay framerate optimization: reaching 21+ FPS (2026-09-03)
 
 **Platform**: Measured on **Windows 11 / Intel Core i9 (24 physical cores) / discrete NVIDIA GeForce RTX 4090 (24 GB VRAM, Vulkan 1.4)**.

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -2911,20 +2911,23 @@ uint32_t fragment_effective_wave_size_for_test(uint32_t requested_wave_size,
 }
 
 uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords) {
-    std::vector<Rdna2Inst> ins;
-    rdna2_walk(code, dwords, ins);
     uint32_t packed = 0;
     // One nibble per MRT, MRT0..MRT7. Sized 2 until 2026-08-15, which silently forced
     // `write_mask &= 0` for slots 2..7 at gpu_execute.hpp's EXP.EN gate -- so a shader exporting to
     // MRT2+ had those attachments dropped no matter what CB_TARGET_MASK and CB_SHADER_MASK said.
     std::array<bool, kFragmentColorOutputs> realized{};
-    for (const auto& in : ins) {
-        if (in.is_end) break;
-        if (in.fmt != Rdna2Format::EXP || in.exp_target >= realized.size() ||
-            realized[in.exp_target] || in.exp_en == 0)
-            continue;
-        packed |= (in.exp_en & 0xFu) << (in.exp_target * 4u);
-        realized[in.exp_target] = true;
+    // This property needs no retained instructions. Match rdna2_walk's bounded decode and
+    // termination rules without allocating/copying a complete instruction vector on every draw.
+    for (size_t pc = 0; pc < dwords;) {
+        const Rdna2Inst in = rdna2_decode_one(code + pc, dwords - pc);
+        if (in.is_end || in.fmt == Rdna2Format::Unknown) break;
+        if (in.fmt == Rdna2Format::EXP && in.exp_target < realized.size() &&
+            !realized[in.exp_target] && in.exp_en != 0) {
+            packed |= (in.exp_en & 0xFu) << (in.exp_target * 4u);
+            realized[in.exp_target] = true;
+        }
+        if (in.len_dwords == 0) break;
+        pc += in.len_dwords;
     }
     return packed;
 }
@@ -3353,8 +3356,6 @@ VertexPrologInfo rdna2_vertex_prolog_info(const uint32_t* code, size_t dwords) {
     VertexPrologInfo result;
     if (!code || !dwords) return result;
 
-    std::vector<Rdna2Inst> instructions;
-    rdna2_walk(code, dwords, instructions);
     const bool prologlog = getenv("PROSPER_PROLOGLOG") != nullptr;
     uint64_t phash = 0xcbf29ce484222325ull;
     if (prologlog)
@@ -3367,7 +3368,13 @@ VertexPrologInfo rdna2_vertex_prolog_info(const uint32_t* code, size_t dwords) {
         fprintf(stderr, "[prologlog] hash=%016llx dwords=%zu %s pc=%u fmt=%d\n",
                 (unsigned long long)phash, dwords, what, at ? at->pc : 0u, at ? (int)at->fmt : -1);
     };
-    for (const Rdna2Inst& instruction : instructions) {
+    // Only the prefix before the transfer can belong to a fetch prolog. Track its branch-target
+    // bounds while decoding, so neither the prefix nor the unused shader tail needs a vector.
+    int64_t min_branch_target = 0;
+    int64_t max_branch_target = 0;
+    for (size_t pc = 0; pc < dwords;) {
+        Rdna2Inst instruction = rdna2_decode_one(code + pc, dwords - pc);
+        instruction.pc = static_cast<uint32_t>(pc);
         // A fetch prolog has no architectural output or program termination of its own. Encountering
         // either before the transfer means this is a complete/different shader, not the split ABI.
         if (instruction.is_end || instruction.fmt == Rdna2Format::EXP ||
@@ -3375,38 +3382,36 @@ VertexPrologInfo rdna2_vertex_prolog_info(const uint32_t* code, size_t dwords) {
             prolog_note("BAIL", &instruction);
             return {};
         }
-        if (instruction.fmt != Rdna2Format::SOP1 || instruction.opcode != 0x20)
-            continue;
-
-        // GFX9+ merged-stage fetch prologs receive the continuation PC in reserved s[6:7]. Keeping
-        // this exact pair in the recognizer prevents an arbitrary indirect jump from becoming host
-        // fallthrough merely because a second program happened to be bound.
-        if (instruction.n_src != 1 || instruction.src[0].kind != OperandKind::SGPR ||
-            instruction.src[0].value != 6 || instruction.len_dwords != 1)
-            return {};
-        prolog_note("TRANSFER", &instruction);
-        result.valid = instruction.pc != 0;
-        result.setpc_pc = instruction.pc;
-        result.prefix_dwords = instruction.pc;
-        break;
+        if (instruction.fmt == Rdna2Format::SOP1 && instruction.opcode == 0x20) {
+            // GFX9+ merged-stage fetch prologs receive the continuation PC in reserved s[6:7].
+            // Keep this exact pair: an arbitrary indirect jump must not become host fallthrough.
+            if (instruction.n_src != 1 || instruction.src[0].kind != OperandKind::SGPR ||
+                instruction.src[0].value != 6 || instruction.len_dwords != 1)
+                return {};
+            prolog_note("TRANSFER", &instruction);
+            // Every direct branch must remain inside the retained prefix or land exactly on the
+            // transfer (main pc0 after linking), never in discarded padding/data. The linked body
+            // recompiler performs the remaining structured-CFG validation.
+            if (instruction.pc == 0 || min_branch_target < 0 ||
+                max_branch_target > instruction.pc)
+                return {};
+            result.valid = true;
+            result.setpc_pc = instruction.pc;
+            result.prefix_dwords = instruction.pc;
+            return result;
+        }
+        if (instruction.fmt == Rdna2Format::SOPP &&
+            (instruction.opcode == 0x02 ||
+             (instruction.opcode >= 0x04 && instruction.opcode <= 0x09))) {
+            const int64_t target = static_cast<int64_t>(instruction.pc) + instruction.len_dwords +
+                                   static_cast<int64_t>(instruction.simm16);
+            min_branch_target = std::min(min_branch_target, target);
+            max_branch_target = std::max(max_branch_target, target);
+        }
+        if (instruction.len_dwords == 0) break;
+        pc += instruction.len_dwords;
     }
-    if (!result.valid) return {};
-
-    // Replacing the transfer with fallthrough is valid only when every direct branch in the prolog
-    // remains inside the retained prefix (or lands exactly on the transfer, which becomes main pc0).
-    // A branch into discarded padding/data would otherwise be silently redirected into unrelated
-    // main code. The linked body recompiler performs the remaining structured-CFG validation.
-    for (const Rdna2Inst& instruction : instructions) {
-        if (instruction.pc >= result.setpc_pc) break;
-        if (instruction.fmt != Rdna2Format::SOPP ||
-            (instruction.opcode != 0x02 &&
-             (instruction.opcode < 0x04 || instruction.opcode > 0x09)))
-            continue;
-        const int64_t target = static_cast<int64_t>(instruction.pc) + instruction.len_dwords +
-                               static_cast<int64_t>(instruction.simm16);
-        if (target < 0 || target > result.setpc_pc) return {};
-    }
-    return result;
+    return {};
 }
 
 namespace {

--- a/prosper/tests/gpu/recompiler/test_shader_property_scans.cpp
+++ b/prosper/tests/gpu/recompiler/test_shader_property_scans.cpp
@@ -1,0 +1,214 @@
+// CPU-only equivalence and allocation regressions for the two per-draw shader property scans.
+// Keep the vector references independent of the production streaming implementations. No cache,
+// Vulkan device, guest mapping, diagnostic output, or elapsed-time threshold participates here.
+#include "gpu/recompiler/rdna2_decode.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <new>
+#include <vector>
+
+using namespace prosper::gpu;
+
+namespace {
+thread_local bool count_allocations = false;
+thread_local size_t allocations = 0;
+int failures = 0;
+size_t checks = 0;
+
+void check(bool ok, const char* label) {
+    ++checks;
+    if (!ok) { ++failures; std::printf("[FAIL] %s\n", label); }
+}
+} // namespace
+
+// Rdna2Inst vectors use ordinary (not over-aligned) new. Count only while the single-threaded
+// public property call is active; fixture/reference allocations and printf stay outside the scope.
+static_assert(alignof(Rdna2Inst) <= alignof(std::max_align_t));
+void* operator new(std::size_t size) {
+    if (count_allocations) ++allocations;
+    if (void* p = std::malloc(size ? size : 1)) return p;
+    throw std::bad_alloc();
+}
+void* operator new[](std::size_t size) { return ::operator new(size); }
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
+
+namespace {
+uint32_t vector_export_mask(const uint32_t* code, size_t dwords) {
+    std::vector<Rdna2Inst> instructions;
+    rdna2_walk(code, dwords, instructions);
+    uint32_t packed = 0;
+    std::array<bool, kFragmentColorOutputs> realized{};
+    for (const auto& in : instructions) {
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::EXP || in.exp_target >= realized.size() ||
+            realized[in.exp_target] || in.exp_en == 0)
+            continue;
+        packed |= (in.exp_en & 0xfu) << (in.exp_target * 4u);
+        realized[in.exp_target] = true;
+    }
+    return packed;
+}
+
+VertexPrologInfo vector_prolog(const uint32_t* code, size_t dwords) {
+    VertexPrologInfo result;
+    if (!code || !dwords) return result;
+    std::vector<Rdna2Inst> instructions;
+    rdna2_walk(code, dwords, instructions);
+    for (const auto& in : instructions) {
+        if (in.is_end || in.fmt == Rdna2Format::EXP || in.fmt == Rdna2Format::Unknown)
+            return {};
+        if (in.fmt != Rdna2Format::SOP1 || in.opcode != 0x20) continue;
+        if (in.n_src != 1 || in.src[0].kind != OperandKind::SGPR ||
+            in.src[0].value != 6 || in.len_dwords != 1)
+            return {};
+        result.valid = in.pc != 0;
+        result.setpc_pc = in.pc;
+        result.prefix_dwords = in.pc;
+        break;
+    }
+    if (!result.valid) return {};
+    for (const auto& in : instructions) {
+        if (in.pc >= result.setpc_pc) break;
+        if (in.fmt != Rdna2Format::SOPP ||
+            (in.opcode != 0x02 && (in.opcode < 0x04 || in.opcode > 0x09)))
+            continue;
+        const int64_t target = static_cast<int64_t>(in.pc) + in.len_dwords + in.simm16;
+        if (target < 0 || target > result.setpc_pc) return {};
+    }
+    return result;
+}
+
+bool same_prolog(const VertexPrologInfo& a, const VertexPrologInfo& b) {
+    return a.valid == b.valid && a.setpc_pc == b.setpc_pc &&
+           a.prefix_dwords == b.prefix_dwords;
+}
+
+void compare_prefixes(const uint32_t* code, size_t dwords, const char* label) {
+    for (size_t length = 0; length <= dwords; ++length) {
+        const uint32_t expected_mask = vector_export_mask(code, length);
+        const VertexPrologInfo expected_prolog = vector_prolog(code, length);
+        allocations = 0;
+        count_allocations = true;
+        const uint32_t actual_mask = fragment_color_export_mask(code, length);
+        count_allocations = false;
+        const size_t mask_allocations = allocations;
+        allocations = 0;
+        count_allocations = true;
+        const VertexPrologInfo actual_prolog = rdna2_vertex_prolog_info(code, length);
+        count_allocations = false;
+        const size_t prolog_allocations = allocations;
+        const bool equivalent = actual_mask == expected_mask &&
+                                same_prolog(actual_prolog, expected_prolog);
+        const bool allocation_free = mask_allocations == 0 && prolog_allocations == 0;
+        if (!equivalent || !allocation_free)
+            std::printf("  case=%s length=%zu mask=%08x/%08x allocations=%zu/%zu\n",
+                        label, length, actual_mask, expected_mask,
+                        mask_allocations, prolog_allocations);
+        check(equivalent, "both properties match vector reference at this supplied-length prefix");
+        check(allocation_free, "normal property scans allocate no instruction vectors");
+    }
+}
+
+constexpr uint32_t nop = 0xBF800000u;
+constexpr uint32_t endpgm = 0xBF810000u;
+constexpr uint32_t transfer = 0xBE802006u;
+constexpr uint32_t unknown = 0xffffffffu;
+constexpr uint32_t exp_word(uint32_t target, uint32_t en) {
+    return 0xF8001000u | (target << 4u) | en;
+}
+constexpr uint32_t branch(uint32_t opcode, int displacement) {
+    return 0xBF800000u | (opcode << 16u) | static_cast<uint16_t>(displacement);
+}
+} // namespace
+
+int main() {
+    // The allocation contract deliberately excludes the optional diagnostic's deduplicating set.
+#ifdef _WIN32
+    _putenv_s("PROSPER_PROLOGLOG", "");
+#else
+    unsetenv("PROSPER_PROLOGLOG");
+#endif
+    check(rdna2_decode_one(&unknown, 1).fmt == Rdna2Format::Unknown,
+          "unknown terminator control really decodes as Unknown");
+    const uint32_t allocation_control[] = {nop, endpgm};
+    allocations = 0;
+    count_allocations = true;
+    const uint32_t control_mask = vector_export_mask(allocation_control, 2);
+    count_allocations = false;
+    check(allocations > 0 && control_mask == 0,
+          "old vector reference positively exercises the allocation counter");
+
+    compare_prefixes(nullptr, 0, "empty");
+    check(!rdna2_vertex_prolog_info(nullptr, 7).valid, "null prolog remains invalid");
+    const std::vector<std::vector<uint32_t>> corpus = {
+        {nop}, {endpgm, transfer}, {unknown, transfer}, {transfer},
+        {nop, transfer, unknown}, {nop, transfer, branch(2, 32767), endpgm},
+        {nop, 0xBE802008u, transfer}, // wrong SGPR pair before a later otherwise-valid transfer
+        {nop, 0xBE802080u, transfer}, // inline constant, not the reserved SGPR pair
+        {nop, exp_word(0, 0), 0, transfer}, // even a zero-mask export rejects a prolog
+        {exp_word(0, 3), 0, endpgm, exp_word(7, 15), 0},
+        {exp_word(0, 3), 0, unknown, exp_word(7, 15), 0},
+        {exp_word(8, 15), 0, exp_word(7, 10), 0, endpgm},
+        {exp_word(0, 0), 0, exp_word(0, 3), 0, exp_word(0, 12), 0,
+         exp_word(7, 0), 0, exp_word(7, 10), 0, endpgm},
+        {0xBE8003FFu, 0x12345678u, transfer}, // literal scalar instruction, prefixes split it
+        {0xE00C2000u, 0x80010000u, nop, transfer}, // two-word buffer instruction
+        {branch(2, -2), branch(4, 1), nop, transfer}, // bad minimum followed by a valid target
+        {branch(2, 4), branch(4, 1), nop, transfer}, // bad maximum followed by a valid target
+        {branch(2, 2), branch(4, -2), nop, transfer}, // both boundary targets 3 and 0
+        {branch(3, 32767), nop, transfer}, // opcode outside the exact direct-branch set
+    };
+    for (const auto& code : corpus) compare_prefixes(code.data(), code.size(), "fixed corpus");
+
+    const auto& duplicate_exports = corpus[12];
+    check(fragment_color_export_mask(duplicate_exports.data(), duplicate_exports.size()) ==
+              0xa0000003u,
+          "first nonzero export wins independently for MRT0 and MRT7");
+    check(fragment_color_export_mask(corpus[10].data(), corpus[10].size()) == 3,
+          "Unknown prevents a later MRT7 export from affecting the mask");
+    check(!rdna2_vertex_prolog_info(corpus[15].data(), corpus[15].size()).valid &&
+          !rdna2_vertex_prolog_info(corpus[16].data(), corpus[16].size()).valid &&
+          rdna2_vertex_prolog_info(corpus[17].data(), corpus[17].size()).valid,
+          "branch minimum and maximum each reject independently, both boundaries are accepted");
+
+    for (uint32_t opcode : {2u, 4u, 5u, 6u, 7u, 8u, 9u}) {
+        for (int displacement : {-32768, -3, -2, -1, 0, 1, 2, 32767}) {
+            const uint32_t code[] = {branch(opcode, displacement), nop, transfer};
+            compare_prefixes(code, 3, "signed branch bounds");
+            const auto info = rdna2_vertex_prolog_info(code, 3);
+            const bool valid = displacement >= -1 && displacement <= 1;
+            check(info.valid == valid && (!valid ||
+                      (info.setpc_pc == 2 && info.prefix_dwords == 2)),
+                  "every recognized direct-branch opcode honors signed prefix bounds");
+        }
+    }
+
+    // Reuse precisely the same address/length while changing both property results. No address-only
+    // memoization can pass this arm. Fixture construction and mutations precede allocation scopes.
+    uint32_t mutable_code[] = {nop, transfer, endpgm, endpgm};
+    compare_prefixes(mutable_code, 4, "mutation before");
+    check(rdna2_vertex_prolog_info(mutable_code, 4).valid, "initial mutable prolog is valid");
+    mutable_code[1] = exp_word(7, 5);
+    mutable_code[2] = 0;
+    compare_prefixes(mutable_code, 4, "mutation after");
+    check(!rdna2_vertex_prolog_info(mutable_code, 4).valid &&
+          fragment_color_export_mask(mutable_code, 4) == 0x50000000u,
+          "same-address mutation immediately changes prolog and MRT7 properties");
+    mutable_code[1] = transfer;
+    mutable_code[2] = endpgm;
+    compare_prefixes(mutable_code, 4, "mutation restored");
+    check(rdna2_vertex_prolog_info(mutable_code, 4).valid &&
+          fragment_color_export_mask(mutable_code, 4) == 0,
+          "restoring bytes restores both properties without stale state");
+
+    std::printf("shader property scans: %zu checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/recompiler/test_shader_property_scans.cpp
+++ b/prosper/tests/gpu/recompiler/test_shader_property_scans.cpp
@@ -130,12 +130,12 @@ constexpr uint32_t branch(uint32_t opcode, int displacement) {
 } // namespace
 
 int main() {
-    // The allocation contract deliberately excludes the optional diagnostic's deduplicating set.
-#ifdef _WIN32
-    _putenv_s("PROSPER_PROLOGLOG", "");
-#else
-    unsetenv("PROSPER_PROLOGLOG");
-#endif
+    // CTest removes this before process startup. Do not mutate a diagnostic that other code can
+    // cache: the allocation contract excludes its deduplicating set, including on direct runs.
+    if (std::getenv("PROSPER_PROLOGLOG")) {
+        std::fprintf(stderr, "shader property scans: PROSPER_PROLOGLOG must be absent\n");
+        return 2;
+    }
     check(rdna2_decode_one(&unknown, 1).fmt == Rdna2Format::Unknown,
           "unknown terminator control really decodes as Unknown");
     const uint32_t allocation_control[] = {nop, endpgm};


### PR DESCRIPTION
## Scope

Refs #3065. Reduce repeated CPU work in two per-draw shader-property queries without changing shader translation or adding a cache.

`fragment_color_export_mask` and `rdna2_vertex_prolog_info` previously constructed complete decoded-instruction vectors to produce small properties. The native Performance Story profile identifies both queries among repeated `rdna2_walk` callers. Streaming removes these allocations and copies, and stops prolog recognition once its result is determined.

## Contracts

- Preserve bounded decoder behavior, terminators, Unknown instructions, truncated inputs, and the first nonzero export per MRT0–MRT7.
- Accept only the same single-dword transfer through s[6:7]; every recognized direct branch must target the retained prefix or exactly the transfer. Track branch extrema instead of rescanning a vector.
- Preserve same-address mutation behavior and optional prolog diagnostics. No new cache, hash assumption, guest-state override, draw/dispatch skip, or resource/write-watch change.
- Equivalence is scoped to bounded shader inputs with representable instruction PCs, as used by live callers; no claim is made about artificial arrays beyond the 32-bit PC range.

## Evidence

The CPU-only regression compares independent previous vector algorithms with both public queries at every supplied-length prefix, plus explicit export, signed-branch, transfer-source and mutation oracles. Allocation checks include a positive old-reference control. Initial candidate: 725 checks, zero failures. Temporarily restoring both previous production functions: 251 allocation failures, with the property-equivalence checks still passing. Both candidate functions were then restored and rebuilt; the two CPU CTests passed again.

The private native F9 corpus contains 139 unique fragment and 88 vertex streams. All 227 property results match. Six alternating CPU-only trials give unweighted sums of per-stream median call times of 1.368 → 0.224 ms for fragment masks and 0.215 → 0.00681 ms for prolog queries. All captured vertex streams reject as split prologs; synthetic tests cover accepted transfers. These totals are not frame costs, live call frequencies or FPS gains.

The baseline route renders the bank at “Go to the guard” in Performance mode, on the native adopted renderer device/present queue. Its complete F8 window has 779 renderer / 2,120 compute records with zero drops and 5.98 guest/host flips per second. This repeats an existing checkpoint; no new visual milestone is claimed. Raw capture/game data remains private. See the [baseline report](https://github.com/mattias800/prosper/issues/3065#issuecomment-5556532664).

## Verification

Exact head `c5b2b96be085db87ce18b6abdd19738a510ae34f` builds successfully and passes **6/6 focused CTests**, including the cached-environment check. The first CI attempt caught runtime diagnostic-variable mutation in the fixture; the correction removes that variable in the CTest launcher instead and makes direct execution reject an inherited setting. The inherited-setting CTest control passes; direct execution refuses with exit 2. No scanner or production behavior was weakened.

Native candidate guard completed: **450.896 seconds, exit 0, no device-loss signature**, inspected Performance settings and the rendered bank at “Go to the guard,” complete F8 (779 renderer / 2,113 compute records, zero drops) and 73-submit F9. It ran the retained `27ce5c94` executable; production source is identical to the final fixture-only correction. The candidate's 6.1816 guest/host flips/s versus baseline 5.9807 is one instrumented pair, **not a repeatable FPS-improvement claim**. Its separate CPU recording uses matching live-process library identities. [Exact-head author evidence and native guard](https://github.com/mattias800/prosper/pull/3395#issuecomment-5556644502). Merge remains gated on current-head independent review and all applicable CI.

```sh
export PROSPER_GAME_ROOT=<DUMP_ROOT>
export TMPDIR=<WORKTREE>/prosper/build-linux/tmpdir
cmake -S prosper -B prosper/build-linux -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG -g1 -fno-omit-frame-pointer" \
  -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 -DPROSPER_APP=ON
cmake --build prosper/build-linux -j6 --target prosper-app test_shader_property_scans \
  test_rdna2_decode test_recompiled_fragment test_recompiled_shaders test_rdna2_to_spirv
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure \
  -R '^(cached_env_arming_logic|shader_property_scans|rdna2_decode_walk|recompiled_fragment_render|recompiled_shaders_render|rdna2_to_spirv_exec)$'
```

Main risk is changing a stopping or branch-bound rule while removing storage; differential prefixes, explicit semantic controls and the existing execution tests address it. No cross-platform APIs change. Full snapshot inventory is not requested for this focused CPU optimization.
