### PR TITLE
Restore Sonic audio, retain render targets on GPU, and adopt Vulkan 1.4

### DIFF
--- a/.github/actions/setup-vulkan/action.yml
+++ b/.github/actions/setup-vulkan/action.yml
@@ -1,0 +1,58 @@
+name: Vulkan 1.4 toolchain
+description: Build pinned Khronos headers and loader while retaining the runner's Mesa driver and validation layer.
+runs:
+  using: composite
+  steps:
+    - name: Identify the build distribution
+      id: host
+      shell: bash
+      run: |
+        . /etc/os-release
+        printf 'distribution=%s-%s\n' "$ID" "$VERSION_ID" >> "$GITHUB_OUTPUT"
+
+    - name: Cache headers and loader
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/prosper-vulkan
+        key: vulkan-1.4.341-${{ runner.os }}-${{ runner.arch }}-${{ steps.host.outputs.distribution }}-1
+
+    - name: Build headers and loader
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        sudo apt-get install -y libx11-dev libxcb1-dev libxrandr-dev libwayland-dev
+        vulkan_root="$RUNNER_TEMP/prosper-vulkan-build"
+        vulkan_prefix="$RUNNER_TEMP/prosper-vulkan"
+        mkdir -p "$vulkan_root/tmpdir"
+        export TMPDIR="$vulkan_root/tmpdir"
+        cd "$vulkan_root"
+        curl --fail --location --retry 3 \
+          https://codeload.github.com/KhronosGroup/Vulkan-Headers/tar.gz/refs/tags/v1.4.341 \
+          --output headers.tar.gz
+        curl --fail --location --retry 3 \
+          https://codeload.github.com/KhronosGroup/Vulkan-Loader/tar.gz/refs/tags/v1.4.341 \
+          --output loader.tar.gz
+        printf '%s\n' \
+          '8876aad926b2e72bdefddc34885472d5332e2d20aa3ed57313466f0bc982cf3f  headers.tar.gz' \
+          '9a8c6f1aace4a03641429a09bc823073f2375abf2d62ac5a4d38c46e732b2d85  loader.tar.gz' \
+          | sha256sum --check
+        tar -xzf headers.tar.gz
+        tar -xzf loader.tar.gz
+        cmake -S Vulkan-Headers-1.4.341 -B headers-build -G Ninja \
+          -DCMAKE_INSTALL_PREFIX="$vulkan_prefix"
+        cmake --install headers-build
+        cmake -S Vulkan-Loader-1.4.341 -B loader-build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$vulkan_prefix" \
+          -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_PREFIX_PATH="$vulkan_prefix" \
+          -DBUILD_TESTS=OFF -DUPDATE_DEPS=OFF
+        cmake --build loader-build --parallel 2
+        cmake --install loader-build
+
+    - name: Select the Vulkan toolchain
+      shell: bash
+      run: |
+        vulkan_prefix="$RUNNER_TEMP/prosper-vulkan"
+        printf 'VULKAN_SDK=%s\n' "$vulkan_prefix" >> "$GITHUB_ENV"
+        printf 'LD_LIBRARY_PATH=%s/lib%s\n' "$vulkan_prefix" \
+          "${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ jobs:
       # silently removed 27 tests (~1,700 assertions) from every "green" CI run, including every
       # shader-recompiler and GPU-execution differential. They are designed for a software device
       # (llvmpipe/lavapipe) and run in seconds locally, so CI can run them too.
+      # The live runtime requires Vulkan 1.4; Ubuntu 24.04's headers/loader are 1.3.
+      # Keep the distribution's Mesa ICD and validation layer for the existing test baseline.
+      - name: Set up Vulkan 1.4
+        uses: ./.github/actions/setup-vulkan
+
       - name: Configure
         run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROSPER_DIAGNOSTICS=ON
 
@@ -584,6 +589,11 @@ jobs:
             libpulse-dev libasound2-dev libavformat-dev libavcodec-dev libavutil-dev \
             libswresample-dev libswscale-dev libva-dev
 
+      # The live runtime requires Vulkan 1.4; Ubuntu 24.04's headers/loader are 1.3.
+      # Keep the distribution's Mesa ICD and validation layer for the existing test baseline.
+      - name: Set up Vulkan 1.4
+        uses: ./.github/actions/setup-vulkan
+
       - name: Configure
         run: cmake -S prosper -B prosper/build-app -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON
 
@@ -623,6 +633,11 @@ jobs:
             libpulse-dev libasound2-dev libavformat-dev libavcodec-dev libavutil-dev \
             libswresample-dev libswscale-dev libva-dev \
             desktop-file-utils file binutils
+
+      # The live runtime requires Vulkan 1.4; Ubuntu 24.04's headers/loader are 1.3.
+      # Keep the distribution's Mesa ICD and validation layer for the existing test baseline.
+      - name: Set up Vulkan 1.4
+        uses: ./.github/actions/setup-vulkan
 
       - name: Configure
         run: >-

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -120,6 +120,12 @@ prosper/
 ```
 
 ## Build
+
+The live Vulkan renderer, compute backend, and windowed frontend require Vulkan 1.4 headers,
+loader, and a Vulkan 1.4 device. Optional features are checked individually; no experimental driver
+flags are required. Older MoltenVK devices no longer satisfy the runtime requirement. See
+[Vulkan runtime](docs/VULKAN_RUNTIME.md) for capability policy and modernization measurements.
+
 ```
 cmake -S . -B build -G Ninja
 cmake --build build

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -48,6 +48,28 @@ cmake -S prosper -B build -DPROSPER_AUDIO_SDL3=ON   # uses system SDL3 if presen
   (matching hardware pacing). Per-channel volumes are mapped to the stream gain.
 - When enabled, `boot_trace` calls `install_sdl3_audio_sink()` at startup automatically.
 
