### PR TITLE
gpu: remove per-pass texture-cache statistics traversal

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3036,7 +3036,8 @@ if(TARGET prosper_core)
       # Reaches `shared/...` through render_runner.h, which resolves from `frontends`.
       target_include_directories(test_texture_sample_render PRIVATE frontends)
       target_link_libraries(test_texture_sample_render PRIVATE prosper_core Vulkan::Vulkan)
-      add_test(NAME texture_sample_render COMMAND test_texture_sample_render)
+      add_test(NAME texture_sample_render COMMAND ${CMAKE_COMMAND} -E env
+          --unset=PROSPER_BACKEND_TEXTURE_CACHE_MB $<TARGET_FILE:test_texture_sample_render>)
 
       # Multi-draw backend: N draws composited into ONE cleared-once framebuffer (red opaque + green
       # additive -> yellow center proves accumulation into a single target).

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -47,7 +47,9 @@ this document is the map that helps the next orchestrator find and interpret tha
 - **GTA V native Linux performance (2026-09-06):** #3065 owns the current CPU/resource-budget
   investigation. The Performance Story route renders the bank; its latest instrumented baseline
   is about 6 guest flips/s, not the separate Windows throughput figure. See `GTA5_STATUS.md` for
-  the bounded shader-property scan experiment and the issue for native comparison evidence.
+  the shader-property and constant-time texture-statistics changes, and the issue for native
+  comparison evidence. The latter removes a cache-wide census identified in sampled user CPU;
+  it does not change texture validation or establish an FPS gain.
 
 ### The standing objective, in the user's words
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -98,6 +98,23 @@ covered separately by the CPU regression. Its allocation controls fail with the 
 implementations while the property-equivalence checks remain green. Native comparison and exact
 verification evidence are tracked in #3065.
 
+### Constant-time texture binding statistics (#3065)
+
+The next retained native profile (production source equivalent to main `f9188bd39`) contains
+31,373 userspace samples and 52,814,729,223 summed sample periods. Three instruction addresses
+in the exact binary's end-of-pass texture-binding census account for 1,156,672,656 periods:
+**2.19006% of sampled user cycles**, not frame time or a projected FPS gain. That loop walks
+every persistent texture image solely to sum its binding-map size; it is not texture validation
+or upload. Exact-ELF callchains and disassembly distinguish this bookkeeping from those costs.
+
+The backend now maintains the same aggregate under its existing persistent-resource lock:
+successful binding insertion adds one, binding eviction removes one, and image retirement
+subtracts that image's bindings. Invalid content remains counted until actually retired.
+Rendering, upload/validation policy, cache limits and the statistics publication point are
+unchanged. Focused tests cover multiple images, invalid-but-resident content, both eviction
+paths and view/sampler failures before and after eviction. Native comparison evidence and
+the still-open broader resource-preparation budget remain in #3065.
+
 ## Gameplay framerate optimization: reaching 21+ FPS (2026-09-03)
 
 **Platform**: Measured on **Windows 11 / Intel Core i9 (24 physical cores) / discrete NVIDIA GeForce RTX 4090 (24 GB VRAM, Vulkan 1.4)**.

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -6223,6 +6223,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     static std::unordered_map<PersistentTextureKey, PersistentTextureImage,
                               PersistentTextureKeyHash> persistent_texture_images;
     static VkDeviceSize persistent_texture_bytes = 0;
+    // Exact sum of each retained image's binding count. This domain is protected by the
+    // BackendPersistentResourceGuard above; update on successful insertion/erasure, not on
+    // content invalidation (which leaves the bindings resident until the image is retired).
+    // Recounting every cached image after every pass made statistics an O(cache size) hot loop.
+    static size_t persistent_texture_binding_entries = 0;
     static uint64_t persistent_texture_generation = 0;
     constexpr size_t persistent_texture_max_entries = 1024;
     const uint64_t texture_generation = ++persistent_texture_generation;
@@ -7614,6 +7619,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 if (cached->second.memory)
                                     vkFreeMemory(dev, cached->second.memory, nullptr);
                                 persistent_texture_bytes -= cached->second.bytes;
