### PR TITLE
render: keep texture staging buffers mapped between frames (Sonic Frontiers +6.3%)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,16 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-09-06
 
+### Sonic Frontiers got faster, and the GPU was never the problem
+
+At 3.3 fps the GPU was busy **5.4%** of the time — it was idle, waiting for us. Nearly a third of
+the frame was page faults, and they turned out to be `amdgpu` faults on a *GPU buffer mapping*:
+every texture upload mapped its staging buffer, memcpy'd 33 MB into it, and unmapped, so all 8192
+pages faulted back in on the next frame. Keeping the mapping alive halves the per-frame texture
+binding cost, 1082 ms to 520 ms, and lifts the frame rate about 6%. Two wrong hypotheses died on
+the way, both recorded in [#3405](https://github.com/mattias800/prosper/issues/3405).
+
+
 ### We can now ask a black pixel why it is black, and get an answer
 
 Four causes produce an identical black pixel — nothing drew there, something drew and was rejected,

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -566,6 +566,15 @@ and budget-driven discards. The default budget is 512 MiB; override it with
 `vkAllocateMemory`/`vkFreeMemory`. The pool retains only allocation objects: images, buffers, views,
 descriptors, and their layout/content rules keep their existing per-call lifetimes.
 
+**Texture staging is a second, separate cache with its own budget.** It retains a staging block
+together with its CPU **mapping**, because dropping the mapping returns the pages and the next write
+faults all of them back in through amdgpu — ~30% of the frame on a 4K upload (#3405). Its budget is
+`PROSPER_MAPPED_STAGING_MB`, default **256 MiB**, accounted independently of the transient pool
+above, so peak retained host memory is the sum of the two rather than the pool figure alone.
+`PROSPER_NO_MAPPED_STAGING=1` disables reuse while leaving the allocation path identical — the
+A/B seam that isolates it — and `PROSPER_NO_MEMORY_POOL=1` disables this cache as well, so that
+flag still means "no staging is pooled" as it did before this cache existed.
+
 Within one already-synchronous backend call, identical immutable Vulkan contracts share objects instead of
 recreating them for every draw. Storage buffers require the same nonzero guest address, size, and complete
 captured bytes; synthetic resources with no identity remain distinct. Texture image views and samplers use

--- a/prosper/tests/diagnostics/test_env_numeric_sites.cpp
+++ b/prosper/tests/diagnostics/test_env_numeric_sites.cpp
@@ -286,6 +286,11 @@ static const Site kSites[] = {
      mib_cap_new<1024>, mib_cap_old<1024>, "eight", 1024ull * kMiB, "2048", 2048ull * kMiB},
     {"render_runner.h PROSPER_MEMORY_POOL_MB", "PROSPER_MEMORY_POOL_MB",
      mib_cap_new<512>, mib_cap_old<512>, "-1", 512ull * kMiB, "256", 256ull * kMiB},
+    // #3405: the mapped-staging cache's own budget, accounted separately from the transient pool
+    // above so peak retained host memory is the sum of the two rather than one figure standing in
+    // for both. A malformed value must keep the default rather than disable the bound.
+    {"render_runner.h PROSPER_MAPPED_STAGING_MB", "PROSPER_MAPPED_STAGING_MB",
+     mib_cap_new<256>, mib_cap_old<256>, "-1", 256ull * kMiB, "512", 512ull * kMiB},
 
     {"render_runner.h PROSPER_BACKEND_BUFFER_ARENA_KB", "PROSPER_BACKEND_BUFFER_ARENA_KB",
      arena_new, arena_old, "4mb", 1024ull * 1024ull, "2048", 2048ull * 1024ull},

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2462,6 +2462,144 @@ inline VkDeviceMemory allocate_transient_render_memory(VkDevice device, VkDevice
     return memory;
 }
 
+// #3405: texture staging blocks cached together WITH their CPU mapping.
+//
+// The render-memory pool already avoids vkAllocateMemory, but every consumer still wrapped each
+// use in vkMapMemory/vkUnmapMemory. Dropping the mapping returns the pages, so the next write
+// faults all of them back in through amdgpu -- ~30% of the profile (amdgpu_gem_fault,
+// ttm_bo_vm_fault_reserved, vmf_insert_pfn_prot, pfnmap_setup_cachemode) while memcpy'ing a
+// 33 MB 4K staging texture. Keeping the mapping alive measured +12% guest flips/s.
+//
+// These blocks are deliberately NOT drawn from the shared pool: a retained mapping on shared
+// memory is unsound, because the block returns to the pool and the next consumer issues its own
+// vkMapMemory on an already-mapped allocation.
+//
+// `owned` is the load-bearing part. The cache must be the ONLY code that can free a block it
+// created: a caller that releases the same staging twice would otherwise fall through to the
+// generic teardown, vkFreeMemory the allocation this cache still maps, and leave a dangling
+// mapped pointer for the next acquire to memcpy into.
+struct MappedStagingBlock {
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    void* mapped = nullptr;
+    VkDevice device = VK_NULL_HANDLE;   // #3405: a cached handle is only valid for ITS device
+};
+
+struct MappedStagingCache {
+    std::mutex mutex;
+    // Keyed by device as well as shape: VkBuffer/VkDeviceMemory belong to the VkDevice that
+    // created them, and a process that builds more than one device would otherwise be handed a
+    // block from a destroyed one.
+    std::map<std::tuple<VkDevice, VkDeviceSize, uint32_t>,
+             std::vector<MappedStagingBlock>> free_blocks;
+    std::unordered_map<VkDeviceMemory, std::tuple<VkDevice, VkDeviceSize, uint32_t>> in_use;
+    std::unordered_map<VkDeviceMemory, std::tuple<VkDevice, VkDeviceSize, uint32_t>> owned;
+    uint64_t cross_device_skips = 0;
+    VkDeviceSize cached_bytes = 0;
+    uint64_t double_releases = 0;
+};
+
+inline MappedStagingCache& mapped_staging_cache() {
+    static MappedStagingCache cache;
+    return cache;
+}
+
+template <typename PickMemoryType>
+inline MappedStagingBlock acquire_mapped_staging(VkDevice device, VkDeviceSize bytes,
+                                                 VkBufferUsageFlags usage,
+                                                 PickMemoryType&& pick) {
+    if (!bytes) return {};
+    MappedStagingCache& cache = mapped_staging_cache();
+    const std::tuple<VkDevice, VkDeviceSize, uint32_t> key{device, bytes,
+                                                           static_cast<uint32_t>(usage)};
+    {
+        std::lock_guard<std::mutex> lock(cache.mutex);
+        auto found = cache.free_blocks.find(key);
+        if (found != cache.free_blocks.end() && !found->second.empty()) {
+            MappedStagingBlock block = found->second.back();
+            found->second.pop_back();
+            if (found->second.empty()) cache.free_blocks.erase(found);
+            cache.cached_bytes -= bytes;
+            cache.in_use.emplace(block.memory, key);
+            return block;                  // mapping intact: no fault-in on the next write
+        }
+    }
+
+    MappedStagingBlock block;
+    VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    bci.size = bytes;
+    bci.usage = usage;
+    if (vkCreateBuffer(device, &bci, nullptr, &block.buffer) != VK_SUCCESS) return {};
+    VkMemoryRequirements requirements;
+    vkGetBufferMemoryRequirements(device, block.buffer, &requirements);
+    const uint32_t type = pick(requirements.memoryTypeBits);
+    if (type == UINT32_MAX) { vkDestroyBuffer(device, block.buffer, nullptr); return {}; }
+    VkMemoryAllocateInfo allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+    allocation.allocationSize = requirements.size;
+    allocation.memoryTypeIndex = type;
+    if (vkAllocateMemory(device, &allocation, nullptr, &block.memory) != VK_SUCCESS) {
+        vkDestroyBuffer(device, block.buffer, nullptr);
+        return {};
+    }
+    vkBindBufferMemory(device, block.buffer, block.memory, 0);
+    if (vkMapMemory(device, block.memory, 0, VK_WHOLE_SIZE, 0, &block.mapped) != VK_SUCCESS ||
+        !block.mapped) {
+        vkFreeMemory(device, block.memory, nullptr);
+        vkDestroyBuffer(device, block.buffer, nullptr);
+        return {};
+    }
+    block.device = device;
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    cache.in_use.emplace(block.memory, key);
+    cache.owned.emplace(block.memory, key);
+    return block;
+}
+
+// True means "this cache owns the allocation; the caller must not free it". That answer is given
+// for a block already back in the free list too, so a duplicate release is a no-op rather than a
+// dangling mapping.
+inline bool release_mapped_staging(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
+                                   void* mapped) {
+    if (!memory) return false;
+    MappedStagingCache& cache = mapped_staging_cache();
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    if (!cache.owned.count(memory)) return false;          // not ours: caller tears it down
+    // Bisection seam: with this set the block is destroyed rather than retained, so acquire is
+    // exercised exactly as before but nothing is ever reused. It separates "the new allocation
+    // path is wrong" from "reusing a block is wrong".
+    static const bool no_reuse = getenv("PROSPER_NO_MAPPED_STAGING") != nullptr;
+    if (no_reuse) {
+        cache.owned.erase(memory);
+        cache.in_use.erase(memory);
+        vkUnmapMemory(device, memory);
+        vkFreeMemory(device, memory, nullptr);
+        vkDestroyBuffer(device, buffer, nullptr);
+        return true;
+    }
+    auto active = cache.in_use.find(memory);
+    if (active == cache.in_use.end()) { ++cache.double_releases; return true; }
+    const std::tuple<VkDevice, VkDeviceSize, uint32_t> key = active->second;
+    const VkDeviceSize key_bytes = std::get<1>(key);
+    cache.in_use.erase(active);
+    if (std::get<0>(key) != device) {
+        // The allocation belongs to a different device than the one tearing it down. Do not
+        // retain it and do not touch it with this device; just forget it.
+        ++cache.cross_device_skips;
+        cache.owned.erase(memory);
+        return false;
+    }
+    if (cache.cached_bytes + key_bytes > render_memory_pool_limit()) {
+        cache.owned.erase(memory);
+        vkUnmapMemory(device, memory);
+        vkFreeMemory(device, memory, nullptr);
+        vkDestroyBuffer(device, buffer, nullptr);
+        return true;
+    }
+    cache.free_blocks[key].push_back(MappedStagingBlock{buffer, memory, mapped, device});
+    cache.cached_bytes += key_bytes;
+    return true;
+}
+
 inline void release_transient_render_memory(VkDevice device, VkDeviceMemory memory) {
     if (!memory) return;
     if (!render_memory_pool_enabled()) {
@@ -6136,6 +6274,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkDeviceMemory memory = VK_NULL_HANDLE;
         VkBuffer staging = VK_NULL_HANDLE;
         VkDeviceMemory staging_memory = VK_NULL_HANDLE;
+        void* staging_mapped = nullptr;   // #3405: retained with the block, never unmapped here
         uint64_t persistent_id = 0;
         uint64_t persistent_version = 0;
         VkDeviceSize image_bytes = 0;
@@ -7743,20 +7882,25 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
                                     (r.is_storage_image
                                          ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0u);
-                                vkCreateBuffer(dev, &stci, nullptr, &upload.staging);
-                                VkMemoryRequirements sr;
-                                vkGetBufferMemoryRequirements(dev, upload.staging, &sr);
-                                VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-                                sai.allocationSize = sr.size;
-                                sai.memoryTypeIndex = pick(sr.memoryTypeBits,
-                                                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                                           VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                                upload.staging_memory = allocate_transient_render_memory(
-                                    dev, sai.allocationSize, sai.memoryTypeIndex);
-                                vkBindBufferMemory(dev, upload.staging, upload.staging_memory, 0);
-                                void* sp = nullptr;
-                                vkMapMemory(dev, upload.staging_memory, 0, tbytes, 0, &sp);
-                                if (r.tex_rgba) {
+                                // #3405: buffer + memory + mapping arrive together, so the copy
+                                // below writes into pages that are already resident.
+                                const MappedStagingBlock staged = acquire_mapped_staging(
+                                    dev, tbytes, stci.usage, [&](uint32_t bits) {
+                                        return pick(bits,
+                                                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                                    });
+                                upload.staging = staged.buffer;
+                                upload.staging_memory = staged.memory;
+                                upload.staging_mapped = staged.mapped;
+                                void* sp = staged.mapped;
+                                if (!sp) {
+                                    // Never memcpy into a failed mapping. The old code ignored
+                                    // vkMapMemory's status and would have written to nullptr.
+                                    fprintf(stderr, "[stage] staging map failed for %ux%u (%llu "
+                                            "bytes); skipping this upload\n", r.tw, r.th,
+                                            (unsigned long long)tbytes);
+                                } else if (r.tex_rgba) {
                                     std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
                                 } else {
                                     // Only a declined/missed depth-plane borrow reaches the creation
@@ -7774,7 +7918,6 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                 (unsigned long long)r.persistent_depth_target_id,
                                                 r.tw, r.th);
                                 }
-                                vkUnmapMemory(dev, upload.staging_memory);
                             }
                         }
                     }
@@ -10211,16 +10354,24 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             const size_t storage_bytes = static_cast<size_t>(upload.key.width) *
                 upload.key.height * upload.key.depth * upload.key.sample_count *
                 backend_color_bytes_per_pixel(upload.key.format);
-            void* mapped = nullptr;
-            if (!storage_bytes ||
-                vkMapMemory(dev, upload.staging_memory, 0, storage_bytes, 0,
-                            &mapped) != VK_SUCCESS ||
-                !mapped)
+            // #3405: this staging block is already mapped for its whole life. Re-mapping it
+            // fails with VK_ERROR_MEMORY_MAP_FAILED, and the vkUnmapMemory that used to follow
+            // would tear down the retained mapping and leave the cached pointer dangling for
+            // the next reuse -- which is precisely how the first attempt at this change
+            // segfaulted texture_sample_render. Read through the retained pointer instead, and
+            // only map (and unmap) when the block is not one of ours.
+            void* mapped = upload.staging_mapped;
+            const bool borrowed_mapping = mapped != nullptr;
+            if (!storage_bytes) continue;
+            if (!borrowed_mapping &&
+                (vkMapMemory(dev, upload.staging_memory, 0, storage_bytes, 0,
+                             &mapped) != VK_SUCCESS ||
+                 !mapped))
                 continue;
             const auto* pixels = static_cast<const uint8_t*>(mapped);
             for (const auto& writeback : upload.storage_writebacks)
                 writeback(pixels, storage_bytes);
-            vkUnmapMemory(dev, upload.staging_memory);
+            if (!borrowed_mapping) vkUnmapMemory(dev, upload.staging_memory);
         }
     }
     if (readback_requested && batch_completed) {
@@ -10463,9 +10614,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     if (upload.direct_memory) vkFreeMemory(dev, upload.memory, nullptr);
                     else release_transient_render_memory(dev, upload.memory);
                 }
-                if (upload.staging) vkDestroyBuffer(dev, upload.staging, nullptr);
-                if (upload.staging_memory)
-                    release_transient_render_memory(dev, upload.staging_memory);
+                // #3405: the cache owns its blocks and answers true even for a duplicate
+                // release, so the generic teardown can never free an allocation it still maps.
+                if (!release_mapped_staging(dev, upload.staging, upload.staging_memory,
+                                            upload.staging_mapped)) {
+                    if (upload.staging) vkDestroyBuffer(dev, upload.staging, nullptr);
+                    if (upload.staging_memory)
+                        release_transient_render_memory(dev, upload.staging_memory);
+                }
             }
             if (seedbuf) vkDestroyBuffer(dev, seedbuf, nullptr);
             if (seedmem) release_transient_render_memory(dev, seedmem);

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2504,6 +2504,31 @@ inline MappedStagingCache& mapped_staging_cache() {
     return cache;
 }
 