+## AudioOut2 submission ownership (#3411)
+
+`PortSetAttributes` copies each PCM grain while the caller's buffer is valid and separates its
+interleaved samples into independently owned float buffers for every port/channel. MAIN channels
+are folded into the context's stereo bed only at `ContextPush`; auxiliary outputs keep their own
+source buffers and are not mixed into the speakers. A push consumes a submission once. A missing
+submission contributes silence while the host stream keeps its normal cadence.
+
+Sonic Frontiers reuses one scratch address for its eight-channel MAIN output and stereo auxiliary
+output. Reading that address at Push lost the MAIN samples when the auxiliary submission cleared
+it. Retaining the last copied grain indefinitely also failed: a 105-second capture contained
+7,824 repeated audible grains out of 9,489, producing severe buzzing. With one-time consumption,
+another 105-second capture contained 1,665 audible grains and **zero adjacent repeats**. This fixes
+ownership and replay, not the producer's low delivery rate: the windowed run delivered only about
+33–40 fresh grains per second against 188 output intervals. The listener confirmed recognizable
+Sonic ring audio, with severe interruptions. A renderer-disabled control raised fresh submissions
+to about 106 per second, still below 188; continuous playback remains unresolved (#3411).
+
+`audio_hle` exercises shared scratch reuse by two MAIN outputs and an auxiliary output, distinct
+left/right contributions, F32 and S16 conversion, replacement with silence, and a missing next
+submission. Existing channel-routing and context-lifetime checks remain in the same suite.
+
 ## Diagnosing a silent title — `PROSPER_AUDIO_FLOW=1`
 
 "No audio" has three mutually exclusive causes that are **indistinguishable from outside** and need
@@ -91,8 +113,9 @@ verdict is in `LIFE:`.
 | no `[audio-flow]` lines at all | the guest never created an AudioOut2 context |
 | `ctx…created` but no interval lines | a context exists, but the pump loop never runs |
 | `advance=N push=0` | the pump runs but never submits — **case 1** |
-| `push=N`, **`BED LIFE: nonzero=0/M`** | real submissions carrying exact silence — **case 2** |
-| `push=N`, **`BED LIFE: nonzero>0`** | signal reaches the host sink — **case 3**, look at the sink/volume |
+| `push=N`, **`BED LIFE: nonzero=0/M`** | the mixed bed is silent; inspect port submission and routing counters to distinguish missing data, silent data, and discarded data |
+| `push=N`, **`BED LIFE: nonzero>0`** | signal reaches the bed; confirm sink-open status and delivery before attributing any remaining fault to volume |
+| `no-grain=N` | this port supplied no fresh grain for N push intervals; silence filled those intervals instead of replaying old audio |
 | any port with `LIFE: nonzero>0` but `mixed=0` | **prosper is discarding real audio** — read `skip-fmt` / `skip-not-main` to see why |
 
 The last row is the one that matters most and is invisible in the bed alone: a port can carry the
@@ -306,7 +329,7 @@ a reported gap.
 
 ## Is the grain prosper READS the grain the guest WRITES? — `PROSPER_AUDIO_STAMP`
 
-Everything above is computed from one read of the guest's buffer, so none of it can separate the
+Signal measurements use the owned submission copied at SetAttributes. They cannot separate the
 two causes of a port that measures exactly zero:
 
 - **(a)** the guest holds the bus open and mixes silence into it — a non-defect, and
@@ -318,7 +341,7 @@ two causes of a port that measures exactly zero:
 instrument until something outside that instrument says otherwise, and no additional statistic
 derived from the same read can be that something — it would inherit the assumption under test.
 
-`PROSPER_AUDIO_STAMP` settles it by **writing**. After the mix has consumed a grain it stamps the
+`PROSPER_AUDIO_STAMP` probes this by **writing**. Independently of the owned mix buffers, it stamps the
 guest's own grain buffer with a per-channel-distinct pattern, and on the next push classifies what
 comes back:
 

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -1669,6 +1669,24 @@ which trap 38 correctly refuses to accept as an attribution.
    to SPIR-V. The other large piece.
 5. **libSceAmpr audio.** Mix/output via a host audio backend (or a null sink first).
 
+## Sonic Frontiers shader validation (2026-09-07, #3416 / #3417)
+
+The captured position-only guest vertex program contains no PARAM export, while its paired fragment
+program consumes attribute zero. Sticky input controls select PARAM0; they do not request
+`DEFAULT_VAL`. The vertex recompiler now declares every proven consumed location even when the guest
+never writes it. This satisfies Vulkan's interface contract without inserting an invented default
+or overwriting a real export. Unknown consumption does not expand the interface from stale controls.
+
+The renderer and standalone compute device also enable `shaderImageGatherExtended` when supported,
+matching the recompiler's existing dynamic-offset gather capability (#3417). A 105-second baseline
+reported the missing gather feature and missing vertex-output VUIDs. After both fixes and #3415, a
+45-second windowed intro run presented 451 frames with the validation messenger active and **zero
+warnings or errors**. This covers that intro path, not the entire game's shader set.
+
+`vertex_output_budget` checks that a consumed-but-unexported parameter has a declaration and no
+fabricated store, while a real export still writes it. `spv_validate` validates the new module shape;
+`interp_render` verifies real interpolants and explicit defaults still render correctly (3/3 tests).
+
 ## Testing
 
 Everything above must stay behind programmatic checks (agentic-first). Current suite (7 tests):

--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -8,7 +8,26 @@ own embedded shader source paths (`Library\hedgehog\…`, `Library\needle\…`) 
 
 ## Current rung — gameplay reached, world not rendered
 
-### Intro audio and retained color targets (2026-09-07, #3411 / #3415)
+A committed input route (`scripts/sonic-frontiers-PPSA03831/reach-gameplay.pad`) takes the title
+from boot to **`GameModeStage` running a Cyber Space stage (`w6d01`)** with real GPU work: the
+guest streams all one hundred `w6d01_trr_s00..s99` terrain sectors plus `w6d01_gedit`, loads
+`ui_gamemodestage*.pac`, streams `sound/cyber_sound/bgm_cyber.awb`, and its submitted draw rate
+rises from **48 draws/flip on the title screen to a sustained 449 draws/flip** in the stage.
+
+The gameplay HUD composites correctly at 3840x2160 — ring counter, the five Red Star Ring slots,
+the boost gauge, and **a stage timer that advances monotonically with the guest's flips**
+(00:52.39 -> 00:56.76 across one 55-sample capture; 01:02.36 -> 01:05.83 across a second run).
+A running stage clock is the discriminator this title offers and a menu cannot fake it: no
+aggregate frame metric was used to make the call. Checked-in capture:
+`assets/screenshots/sonic-frontiers-cyberspace-hud.webp` (direct unmodified `tools/screenshot` frame,
+3840x2160, route arm, stage clock at 00:55.89).
+
+**What is not there is the world.** The 3840x2160 frame is black behind the HUD, because
+**16 of the stage's 32 compute programs never execute** (#2790). See the section below. So the rung is deliberately not
+ticked as a rendered-gameplay milestone: the route reaches gameplay, and a rendering defect stands
+between that and a gameplay screenshot.
+
+## Intro audio and retained color targets (2026-09-07, #3411 / #3415)
 
 AudioOut2 now owns a separate float buffer for every port/channel and consumes each submitted grain
 once. The guest shares a scratch address between its MAIN and auxiliary outputs; copying only at
@@ -34,25 +53,6 @@ run; smooth audio is not yet established.
 `mrt_binding` and `texture_sample_render` pass. The latter checks exact CPU-reference pixels for 2D
 and arrayed views of a retained single-layer image, including feedback copies; its Vulkan validation
 messenger was active and reported no errors or warnings.
-
-A committed input route (`scripts/sonic-frontiers-PPSA03831/reach-gameplay.pad`) takes the title
-from boot to **`GameModeStage` running a Cyber Space stage (`w6d01`)** with real GPU work: the
-guest streams all one hundred `w6d01_trr_s00..s99` terrain sectors plus `w6d01_gedit`, loads
-`ui_gamemodestage*.pac`, streams `sound/cyber_sound/bgm_cyber.awb`, and its submitted draw rate
-rises from **48 draws/flip on the title screen to a sustained 449 draws/flip** in the stage.
-
-The gameplay HUD composites correctly at 3840x2160 — ring counter, the five Red Star Ring slots,
-the boost gauge, and **a stage timer that advances monotonically with the guest's flips**
-(00:52.39 -> 00:56.76 across one 55-sample capture; 01:02.36 -> 01:05.83 across a second run).
-A running stage clock is the discriminator this title offers and a menu cannot fake it: no
-aggregate frame metric was used to make the call. Checked-in capture:
-`assets/screenshots/sonic-frontiers-cyberspace-hud.webp` (direct unmodified `tools/screenshot` frame,
-3840x2160, route arm, stage clock at 00:55.89).
-
-**What is not there is the world.** The 3840x2160 frame is black behind the HUD, because
-**16 of the stage's 32 compute programs never execute** (#2790). See the section below. So the rung is deliberately not
-ticked as a rendered-gameplay milestone: the route reaches gameplay, and a rendering defect stands
-between that and a gameplay screenshot.
 
 ## What stood between the title screen and gameplay: a twelve-page boot notice queue
 

--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -8,6 +8,33 @@ own embedded shader source paths (`Library\hedgehog\…`, `Library\needle\…`) 
 
 ## Current rung — gameplay reached, world not rendered
 
+### Intro audio and retained color targets (2026-09-07, #3411 / #3415)
+
+AudioOut2 now owns a separate float buffer for every port/channel and consumes each submitted grain
+once. The guest shares a scratch address between its MAIN and auxiliary outputs; copying only at
+Push lost MAIN audio, and repeating the last saved grain produced buzzing. The listener confirmed
+recognizable Sonic ring audio after the fix. Severe delivery gaps remain; see `AUDIO.md` for the
+submission measurements and regression tests.
+
+One-layer `img_dim=5` color samples now pass all four retained-target gates: later-consumer
+inspection, lazy readback suppression, frontend target selection, and backend borrowing. Multi-layer,
+MSAA, storage, and incompatible extents remain excluded. The sampled view follows SPIR-V reflection;
+this title's depth-one descriptors ordinarily compile to non-arrayed base-slice images. No mutable
+UNORM/UINT reinterpretation from the #3407 WIP branch is enabled.
+
+Two 105-second windowed immediate-present runs used separate fresh save directories, audio-flow and
+readback-reason diagnostics, and no concurrent builds. The baseline at `46f9853e` presented **470**
+frames; the changed binary presented **1,086** (**2.31×**). Their last cumulative readback reports
+showed `same_batch_cpu=6247/128061MB` and `same_batch_cpu=0/0MB`, respectively (the diagnostic's MB
+unit is MiB, and reports are periodic, not final totals). These counters do not include every
+compute-side rematerialization. Fresh MAIN submissions increased from roughly 35–40 to 80–92 per
+second, still below the required 188. The listener confirmed correct colors and audio in the faster
+run; smooth audio is not yet established.
+
+`mrt_binding` and `texture_sample_render` pass. The latter checks exact CPU-reference pixels for 2D
+and arrayed views of a retained single-layer image, including feedback copies; its Vulkan validation
+messenger was active and reported no errors or warnings.
+
 A committed input route (`scripts/sonic-frontiers-PPSA03831/reach-gameplay.pad`) takes the title
 from boot to **`GameModeStage` running a Cyber Space stage (`w6d01`)** with real GPU work: the
 guest streams all one hundred `w6d01_trr_s00..s99` terrain sectors plus `w6d01_gedit`, loads

--- a/prosper/docs/VULKAN_RUNTIME.md
+++ b/prosper/docs/VULKAN_RUNTIME.md
@@ -1,0 +1,80 @@
+# Vulkan runtime and modernization (#3414)
+
+The live graphics backend, standalone live compute backend, and app's fallback presentation device
+require Vulkan **1.4**. Each instance-creation path resolves `vkEnumerateInstanceVersion` before
+requesting 1.4; an absent function, failed query, or older loader produces a diagnostic. Physical
+device selection independently rejects older devices. Standalone compatibility probes and synthetic
+Vulkan harnesses can still request older versions; they do not define the shipping runtime's floor.
+
+Build these backends with Vulkan 1.4 headers. Linux is the primary target; the contract uses standard
+Vulkan APIs and does not depend on an AMD extension or an experimental driver flag. NVIDIA and
+Windows devices must satisfy the same version and feature checks. This change was tested on Linux
+RADV, not certified on NVIDIA or Windows. MoltenVK devices exposing less than 1.4 are no longer
+accepted, as permitted by the owner's platform-priority decision in #3414.
+
+## Features already consumed
+
+Graphics now queries descriptor indexing, buffer int64 atomics, robust image access, and subgroup
+size control as core features. Standalone compute queries its descriptor indexing and int64 atomics
+the same way. An absent promoted extension name no longer disables a supported core feature.
+`VkPhysicalDeviceFeatures2` still checks the individual bits, and device creation requests only the
+bits in use. Shared compute inherits the renderer's **enabled** capabilities.
+
+Host image copy support is logged for the selected physical device, explicitly distinguished from
+enablement. It is not enabled or used by this change. Timeline semaphores, synchronization2, dynamic
+rendering, and push descriptors likewise remain follow-up work, not benefits delivered by changing
+the API version.
+
+Validation: the combined change passes 11 focused CTest cases covering audio, retained targets,
+shader interfaces, SPIR-V validation, device publication, and live compute. With validation enabled,
+`game_compute_exec` still emits the existing #1710 push-constant IDs `07987`/`08602`, and
+`interp_render` emits the existing #1715 geometry-invocation ID `00715`; all three are recorded in
+`tools/vkval/allowlist.txt`. This is not a claim of a validation-clean whole suite. A separate
+45-second windowed Sonic run presented 452 frames with an active validation messenger and **zero**
+validation warnings/errors, without experimental driver flags.
+
+## Host image copy: checked capability, not assumed hardware limitation
+
+On the measured Radeon 8060S / RADV STRIX_HALO device with Mesa 26.1.4, `hostImageCopy=false` by
+default. The concurrently enumerated llvmpipe device reports true; its result must not be attributed
+to the hardware GPU. Vulkan 1.4 explicitly permits omitting this feature when the implementation
+provides an additional transfer-capable queue.
+
+This is a driver default, not proof the chip cannot implement the operation. Mesa 26.1.4 gates it
+behind `RADV_EXPERIMENTAL=hic`; a capability-only probe with that process-local switch reported true
+on the same Radeon. Mesa 26.2 enables it by default on GFX10.3 and newer. No system settings or driver
+packages were changed, and the experiment is not part of the runtime launch contract.
+
+References: [Vulkan host image copy](https://docs.vulkan.org/refpages/latest/refpages/source/VK_EXT_host_image_copy.html),
+[Mesa 26.1.4 feature gate](https://gitlab.freedesktop.org/mesa/mesa/-/blob/mesa-26.1.4/src/amd/vulkan/radv_physical_device.c),
+[Mesa 26.2 feature gate](https://gitlab.freedesktop.org/mesa/mesa/-/blob/mesa-26.2.0/src/amd/vulkan/radv_physical_device.c).
+
+A future optional implementation must check the feature, image usage/format support, permitted host
+copy layouts, and device-access performance properties, with the existing staging path retained.
+GPU writes still need a host-read availability dependency and completion before a host copy reads
+them. The API removes staging machinery; it does not remove required synchronization or format
+conversion. Test it on drivers that advertise support normally, without requiring experimental flags.
+
+## Measurements after the retained-target fix
+
+The #3415 change eliminated the observed same-batch CPU readbacks in two comparable 105-second
+Sonic Frontiers intro runs and raised presented frames from 470 to 1,086. See
+[title evidence](SONIC_FRONTIERS_STATUS.md). That improvement precedes the Vulkan version change.
+
+A subsequent 75-second windowed CPU profile at `d32e4cee` recorded 2,691 `cpu-clock:u` samples at
+99 Hz, with no lost samples. It included one scheduled screenshot and is a cost profile, not a
+clean comparative FPS benchmark. Self CPU sample shares included memset 18.80%, memmove 17.17%,
+compute texel conversion 11.78%, tiling 7.25%, memcmp 5.72%, and detiling 2.64%. Guest native code and
+blocked time are not fully represented by these host userspace samples.
+
+The renderer's cumulative timings reported about 0.77 ms waiting per backend submission versus
+0.01 ms for pipeline creation; compute dispatches averaged 3.13 ms including their surrounding work.
+The compute backend already reuses its dispatch fence. Replacing that fence with a timeline semaphore
+alone would not remove a wait where the CPU immediately consumes the dispatch result. Pipeline
+permutation reduction is also not established as the next bottleneck by this run.
+
+Prioritize the measured image conversion/copy traffic and dependencies forcing synchronous result
+consumption. Adopt synchronization2 with producer/consumer stage knowledge, not by mechanically
+renaming `ALL_COMMANDS` barriers. Dynamic rendering can simplify object lifetime, but neither it nor
+the version bump has a measured performance gain here yet. Audio is recognizable after #3411 and
+its production rate improved with #3415; sustained delivery remains below the required sample rate.

--- a/prosper/docs/VULKAN_RUNTIME.md
+++ b/prosper/docs/VULKAN_RUNTIME.md
@@ -12,6 +12,12 @@ Windows devices must satisfy the same version and feature checks. This change wa
 RADV, not certified on NVIDIA or Windows. MoltenVK devices exposing less than 1.4 are no longer
 accepted, as permitted by the owner's platform-priority decision in #3414.
 
+Linux CI installs pinned Khronos 1.4.341 headers and loader through
+`.github/actions/setup-vulkan`, with archive checksums and a cache keyed by distribution version.
+Ubuntu 24.04's system headers/loader predate this runtime floor. The jobs retain their distribution
+Mesa ICD and validation layer; updating the loader does not substitute a different GPU driver or
+remove the existing validation baseline.
+
 ## Features already consumed
 
 Graphics now queries descriptor indexing, buffer int64 atomics, robust image access, and subgroup

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -21,6 +21,7 @@
 #include "capture_schedule.hpp"        // exact host-frame screenshot calibration trigger
 #include "shared/present/present_blit.hpp"           // GPU scanout handoff: acquire/release the renderer's front image
 #include "shared/present/present_blit_policy.hpp"    // reject stale CPU/GPU representations of guest flips
+#include "shared/device/vulkan_runtime.hpp"
 #include "hle/sync/sync_futex.hpp"         // dump_guest_sync_trace (PROSPER_SYNC_RING deadlock history)
 #include "host/platform/lifecycle.hpp"          // frontend-owned stop/pause gates
 #include "host/platform/gpu_submit_gate.hpp"     // #3225: drain guest GPU submits before _Exit
@@ -241,7 +242,9 @@ bool create_instance(Vk& vk, SDL_Window* win) {
                exts.end());
 #endif
     VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
-    app.pApplicationName = "prosper-app"; app.apiVersion = VK_API_VERSION_1_1;
+    if (!prosper::frontend::require_vulkan_runtime_loader("app")) return false;
+    app.pApplicationName = "prosper-app";
+    app.apiVersion = prosper::frontend::kVulkanRuntimeVersion;
     VkInstanceCreateInfo ci{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
     ci.pApplicationInfo = &app;
     ci.enabledExtensionCount = (uint32_t)exts.size();
@@ -259,6 +262,9 @@ bool pick_device(Vk& vk) {
     if (!n) { fprintf(stderr, "[app] no Vulkan device\n"); return false; }
     std::vector<VkPhysicalDevice> devs(n); vkEnumeratePhysicalDevices(vk.instance, &n, devs.data());
     for (auto d : devs) {
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(d, &properties);
+        if (!prosper::frontend::vulkan_runtime_version_supported(properties.apiVersion)) continue;
         uint32_t qn = 0; vkGetPhysicalDeviceQueueFamilyProperties(d, &qn, nullptr);
         std::vector<VkQueueFamilyProperties> q(qn); vkGetPhysicalDeviceQueueFamilyProperties(d, &qn, q.data());
         for (uint32_t i = 0; i < qn; i++) {
@@ -267,7 +273,7 @@ bool pick_device(Vk& vk) {
         }
         if (vk.phys) break;
     }
-    if (!vk.phys) { fprintf(stderr, "[app] no graphics+present queue family\n"); return false; }
+    if (!vk.phys) { fprintf(stderr, "[app] no Vulkan 1.4 device with a graphics+present queue family\n"); return false; }
 
     float pr = 1.0f;
     VkDeviceQueueCreateInfo qi{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
@@ -290,6 +296,7 @@ bool pick_device(Vk& vk) {
 
     VkPhysicalDeviceProperties pp; vkGetPhysicalDeviceProperties(vk.phys, &pp);
     fprintf(stderr, "[app] Vulkan device: %s\n", pp.deviceName);
+    prosper::frontend::log_vulkan_runtime_device("app", vk.phys, pp);
     return true;
 }
 

--- a/prosper/frontends/shared/device/vulkan_device_select.hpp
+++ b/prosper/frontends/shared/device/vulkan_device_select.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include "vulkan_runtime.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -30,13 +31,16 @@ static_assert(vulkan_device_type_rank(VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) >
               vulkan_device_type_rank(VK_PHYSICAL_DEVICE_TYPE_CPU));
 
 // Vulkan does not promise that physical devices are enumerated in performance order. Prefer a
-// hardware GPU when one supports the queue and robustness contract, while retaining llvmpipe and
-// other CPU implementations as a headless fallback.
+// hardware GPU when one supports the runtime version, queue and robustness contract, retaining
+// llvmpipe and other CPU implementations as a headless fallback.
 inline VulkanDeviceSelection select_vulkan_device(
     const std::vector<VkPhysicalDevice>& devices, VkQueueFlags required_queue_flags) {
     VulkanDeviceSelection best;
     int best_rank = -1;
     for (VkPhysicalDevice device : devices) {
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(device, &properties);
+        if (!vulkan_runtime_version_supported(properties.apiVersion)) continue;
         VkPhysicalDeviceFeatures features{};
         vkGetPhysicalDeviceFeatures(device, &features);
         if (!features.robustBufferAccess) continue;
@@ -54,8 +58,6 @@ inline VulkanDeviceSelection select_vulkan_device(
         }
         if (queue_family == UINT32_MAX) continue;
 
-        VkPhysicalDeviceProperties properties{};
-        vkGetPhysicalDeviceProperties(device, &properties);
         const int rank = vulkan_device_type_rank(properties.deviceType);
         if (rank > best_rank) {
             best = {device, queue_family, properties};

--- a/prosper/frontends/shared/device/vulkan_runtime.hpp
+++ b/prosper/frontends/shared/device/vulkan_runtime.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+#include <cstdio>
+
+namespace prosper::frontend {
+
+// Runtime backends share one floor. Standalone Vulkan compatibility probes may deliberately
+// request older versions; they do not create devices that the runtime adopts.
+inline constexpr uint32_t kVulkanRuntimeVersion = VK_API_VERSION_1_4;
+
+constexpr bool vulkan_runtime_version_supported(uint32_t version) {
+    return VK_API_VERSION_VARIANT(version) == 0 && version >= kVulkanRuntimeVersion;
+}
+
+inline bool require_vulkan_runtime_loader(
+    const char* owner, PFN_vkGetInstanceProcAddr get_proc = vkGetInstanceProcAddr) {
+    const auto enumerate = reinterpret_cast<PFN_vkEnumerateInstanceVersion>(
+        get_proc(VK_NULL_HANDLE, "vkEnumerateInstanceVersion"));
+    // The function is absent on a Vulkan 1.0 loader. Do not call a newer entry point directly
+    // before checking it, or the diagnostic itself depends on the version it needs to reject.
+    uint32_t version = VK_API_VERSION_1_0;
+    const VkResult result = enumerate ? enumerate(&version) : VK_SUCCESS;
+    if (result != VK_SUCCESS) {
+        std::fprintf(stderr, "[%s] Vulkan loader version query failed (%d)\n", owner, result);
+        return false;
+    }
+    if (!vulkan_runtime_version_supported(version)) {
+        std::fprintf(stderr, "[%s] Vulkan 1.4 required; loader reports %u.%u.%u\n", owner,
+                     VK_API_VERSION_MAJOR(version), VK_API_VERSION_MINOR(version),
+                     VK_API_VERSION_PATCH(version));
+        return false;
+    }
+    return true;
+}
+
+inline void log_vulkan_runtime_device(const char* owner, VkPhysicalDevice device,
+                                      const VkPhysicalDeviceProperties& properties) {
+    // Support is queried on the selected device, not inferred from the loader version or
+    // another ICD (software devices can advertise features a hardware GPU lacks).
+    VkPhysicalDeviceHostImageCopyFeatures host_copy{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES};
+    VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+    features.pNext = &host_copy;
+    vkGetPhysicalDeviceFeatures2(device, &features);
+    std::fprintf(stderr, "[%s] Vulkan runtime 1.4, device API %u.%u.%u; "
+                         "hostImageCopy supported=%u (not enabled)\n", owner,
+                 VK_API_VERSION_MAJOR(properties.apiVersion),
+                 VK_API_VERSION_MINOR(properties.apiVersion),
+                 VK_API_VERSION_PATCH(properties.apiVersion), host_copy.hostImageCopy);
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3112,6 +3112,8 @@ struct VulkanComputeContext {
         VkPhysicalDeviceFeatures enabled{};
         enabled.robustBufferAccess = VK_TRUE;
         enabled.shaderInt64 = supported.shaderInt64;
+        // The standalone device must enable the same gather capability as the shared renderer.
+        enabled.shaderImageGatherExtended = supported.shaderImageGatherExtended;
         // Image bindings (#590): enable the format-free storage-image features when available.
         image_support = supported.shaderStorageImageReadWithoutFormat &&
                         supported.shaderStorageImageWriteWithoutFormat;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3079,8 +3079,9 @@ struct VulkanComputeContext {
             min_native_subgroup_size = max_native_subgroup_size = 0;
             pipeline_cache = VK_NULL_HANDLE;
         }
+        if (!require_vulkan_runtime_loader("compute")) return false;
         VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
-        app.apiVersion = VK_API_VERSION_1_1;
+        app.apiVersion = kVulkanRuntimeVersion;
         VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
         ici.pApplicationInfo = &app;
         if (vkCreateInstance(&ici, nullptr, &instance) != VK_SUCCESS) return false;
@@ -3093,10 +3094,14 @@ struct VulkanComputeContext {
         const auto selection = select_vulkan_device(devices, VK_QUEUE_COMPUTE_BIT);
         physical = selection.device;
         queue_family = selection.queue_family;
-        if (!physical || queue_family == UINT32_MAX) return false;
+        if (!physical || queue_family == UINT32_MAX) {
+            std::fprintf(stderr, "[compute] no Vulkan 1.4 device with a compute queue and robustBufferAccess\n");
+            return false;
+        }
         std::fprintf(stderr, "[compute] Vulkan device: %s (%s)\n",
                      selection.properties.deviceName,
                      vulkan_device_type_name(selection.properties.deviceType));
+        log_vulkan_runtime_device("compute", physical, selection.properties);
 
         float priority = 1.0f;
         VkDeviceQueueCreateInfo qci{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
@@ -3132,81 +3137,33 @@ struct VulkanComputeContext {
         // device set and emit indexed-array SPIR-V against a device that cannot execute it — silent
         // undefined behaviour rather than a clean failure. Successful contracts are fixed storage-
         // buffer arrays, so only their non-uniform indexing feature is requested.
-        VkPhysicalDeviceDescriptorIndexingFeaturesEXT di_features{
-            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
-        bool di_ext_advertised = false;
-        { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
-          std::vector<VkExtensionProperties> de(ne);
-          vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, de.data());
-          for (auto& e : de) {
-              if (std::strcmp(e.extensionName, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) continue;
-              di_ext_advertised = true;
-              VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-              f2.pNext = &di_features;
-              vkGetPhysicalDeviceFeatures2(physical, &f2);
-              const bool have_ssbo_arrays =
-                  di_features.shaderStorageBufferArrayNonUniformIndexing;
-              if (have_ssbo_arrays) {
-                  VkPhysicalDeviceDescriptorIndexingFeaturesEXT want{
-                      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
-                  want.shaderStorageBufferArrayNonUniformIndexing = VK_TRUE;
-                  di_features = want;
-                  di_features.pNext = const_cast<void*>(dci.pNext);
-                  dci.pNext = &di_features;
-                  dev_exts.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
-                  descriptor_indexing_support = true;
-                  std::fprintf(stderr, "[compute] descriptor indexing ENABLED (own device)\n");
-              } else {
-                  std::fprintf(stderr,
-                               "[compute] VK_EXT_descriptor_indexing lacks "
-                               "shaderStorageBufferArrayNonUniformIndexing\n");
-              }
-              break;
-          } }
-        // The third case, and the only one that was silent: the extension is not advertised at all, so
-        // the loop above never enters its body and nothing above prints. "Absent" and "the scan never
-        // ran" would then look identical in a log -- the same ambiguity that let the adopt path claim an
-        // inheritance nobody could contradict. Report it so every outcome of this decision is visible.
-        // Guarded on `di_ext_advertised`, NOT on `descriptor_indexing_support`: the feature flag is also
-        // false in the present-but-incomplete case, which already printed its own itemised line, and this
-        // message would then contradict it with "not advertised" about a device that advertised it.
-        if (!di_ext_advertised)
-            std::fprintf(stderr, "[compute] descriptor indexing unavailable: "
-                                 "VK_EXT_descriptor_indexing not advertised by this device\n");
-        // Live raw translation chooses its qword-atomic config from SharedVulkanContext before this
-        // lazy private-device path can run, so private discovery deliberately does not advertise an
-        // admission capability. Still enable the feature here when available: this path can execute
-        // already-compiled/captured modules whose config was established by their replay owner.
+        // Descriptor indexing and shader-buffer int64 atomics are core in 1.2. The runtime
+        // requires 1.4, so an absent promoted extension name must not disable either feature.
+        VkPhysicalDeviceDescriptorIndexingFeatures di_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
         VkPhysicalDeviceShaderAtomicInt64Features atomic_int64_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
-        bool atomic_int64_ext_advertised = false;
-        bool private_storage_buffer_int64_atomics = false;
-        { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
-          std::vector<VkExtensionProperties> de(ne);
-          vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, de.data());
-          for (const auto& e : de) {
-              if (std::strcmp(e.extensionName, VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME))
-                  continue;
-              atomic_int64_ext_advertised = true;
-              VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-              f2.pNext = &atomic_int64_features;
-              vkGetPhysicalDeviceFeatures2(physical, &f2);
-              if (supported.shaderInt64 &&
-                  atomic_int64_features.shaderBufferInt64Atomics) {
-                  VkPhysicalDeviceShaderAtomicInt64Features want{
-                      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
-                  want.shaderBufferInt64Atomics = VK_TRUE;
-                  atomic_int64_features = want;
-                  atomic_int64_features.pNext = const_cast<void*>(dci.pNext);
-                  dci.pNext = &atomic_int64_features;
-                  dev_exts.push_back(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
-                  private_storage_buffer_int64_atomics = true;
-              }
-              break;
-          } }
-        std::fprintf(stderr, "[compute] storage-buffer int64 atomics %s (own device%s)\n",
-                     private_storage_buffer_int64_atomics ? "ENABLED" : "unavailable",
-                     atomic_int64_ext_advertised ? "" : ", extension not advertised");
+        VkPhysicalDeviceFeatures2 features2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+        features2.pNext = &di_features;
+        di_features.pNext = &atomic_int64_features;
+        vkGetPhysicalDeviceFeatures2(physical, &features2);
+        descriptor_indexing_support = di_features.shaderStorageBufferArrayNonUniformIndexing;
+        const bool private_storage_buffer_int64_atomics =
+            supported.shaderInt64 && atomic_int64_features.shaderBufferInt64Atomics;
+        // Only request the bits used by this backend, not every bit returned by the query.
+        di_features = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
+        di_features.shaderStorageBufferArrayNonUniformIndexing = descriptor_indexing_support;
+        atomic_int64_features = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+        atomic_int64_features.shaderBufferInt64Atomics = private_storage_buffer_int64_atomics;
+        di_features.pNext = &atomic_int64_features;
+        dci.pNext = &di_features;
+        std::fprintf(stderr, "[compute] descriptor indexing %s (own device, core feature)\n",
+                     descriptor_indexing_support ? "ENABLED" : "unavailable");
+        // Private discovery does not publish an admission capability: raw live translation
+        // chooses its qword-atomic config before this lazy initialization can run. This still
+        // allows replaying modules compiled against a known feature contract.
+        std::fprintf(stderr, "[compute] storage-buffer int64 atomics %s (own device, core feature)\n",
+                     private_storage_buffer_int64_atomics ? "ENABLED" : "unavailable");
 #ifdef __APPLE__
         // Spec-mandated on MoltenVK: enable VK_KHR_portability_subset when advertised (always is).
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
@@ -3215,12 +3172,6 @@ struct VulkanComputeContext {
           for (auto& e : de) if (!std::strcmp(e.extensionName, "VK_KHR_portability_subset")) {
               dev_exts.push_back("VK_KHR_portability_subset"); break; } }
 #endif
-        // Assigned OUTSIDE the Apple guard. Before stage 1 the only extension this path ever requested
-        // was VK_KHR_portability_subset, so the assignment lived inside `#ifdef __APPLE__` and every
-        // other platform passed a zero-length list. Leaving it there would have silently dropped the
-        // descriptor-indexing extension on Linux and Windows -- the pNext feature struct would be sent
-        // without its extension enabled, which is exactly the shape that produces a validation error
-        // far from its cause.
         dci.enabledExtensionCount = (uint32_t)dev_exts.size();
         dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
         if (vkCreateDevice(physical, &dci, nullptr, &device) != VK_SUCCESS) return false;

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -3234,7 +3234,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // resource fell through to stale guest bytes with no snapshot to use.
                             const bool direct_serves = prosper::frontend::mrt_direct_serves(
                                 draw, sampled_source_addr, tw, th,
-                                fr.is_storage_image, r.img_dim,
+                                fr.is_storage_image, r.img_dim, r.depth, r.sample_count,
                                 sampled_extent_compatible,
                                 prosper::test::find_persistent_color_target(
                                     sampled_source_addr, surface.w, surface.h,
@@ -3313,7 +3313,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // A retained render target was created for color-attachment + sampled usage,
                         // not storage usage. Storage images therefore take the decoded/upload path.
                         const bool has_gpu_live_rtt = !fr.is_storage_image && live_gpu_targets &&
-                            r.img_dim == 1u &&
+                            prosper::frontend::rtt_single_layer_sample_shape(
+                                r.img_dim, r.depth, r.sample_count) &&
                             live_rtt != g_rtt.end() && live_rtt->second.gpu_valid &&
                             prosper::frontend::rtt_sampled_extent_compatible(
                                 tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
@@ -4309,6 +4310,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             fr.tw = live_rtt->second.w;
                             fr.th = live_rtt->second.h;
                             fr.td = 1; fr.img_dim = r.img_dim;
+                            // A depth-one T# array can compile to either a base-slice 2D image or
+                            // a real arrayed image. Bind the view the shader actually declared.
+                            fr.guest_array = reflected_binding->image_arrayed;
                             fr.texture_format = live_rtt->second.format;
                             // CB_COLOR renders one mip view per target, while this T# samples the
                             // complete allocation. Reconstruct the target identities and retain
@@ -8715,7 +8719,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     const bool sampled_extent_compatible =
                                         prosper::frontend::rtt_sampled_extent_compatible(
                                             rw, rh, gw, gh, render_scale, false);
-                                    if (resource.img_dim == 1u && sampled_extent_compatible) {
+                                    const bool sampled_shape =
+                                        prosper::frontend::rtt_single_layer_sample_shape(
+                                            resource.img_dim, resource.depth, resource.sample_count);
+                                    if (sampled_shape && sampled_extent_compatible) {
                                         result.sampled_exact = true;
                                         result.feedback |= same_pass_target;
                                     }
@@ -8724,13 +8731,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     // the render pass. Storage, dimension, and extent mismatches still
                                     // require the CPU representation.
                                     const bool direct_bindable =
-                                        resource.cls == RC::Texture && resource.img_dim == 1u &&
+                                        resource.cls == RC::Texture && sampled_shape &&
                                         sampled_extent_compatible;
                                     if (!direct_bindable) {
                                         result.cpu_needed = true;
                                         result.storage_references +=
                                             resource.cls == RC::StorageImage;
-                                        result.dimension_mismatches += resource.img_dim != 1u;
+                                        result.dimension_mismatches += !sampled_shape;
                                         result.extent_mismatches += !sampled_extent_compatible;
                                         result.feedback_references += same_pass_target;
                                         static const uint64_t diagnose_min_submit = [] {
@@ -8757,7 +8764,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                         ? "storage" : "texture",
                                                     resource.img_dim, rw, rh, gw, gh,
                                                     resource.cls == RC::StorageImage ? 1u : 0u,
-                                                    resource.img_dim != 1u ? 1u : 0u,
+                                                    !sampled_shape ? 1u : 0u,
                                                     !sampled_extent_compatible ? 1u : 0u,
                                                     same_pass_target ? 1u : 0u);
                                         }

--- a/prosper/frontends/shared/rtt/mrt_binding.hpp
+++ b/prosper/frontends/shared/rtt/mrt_binding.hpp
@@ -5,6 +5,7 @@
 #include "gpu/execute/gpu_execute.hpp"
 #include "gpu/state/render_state.hpp"
 #include "shared/rtt/mrt_extent.hpp"
+#include "shared/rtt/rtt_scale.hpp"
 
 // THE definition of an active colour binding.
 //
@@ -303,12 +304,14 @@ bool mrt_draw_binds_target(const prosper::gpu::DrawItem& draw, uint64_t addr,
 template <typename FormatDefined>
 bool mrt_direct_serves(const prosper::gpu::DrawItem& draw, uint64_t sampled,
                        uint32_t sampled_width, uint32_t sampled_height,
-                       bool is_storage_image, uint32_t img_dim, bool extent_compatible,
+                       bool is_storage_image, uint32_t img_dim, uint32_t layers,
+                       uint32_t samples, bool extent_compatible,
                        bool has_persistent_target, FormatDefined format_defined,
                        bool feedback_copy_supported = false) {
     const bool feedback = mrt_draw_binds_target_view(
         draw, sampled, sampled_width, sampled_height, format_defined);
-    return !is_storage_image && img_dim == 1u && extent_compatible && has_persistent_target &&
+    return !is_storage_image && rtt_single_layer_sample_shape(img_dim, layers, samples) &&
+           extent_compatible && has_persistent_target &&
            (!feedback || feedback_copy_supported);
 }
 

--- a/prosper/frontends/shared/rtt/rtt_scale.hpp
+++ b/prosper/frontends/shared/rtt/rtt_scale.hpp
@@ -18,6 +18,13 @@
 // which an exact integer-ratio check incorrectly sent through CPU readback.
 namespace prosper::frontend {
 
+// Retained color targets contain one single-sampled 2D subresource. A depth-one array may view
+// that same subresource; its Vulkan view must still match the consuming shader's arrayedness.
+constexpr bool rtt_single_layer_sample_shape(uint32_t dimension, uint32_t layers,
+                                             uint32_t samples) {
+    return (dimension == 1u || dimension == 5u) && layers == 1u && samples == 1u;
+}
+
 constexpr uint32_t rtt_integer_upscale_factor(uint32_t dst_w, uint32_t dst_h,
                                               uint32_t src_w, uint32_t src_h) {
     if (!src_w || !src_h || dst_w <= src_w || dst_h <= src_h) return 0;

--- a/prosper/frontends/shared/tests/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_binding.cpp
@@ -174,26 +174,36 @@ int main() {
 
         // Sampling an unrelated surface: the direct image serves.
         CHECK(mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
-                                /*is_storage_image=*/false, /*img_dim=*/1u,
+                                /*is_storage_image=*/false, /*img_dim=*/1u, 1u, 1u,
                                 /*extent_compatible=*/true, /*has_persistent_target=*/true,
                                 format_defined));
         // Sampling THIS pass's MRT2: it must not, or the descriptor and the colour attachment
         // become the same image.
-        CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 1u, true, true,
+        CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 1u, 1u, 1u, true, true,
                                  format_defined));
-        CHECK(mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 1u, true, true,
+        CHECK(mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 1u, 1u, 1u, true, true,
                                 format_defined, /*feedback_copy_supported=*/true));
         // The non-feedback preconditions still gate it.
         CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
-                                 /*is_storage_image=*/true, 1u, true, true,
+                                 /*is_storage_image=*/true, 1u, 1u, 1u, true, true,
                                  format_defined));
-        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
-                                 false, /*img_dim=*/5u, true, true,
+        CHECK(mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
+                                 false, /*img_dim=*/5u, 1u, 1u, true, true,
                                  format_defined));
+        CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 5u, 1u, 1u,
+                                 true, true, format_defined));
+        CHECK(mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 5u, 1u, 1u,
+                                true, true, format_defined, true));
+        CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 5u, 2u, 1u,
+                                 true, true, format_defined, true));
+        CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 5u, 1u, 4u,
+                                 true, true, format_defined, true));
+        CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 2u, 1u, 1u,
+                                 true, true, format_defined, true));
         CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
-                                 false, 1u, /*extent_compatible=*/false,
+                                 false, 1u, 1u, 1u, /*extent_compatible=*/false,
                                  true, format_defined));
-        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u, false, 1u, true,
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u, false, 1u, 1u, 1u, true,
                                  /*has_persistent_target=*/false, format_defined));
 
         // The uniform fast path carries the same gate. It and mrt_direct_serves must agree: if this
@@ -214,7 +224,7 @@ int main() {
         masked.color_targets[2].base = kMrt2;
         masked.ps.color_targets[2].format = 37u;
         masked.ps.color_targets[2].write_mask = 0u;
-        CHECK(mrt_direct_serves(masked, kMrt2, 64u, 32u, false, 1u, true, true,
+        CHECK(mrt_direct_serves(masked, kMrt2, 64u, 32u, false, 1u, 1u, 1u, true, true,
                                 format_defined));
     }
 

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -4145,6 +4145,15 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
             b.export_param(ps_input, xyz_one ? one : zero, xyz_one ? one : zero,
                            xyz_one ? one : zero, w_one ? one : zero);
         }
+        // A PS can read a PARAM that this VS never exports (#3416: a position-only guest VS
+        // paired with a PS reading attr0). Vulkan requires the matching declaration even when
+        // its value is unwritten. Complete only the proven consumed interface; do not invent a
+        // store/default or expand sticky controls into 32 outputs. Real exports and explicit
+        // DEFAULT_VAL controls above still supply their values through the same variables.
+        if (pixel_inputs->consumed_known) {
+            for (uint32_t ps_input = 0; ps_input < pixel_inputs->controls.size(); ++ps_input)
+                if (pixel_inputs->consumes(ps_input)) b.vtx_output(ps_input);
+        }
     }
     return b.finish();
 }

--- a/prosper/src/hle/audio/hle_audio.cpp
+++ b/prosper/src/hle/audio/hle_audio.cpp
@@ -626,13 +626,18 @@ uint32_t   g_a2_users = 0;
 // each tick the guest calls PortSetAttributes(port, attrs, count) where an attribute triple
 // {u32 id=0, u32 reserved, value_ptr, value_size=8} carries a guest pointer to the port's current grain of
 // interleaved PCM (grain frames from the context param, 256 live). ContextAdvance
-// advances engine state and ContextPush submits the grain to the device. We store each port's PCM
-// pointer here and mix + forward all ports' grains to the host AudioSink at Push.
+// advances engine state and ContextPush submits the grain to the device. SetAttributes must copy
+// each grain: guests reuse one scratch buffer for multiple ports before Advance/Push (#3411).
 struct A2PortState {
     bool     used = false;
     uint32_t generation = 0;
     uint64_t context = 0;      // owning context; Push must not submit another context's ports
-    uint64_t pcm_ptr = 0;      // guest address of this port's current PCM grain (attr id 0)
+    uint64_t pcm_ptr = 0;      // source address, retained for diagnostics (attr id 0)
+    // Normalize the guest's interleaved grain into independently owned channel buffers. Neither
+    // another output's scratch reuse nor the final stereo mix can change these source channels.
+    std::array<std::vector<float>, kAudioMaxBedChannels> pcm_channels;
+    uint32_t pcm_frames = 0;
+    bool pcm_pending = false; // a submission is consumed once, never looped to fill a late grain
     uint16_t type = 0;         // portParam +0x00: 0 = MAIN (speaker output); others aux (personal/...)
     uint32_t data_format = 0;  // portParam +0x04: bits 8..15=channels, bits 0..6=0 F32 / 1 S16,
                                // bit 7 selects the standard 8-channel order
@@ -679,7 +684,7 @@ using FlowSignal = AudioSignalStats;
 
 struct FlowPort {
     uint64_t reads = 0, mixed = 0, frames = 0, bytes = 0;
-    uint64_t no_pcm = 0, skip_fmt = 0, skip_not_main = 0, short_read = 0;
+    uint64_t no_pcm = 0, no_grain = 0, skip_fmt = 0, skip_not_main = 0, short_read = 0;
     uint16_t type = 0;
     uint32_t data_format = 0;
     FlowSignal sig;
@@ -795,7 +800,7 @@ void audio_flow_report(uint32_t slot) {
         fprintf(stderr,
                 "[audio-flow]   port%u type=0x%x fmt=0x%x reads=%llu mixed=%llu frames=%llu bytes=%llu"
                 " peak=%.5f rms=%.5f nonzero=%llu/%llu nan=%llu no-pcm=%llu skip-fmt=%llu"
-                " skip-not-main=%llu short=%llu"
+                " skip-not-main=%llu short=%llu no-grain=%llu"
                 " | LIFE: nonzero=%llu/%llu peak=%.5f rms=%.5f nan=%llu\n",
                 i + 1, p.type, p.data_format, (unsigned long long)p.reads,
                 (unsigned long long)p.mixed, (unsigned long long)p.frames,
@@ -804,12 +809,13 @@ void audio_flow_report(uint32_t slot) {
                 (unsigned long long)p.nan_samples,
                 (unsigned long long)p.no_pcm, (unsigned long long)p.skip_fmt,
                 (unsigned long long)p.skip_not_main, (unsigned long long)p.short_read,
+                (unsigned long long)p.no_grain,
                 (unsigned long long)p.life.nonzero, (unsigned long long)p.life.samples,
                 p.life.peak, p.life.rms(), (unsigned long long)p.life_nan);
         // Per-interval counters: reset so each line describes the LAST second, not the whole run.
         // The `life:` totals above are deliberately NOT reset.
         p.reads = p.mixed = p.frames = p.bytes = 0;
-        p.no_pcm = p.skip_fmt = p.skip_not_main = p.short_read = p.nan_samples = 0;
+        p.no_pcm = p.no_grain = p.skip_fmt = p.skip_not_main = p.short_read = p.nan_samples = 0;
         p.seen = false;
         p.sig.reset();
     }
@@ -1864,7 +1870,7 @@ HLE(audio2_port_get_state) {
 // Attribute = {u32 id, u32 reserved, const void* value, size_t valueSize} (0x18 stride).
 // `reserved` is ABI padding and may be indeterminate (GTA V leaves stack-address bits there), so
 // it must never be folded into the id. Live-decoded ids:
-//   0 = per-grain PCM data pointer (value: a guest pointer qword to interleaved stereo f32 samples).
+//   0 = per-grain PCM data pointer (value: a guest pointer qword; port format sizes the samples).
 // Unknown ids are skipped fail-visibly under PROSPER_AUDIO2LOG. CONFIDENCE: HIGH (Evergate + GTA V).
 HLE(audio2_port_set_attr) {
     A2LOG("sceAudioOut2PortSetAttributes");
@@ -1884,6 +1890,36 @@ HLE(audio2_port_set_attr) {
             uint64_t pcm = 0;
             if (audio_read_bytes(at.vptr, &pcm, 8)) {
                 port->pcm_ptr = pcm;
+                port->pcm_frames = 0;
+                port->pcm_pending = pcm != 0;
+                const auto* context = audio2_context_locked(port->context);
+                const uint32_t frames = context && context->grain >= 64 && context->grain <= 4096
+                    ? context->grain : 256;
+                const uint32_t channels = audio2_format_channels(port->data_format);
+                const uint32_t type = port->data_format & 0x7fu;
+                if (pcm && channels >= 1 && channels <= kAudioMaxBedChannels &&
+                    (type == 0 || type == 1)) {
+                    const size_t sample_bytes = type == 0 ? sizeof(float) : sizeof(int16_t);
+                    static thread_local std::vector<uint8_t> source;
+                    source.resize(static_cast<size_t>(frames) * channels * sample_bytes);
+                    const size_t got = audio_read_bytes_partial(pcm, source.data(), source.size());
+                    port->pcm_frames = static_cast<uint32_t>(got / (channels * sample_bytes));
+                    for (uint32_t channel = 0; channel < channels; ++channel) {
+                        auto& output = port->pcm_channels[channel];
+                        output.resize(port->pcm_frames);
+                        for (uint32_t frame = 0; frame < port->pcm_frames; ++frame) {
+                            const auto* sample = source.data() +
+                                (static_cast<size_t>(frame) * channels + channel) * sample_bytes;
+                            if (type == 0) {
+                                std::memcpy(&output[frame], sample, sizeof(float));
+                            } else {
+                                int16_t value;
+                                std::memcpy(&value, sample, sizeof(value));
+                                output[frame] = value * (1.0f / 32768.0f);
+                            }
+                        }
+                    }
+                }
                 // Reached-ness: the guest handing us a PCM buffer address is the last step before
                 // submission, so this separates "never wired up audio" from "wired up, never pushed".
                 if (pcm && audio_flow()) ++g_flow_pcm_published;
@@ -1950,7 +1986,7 @@ HLE(audio2_ctx_push) {
     A2LOG("sceAudioOut2ContextPush");
     uint32_t grain = 256;
     uint32_t context_slot = 0;
-    // Reserve one hardware queue slot before reading the guest grain. A nonblocking push on a full
+    // Reserve one hardware queue slot before mixing the submitted grains. A nonblocking push on a full
     // queue returns NOT_READY; a blocking push waits until the 48 kHz device clock drains a slot.
     for (;;) {
         std::chrono::nanoseconds wait_duration{};
@@ -1987,6 +2023,7 @@ HLE(audio2_ctx_push) {
     static thread_local std::vector<float> tmp;
     static thread_local std::vector<int16_t> tmp_s16;
     bool have_pcm = false;
+    bool have_main_stream = false;
     {
         std::lock_guard<std::mutex> lk(g_a2_mx);
         A2Context* c = audio2_context_locked(a0);
@@ -2000,7 +2037,7 @@ HLE(audio2_ctx_push) {
         float object_peak = 0.0f;
         int object_peak_port = 0;
         int pidx_probe = 0;
-        for (const auto& ps : g_a2_port_state) {
+        for (auto& ps : g_a2_port_state) {
             const int this_pidx = pidx_probe++;
             if (!ps.used || ps.context != a0) continue;
             // A port belonging to this context but carrying no published PCM pointer is a distinct
@@ -2099,23 +2136,23 @@ HLE(audio2_ctx_push) {
                 }
                 continue;
             }
-            const uint32_t read_samples = channels * grain;
-            size_t frames_got = 0;
-            if (data_type == 0) {
-                if (tmp.size() < read_samples) tmp.resize(read_samples);
-                const size_t got = audio_read_bytes_partial(
-                    ps.pcm_ptr, tmp.data(), sizeof(float) * read_samples);
-                frames_got = got / (sizeof(float) * channels);
-            } else {
-                if (tmp_s16.size() < read_samples) tmp_s16.resize(read_samples);
-                const size_t got = audio_read_bytes_partial(
-                    ps.pcm_ptr, tmp_s16.data(), sizeof(int16_t) * read_samples);
-                frames_got = got / (sizeof(int16_t) * channels);
+            have_main_stream |= ps.type == 0;
+            // The stamp probes writes to the guest source, independently of the owned submission
+            // used by this mix. Opt-in, one port, bounded. See PROSPER_AUDIO_STAMP above.
+            audio_stamp_step((uint32_t)this_pidx, ps.pcm_ptr, channels, data_type, grain);
+            if (!ps.pcm_pending) {
+                if (flow) {
+                    std::lock_guard<std::mutex> flk(g_flow_mx);
+                    FlowPort& fp = g_flow_port[this_pidx];
+                    flow_tag_port(fp, context_slot, ps.type, ps.data_format);
+                    ++fp.no_grain;
+                }
+                continue;
             }
+            ps.pcm_pending = false;
+            const size_t frames_got = std::min(ps.pcm_frames, grain);
             auto sample_at = [&](size_t frame, uint32_t channel) {
-                const size_t sample = frame * channels + channel;
-                return data_type == 0 ? tmp[sample]
-                                      : (float)tmp_s16[sample] * (1.0f / 32768.0f);
+                return ps.pcm_channels[channel][frame];
             };
             // Per-channel layout measurement, before any routing decision, so the fold-down for a
             // wide bed rests on the guest's measured content rather than on an assumed enumeration.
@@ -2134,21 +2171,17 @@ HLE(audio2_ctx_push) {
                             (data_type == 0 ? sizeof(float) : sizeof(int16_t));
                 if (frames_got < grain) ++fp.short_read;
                 for (size_t k = 0, nf = frames_got * channels; k < nf; ++k) {
-                    const float v = data_type == 0 ? tmp[k] : (float)tmp_s16[k] * (1.0f / 32768.0f);
+                    const float v = sample_at(k / channels, k % channels);
                     flow_add_sample(fp, v);   // NaN counted, then treated as the silence it becomes
                 }
                 if (ps.type != 0) ++fp.skip_not_main; else ++fp.mixed;
             }
-            // AFTER this push's grain has been read and measured, and before the mix (which works
-            // from the host-side copy in `tmp`, so it is unaffected): ask whether the guest writes
-            // the buffer we just read. Opt-in, one port, bounded. See PROSPER_AUDIO_STAMP above.
-            audio_stamp_step((uint32_t)this_pidx, ps.pcm_ptr, channels, data_type, grain);
             if (probe) {
                 static uint64_t call_ct[kA2MaxPorts] = {0};
                 const size_t nf = frames_got * channels;
                 size_t nan_ct = 0; float amax = 0.0f;
                 for (size_t k = 0; k < nf; k++) {
-                    float v = data_type == 0 ? tmp[k] : (float)tmp_s16[k] * (1.0f / 32768.0f);
+                    float v = sample_at(k / channels, k % channels);
                     if (v != v) nan_ct++; else { float a = v < 0 ? -v : v; if (a > amax) amax = a; } }
                 // Object-heavy engines keep hundreds of valid but silent ports. Reporting every
                 // silent buffer once per 64 grains both hides the active route and perturbs its
@@ -2255,7 +2288,10 @@ HLE(audio2_ctx_push) {
     };
 
     AudioSink* sink = audio_sink();
-    if (sink && have_pcm) {
+    if (sink && have_main_stream) {
+        // Keep an established stream continuous when a port misses a submission. The cleared bed
+        // supplies silence for that interval; replaying its last grain produces a 187.5 Hz buzz at
+        // the common 256-frame grain, while skipping output starves the host device queue.
         // Forward the mixed grain to the host device; the sink paces one grain per call in real
         // time (same contract as the v1 sceAudioOutOutput path), so no extra sleep on this path.
         // A FAILED device open must fall through to the silent wall-clock pacing below instead:

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -7769,7 +7769,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         }
                         if (!upload.borrowed_compute && !r.is_storage_image &&
                             !upload.assembled_target_mips && persistent_color_targets_enabled &&
-                            r.persistent_render_target_id && r.img_dim == 1) {
+                            r.persistent_render_target_id &&
+                            prosper::frontend::rtt_single_layer_sample_shape(
+                                r.img_dim, r.td, r.sample_count)) {
                             if (auto* target = find_persistent_color_target(
                                     r.persistent_render_target_id, r.tw, r.th,
                                     backend_color_format(r.texture_format))) {
@@ -8033,13 +8035,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     // correct sRGB fix is a coordinated linear-working-space + output-encode change (see the
                     // #263 discussion), NOT a per-view format flip. r.srgb is decoded now as groundwork.
                     tvci.image = upload.image;
-                    // #325: a guest 2D_ARRAY takes an ARRAY view even at one layer. The view type
-                    // has to agree with what the consuming SPIR-V declared, and the recompiler
-                    // decides that from the T# (`res->img_dim == 5`) -- which it can do without
-                    // knowing how many layers the uploader managed to decode. Keying the view on
-                    // the layer COUNT instead would silently disagree whenever an array resolved to
-                    // a single layer, binding a 2D view under an `Arrayed=1` OpTypeImage. A
-                    // one-layer 2D_ARRAY view is perfectly legal and samples layer 0.
+                    // View type follows the shader-facing representation, not the layer count.
+                    // Retained color samples carry reflected arrayedness (#3415); ordinary texture
+                    // uploads share the recompiler's array predicate (#325). A one-layer ARRAY view
+                    // is legal, but img_dim=5 alone also occurs with non-arrayed base-slice shaders.
                     tvci.viewType = r.img_dim == 2 ? VK_IMAGE_VIEW_TYPE_3D
                         : (r.guest_array || r.sample_count > 1u) ? VK_IMAGE_VIEW_TYPE_2D_ARRAY
                                                                  : VK_IMAGE_VIEW_TYPE_2D;

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -1324,6 +1324,8 @@ inline const RenderVkCtx& render_vk_ctx() {
         // honest outcome is the layer error, not a silently miscompiled shader.
         if (supported.shaderInt64)      feats.shaderInt64 = VK_TRUE;
         if (supported.independentBlend) feats.independentBlend = VK_TRUE;
+        // Dynamic texel offsets on OpImageGather require ImageGatherExtended (#3417).
+        feats.shaderImageGatherExtended = supported.shaderImageGatherExtended;
         VkPhysicalDeviceProperties phys_props{}; vkGetPhysicalDeviceProperties(r.phys, &phys_props);
         r.max_compute_workgroup_size_x = phys_props.limits.maxComputeWorkGroupSize[0];
         r.max_compute_workgroup_invocations = phys_props.limits.maxComputeWorkGroupInvocations;

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -433,18 +433,9 @@ inline bool backend_storage_image_numeric_contract_valid(const FrameResource& re
 // The first exact guest-MSAA contract is intentionally narrow. Ordinary resources retain their
 // historical implicit byte-span behavior; a 2D_MSAA plane array must prove all four complete R32F
 // planes are readable before any Vulkan object or memcpy is attempted.
-// A pragmatic ceiling, NOT a portability guarantee -- an earlier revision of this comment claimed
-// 2048 was "Vulkan's guaranteed minimum for maxImageArrayLayers" and that is wrong. The Core
-// Required Limits table gives **256**; 2048 is the Roadmap 2022 / Vulkan 1.4 figure, and this
-// backend requests VK_API_VERSION_1_1 (see vkCreateInstance below), so the guarantee that actually
-// applies here is 256. This box's RADV reports 8192.
-//
-// So what this bound does is keep an absurd layer count away from vkCreateImage, whose result the
-// upload path discards (#3045) -- an over-large arrayLayers yields VK_NULL_HANDLE and is passed
-// straight to vkGetImageMemoryRequirements. It does NOT prove creatability on an arbitrary device;
-// a device reporting the Core minimum of 256 can still reject a 512-layer image, and it will do so
-// through that same unchecked path until #3045 lands. Querying the real limit is the correct fix
-// and belongs with #3045, since this predicate has no device handle.
+// Vulkan 1.4 guarantees at least 2048 maxImageArrayLayers. Keep this admission ceiling even
+// on devices supporting more layers. It does not prove format/usage-specific creatability or
+// allocation success; checking every upload's VkResult is still owed by #3045.
 inline constexpr uint32_t kBackendMaxArrayLayers = 2048u;
 
 // A guest 2D_ARRAY is the same shape as the MSAA plane array with a different provenance: N
@@ -1102,7 +1093,9 @@ struct RenderVkCtx {
 inline const RenderVkCtx& render_vk_ctx() {
     static RenderVkCtx c = [] {
         RenderVkCtx r;
-        VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO}; app.apiVersion = VK_API_VERSION_1_1;
+        if (!prosper::frontend::require_vulkan_runtime_loader("render")) return r;
+        VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
+        app.apiVersion = prosper::frontend::kVulkanRuntimeVersion;
         VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO}; ici.pApplicationInfo = &app;
         // macOS: MoltenVK is linked directly, so VK_KHR_portability_enumeration is neither needed nor
         // accepted here (see prosper-app main.cpp). Only the device-level portability_subset matters.
@@ -1284,10 +1277,14 @@ inline const RenderVkCtx& render_vk_ctx() {
         const auto selection = prosper::frontend::select_vulkan_device(devs, VK_QUEUE_GRAPHICS_BIT);
         r.phys = selection.device;
         r.qfi = selection.queue_family;
-        if (!r.phys || r.qfi == UINT32_MAX) return r;
+        if (!r.phys || r.qfi == UINT32_MAX) {
+            std::fprintf(stderr, "[render] no Vulkan 1.4 device with a graphics queue and robustBufferAccess\n");
+            return r;
+        }
         std::fprintf(stderr, "[render] Vulkan device: %s (%s)\n",
                      selection.properties.deviceName,
                      prosper::frontend::vulkan_device_type_name(selection.properties.deviceType));
+        prosper::frontend::log_vulkan_runtime_device("render", r.phys, selection.properties);
         // Present unification (#1270): if the graphics family exposes a second queue, dedicate index 1
         // to prosper-app's present so the app's blit/present submits never contend the render queue's
         // external-synchronization. On a single-queue family (RADV STRIX_HALO is queueCount==1) the app
@@ -1356,11 +1353,10 @@ inline const RenderVkCtx& render_vk_ctx() {
         feats.pipelineStatisticsQuery = supported.pipelineStatisticsQuery;
         r.pipeline_stats_enabled = supported.pipelineStatisticsQuery;
         if (supported.occlusionQueryPrecise) { feats.occlusionQueryPrecise = VK_TRUE; r.occlusion_precise = true; }
-        // robustImageAccess (VK_EXT_image_robustness): OpImageRead OOB must return zero (#131). Guarded.
-        // Device extensions accumulate into a vector so the (optional) image-robustness and (macOS)
-        // portability-subset extensions coexist.
+        // OpImageRead OOB must return zero (#131); enable robustImageAccess when supported.
+        // Only features not promoted to core still require extension names below.
         std::vector<const char*> dev_exts;
-        VkPhysicalDeviceImageRobustnessFeaturesEXT irf{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT};
+        VkPhysicalDeviceImageRobustnessFeatures irf{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES};
         VkPhysicalDeviceSubgroupSizeControlFeatures subgroup_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES};
         VkPhysicalDeviceSubgroupSizeControlProperties subgroup_properties{
@@ -1369,101 +1365,103 @@ inline const RenderVkCtx& render_vk_ctx() {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES};
         VkPhysicalDeviceTransformFeedbackFeaturesEXT tf_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT};
-        VkPhysicalDeviceDescriptorIndexingFeaturesEXT di_features{
-            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
+        VkPhysicalDeviceDescriptorIndexingFeatures di_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
         VkPhysicalDeviceShaderAtomicInt64Features atomic_int64_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+        // These features are core in Vulkan 1.2/1.3. Query the feature bits directly;
+        // promoted extensions need not still be advertised by a Vulkan 1.4 device.
+        {
+            VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+            f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+            if (irf.robustImageAccess) {
+                irf.pNext = const_cast<void*>(dci.pNext);
+                dci.pNext = &irf;
+            }
+        }
+
+        // Runtime-selected storage buffers use bounded fixed arrays. Request only the one
+        // descriptor-indexing feature their non-uniform access chains require.
+        {
+            VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+            f2.pNext = &di_features;
+            vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+            const bool have_ssbo_arrays =
+                di_features.shaderStorageBufferArrayNonUniformIndexing;
+            if (have_ssbo_arrays) {
+                // Request exactly the feature in use, not the whole struct as queried. Enabling a feature
+                // the design does not use widens the driver contract for no benefit, and a
+                // later reader cannot tell which ones are load-bearing.
+                VkPhysicalDeviceDescriptorIndexingFeatures want{
+                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
+                want.shaderStorageBufferArrayNonUniformIndexing = VK_TRUE;
+                di_features = want;
+                di_features.pNext = const_cast<void*>(dci.pNext);
+                dci.pNext = &di_features;
+                r.descriptor_indexing = true;
+                // Log the SUCCESS too, not only the shortfall. A diagnostic that fires only on
+                // failure makes the working case silent and therefore indistinguishable from code
+                // that never ran -- which is the ambiguity that has cost this project several false
+                // zeros today alone. This line is the lever check for stage 1: it is the only way
+                // to confirm the capability was actually acquired rather than merely compiled.
+                if (getenv("PROSPER_GFXLOG"))
+                    fprintf(stderr, "[vk] descriptor indexing ENABLED "
+                                    "(nonUniform ssbo)\n");
+            } else if (getenv("PROSPER_GFXLOG")) {
+                // Report the SHORTFALL, not merely "unavailable": which feature is missing decides
+                // whether a fallback is possible at all, and a bare "not supported" would send the
+                // next reader to the extension list when the extension is present.
+                fprintf(stderr,
+                        "[vk] descriptor indexing lacks "
+                        "shaderStorageBufferArrayNonUniformIndexing\n");
+            }
+        }
+
+        {
+            VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+            f2.pNext = &atomic_int64_features;
+            vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+            if (supported.shaderInt64 &&
+                atomic_int64_features.shaderBufferInt64Atomics) {
+                VkPhysicalDeviceShaderAtomicInt64Features want{
+                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+                want.shaderBufferInt64Atomics = VK_TRUE;
+                atomic_int64_features = want;
+                atomic_int64_features.pNext = const_cast<void*>(dci.pNext);
+                dci.pNext = &atomic_int64_features;
+                r.storage_buffer_int64_atomics = true;
+            }
+        }
+
+        {
+            VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+            f2.pNext = &subgroup_features;
+            vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+            if (subgroup_features.subgroupSizeControl) {
+                VkPhysicalDeviceProperties2 p2{
+                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
+                p2.pNext = &subgroup_core_properties;
+                subgroup_core_properties.pNext = &subgroup_properties;
+                vkGetPhysicalDeviceProperties2(r.phys, &p2);
+                subgroup_features.pNext = const_cast<void*>(dci.pNext);
+                dci.pNext = &subgroup_features;
+                r.subgroup_size_control = true;
+                r.compute_full_subgroups = subgroup_features.computeFullSubgroups;
+                r.min_subgroup_size = subgroup_properties.minSubgroupSize;
+                r.max_subgroup_size = subgroup_properties.maxSubgroupSize;
+                r.max_compute_workgroup_subgroups =
+                    subgroup_properties.maxComputeWorkgroupSubgroups;
+                r.required_subgroup_size_stages =
+                    subgroup_properties.requiredSubgroupSizeStages;
+                r.subgroup_stages = subgroup_core_properties.supportedStages;
+                r.subgroup_operations = subgroup_core_properties.supportedOperations;
+            }
+        }
+
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, nullptr);
           std::vector<VkExtensionProperties> de(ne);
           vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, de.data());
           for (uint32_t i = 0; i < ne; i++) {
-              if (!strcmp(de[i].extensionName, "VK_EXT_image_robustness")) {
-                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-                  f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
-                  if (irf.robustImageAccess) {
-                      irf.pNext = const_cast<void*>(dci.pNext);
-                      dci.pNext = &irf;
-                      dev_exts.push_back("VK_EXT_image_robustness");
-                  }
-              }
-              if (!strcmp(de[i].extensionName, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) {
-                  // Runtime-selected storage buffers use bounded fixed arrays. Request only the one
-                  // descriptor-indexing feature their non-uniform access chains require.
-                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-                  f2.pNext = &di_features;
-                  vkGetPhysicalDeviceFeatures2(r.phys, &f2);
-                  const bool have_ssbo_arrays =
-                      di_features.shaderStorageBufferArrayNonUniformIndexing;
-                  if (have_ssbo_arrays) {
-                      // Request exactly the feature in use, not the whole struct as queried. Enabling a feature
-                      // the design does not use widens the driver contract for no benefit, and a
-                      // later reader cannot tell which ones are load-bearing.
-                      VkPhysicalDeviceDescriptorIndexingFeaturesEXT want{
-                          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
-                      want.shaderStorageBufferArrayNonUniformIndexing = VK_TRUE;
-                      di_features = want;
-                      di_features.pNext = const_cast<void*>(dci.pNext);
-                      dci.pNext = &di_features;
-                      dev_exts.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
-                      r.descriptor_indexing = true;
-                      // Log the SUCCESS too, not only the shortfall. A diagnostic that fires only on
-                      // failure makes the working case silent and therefore indistinguishable from code
-                      // that never ran -- which is the ambiguity that has cost this project several false
-                      // zeros today alone. This line is the lever check for stage 1: it is the only way
-                      // to confirm the capability was actually acquired rather than merely compiled.
-                      if (getenv("PROSPER_GFXLOG"))
-                          fprintf(stderr, "[vk] descriptor indexing ENABLED "
-                                          "(nonUniform ssbo)\n");
-                  } else if (getenv("PROSPER_GFXLOG")) {
-                      // Report the SHORTFALL, not merely "unavailable": which feature is missing decides
-                      // whether a fallback is possible at all, and a bare "not supported" would send the
-                      // next reader to the extension list when the extension is present.
-                      fprintf(stderr,
-                              "[vk] VK_EXT_descriptor_indexing lacks "
-                              "shaderStorageBufferArrayNonUniformIndexing\n");
-                  }
-              }
-              if (!strcmp(de[i].extensionName, VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME)) {
-                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-                  f2.pNext = &atomic_int64_features;
-                  vkGetPhysicalDeviceFeatures2(r.phys, &f2);
-                  if (supported.shaderInt64 &&
-                      atomic_int64_features.shaderBufferInt64Atomics) {
-                      VkPhysicalDeviceShaderAtomicInt64Features want{
-                          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
-                      want.shaderBufferInt64Atomics = VK_TRUE;
-                      atomic_int64_features = want;
-                      atomic_int64_features.pNext = const_cast<void*>(dci.pNext);
-                      dci.pNext = &atomic_int64_features;
-                      dev_exts.push_back(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
-                      r.storage_buffer_int64_atomics = true;
-                  }
-              }
-              if (!strcmp(de[i].extensionName, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME)) {
-                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-                  f2.pNext = &subgroup_features;
-                  vkGetPhysicalDeviceFeatures2(r.phys, &f2);
-                  if (subgroup_features.subgroupSizeControl) {
-                      VkPhysicalDeviceProperties2 p2{
-                          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
-                      p2.pNext = &subgroup_core_properties;
-                      subgroup_core_properties.pNext = &subgroup_properties;
-                      vkGetPhysicalDeviceProperties2(r.phys, &p2);
-                      subgroup_features.pNext = const_cast<void*>(dci.pNext);
-                      dci.pNext = &subgroup_features;
-                      dev_exts.push_back(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME);
-                      r.subgroup_size_control = true;
-                      r.compute_full_subgroups = subgroup_features.computeFullSubgroups;
-                      r.min_subgroup_size = subgroup_properties.minSubgroupSize;
-                      r.max_subgroup_size = subgroup_properties.maxSubgroupSize;
-                      r.max_compute_workgroup_subgroups =
-                          subgroup_properties.maxComputeWorkgroupSubgroups;
-                      r.required_subgroup_size_stages =
-                          subgroup_properties.requiredSubgroupSizeStages;
-                      r.subgroup_stages = subgroup_core_properties.supportedStages;
-                      r.subgroup_operations = subgroup_core_properties.supportedOperations;
-                  }
-              }
               // Geometry-probe (PROSPER_GEOM_PROBE): capture the last pre-rasterization stage. Enable
               // only the base transformFeedback feature; separate geometry streams are not needed.
               if (!strcmp(de[i].extensionName, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {

--- a/prosper/tests/gpu/recompiler/test_vertex_output_budget.cpp
+++ b/prosper/tests/gpu/recompiler/test_vertex_output_budget.cpp
@@ -72,6 +72,27 @@ PixelInputMapping sticky_all_slots_param0() {
     return mapping;
 }
 
+size_t stores_to_location(const std::vector<uint32_t>& spirv, uint32_t location) {
+    uint32_t variable = 0;
+    for (size_t word = 5; word < spirv.size();) {
+        const uint32_t count = spirv[word] >> 16;
+        if (!count || word + count > spirv.size()) return SIZE_MAX;
+        if ((spirv[word] & 0xffffu) == kOpDecorate && count == 4 &&
+            spirv[word + 2] == kDecorationLocation && spirv[word + 3] == location)
+            variable = spirv[word + 1];
+        word += count;
+    }
+    size_t stores = 0;
+    for (size_t word = 5; word < spirv.size();) {
+        const uint32_t count = spirv[word] >> 16;
+        if (!count || word + count > spirv.size()) return SIZE_MAX;
+        if ((spirv[word] & 0xffffu) == 62 && count >= 3 && spirv[word + 1] == variable)
+            ++stores;
+        word += count;
+    }
+    return stores;
+}
+
 }  // namespace
 
 int main() {
@@ -160,6 +181,22 @@ int main() {
     bool covered = true;
     for (uint32_t location : frag_in) if (!bounded_out.count(location)) covered = false;
     CHECK(covered, "every fragment input location is still produced by the vertex stage");
+
+    // #3416: remove the synthetic PARAM export while retaining the fullscreen position export.
+    // The paired PS still reads location 0. Its interface must exist without manufacturing a value
+    // that the guest VS never wrote, and without adding the other 31 sticky controls.
+    std::vector<uint32_t> position_only(vs, vs + vs_dwords - 3);
+    position_only.push_back(0xbf810000u);
+    const auto missing_param = recompile_vertex(
+        position_only.data(), position_only.size(), nullptr, &bounded);
+    CHECK(!missing_param.empty(), "position-only VS with a consumed PS input recompiles");
+    const auto missing_out = interface_locations(missing_param, kStorageClassOutput);
+    CHECK(missing_out == frag_in && missing_out.size() == 1,
+          "an unexported but consumed parameter still has the required Vulkan interface");
+    CHECK(stores_to_location(missing_param, 0) == 0,
+          "an absent guest PARAM export does not acquire an invented value");
+    CHECK(stores_to_location(bounded_vs, 0) > 0,
+          "a real guest PARAM export still writes the consumed location");
 
     // --- The mutation arm: the pre-fix behaviour, and it must blow the limit -------------------
     PixelInputMapping unbounded = sticky_all_slots_param0();   // consumed_known stays false

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -590,6 +590,32 @@ int main() {
                   sampled_stats.sampled_hits == 1,
               "GPU-resident target sampling matches CPU readback+upload byte-for-byte");
 
+        // #3415: a depth-one array can borrow the retained 2D subresource. Exercise both shader
+        // interfaces: the recompiler's ordinary base-slice view and a real arrayed view sampling
+        // layer zero. The latter uses a layered BC descriptor solely to generate Arrayed=1;
+        // the backend binds one retained layer, not that descriptor's source storage.
+        for (bool arrayed : {false, true}) {
+            auto array_rt = rt;
+            array_rt.resources[0].img_dim = 5;
+            array_rt.resources[0].depth = arrayed ? 2 : 1;
+            if (arrayed) array_rt.resources[0].format = DataFormat::Bc7;
+            auto array_sample = gpu_sample;
+            array_sample.fs = recompile_fragment(sample_ps.data(), sample_ps.size(), &array_rt);
+            array_sample.R[0].img_dim = 5;
+            array_sample.R[0].guest_array = arrayed;
+            CHECK(!array_sample.fs.empty(), "single-layer target consumer shader recompiles");
+            const auto pixels = prosper::test::render_draws_rgba({array_sample}, W, H);
+            CHECK(pixels == cpu_roundtrip &&
+                      prosper::test::backend_color_target_stats().sampled_hits == 1,
+                  "single-layer retained target matches the CPU reference for either view type");
+            prosper::test::BackendColorTarget feedback_target{target_id, true, true};
+            const auto feedback_pixels = prosper::test::render_draws_rgba(
+                {array_sample}, W, H, nullptr, nullptr, false, &feedback_target);
+            CHECK(feedback_pixels == cpu_roundtrip &&
+                      prosper::test::backend_color_target_stats().sampled_hits == 1,
+                  "single-layer array feedback snapshots the retained source before drawing");
+        }
+
         prosper::test::FrameResource bgra_gpu_resource = gpu_resource;
         bgra_gpu_resource.render_target_guest_format = VK_FORMAT_B8G8R8A8_UNORM;
         bgra_gpu_resource.swizzle[0] = 6u;

--- a/prosper/tests/hle/audio/test_audio.cpp
+++ b/prosper/tests/hle/audio/test_audio.cpp
@@ -811,6 +811,62 @@ int main() {
     }
     CHECK(call("sceAudioOut2PortDestroy", a2_port) == 0);
 
+    // #3411: MAIN and auxiliary ports can submit from the same scratch buffer. The guest
+    // overwrites it between SetAttributes calls, and again before Advance/Push. Each port must
+    // keep its own submission, including on the S16 path; delaying the copy until Push loses it.
+    for (uint32_t format : {0x200u, 0x201u}) {
+        auto main_param = a2_port_param;
+        main_param.data_format = format;
+        auto aux_param = main_param;
+        aux_param.type = 6;
+        uint64_t main_port = 0, aux_port = 0, second_main = 0;
+        CHECK(call("sceAudioOut2PortCreate", a2_context, PTR(&main_param), PTR(&main_port)) == 0);
+        CHECK(call("sceAudioOut2PortCreate", a2_context, PTR(&aux_param), PTR(&aux_port)) == 0);
+        CHECK(call("sceAudioOut2PortCreate", a2_context, PTR(&main_param), PTR(&second_main)) == 0);
+        std::vector<float> scratch_f32(64 * 2, 0.25f);
+        std::vector<int16_t> scratch_s16(64 * 2, 8192);
+        uint64_t scratch = format == 0x200 ? PTR(scratch_f32.data()) : PTR(scratch_s16.data());
+        A2Attribute scratch_attr{0, 0, PTR(&scratch), sizeof(scratch)};
+        CHECK(call("sceAudioOut2PortSetAttributes", main_port, PTR(&scratch_attr), 1) == 0);
+        for (size_t i = 0; i < scratch_f32.size(); ++i) {
+            scratch_f32[i] = i % 2 ? -0.125f : 0.125f;
+            scratch_s16[i] = i % 2 ? -4096 : 4096;
+        }
+        CHECK(call("sceAudioOut2PortSetAttributes", second_main, PTR(&scratch_attr), 1) == 0);
+        std::fill(scratch_f32.begin(), scratch_f32.end(), -0.5f);
+        std::fill(scratch_s16.begin(), scratch_s16.end(), -16384);
+        CHECK(call("sceAudioOut2PortSetAttributes", aux_port, PTR(&scratch_attr), 1) == 0);
+        std::fill(scratch_f32.begin(), scratch_f32.end(), 0.0f);
+        std::fill(scratch_s16.begin(), scratch_s16.end(), 0);
+        CHECK(call("sceAudioOut2ContextAdvance", a2_context) == 0);
+        sink.outs.clear();
+        CHECK(call("sceAudioOut2ContextPush", a2_context, 1) == 0);
+        CHECK(sink.outs.size() == 1);
+        if (!sink.outs.empty()) {
+            const float* stereo = reinterpret_cast<const float*>(sink.outs[0].pcm.data());
+            for (size_t i = 0; i < 64 * 2; ++i) CHECK(stereo[i] == (i % 2 ? 0.125f : 0.375f));
+        }
+        // A late producer must not loop either port's old grain or starve the host stream.
+        sink.outs.clear();
+        CHECK(call("sceAudioOut2ContextAdvance", a2_context) == 0);
+        CHECK(call("sceAudioOut2ContextPush", a2_context, 1) == 0);
+        CHECK(sink.outs.size() == 1);
+        if (!sink.outs.empty())
+            CHECK(audio_count_nonzero_samples(sink.outs[0].pcm.data(),
+                                              sink.outs[0].pcm.size(), false) == 0);
+        // Republishing that same address replaces the saved grain, including explicit silence.
+        CHECK(call("sceAudioOut2PortSetAttributes", main_port, PTR(&scratch_attr), 1) == 0);
+        sink.outs.clear();
+        CHECK(call("sceAudioOut2ContextPush", a2_context, 1) == 0);
+        CHECK(sink.outs.size() == 1);
+        if (!sink.outs.empty())
+            CHECK(audio_count_nonzero_samples(sink.outs[0].pcm.data(),
+                                              sink.outs[0].pcm.size(), false) == 0);
+        CHECK(call("sceAudioOut2PortDestroy", main_port) == 0);
+        CHECK(call("sceAudioOut2PortDestroy", aux_port) == 0);
+        CHECK(call("sceAudioOut2PortDestroy", second_main) == 0);
+    }
+
     // AudioOut2 main-bed flag bit 1 reserves 20 dB of digital headroom for platform mastering.
     // Restore that reference level only for marked ports, then saturate at the host PCM boundary;
     // the flag-zero byte-for-byte assertion above is the control that ordinary/video ports keep

--- a/prosper/tests/shared/live/test_shared_vulkan_device.cpp
+++ b/prosper/tests/shared/live/test_shared_vulkan_device.cpp
@@ -15,7 +15,44 @@ static int fails = 0;
 #define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
                               else         { printf("  [ok]   %s\n", msg); } } while (0)
 
+static uint32_t loader_version = VK_API_VERSION_1_0;
+static VkResult loader_result = VK_SUCCESS;
+static bool loader_has_enumerator = true;
+static VKAPI_ATTR VkResult VKAPI_CALL fake_enumerate_version(uint32_t* version) {
+    *version = loader_version;
+    return loader_result;
+}
+static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL fake_get_instance_proc(
+        VkInstance instance, const char* name) {
+    CHECK(instance == VK_NULL_HANDLE, "loader version lookup uses no instance");
+    CHECK(std::string(name) == "vkEnumerateInstanceVersion", "looks up the version enumerator");
+    return loader_has_enumerator
+        ? reinterpret_cast<PFN_vkVoidFunction>(fake_enumerate_version) : nullptr;
+}
+
 int main() {
+    // A modern physical device cannot rescue an old loader. Exercise the query failure and
+    // missing-entry-point cases without needing an old driver installed on the test machine.
+    using prosper::frontend::require_vulkan_runtime_loader;
+    loader_has_enumerator = false;
+    CHECK(!require_vulkan_runtime_loader("test", fake_get_instance_proc),
+          "Vulkan 1.0 loader without a version enumerator is rejected");
+    loader_has_enumerator = true;
+    for (uint32_t version : {VK_API_VERSION_1_1, VK_API_VERSION_1_2, VK_API_VERSION_1_3}) {
+        loader_version = version;
+        CHECK(!require_vulkan_runtime_loader("test", fake_get_instance_proc),
+              "pre-1.4 loader is rejected before instance creation");
+    }
+    loader_version = VK_API_VERSION_1_4;
+    CHECK(require_vulkan_runtime_loader("test", fake_get_instance_proc), "1.4 loader accepted");
+    loader_version = VK_MAKE_API_VERSION(0, 1, 4, 354);
+    CHECK(require_vulkan_runtime_loader("test", fake_get_instance_proc), "newer patch accepted");
+    loader_result = VK_ERROR_OUT_OF_HOST_MEMORY;
+    CHECK(!require_vulkan_runtime_loader("test", fake_get_instance_proc),
+          "failed enumeration rejects even a returned modern version");
+    CHECK(!prosper::frontend::vulkan_runtime_version_supported(VK_MAKE_API_VERSION(1, 1, 4, 0)),
+          "a different API variant does not satisfy the Vulkan runtime contract");
+
     // Mirrored compute publication invalidates every overlapping cached interpretation, then
     // re-authorizes only the exact renderer image that received the device-local copy.
     {
@@ -127,10 +164,27 @@ int main() {
     const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
     if (!ctx.ok) {
         printf("test_shared_vulkan_device: no Vulkan device available, skipping\n");
-        return 0;                       // CI images without a usable ICD skip rather than fail
+        return fails ? 1 : 0;           // No ICD skips GPU assertions, not the loader controls above.
     }
 
     const prosper::gpu::SharedVulkanContext shared = prosper::gpu::shared_vulkan_context();
+    VkPhysicalDeviceProperties physical_properties{};
+    vkGetPhysicalDeviceProperties(ctx.phys, &physical_properties);
+    CHECK(prosper::frontend::vulkan_runtime_version_supported(physical_properties.apiVersion),
+          "published physical device satisfies the 1.4 runtime floor");
+    VkPhysicalDeviceVulkan12Features core12{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};
+    VkPhysicalDeviceVulkan13Features core13{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
+    VkPhysicalDeviceFeatures2 core_features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+    core_features.pNext = &core12;
+    core12.pNext = &core13;
+    vkGetPhysicalDeviceFeatures2(ctx.phys, &core_features);
+    CHECK(ctx.descriptor_indexing == (core12.shaderStorageBufferArrayNonUniformIndexing == VK_TRUE),
+          "descriptor indexing admission follows the core feature bit");
+    CHECK(ctx.storage_buffer_int64_atomics ==
+              (core_features.features.shaderInt64 && core12.shaderBufferInt64Atomics),
+          "buffer int64 atomic admission follows both required core bits");
+    CHECK(ctx.subgroup_size_control == (core13.subgroupSizeControl == VK_TRUE),
+          "subgroup size admission follows the core feature bit");
     CHECK(shared.valid(), "renderer publishes a valid shared context once initialized");
     CHECK(shared.device == static_cast<void*>(ctx.dev), "published device is the renderer's device");
     CHECK(shared.queue == static_cast<void*>(ctx.queue), "published queue is the renderer's queue");

--- a/prosper/tools/nid_census/nid_census.cpp
+++ b/prosper/tools/nid_census/nid_census.cpp
@@ -144,24 +144,17 @@ std::vector<fs::path> collect_modules(const std::string& input) {
     return out;
 }
 
-// Every report this tool emits is an ASSERTION OF ABSENCE — "these NIDs have no handler". An
-// absence is only as trustworthy as the population it was measured over, so no output may omit
-// that population. `prefix` is "# " for --tsv (comment lines a consumer skips) and "" for the
-// human report.
-//
-// The two divergences worth stating explicitly, because they SILENTLY REMOVE ROWS:
-//   * a module that failed to parse contributes no imports, so its NIDs read as "not imported
-//     by anything" rather than "not measured";
-//   * this scans the tree for modules, while the loader links a FIXED set (boot_program.cpp) —
-//     it takes exactly two entries from sce_module/, auto-discovers only Media/Plugins/, and
-//     never auto-links .sprx. So a NID satisfied here by a sibling export the loader would not
-//     have linked is excluded from the census but WOULD reach the dispatcher at runtime.
+// Report the population before filtering and the registration state of the shown subset.
+// A module that failed to parse contributes no imports, so its absence must also be explicit.
+// `prefix` is "# " for --tsv (comment lines a consumer skips) and "" for the human report.
 void print_scope(const char* prefix, size_t total, size_t modules_read, size_t modules_failed,
-                 size_t unregistered, size_t shown, size_t satisfied_cross_module,
+                 size_t unregistered, size_t shown, size_t shown_unregistered,
+                 size_t satisfied_cross_module,
                  size_t mismatches, const std::string& lib_filter, bool self_check) {
     printf("%sscope: %zu distinct imported NIDs over %zu module(s) read, %zu unreadable\n",
            prefix, total, modules_read, modules_failed);
-    printf("%sscope: %zu unregistered, %zu shown%s%s\n", prefix, unregistered, shown,
+    printf("%sscope: %zu unregistered before filtering, %zu shown (%zu unregistered)%s%s\n",
+           prefix, unregistered, shown, shown_unregistered,
            lib_filter.empty() ? "" : ", --lib filter=", lib_filter.c_str());
     printf("%sscope: %zu binding(s) excluded as satisfied by a sibling module's export\n",
            prefix, satisfied_cross_module);
@@ -180,9 +173,9 @@ void print_scope(const char* prefix, size_t total, size_t modules_read, size_t m
            "listed here may never execute, and a fault is not explained by its presence. For what a "
            "run actually called, use prosper_on_unimpl's first-seen census from a live boot, or "
            "hle_calls (#1980), and bound it to the window the behaviour occurs in.\n", prefix);
-    printf("%sNOTE: module set is a tree scan, not the loader's link set (boot_program.cpp): "
-           "only Media/Plugins is auto-discovered, .sprx is never auto-linked, and sce_module "
-           "contributes exactly two. Cross-module exclusions are computed over THIS set.\n",
+    printf("%sNOTE: dump roots use the loader's link set (boot_program.cpp); explicit module "
+           "inputs inspect that module alone. Cross-module exclusions use the modules "
+           "selected for each input.\n",
            prefix);
 }
 
@@ -273,7 +266,7 @@ int main(int argc, char** argv) {
 
     // Classify against the live registry.
     std::vector<Row*> selected;
-    size_t total = 0, unregistered = 0;
+    size_t total = 0, unregistered = 0, shown_unregistered = 0;
     for (auto& [nid, r] : rows) {
         total++;
         const bool registered = Hle::registered(nid);
@@ -288,6 +281,7 @@ int main(int argc, char** argv) {
             if (!hit) continue;
         }
         selected.push_back(&r);
+        if (!registered) shown_unregistered++;
     }
 
     // Most-imported first: the count of distinct titles is the reachability rank.
@@ -309,20 +303,26 @@ int main(int argc, char** argv) {
                    r->titles.size(), r->modules, libs.c_str(), tl.c_str());
         }
         print_scope("# ", total, modules_read, modules_failed, unregistered, selected.size(),
-                    satisfied_cross_module, names.mismatches, lib_filter, self_check);
+                    shown_unregistered, satisfied_cross_module, names.mismatches,
+                    lib_filter, self_check);
         return 0;
     }
 
-    printf("\n== imports with NO registered handler -> dispatcher returns 0 ==\n");
-    printf("%-13s %-52s %5s  %s\n", "NID", "name", "#ttl", "import library");
+    printf("%s", show_registered
+        ? "\n== imports (registered and unregistered) ==\n"
+        : "\n== imports with NO registered handler -> dispatcher returns 0 ==\n");
+    printf("%-13s %-52s %10s %5s  %s\n",
+           "NID", "name", "registered", "#ttl", "import library");
     for (const Row* r : selected) {
         std::string libs;
         for (const auto& l : r->libs) { if (!libs.empty()) libs += ","; libs += l; }
-        printf("%-13s %-52s %5zu  %s\n", r->nid.c_str(),
-               r->name.empty() ? "?" : r->name.c_str(), r->titles.size(), libs.c_str());
+        printf("%-13s %-52s %10s %5zu  %s\n", r->nid.c_str(),
+               r->name.empty() ? "?" : r->name.c_str(),
+               Hle::registered(r->nid) ? "yes" : "no", r->titles.size(), libs.c_str());
     }
     printf("\n");
     print_scope("", total, modules_read, modules_failed, unregistered, selected.size(),
-                satisfied_cross_module, names.mismatches, lib_filter, self_check);
+                shown_unregistered, satisfied_cross_module, names.mismatches,
+                lib_filter, self_check);
     return 0;
 }

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -389,6 +389,12 @@ int main(int argc, char** argv) {
     { const uint32_t c[] = {0x36020081u,0x2C040081u,0x7E020D01u,0x7E040D02u,0x7E0A02F6u,0x7E0C02F2u,0x10020B01u,
                             0x08020D01u,0x10040B02u,0x08040D02u,0x7E060280u,0x7E0802F2u,0xF80008CFu,0x04030201u,0xBF810000u};
       dump(dir, "vertex_fullscreen", recompile_vertex(c, sizeof(c)/4), "recompile_vertex");
+      PixelInputMapping consumed;
+      consumed.valid_mask = 0xffffffffu;
+      consumed.consumed_known = true;
+      consumed.consumed_mask = 1u;
+      dump(dir, "vertex_unwritten_consumed_param",
+           recompile_vertex(c, sizeof(c)/4, nullptr, &consumed));
       // Geometry-probe capture variant: gl_Position decorated for transform-feedback readback. Must
       // still pass spirv-val (Xfb capability + execution mode + member Offset/XfbBuffer/XfbStride).
       dump(dir, "vertex_xfb_capture", recompile_vertex(c, sizeof(c)/4, nullptr, nullptr, true)); }

--- a/prosper/tools/vkval/README.md
+++ b/prosper/tools/vkval/README.md
@@ -148,13 +148,13 @@ change touching descriptor counts, descriptor-set layouts, or pipeline keys.**
 
 That trigger list is the shape of the one defect this guard has caught **during review, with every
 other check on the PR already green** — which is a narrower claim than "the one defect it has caught",
-and the narrowness is the point. The six entries in `allowlist.txt` (#1710, #1712, #1713, #1714,
-#1715, #1716, #1717, #1726) are also findings this guard surfaced, but they are pre-existing
-conditions catalogued when it was switched on (#1704). #2471 is different in kind: it arrived *inside*
+and the narrowness is the point. The defects catalogued in `allowlist.txt` are also findings this
+guard surfaced; fixed entries are removed as their errors disappear. The remaining entries cover
+#1710, #1715, and #1716. #2471 is different in kind: it arrived *inside*
 a change under active review. That is what justifies running it yourself rather than trusting CI.
 
-**So treat the list as a floor, not a ceiling.** It is derived from a single case, and those six
-allow-listed IDs are evidence nobody has mined for what else belongs on it. Start here; do not read it
+**So treat the list as a floor, not a ceiling.** It is derived from a single case, and the
+allow-listed IDs are evidence to examine for what else belongs on it. Start here; do not read it
 as complete.
 
 The case, and why nothing else could see it:

--- a/prosper/tools/vkval/allowlist.txt
+++ b/prosper/tools/vkval/allowlist.txt
@@ -71,8 +71,10 @@
 VUID-VkComputePipelineCreateInfo-layout-07987 | required | game_compute_exec, game_compute_exec_no_adaptive_storage_result, game_compute_exec_scratch_poison | Compute module declares a PushConstant block while the layout declares no range (#1710)
 VUID-vkCmdDispatch-maintenance4-08602 | environment-dependent | game_compute_exec, game_compute_exec_no_adaptive_storage_result, game_compute_exec_scratch_poison | Same root cause as 07987: the shader reads push constants that vkCmdPushConstants never wrote (#1710). Absent on the CI runner because validation layers 1.3.275 do not implement this check.
 
-# ---- #1712: Int64 capability declared, shaderInt64 never enabled on any device ------------------
-VUID-VkShaderModuleCreateInfo-pCode-08740 | required | rdna2_to_spirv_exec, texture_sample_render | Recompiled 64-bit integer ops force OpCapability Int64, which no device-creation path in the tree requests (#1712)
+# ---- 08740: the old #1712 Int64 reason became stale when shaderInt64 was enabled.
+# The remaining texture_sample_render report was ImageGatherExtended, fixed by #3417.
+# A control disabling only shaderImageGatherExtended restores 08740 while pixel assertions still
+# pass; restoring the feature removes the validation error. Remove the entry, so recurrence fails.
 
 # ---- #1714: FIXED. independentBlend is now requested when the device advertises it, so the
 # per-attachment blend state we build is legal and this id no longer fires. The scan's `required`


### PR DESCRIPTION
Sonic Frontiers discarded MAIN audio because AudioOut2 ports reused guest scratch memory, and single-layer array samples forced retained color targets through CPU readback. AudioOut2 now owns each output/channel grain and consumes it once; compatible single-layer samples stay on the GPU. Two comparable 105-second windowed runs presented 470 and 1,086 frames (2.31×), with correct colors and recognizable audio confirmed during testing. Severe audio delivery gaps remain.

The combined change also corrects nid_census registration reporting, declares vertex outputs consumed by fragment shaders, enables supported extended image gathers, and raises the live runtime to Vulkan 1.4 with loader/device checks and individual core-feature queries. No experimental driver flags are required. The Vulkan version change itself has no measured performance gain; host image copy and further synchronization modernization remain under #3414.

Linux CI now provisions checksum-pinned Khronos 1.4.341 headers and loader because the Ubuntu 24.04 system headers are 1.3. The existing Mesa ICD and validation-layer baseline are retained.

Validation:
- The CI toolchain build recipe completed locally; three focused device/compute tests passed using the resulting loader.
- Six census filtering/registration cases passed.
- The gather validation control restores error 08740 when shaderImageGatherExtended is disabled and removes it when enabled; the obsolete required-error allowlist entry is removed so a recurrence fails CI.
- All 11 focused CTest cases passed, covering audio, retained targets, shader interfaces, SPIR-V validation, shared devices, and live compute.
- A 45-second Sonic run presented 452 frames with an active Vulkan validation messenger and zero warnings/errors.
- The fallback presentation path also ran successfully using Vulkan 1.4.
- The broader focused suite still emits the repository-allowlisted validation IDs 07987/08602 (#1710) and 00715 (#1715).

The WIP conversion-cache branch was reviewed; its mutable-format reinterpretation was not adopted because it changes pixel semantics. NVIDIA and Windows runtime behavior have not been verified locally. Devices exposing less than Vulkan 1.4, including older MoltenVK implementations, no longer satisfy the live runtime contract.

Merge scope: the owner authorized merging after Linux and other non-Windows/non-macOS CI passes, without waiting for Windows or macOS builds.

Fixes #3410
Fixes #3411
Fixes #3415
Fixes #3416
Fixes #3417
Refs #3414