+                                persistent_texture_binding_entries -= cached->second.bindings.size();
                                 persistent_texture_images.erase(cached);
                                 cached = persistent_texture_images.end();
                             }
@@ -7963,6 +7969,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                         if (victim->second.view)
                                             vkDestroyImageView(dev, victim->second.view, nullptr);
                                         persistent_image->second.bindings.erase(victim);
+                                        --persistent_texture_binding_entries;
                                         ++resource_reuse_stats.persistent_texture_binding_evictions;
                                     }
                                 }
@@ -7996,9 +8003,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 }
                                 if (persistent_image->second.bindings.size() <
                                     max_bindings_per_texture) {
-                                    persistent_image->second.bindings.emplace(
-                                        binding_key, PersistentTextureBinding{
-                                            binding.view, binding.sampler, texture_generation});
+                                    const auto [entry, inserted] =
+                                        persistent_image->second.bindings.emplace(
+                                            binding_key, PersistentTextureBinding{
+                                                binding.view, binding.sampler, texture_generation});
+                                    (void)entry;
+                                    if (inserted) ++persistent_texture_binding_entries;
                                     binding.persistent = true;
                                 }
                             }
@@ -9836,6 +9846,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         vkDestroyImage(dev, victim->second.image, nullptr);
         vkFreeMemory(dev, victim->second.memory, nullptr);
         persistent_texture_bytes -= victim->second.bytes;
+        persistent_texture_binding_entries -= victim->second.bindings.size();
         persistent_texture_images.erase(victim);
         return true;
     };
@@ -9872,8 +9883,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     if (!avoid_cache_eviction)
         while (persistent_texture_bytes > persistent_texture_limit &&
                evict_persistent_texture()) {}
-    for (const auto& [key, image] : persistent_texture_images)
-        resource_reuse_stats.persistent_texture_binding_entries += image.bindings.size();
+    resource_reuse_stats.persistent_texture_binding_entries = persistent_texture_binding_entries;
     texture_stats.persistent_cached_bytes = persistent_texture_bytes;
 
     const auto timing_recorded = timing_enabled ? TimingClock::now() : TimingClock::time_point{};