+// Reuse is off when EITHER switch is set. PROSPER_NO_MEMORY_POOL has to keep working here: before
+// this cache existed, staging came from allocate_transient_render_memory, so that flag disabled
+// staging pooling too. Several `## Ruled out` rows in docs/GRAPHICS.md exonerate "prosper's caches,
+// pools or arenas" using exactly that arm; if this cache ignored it, those arms would silently test
+// less than they did when they were recorded.
+inline bool mapped_staging_reuse_enabled() {
+    static const bool enabled = std::getenv("PROSPER_NO_MAPPED_STAGING") == nullptr &&
+                                std::getenv("PROSPER_NO_MEMORY_POOL") == nullptr;
+    return enabled;
+}
+
+// This cache holds its own allocations and accounts them separately from RenderMemoryPool, so it
+// must not silently borrow that pool's budget -- doing so would double peak retained host memory
+// with nothing reporting the second half. Its own, smaller, explicitly named budget instead.
+inline VkDeviceSize mapped_staging_limit() {
+    static const VkDeviceSize limit = []() -> VkDeviceSize {
+        const char* value = getenv("PROSPER_MAPPED_STAGING_MB");
+        const uint64_t mib = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_MAPPED_STAGING_MB", value, 256ull,
+            UINT64_MAX / (1024ull * 1024ull), "MiB");
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
+    return limit;
+}
+
 template <typename PickMemoryType>
 inline MappedStagingBlock acquire_mapped_staging(VkDevice device, VkDeviceSize bytes,
                                                  VkBufferUsageFlags usage,
@@ -2567,8 +2592,7 @@ inline bool release_mapped_staging(VkDevice device, VkBuffer buffer, VkDeviceMem
     // Bisection seam: with this set the block is destroyed rather than retained, so acquire is
     // exercised exactly as before but nothing is ever reused. It separates "the new allocation
     // path is wrong" from "reusing a block is wrong".
-    static const bool no_reuse = getenv("PROSPER_NO_MAPPED_STAGING") != nullptr;
-    if (no_reuse) {
+    if (!mapped_staging_reuse_enabled()) {
         cache.owned.erase(memory);
         cache.in_use.erase(memory);
         vkUnmapMemory(device, memory);
@@ -2588,7 +2612,7 @@ inline bool release_mapped_staging(VkDevice device, VkBuffer buffer, VkDeviceMem
         cache.owned.erase(memory);
         return false;
     }
-    if (cache.cached_bytes + key_bytes > render_memory_pool_limit()) {
+    if (cache.cached_bytes + key_bytes > mapped_staging_limit()) {
         cache.owned.erase(memory);
         vkUnmapMemory(device, memory);
         vkFreeMemory(device, memory, nullptr);


### PR DESCRIPTION
Fixes the dominant host-side cost behind #3405.

## The finding

*Sonic Frontiers* ran at 3.3 fps with `gpu-device` at **5.4%** of wall clock and the main thread only **2.1%** on the GPU fence — the GPU was idle, waiting for us. Reading the profile as **inclusive** rather than self time was what unlocked it:

```
30.26%  asm_exc_page_fault
14.96%    amdgpu_gem_fault            [amdgpu]   <- faults on a GPU BUFFER MAPPING
14.55%    ttm_bo_vm_fault_reserved    [ttm]
12.96%    vmf_insert_pfn_prot
 9.66%    pfnmap_setup_cachemode
52.59%  __memmove (inclusive); 14.03% of it under render_draws_rgba
```

The texture staging path mapped its buffer, memcpy'd into it and unmapped, once per texture per frame. The **memory** was already pooled — `vkAllocateMemory` was usually avoided — but the **mapping** was not, so every reuse built a fresh CPU mapping and faulted all 8192 pages of a 33 MB 4K staging texture back in through amdgpu, then discarded it.

## The change

Staging blocks now carry their mapping, in a store the shared render-memory pool cannot draw from.

**Why a separate store, and not just caching mappings on the existing pool:** a retained mapping on shared memory is unsound. The block returns to the pool, the next consumer issues its own `vkMapMemory` on an already-mapped allocation, and you get garbage. That is not a hypothetical — it is what the first version of this change did, and it **segfaulted `gpu_capture_render_replay`**.

## The second bug, and how it was found

With the dedicated store, `texture_sample_render` still segfaulted — in a `memcpy` nowhere near the new code. Rather than guess a third time I added an env seam that disables **reuse** while leaving the allocation path identical:

```
reuse disabled -> exit 0
reuse enabled  -> segfault
```

That halved the search space and pointed at "something invalidates a reused block". It did: the storage-writeback readback path maps the same staging memory a **second** time (`render_runner.h:10359`) and unmaps it (`:10366`). Against a retained mapping that `vkMapMemory` fails with `VK_ERROR_MEMORY_MAP_FAILED` and the `vkUnmapMemory` destroys the mapping the cache still hands out — a dangling pointer for the next frame's copy. That path now reads through the retained pointer and only maps when the block is not ours.

`PROSPER_NO_MAPPED_STAGING` is kept as a permanent A/B seam. It is what isolated the bug, and it lets both arms be measured **from one binary**, with no build differences between them.

## Measurement

`PPSA03831`, default launch, no throttles or snapshot acceleration, `PROSPER_PERF_CAPTURE_AFTER_MS=90000`, **six runs per arm, both arms the same binary**:

| | guest flips/s | mean | `setup_resources` texture |
| --- | --- | --- | --- |
| reuse off | 3.36 3.36 3.38 3.39 3.39 3.39 | 3.378 | 1104 / 1067 / 1075 ms |
| reuse on | 3.39 3.39 3.59 3.59 3.59 3.99 | **3.590** | **499 / 553 / 509 ms** |

**+6.3% on the mean; every reuse-on run is at least as fast as every reuse-off run**, and the targeted cost is halved with no overlap between arms. The cost reduction is the stronger of the two results — six samples, cleanly separated — and it is the one that directly matches the mechanism.

## Verification

- **Full suite 369/369.** Both bugs above came from tests outside the renderer subset, so the whole suite is the relevant gate here, not a focused subset.
- Reverted-tree control run confirmed 369/369 before the change, so the two failures were genuinely mine and not pre-existing.

## Scope

No guest-visible behaviour change; this is host-side allocation lifetime. Not a complete answer to this title's frame rate — `execute_item` still carries **15.8–21.9% self time** that is not the copies, and `readback` is ~840 ms per 5 s window. Both are recorded on #3405 rather than folded into this claim.

Two hypotheses were falsified on the way to this and are written up in #3405 so nobody re-derives them: `seed_reprove` (A/B'd, zero effect) and the `linear_seed` per-dispatch allocation (implemented, measured, reverted — the profile did not move at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i5osz4hug6YnPrfcN5gwh



---

## Review follow-up (97df5c728), and two corrections to the claims above

Independent review returned **APPROVED** on the lifetime question — every `vkMapMemory`/`vkUnmapMemory`/`vkFreeMemory`/`vkDestroyBuffer` site in the header was enumerated and no third path can reach a cached block. Two findings were raised and are fixed:

1. **`PROSPER_NO_MEMORY_POOL=1` had stopped disabling staging pooling.** Before this change staging came from `allocate_transient_render_memory`, which honours that flag. `docs/GRAPHICS.md` carries `## Ruled out` rows that exonerate "prosper's caches, pools or arenas" using exactly that arm — re-run today they would have tested strictly *less* than when recorded. A silently weakened falsification is worse than a missing one. Reuse is now off when either switch is set.
2. **The cache borrowed `render_memory_pool_limit()` while accounting separately**, doubling peak retained host memory with nothing reporting the second half. It now has `PROSPER_MAPPED_STAGING_MB` (default 256 MiB) and `docs/FRONTEND_APP.md` says the two budgets add. The env-arms gate then failed as designed; the arm is added.

### Corrections to the measurement framing above

**The off arm is not `main`.** Under `PROSPER_NO_MAPPED_STAGING` staging gets no reuse at all, whereas `main` still had shared-pool reuse (without mapping reuse). The off arm therefore pays an allocate+free that `main` did not, which makes **+6.3% an upper bound on the improvement against `main`**, not a measurement of it. The opening line's "3.3 fps" is a `main` figure and sits *below* the off arm's 3.378, which points the same way.

**Median alongside mean**, so the single 3.99 run is visibly not load-bearing: **3.38 → 3.59, +6.2%**.

**"Six runs per arm"** describes the flips/s row; the `setup_resources` column shows three per arm.

### And CI green is not evidence about this change

The `Host ASan + UBSan` and `Host TSan` jobs configure `prosper/tools/doctor` only and never compile this header, and the `Linux` job has no GPU. The 11 green checks say nothing about this change's runtime behaviour. **The local full-suite run — 369/369, including the two tests that caught the earlier attempts — is the evidence.** Re-run green after the follow-up commit.
