### PR TITLE
compute: parallelise the sampled texel-conversion arms (Sonic Frontiers +18.7%)

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -8141,7 +8141,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         // RGBA16F.  Re-quantize those numeric values into the exact sampled Vulkan
                         // layout.  Guest-backed surfaces take the lossless memcpy path below.
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        for (size_t t = 0; t < texels; ++t) {
+                        // #3407: per-texel and independent -- every write is upload[t*n+c],
+                        // disjoint across t -- so this is the same shape as the arm below that
+                        // already uses the helper. Leaving it scalar is why a 4K conversion took
+                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
+                        // on bytes touched per texel; the helper uses it only to size the pool.
+                        parallel_compute_texels(
+                            texels, texels * 16u, [&](size_t begin, size_t end) {
+                        for (size_t t = begin; t < end; ++t) {
                             uint32_t channels[4]{};
                             for (uint32_t c = 0; c < 4; ++c) {
                                 float value = 0.0f;
@@ -8162,6 +8169,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                 (channels[2] << 20) | (channels[3] << 30);
                             std::memcpy(upload + t * sizeof(packed), &packed, sizeof(packed));
                         }
+                            });
                     } else if (sampled_float16_native &&
                                ((source_f16x2 && sampled_components == 2) ||
                                 (source_f16x1 && sampled_components == 1))) {
@@ -8181,7 +8189,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         }
                     } else if (sampled_uint8_native) {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        for (size_t t = 0; t < texels; ++t) {
+                        // #3407: per-texel and independent -- every write is upload[t*n+c],
+                        // disjoint across t -- so this is the same shape as the arm below that
+                        // already uses the helper. Leaving it scalar is why a 4K conversion took
+                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
+                        // on bytes touched per texel; the helper uses it only to size the pool.
+                        parallel_compute_texels(
+                            texels, texels * 16u, [&](size_t begin, size_t end) {
+                        for (size_t t = begin; t < end; ++t) {
                             for (uint32_t c = 0; c < sampled_components; ++c) {
                                 if (source_r8) {
                                     upload[t] = pixels[t];
@@ -8200,9 +8215,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                 }
                             }
                         }
+                            });
                     } else if (sampled_unorm8x2) {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        for (size_t t = 0; t < texels; ++t) {
+                        // #3407: per-texel and independent -- every write is upload[t*n+c],
+                        // disjoint across t -- so this is the same shape as the arm below that
+                        // already uses the helper. Leaving it scalar is why a 4K conversion took
+                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
+                        // on bytes touched per texel; the helper uses it only to size the pool.
+                        parallel_compute_texels(
+                            texels, texels * 16u, [&](size_t begin, size_t end) {
+                        for (size_t t = begin; t < end; ++t) {
                             for (uint32_t c = 0; c < 2; ++c) {
                                 if (source_rg8) {
                                     upload[t * 2 + c] = pixels[t * 2 + c];
@@ -8219,9 +8242,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                 }
                             }
                         }
+                            });
                     } else if (sampled_unorm16_native) {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        for (size_t t = 0; t < texels; ++t) {
+                        // #3407: per-texel and independent -- every write is upload[t*n+c],
+                        // disjoint across t -- so this is the same shape as the arm below that
+                        // already uses the helper. Leaving it scalar is why a 4K conversion took
+                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
+                        // on bytes touched per texel; the helper uses it only to size the pool.
+                        parallel_compute_texels(
+                            texels, texels * 16u, [&](size_t begin, size_t end) {
+                        for (size_t t = begin; t < end; ++t) {
                             for (uint32_t c = 0; c < sampled_components; ++c) {
                                 uint16_t value = 0;
                                 if (source_unorm8) {
@@ -8239,6 +8270,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                             &value, sizeof(value));
                             }
                         }
+                            });
                     } else if (f32) {
                         const size_t texels = static_cast<size_t>(volume_texels);
                         const uint32_t output_components =
@@ -8267,13 +8299,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             });
                     } else if (source_r8 && r8) {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        for (size_t t = 0; t < texels; ++t) {
+                        // #3407: per-texel and independent -- every write is upload[t*n+c],
+                        // disjoint across t -- so this is the same shape as the arm below that
+                        // already uses the helper. Leaving it scalar is why a 4K conversion took
+                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
+                        // on bytes touched per texel; the helper uses it only to size the pool.
+                        parallel_compute_texels(
+                            texels, texels * 16u, [&](size_t begin, size_t end) {
+                        for (size_t t = begin; t < end; ++t) {
                             const uint8_t value = pixels[t];
                             upload[t * 4 + 0] = value;
                             upload[t * 4 + 1] = value;
                             upload[t * 4 + 2] = value;
                             upload[t * 4 + 3] = value;
                         }
+                            });
                     } else if (source_unorm8) {
                         if (!copy_snapshot_exact()) {
                             skip_image(r, "renderer RTT RGBA8 copy byte count mismatch");
@@ -8281,7 +8321,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         }
                     } else {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        for (size_t t = 0; t < texels; ++t) {
+                        // #3407: per-texel and independent -- every write is upload[t*n+c],
+                        // disjoint across t -- so this is the same shape as the arm below that
+                        // already uses the helper. Leaving it scalar is why a 4K conversion took
+                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
+                        // on bytes touched per texel; the helper uses it only to size the pool.
+                        parallel_compute_texels(
+                            texels, texels * 16u, [&](size_t begin, size_t end) {
+                        for (size_t t = begin; t < end; ++t) {
                             for (uint32_t c = 0; c < 4; ++c) {
                                 uint16_t half = 0;
                                 std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
@@ -8292,6 +8339,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                     std::lround(value * 255.0f));
                             }
                         }
+                            });
                     }
                     if (trace) {
                         const uint64_t snapshot_hash = fnv1a(live_target.pixels->data(),

--- a/prosper/tests/diagnostics/test_env_numeric_sites.cpp
+++ b/prosper/tests/diagnostics/test_env_numeric_sites.cpp
@@ -100,6 +100,19 @@ static uint64_t mib_cap_old(const char* t) {
     return mib * 1024ull * 1024ull;
 }
 
+// --- tests/fixtures/render_runner.h : PROSPER_RENDER_COPY_THREADS -----------------------------
+// #3407: worker count for the parallel texture-staging copy. 0 means "derive from the core count",
+// so a malformed value must land on 0 rather than a wrapped 32 -- which is what a strtoul parse of
+// "-1" produced before this site used the helper.
+static uint64_t copy_threads_new(const char* n, const char* t) {
+    return env_u64_or_default_capped(n, t, 0ull, 32ull, "threads");
+}
+static uint64_t copy_threads_old(const char* t) {
+    if (!t || !*t) return 0ull;
+    const unsigned long parsed = std::strtoul(t, nullptr, 10);
+    return parsed > 32ul ? 32ull : static_cast<uint64_t>(parsed);
+}
+
 // --- tests/fixtures/render_runner.h : PROSPER_BACKEND_BUFFER_ARENA_KB --------------------------
 static uint64_t arena_new(const char* n, const char* t) {
     const uint64_t kib = env_u64_or_default_capped(n, t, 1024ull, UINT64_MAX / 1024ull, "KiB");
@@ -291,6 +304,8 @@ static const Site kSites[] = {
     // for both. A malformed value must keep the default rather than disable the bound.
     {"render_runner.h PROSPER_MAPPED_STAGING_MB", "PROSPER_MAPPED_STAGING_MB",
      mib_cap_new<256>, mib_cap_old<256>, "-1", 256ull * kMiB, "512", 512ull * kMiB},
+    {"render_runner.h PROSPER_RENDER_COPY_THREADS", "PROSPER_RENDER_COPY_THREADS",
+     copy_threads_new, copy_threads_old, "-1", 0ull, "4", 4ull},
 
     {"render_runner.h PROSPER_BACKEND_BUFFER_ARENA_KB", "PROSPER_BACKEND_BUFFER_ARENA_KB",
      arena_new, arena_old, "4mb", 1024ull * 1024ull, "2048", 2048ull * 1024ull},

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -3,7 +3,8 @@
 // pixels. Used to verify recompiled shaders end-to-end (render -> readback -> pixel asserts). The
 // including test links Vulkan::Vulkan.
 #pragma once
-#include <thread>   // #3407: parallel_render_memcpy
+#include <system_error>   // #3407: the catch in parallel_render_memcpy
+#include <thread>         // #3407: parallel_render_memcpy
 #include "host/memory/guest_write_watch.hpp"   // VA->phys for the #2932 target census
 #include "shared/rtt/mrt_extent.hpp"
 #include <vulkan/vulkan.h>

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2422,11 +2422,14 @@ inline RenderMemoryPool& render_memory_pool() {
 // returns, so the copy is complete before the caller unmaps or submits. Small copies stay on the
 // calling thread, because thread creation would cost more than the copy.
 inline void parallel_render_memcpy(void* dst, const void* src, size_t bytes) {
-    static const unsigned configured = [] {
+    static const unsigned configured = []() -> unsigned {
+        // env_numeric, not strtoul: a malformed or negative value must keep the default rather
+        // than wrap. "-1" through strtoul is 32 workers, which is the opposite of what a reader
+        // setting it to -1 to "turn it off" would expect.
         const char* value = getenv("PROSPER_RENDER_COPY_THREADS");
-        if (!value || !*value) return 0u;
-        const unsigned long parsed = std::strtoul(value, nullptr, 10);
-        return static_cast<unsigned>(std::min(parsed, 32ul));
+        const uint64_t parsed = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_RENDER_COPY_THREADS", value, 0ull, 32ull, "threads");
+        return static_cast<unsigned>(parsed);
     }();
     // Below this the copy is not worth splitting; above it the win is real and bandwidth-bound,
     // which is why the worker count is capped rather than scaled to the core count.
@@ -2442,19 +2445,39 @@ inline void parallel_render_memcpy(void* dst, const void* src, size_t bytes) {
         std::min<size_t>(wanted, bytes / (1u << 20)));
     if (threads <= 1) { std::memcpy(dst, src, bytes); return; }
     const size_t chunk = (bytes + threads - 1) / threads;
-    std::vector<std::thread> workers;
+
+    // jthread plus a synchronous tail, mirroring parallel_compute_texels. Two failures have to be
+    // survived and they pull in opposite directions: if pthread_create fails, a plain
+    // std::vector<std::thread> would destroy a joinable thread while unwinding and call
+    // std::terminate() -- in the LIVE RENDERER, on a path whose predecessor (a bare memcpy) could
+    // not fail at all. But merely catching would be worse than aborting: the ranges that never got
+    // a worker would go uncopied and the texture would be silently wrong. So every range that did
+    // not get a thread is copied on this thread below, and transient resource pressure degrades to
+    // less parallelism instead of either a crash or corruption.
+    std::vector<std::jthread> workers;
     workers.reserve(threads - 1);
-    for (unsigned t = 1; t < threads; ++t) {
-        const size_t begin = std::min(bytes, static_cast<size_t>(t) * chunk);
-        const size_t end = std::min(bytes, begin + chunk);
-        if (begin >= end) break;
-        workers.emplace_back([dst, src, begin, end] {
-            std::memcpy(static_cast<uint8_t*>(dst) + begin,
-                        static_cast<const uint8_t*>(src) + begin, end - begin);
-        });
+    unsigned next_worker = 1;
+    try {
+        for (; next_worker < threads; ++next_worker) {
+            const size_t begin = std::min(bytes, static_cast<size_t>(next_worker) * chunk);
+            const size_t end = std::min(bytes, begin + chunk);
+            if (begin >= end) break;
+            workers.emplace_back([dst, src, begin, end] {
+                std::memcpy(static_cast<uint8_t*>(dst) + begin,
+                            static_cast<const uint8_t*>(src) + begin, end - begin);
+            });
+        }
+    } catch (const std::system_error&) {
+        // Fall through: ranges that did not get a worker are copied synchronously below.
     }
     std::memcpy(dst, src, std::min(bytes, chunk));   // this thread takes the first chunk
-    for (std::thread& worker : workers) worker.join();
+    for (; next_worker < threads; ++next_worker) {
+        const size_t begin = std::min(bytes, static_cast<size_t>(next_worker) * chunk);
+        const size_t end = std::min(bytes, begin + chunk);
+        if (begin >= end) break;
+        std::memcpy(static_cast<uint8_t*>(dst) + begin,
+                    static_cast<const uint8_t*>(src) + begin, end - begin);
+    }
 }
 
 inline bool render_memory_pool_enabled() {

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -3,6 +3,7 @@
 // pixels. Used to verify recompiled shaders end-to-end (render -> readback -> pixel asserts). The
 // including test links Vulkan::Vulkan.
 #pragma once
+#include <thread>   // #3407: parallel_render_memcpy
 #include "host/memory/guest_write_watch.hpp"   // VA->phys for the #2932 target census
 #include "shared/rtt/mrt_extent.hpp"
 #include <vulkan/vulkan.h>
@@ -2410,6 +2411,50 @@ struct RenderMemoryPoolStats {
 inline RenderMemoryPool& render_memory_pool() {
     static RenderMemoryPool pool;
     return pool;
+}
+
+// #3407: a 4K texture upload is a single ~33 MB memcpy into mapped staging, and it was running on
+// one core while the rest of the machine idled -- 16.96% of the whole profile on Sonic Frontiers'
+// intro, measured as the caller of __memmove. The compute side already had this treatment
+// (parallel_compute_texels); the renderer had no threading at all.
+//
+// Deliberately simple: disjoint destination ranges, every worker joined before the function
+// returns, so the copy is complete before the caller unmaps or submits. Small copies stay on the
+// calling thread, because thread creation would cost more than the copy.
+inline void parallel_render_memcpy(void* dst, const void* src, size_t bytes) {
+    static const unsigned configured = [] {
+        const char* value = getenv("PROSPER_RENDER_COPY_THREADS");
+        if (!value || !*value) return 0u;
+        const unsigned long parsed = std::strtoul(value, nullptr, 10);
+        return static_cast<unsigned>(std::min(parsed, 32ul));
+    }();
+    // Below this the copy is not worth splitting; above it the win is real and bandwidth-bound,
+    // which is why the worker count is capped rather than scaled to the core count.
+    constexpr size_t kMinParallelBytes = 2u << 20;
+    const unsigned hardware = std::thread::hardware_concurrency();
+    const unsigned wanted = configured ? configured
+                                       : std::min(hardware ? hardware : 4u, 8u);
+    if (bytes < kMinParallelBytes || wanted <= 1) {
+        std::memcpy(dst, src, bytes);
+        return;
+    }
+    const unsigned threads = static_cast<unsigned>(
+        std::min<size_t>(wanted, bytes / (1u << 20)));
+    if (threads <= 1) { std::memcpy(dst, src, bytes); return; }
+    const size_t chunk = (bytes + threads - 1) / threads;
+    std::vector<std::thread> workers;
+    workers.reserve(threads - 1);
+    for (unsigned t = 1; t < threads; ++t) {
+        const size_t begin = std::min(bytes, static_cast<size_t>(t) * chunk);
+        const size_t end = std::min(bytes, begin + chunk);
+        if (begin >= end) break;
+        workers.emplace_back([dst, src, begin, end] {
+            std::memcpy(static_cast<uint8_t*>(dst) + begin,
+                        static_cast<const uint8_t*>(src) + begin, end - begin);
+        });
+    }
+    std::memcpy(dst, src, std::min(bytes, chunk));   // this thread takes the first chunk
+    for (std::thread& worker : workers) worker.join();
 }
 
 inline bool render_memory_pool_enabled() {
@@ -7925,7 +7970,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                             "bytes); skipping this upload\n", r.tw, r.th,
                                             (unsigned long long)tbytes);
                                 } else if (r.tex_rgba) {
-                                    std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
+                                    parallel_render_memcpy(sp, r.tex_rgba,
+                                                           static_cast<size_t>(tbytes));
                                 } else {
                                     // Only a declined/missed depth-plane borrow reaches the creation
                                     // path with no CPU pixels (#1275: the bridge deliberately carries


### PR DESCRIPTION
Follow-on to #3406, addressing the dominant cost identified in #3407.

## The finding

The sampled conversion chain has **seven** per-texel arms. Exactly **one** used `parallel_compute_texels`; the other six were plain scalar loops.

That reconciles two measurements on Sonic Frontiers' intro that never fitted together: **1630 ms of conversion work in a 4760 ms window, while the whole process used 1.01 cores.** A 4K conversion was running on one core of a 32-core machine.

The helper has existed all along, is used in eight other places in this same file, and its own comment describes precisely this failure on a different title:

> *"Astro Bot's 4K FP16 target is 8.3 million texels, so leaving its lookup/pack walk on one core made a ~5 ms GPU dispatch wait on hundreds of milliseconds of host work."*

The sampled arms just never got the same treatment.

## Why it is safe

Every write in these loops is `upload[t * n + c]` — disjoint across `t`. They are parallel by construction, and identical in shape to the arm immediately below them that was already wrapped.

The one way wrapping a loop in a lambda *can* change meaning is control flow: a `break` that used to leave the whole loop would now leave only its chunk, with the other threads continuing. There are `break` statements in this region, so I checked each wrapped body mechanically rather than by eye — all six are free of `break`, `continue` and `return`; those `break`s belong to the enclosing branch chain. No wrapped body has cross-iteration state either.

## Measurement

`PPSA03831`, default launch, no throttles, three runs per arm, **both arms from the same binary** — `PROSPER_COMPUTE_CONVERSION_THREADS=1` forces the old scalar path, so there is no build difference between them:

| arm | guest flips/s | mean | compute time |
| --- | --- | --- | --- |
| scalar (`THREADS=1`) | 3.59, 3.39, 3.58 | 3.52 | 1792.7 / 1800.6 / 1803.9 ms |
| parallel (default) | 4.38, 4.38, 3.79 | **4.18** | **907.6 / 890.3 / 869.7 ms** |

**Compute time halved; frame rate +18.7%.** `process CPU` rises 0.96 → 1.29 cores rather than toward 16, because these loops are memory-bandwidth-bound — which is also why the helper caps at sixteen workers.

This is the largest single improvement measured on this title, and it is a **scheduling** fix rather than an algorithmic one: the same work, spread across cores that were already sitting idle.

## Verification

- Full suite **369/369**.
- Mechanical check that no wrapped body contains `break`/`continue`/`return`.
- A/B from one binary, three runs per arm; every parallel run is faster than every scalar run except one (3.79 vs 3.59), and the compute-time column is cleanly separated with no overlap.

## Scope, and what this does not fix

This does not remove the conversion, it spreads it. #3407 records the two changes that would remove it: caching the ~90% of conversions that reconvert identical bytes, and the fact that prosper has **no GPU tiling or format-conversion path at all**, so renderer-owned surfaces round-trip through the CPU.

For scale: with this landed the intro is ~4.2 fps against a 30 fps target, and `gpu-device` remains ~6% of wall clock. The GPU could already run this above 60 fps; the remaining work is architectural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i5osz4hug6YnPrfcN5gwh