--- a/prosper/tests/gpu/test_render_object_create_failure.cpp
+++ b/prosper/tests/gpu/test_render_object_create_failure.cpp
@@ -309,6 +309,8 @@ int main() {
         std::vector<uint8_t> warm_px;
         const std::string warm_log = render(make_draw(0.0f), RenderVkObjectCreateSite::None,
                                             "warm", &warm_px);
+        const size_t warm_binding_entries =
+            prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries;
         CHECK(center_red(warm_px) > 0xC0 && !has(warm_log, "[render-object-create-failed]"),
               "persistent texture: the warming render succeeds and is silent");
 
@@ -323,6 +325,9 @@ int main() {
               "texture-view-persistent: the failure names its own site, API and VkResult");
         CHECK(pv_px.size() == static_cast<size_t>(W) * H * 4 && center_red(pv_px) < 0x20,
               "texture-view-persistent: the draw is skipped rather than caching a null view");
+        CHECK(prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries ==
+                  warm_binding_entries,
+              "failed persistent view creation adds no binding to the exact aggregate");
 
         // A DIFFERENT sampler contract is a different binding key, so this misses the binding
         // cache too and reaches the same pair. Fail the sampler this time.
@@ -335,6 +340,9 @@ int main() {
               "texture-sampler-persistent: the failure names its own site, API and VkResult");
         CHECK(psm_px.size() == static_cast<size_t>(W) * H * 4 && center_red(psm_px) < 0x20,
               "texture-sampler-persistent: the draw is skipped rather than caching a null sampler");
+        CHECK(prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries ==
+                  warm_binding_entries,
+              "failed persistent sampler creation adds no binding despite successful view creation");
 
         // THE POINT OF THIS BLOCK. Before #3210 the two persistent sites emplaced whatever the
         // failed create left behind into PersistentTextureImage::bindings, so ONE failure was
@@ -354,10 +362,12 @@ int main() {
                   !has(recovered_log_a, "[render-object-create-failed]"),
               "a later draw with the FAILED binding key renders -- no null was cached");
         CHECK(after_a.persistent_texture_binding_misses == 1 &&
-                  after_a.persistent_texture_binding_hits == 0,
+                  after_a.persistent_texture_binding_hits == 0 &&
+                  after_a.persistent_texture_binding_entries == warm_binding_entries + 1,
               "...and it had to re-create the binding, proving the failure left no entry behind");
         CHECK(after_b.persistent_texture_binding_hits == 1 &&
-                  after_b.persistent_texture_binding_misses == 0 && recovered_a == recovered_b,
+                  after_b.persistent_texture_binding_misses == 0 && recovered_a == recovered_b &&
+                  after_b.persistent_texture_binding_entries == warm_binding_entries + 1,
               "the re-created binding is then cached and re-served byte-identically");
 
         std::vector<uint8_t> psm_recovered;
@@ -367,6 +377,45 @@ int main() {
         CHECK(center_red(psm_recovered) > 0xC0 &&
                   !has(psm_recovered_log, "[render-object-create-failed]"),
               "the sampler-failure binding key likewise re-creates cleanly on the next draw");
+        CHECK(prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries ==
+                  warm_binding_entries + 2,
+              "recovering the second failed key contributes exactly one additional binding");
+
+        // Failure AFTER eviction is a different transaction: the removed old binding stays gone
+        // even when its replacement cannot be created. Fill the remaining 30 contracts first.
+        for (uint32_t i = 2; i < 32; ++i) {
+            std::vector<uint8_t> fill_px;
+            const std::string fill_log = render(make_draw(static_cast<float>(i) / 64.0f),
+                RenderVkObjectCreateSite::None, "fill_binding_limit", &fill_px);
+            CHECK(center_red(fill_px) > 0xC0 && !has(fill_log, "[render-object-create-failed]") &&
+                      prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries ==
+                          warm_binding_entries + i + 1,
+                  "fill to 32 valid contracts increments the aggregate one binding at a time");
+        }
+        for (uint32_t i = 32; i < 34; ++i) {
+            const auto site = i == 32 ? RenderVkObjectCreateSite::TextureViewPersistent
+                                      : RenderVkObjectCreateSite::TextureSamplerPersistent;
+            const char* site_log = i == 32 ? "site=texture-view-persistent"
+                                           : "site=texture-sampler-persistent";
+            const auto full_cache_draw = make_draw(static_cast<float>(i) / 64.0f);
+            std::vector<uint8_t> failed_px;
+            const std::string failed_log = render(full_cache_draw, site, "failure_after_eviction", &failed_px);
+            const auto failed_stats = prosper::test::backend_resource_reuse_stats();
+            CHECK(has(failed_log, site_log) && center_red(failed_px) < 0x20 &&
+                      failed_px.size() == static_cast<size_t>(W) * H * 4 &&
+                      failed_stats.persistent_texture_binding_entries == warm_binding_entries + 31 &&
+                      failed_stats.persistent_texture_binding_evictions == 1,
+                  "evict then fail view/sampler creation leaves exactly 31 owned bindings");
+            std::vector<uint8_t> repaired_px;
+            const std::string repaired_log = render(full_cache_draw, RenderVkObjectCreateSite::None,
+                "repair_after_eviction", &repaired_px);
+            const auto repaired_stats = prosper::test::backend_resource_reuse_stats();
+            CHECK(repaired_px == recovered_a && !has(repaired_log, "[render-object-create-failed]") &&
+                      repaired_stats.persistent_texture_binding_entries == warm_binding_entries + 32 &&
+                      repaired_stats.persistent_texture_binding_misses == 1 &&
+                      repaired_stats.persistent_texture_binding_evictions == 0,
+                  "retry inserts one binding into the vacant slot without a second eviction");
+        }
     }
 
     // ---- Deliberately unaffected: a STORAGE image has no sampler, and must not be dropped ----

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -23,6 +23,10 @@ static int fails = 0;
 
 int main() {
     printf("== test_texture_sample_render ==\n");
+    if (std::getenv("PROSPER_BACKEND_TEXTURE_CACHE_MB")) {
+        std::fprintf(stderr, "texture sample test requires PROSPER_BACKEND_TEXTURE_CACHE_MB absent\n");
+        return 2;
+    }
     const uint32_t W = 64, H = 64;
     const auto center_red_at = [](const std::vector<uint8_t>& pixels,
                                   uint32_t width, uint32_t height) -> uint8_t {
@@ -340,6 +344,8 @@ int main() {
 
         std::vector<uint8_t> first = prosper::test::render_draws_rgba({draw}, W, H);
         const auto first_stats = prosper::test::backend_texture_upload_stats();
+        CHECK(prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries == 0,
+              "publishing a new image does not count its transient first-use binding");
         std::vector<uint8_t> reused = prosper::test::render_draws_rgba({draw}, W, H);
         const auto reused_stats = prosper::test::backend_texture_upload_stats();
         const auto first_binding_stats = prosper::test::backend_resource_reuse_stats();
@@ -351,7 +357,8 @@ int main() {
                    reused_stats.upload_bytes == 0,
               "same exact-validated texture version skips its next callback upload");
         CHECK(first_binding_stats.persistent_texture_binding_misses == 1 &&
-                  first_binding_stats.persistent_texture_binding_hits == 0,
+                  first_binding_stats.persistent_texture_binding_hits == 0 &&
+                  first_binding_stats.persistent_texture_binding_entries == 1,
               "first persistent-image reuse retains its exact image-view/sampler binding");
         CHECK(reused_binding_stats.persistent_texture_binding_hits == 1 &&
                   reused_binding_stats.persistent_texture_binding_misses == 0 &&
@@ -370,6 +377,9 @@ int main() {
             std::vector<uint8_t> bounded = prosper::test::render_draws_rgba({draw}, W, H);
             CHECK(!bounded.empty(), "bounded persistent texture binding renders");
             bounded_binding_stats = prosper::test::backend_resource_reuse_stats();
+            CHECK(bounded_binding_stats.persistent_texture_binding_entries ==
+                      (i < 32 ? i + 1 : 32),
+                  "every new binding increments the exact census, eviction keeps it bounded");
         }
         CHECK(bounded_binding_stats.persistent_texture_binding_evictions == 1 &&
                   bounded_binding_stats.persistent_texture_binding_entries == 32,
@@ -426,6 +436,98 @@ int main() {
               "a new exact-validated content version cannot hit the prior image");
         CHECK(!changed.empty() && changed != reused,
               "a new content version uploads and renders its changed pixels");
+
+        CHECK(prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries == 32,
+              "publishing a second image preserves all bindings of the first image");
+        const std::vector<uint8_t> second_image_reused =
+            prosper::test::render_draws_rgba({draw}, W, H);
+        const auto second_image_bindings = prosper::test::backend_resource_reuse_stats();
+        const std::vector<uint8_t> second_image_hit =
+            prosper::test::render_draws_rgba({draw}, W, H);
+        CHECK(second_image_reused == changed && second_image_hit == changed &&
+                  second_image_bindings.persistent_texture_binding_entries == 33 &&
+                  second_image_bindings.persistent_texture_binding_misses == 1 &&
+                  prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries == 33 &&
+                  prosper::test::backend_resource_reuse_stats().persistent_texture_binding_hits == 1,
+              "aggregate counts 32 bindings plus a second image's binding, unchanged on a hit");
+        const auto second_image_draw = draw;
+
+        // Retire an INVALID image which already owns 32 bindings, not just the zero-binding cold
+        // upload above. A discarded version refresh invalidates it; the retry must subtract all
+        // those bindings while preserving the second image's one binding.
+        resource.persistent_texture_id = 0x7020000000000001ull;
+        resource.persistent_texture_version = 2;
+        resource.tex_rgba = texels;
+        draw.R = {resource};
+        constexpr uint64_t refresh_target_id = 0x75900000000000f2ull;
+        prosper::test::BackendColorTarget refresh_target{refresh_target_id, false, false};
+        prosper::test::BackendSubmissionBatch refresh_batch;
+        const std::vector<uint8_t> refresh_pending = prosper::test::render_draws_rgba(
+            {draw}, W, H, nullptr, nullptr, false, &refresh_target,
+            nullptr, nullptr, nullptr, &refresh_batch, false);
+        const auto pending_binding_stats = prosper::test::backend_resource_reuse_stats();
+        refresh_batch.discard();
+        refresh_batch.complete();
+        const std::vector<uint8_t> while_first_invalid =
+            prosper::test::render_draws_rgba({second_image_draw}, W, H);
+        const auto resident_invalid_bindings = prosper::test::backend_resource_reuse_stats();
+        CHECK(while_first_invalid == changed &&
+                  resident_invalid_bindings.persistent_texture_binding_entries == 33 &&
+                  resident_invalid_bindings.persistent_texture_binding_hits == 1 &&
+                  prosper::test::backend_texture_upload_stats().unique_uploads == 0,
+              "invalid but resident image keeps its 32 bindings counted until actual retirement");
+        const std::vector<uint8_t> refresh_retry = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto retry_bindings = prosper::test::backend_resource_reuse_stats();
+        const auto retry_uploads = prosper::test::backend_texture_upload_stats();
+        CHECK(refresh_pending.empty() && !refresh_batch.pending() &&
+                  pending_binding_stats.persistent_texture_binding_entries == 33 &&
+                  retry_bindings.persistent_texture_binding_entries == 1 &&
+                  retry_uploads.persistent_misses == 1 && retry_uploads.unique_uploads == 1 &&
+                  refresh_retry == reused,
+              "invalid-image replacement subtracts all 32 owned bindings, retains other image, restores pixels");
+        const std::vector<uint8_t> refresh_retry_hit = prosper::test::render_draws_rgba({draw}, W, H);
+        CHECK(refresh_retry_hit == refresh_retry &&
+                  prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries == 2,
+              "rebuilt image contributes exactly one new persistent binding on its next use");
+        prosper::test::invalidate_persistent_color_target(refresh_target_id);
+
+        // The existing device-budget seam avoids driver-specific allocation sizes or 1025 calls.
+        // One byte admits no RGBA texture. An unrelated current image leaves both old images idle,
+        // so end-of-pass LRU eviction must remove their bindings and restore the census to zero.
+        const VkDeviceSize saved_budget = prosper::test::persistent_texture_cache_device_budget();
+        {
+            struct ScopedTextureBudget {
+                VkDeviceSize saved;
+                ScopedTextureBudget() {
+                    prosper::test::BackendPersistentResourceGuard guard;
+                    saved = prosper::test::persistent_texture_cache_device_budget();
+                    prosper::test::persistent_texture_cache_device_budget() = 1;
+                }
+                ~ScopedTextureBudget() {
+                    prosper::test::BackendPersistentResourceGuard guard;
+                    prosper::test::persistent_texture_cache_device_budget() = saved;
+                }
+            } budget_guard;
+            CHECK(prosper::test::persistent_texture_cache_limit() == 1,
+                  "one-byte device-budget lever is effective, not shadowed by an environment override");
+            auto eviction_draw = draw;
+            eviction_draw.R[0].persistent_texture_id = 0x70200000000000f3ull;
+            const std::vector<uint8_t> evicting_pixels =
+                prosper::test::render_draws_rgba({eviction_draw}, W, H);
+            CHECK(evicting_pixels == reused &&
+                      prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries == 0 &&
+                      prosper::test::backend_texture_upload_stats().persistent_cached_bytes == 0,
+                  "whole-image LRU eviction removes every retained binding without changing rendered pixels");
+        }
+        CHECK(prosper::test::persistent_texture_cache_device_budget() == saved_budget,
+              "scoped eviction pressure restores the previous device budget");
+        const std::vector<uint8_t> after_eviction = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto after_eviction_uploads = prosper::test::backend_texture_upload_stats();
+        const std::vector<uint8_t> after_eviction_hit = prosper::test::render_draws_rgba({draw}, W, H);
+        CHECK(after_eviction == reused && after_eviction_hit == reused &&
+                  after_eviction_uploads.persistent_misses == 1 &&
+                  prosper::test::backend_resource_reuse_stats().persistent_texture_binding_entries == 1,
+              "post-eviction image and binding are rebuilt from zero with exact output");
     }
 
     // A guest color target can remain on the backend GPU between render calls and be sampled by


### PR DESCRIPTION
## Scope

Refs #3065 (partial; leave the broader performance issue open).

Every render pass currently walks every persistent texture image solely to count its bindings for statistics. In the retained native Performance Story profile, three instruction addresses in the exact disassembled loop account for 1,156,672,656 of 52,814,729,223 sampled user-cycle periods (2.19006%; 31,373 samples). This is bookkeeping cost, not texture upload/validation or an FPS prediction.

Maintain the identical aggregate at actual membership changes under the existing `BackendPersistentResourceGuard`: successful insertion +1, binding eviction -1, image retirement minus its binding count. Invalid content remains resident and counted until retirement. New images initially own no persistent bindings. Preserve the old statistics publication point and early-return behavior.

No rendering, shader, validation, upload, eviction-policy, cache-limit, worker or frame-cadence change. The new bookkeeping can become stale if a future mutation forgets its update; focused tests pin the current mutation paths. No new progression or end-to-end speedup is claimed.

## Verification

Exact-head author verification on `8185b4210989b803556e9a005d8a2023ded98c10` passed: Release app/five test targets, 6/6 focused CTests, inherited-budget launcher control 1/1, and direct inherited-budget refusal exit 2. [Detailed author evidence](https://github.com/mattias800/prosper/pull/3396#issuecomment-5556843952). Independent registered review APPROVED this same head. Native acceptance passed and all nine applicable CI jobs passed (run 34011077679; Progress tracker and Publish Release intentionally skipped).

The focused tests check insertion/hits, the 32-binding limit, multiple images, discarded refresh of an already-bound image, invalid-but-resident membership, whole-image LRU eviction, and failed view/sampler creation both before and after eviction. They pair counts with rendered pixel checks. The one-byte eviction-budget control uses the existing device-budget seam with RAII restoration. Only this test's CTest launcher removes an inherited `PROSPER_BACKEND_TEXTURE_CACHE_MB`; direct execution refuses it instead of mutating a cached environment setting.

Build configuration: Release `-O3 -DNDEBUG -g1 -fno-omit-frame-pointer`, `PROSPER_APP=ON`, `GAME_DUMP=<DUMP_ROOT>/PPSA24651-app0`, inside the development container with worktree-local real-disk `TMPDIR`.

```sh
cmake --build prosper/build-linux -j6 --target prosper-app test_texture_sample_render test_render_object_create_failure test_host_read_barrier test_mip_assembly_barrier test_render_diagnostic_paths
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure -R '^(texture_sample_render|render_object_create_failure|host_read_barrier|mip_assembly_barrier|render_diagnostic_paths|cached_env_arming_logic)$'
```

Local RADV runs: 6/6 CTests passed, exit 0. Independently omitting each membership update and rebuilding the two focused tests produced the expected CTest exit 8: insertion (42 texture / 37 failure-fixture assertions), binding eviction (9 / 4), invalid-image retirement (4 / 0), whole-image LRU retirement (2 / 0). Source was restored after every arm. The original scan should remain functionally equivalent, not fail these correctness tests.

Native result: unchanged `reach-performance-story.pad`, fresh save roots, full resolution/cadence, immediate presentation and default workers; inspected direct settings and bank-rendering captures through “Go to the guard.” Run completed in 450.966 seconds, exit 0, without a device-loss signal. Quiet gate 300.582 seconds; 30 runtime censuses show no foreign DRM client. F8 completed with 848 renderer / 2,277 compute records and zero drops; F9 completed with 73 submits and matching frontend image. A separately bounded container-side CPU profile retained 12,864 samples with no reported loss; app/libc/RADV build IDs match the identities measured through the live process root. GPU lease released.

The F8 attribution window reports 6.5793 guest/host flips/s versus 6.1816 in the retained baseline (previous native candidate, relevant production source equal to main `f9188bd39`). This single instrumented pair is not a repeatable throughput gain. Raw captures, binaries and machine paths remain private. No new visual milestone is claimed.
