### PR TITLE
Reuse graphics pipelines and keep RGBA8 integer copies on the GPU

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3063,6 +3063,11 @@ if(TARGET prosper_core)
       target_link_libraries(test_multidraw_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME multidraw_render COMMAND test_multidraw_render)
 
+      add_executable(test_renderer_uint_copy tests/gpu/execute/test_renderer_uint_copy.cpp)
+      target_include_directories(test_renderer_uint_copy PRIVATE tests frontends)
+      target_link_libraries(test_renderer_uint_copy PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
+      add_test(NAME renderer_uint_copy COMMAND test_renderer_uint_copy)
+
       # #3180: a failed color-target vkCreateImage must name its site and the real VkResult. Same
       # block as the other render_runner.h tests -- it needs the `tests` and `frontends` include
       # roots and a real Vulkan device.

--- a/prosper/docs/GRAPHICS_PIPELINES_AND_RTT_2026_09.md
+++ b/prosper/docs/GRAPHICS_PIPELINES_AND_RTT_2026_09.md
@@ -1,0 +1,120 @@
+# Graphics pipeline and RTT investigation (2026-09-07)
+
+Issues: [#3378](https://github.com/mattias800/prosper/issues/3378),
+[#3419](https://github.com/mattias800/prosper/issues/3419),
+[#3407](https://github.com/mattias800/prosper/issues/3407).
+Baseline: `88aba88c1` (#3418), Linux RADV STRIX_HALO, Vulkan 1.4.
+
+## Graphics pipelines
+
+The renderer now supplies a device-lifetime `VkPipelineCache` to graphics pipeline creation.
+This is separate from prosper's bounded map of existing `VkPipeline` handles. The existing
+backend resource lock serializes access; failure to create the driver cache retains uncached
+pipeline creation. No driver blob is loaded from disk. Cross-run persistence remains deferred:
+compute's opt-in persistence has a documented NVIDIA driver crash, and the interactive frontend
+uses `_Exit` rather than normal destruction. This change does not promise cross-run reuse.
+
+Depth test/write/compare, stencil enable and operations, culling/winding, topology and primitive
+restart are recorded dynamically for every draw, including the draw-isolation diagnostic. The
+pipeline key retains attachment formats and topology **class**. A depth-only attachment and a
+depth/stencil attachment remain different contracts. Line and triangle pipelines remain distinct.
+
+The commands are required by [core Vulkan 1.3](https://docs.vulkan.org/refpages/latest/refpages/source/VK_VERSION_1_3.html),
+below the runtime's 1.4 floor; no experimental driver setting or optional dynamic-state extension
+is required. Unrestricted changes between topology classes are deliberately not assumed.
+
+### Joe & Mac: the stutter hypothesis remains unproved
+
+Two native-1080p, windowed immediate-present runs used `PROSPER_FLIP_PACE_FPS=60`, separate saves,
+the recorded level-1 route, a frame-3600 screenshot, and an F8 trigger after 85 seconds. Both
+screenshots show the level-1 opening correctly. Neither run had concurrent compiler/GPU load.
+
+The five-second post-trigger renderer records were:
+
+| Metric | Baseline | Driver cache + dynamic state |
+| --- | ---: | ---: |
+| Renderer callbacks | 308 | 314 |
+| Pipeline references | 26,488 | 27,632 |
+| Pipeline misses | 6 | 4 |
+| Evictions | 0 | 0 |
+| Pipeline entries during capture | 192–198 | 192–196 |
+| Largest pipeline setup step | 2.242 ms | 2.107 ms |
+| Largest renderer callback | 5.702 ms | 5.386 ms |
+
+Pipeline setup includes key lookup as well as creation. These single runs do not establish a
+stutter cure or a material FPS improvement. The very low warm miss rate also means most rendering
+time cannot be removed by either pipeline-cache change. An earlier attempt omitted the `@` in the
+pad-script setting and remained at the title screen; its 53-entry cache is **not gameplay evidence**.
+
+## Sonic: preserve integer values without a CPU RTT round trip
+
+The remaining hot sampled-image preparation in the baseline was the generic copy program's
+4K RGBA8 renderer targets sampled as `Uint8x4`. The CPU path copies their bytes unchanged. An
+80-second diagnostic run performed 2,517 4K sampled preparations, totaling 4.980 seconds in
+`prepare_ms`; this count also includes depth imports whose preparation time is zero.
+
+The #3407 WIP admitted the UNORM/UINT pair but still selected the imported image's UNORM format
+for its view. Its performance counters did not prove correct sampling. The new path instead
+copies a pinned renderer RGBA8 UNORM image into a distinct RGBA8 UINT image before dispatch.
+[Vulkan image copies permit size-compatible color formats](https://docs.vulkan.org/refpages/latest/refpages/source/vkCmdCopyImage.html).
+The UINT view consequently supplies integer channel values, matching the working CPU route.
+
+Eligibility requires the same device, exact dimensions, a single 2D image, reflected unsigned
+sampling, and explicit transfer-source usage. Other formats and incompatible imports retain the
+existing path. The source layout is restored, including when another descriptor borrows that same
+image in GENERAL. Each acquired pin is released, including folded aliases. No host staging buffer
+or lazy CPU snapshot is needed for an eligible copy.
+
+The live Sonic run confirmed `color-bits-copy=1` for both hot RGBA8/UINT inputs. In the
+five-second F8 windows, mean compute setup fell from 1.040 ms over 791 records to 0.432 ms over
+798 records. This is one pair of startup captures, not a matched whole-game benchmark or evidence
+that audio underruns are fixed. Sonic's title screen has longstanding rendering defects and is
+not used as a correctness oracle for this change.
+
+This addresses the measured renderer-owned RGBA8/UINT materialization. It is not a general GPU
+detiler: guest-backed tiling, other numeric conversions, and compute guest writeback still exist.
+The WIP's CPU conversion cache was not reused; its recorded zero hit rate followed from changing
+renderer publications rather than an unwired lookup.
+
+## Reproducing the measurements and guards
+
+The renderer/compute integration test checks every byte value in every channel, repeated updates
+at the same image identity, duplicate UINT descriptors, both orderings of mixed UNORM/UINT
+descriptors, source preservation, balanced pins, and CPU fallback for missing transfer-source
+usage or mismatched extents. Restoring a UNORM destination makes its value assertions fail and
+triggers `VUID-vkCmdDispatch-format-07753`. Separately, removing the driver cache makes the
+graphics-cache guard fail; putting depth compare back into the pipeline key makes the dynamic
+state reuse guard fail. All three mutations were restored before final validation.
+
+The complete build and all 370 configured tests passed. The full Vulkan validation scanner then
+passed all 370 tests again with synchronization validation armed by its deliberate-hazard probe.
+It found only the four existing, test-scoped allowlisted IDs associated with #1710, #1715 and
+#1716 (71 messages); no new validation IDs or synchronization hazards appeared. A prior scan of
+a run using only `PROSPER_VK_VALIDATION=1` lacked the legacy fixtures' required validation
+findings, so it was not accepted as the full validation guard. The scanner invocation below
+enables the layer globally and supplies the verified result.
+
+Build `prosper-app`, `test_pipeline_render`, `test_multidraw_render`, `test_renderer_uint_copy`,
+`test_render_diagnostic_paths`, and `test_game_compute` with the normal Vulkan-enabled build.
+
+```sh
+PROSPER_VK_VALIDATION=1 ctest --test-dir <BUILD> --no-tests=error -V \
+  -R '^(pipeline_render|multidraw_render|renderer_uint_copy|render_diagnostic_paths|game_compute_exec)$'
+
+python3 prosper/tools/vkval/vk_validation_scan.py --build-dir <BUILD> --sync
+
+PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_FLIP_PACE_FPS=60 PROSPER_RENDER_TIMING=1 \
+PROSPER_PAD_SCRIPT=@prosper/scripts/joe-mac/reach-gameplay.pad \
+PROSPER_SAVE0=<FRESH_SAVE> PROSPER_CAPTURE_DIR=<EVIDENCE> \
+PROSPER_CAPTURE_SCREENSHOT_AT_FRAME=3600 PROSPER_CAPTURE_SCREENSHOT=<EVIDENCE>/frame.bmp \
+PROSPER_PERF_CAPTURE_AFTER_MS=85000 \
+timeout -k 8s -s INT 130s <BUILD>/prosper-app \
+  --dump <DUMP_ROOT>/PPSA02801-app0 --fps --present-mode immediate
+```
+
+For the Sonic preparation census, use `PPSA03831-app0`, omit the flip cap, enable
+`PROSPER_COMPUTE_IMAGE_TIMING=1`, and trigger F8 at 55 seconds. The `.prperf` artifact is JSONL;
+sum `backend_pipeline_*` on `renderer` records, and preserve the header/footer to verify revision,
+capture duration and dropped records. The per-image log reports `color-bits-copy=1` for the new
+device copy. A configured screenshot path is not evidence that a screenshot was written: open it.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3301,6 +3301,11 @@ struct BoundImage {
     VkImage depth_bits_image = VK_NULL_HANDLE;
     VkFormat depth_bits_format = VK_FORMAT_UNDEFINED;
     uint32_t depth_bits_saved_layout = 0;
+    // RGBA8 UNORM -> UINT preserves the CPU snapshot's bytes, but must sample an INTEGER
+    // image. Copy into an owned UINT image; no mutable image or mismatched UNORM view is needed.
+    bool color_bits_source = false;
+    VkImage color_bits_image = VK_NULL_HANDLE;
+    uint32_t color_bits_saved_layout = 0;
     VkFormat imported_format = VK_FORMAT_UNDEFINED;
     prosper::gpu::LiveTargetPixelFormat imported_pixel_format =
         prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm;
@@ -5914,7 +5919,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             // A pin is taken per successful import, so it is released per import -- including for a
             // binding that a later alias check folded into an earlier one (#1095).
-            if (images[i].imported || images[i].depth_bits_source)
+            if (images[i].imported || images[i].depth_bits_source || images[i].color_bits_source)
                 release_live_render_target_image(images[i].imported_addr);
             if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
@@ -6665,6 +6670,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                               format_float_sampling && unorm_rtt_value_reuse_enabled);
                     const bool compatible_device =
                         import.device == static_cast<void*>(ctx.device);
+                    const bool color_bits_copy = ordinary_2d_view && !depth_import &&
+                        compatible_device && import.transfer_src &&
+                        import.width == r->width && import.height == r->height &&
+                        import.format == LiveTargetPixelFormat::Rgba8Unorm &&
+                        r->format == DataFormat::Uint8 && r->num_components == 4 &&
+                        image_descriptors[i].image_numeric_class == SpirvImageNumericClass::Uint;
                     const bool direct_extent =
                         prosper::frontend::rtt_direct_import_compatible(
                             bi.storage, r->width, r->height, import.width, import.height,
@@ -6673,7 +6684,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // transfer below copies exact texels and deliberately performs no resampling.
                     const bool depth_bits_extent =
                         import.width == r->width && import.height == r->height;
-                    if (compatible_format && direct_extent && compatible_device &&
+                    if (color_bits_copy) {
+                        bi.color_bits_source = true;
+                        bi.color_bits_image = static_cast<VkImage>(import.image);
+                        bi.color_bits_saved_layout = import.layout;
+                        bi.imported_addr = r->gpu_addr;
+                        bi.imported_width = import.width;
+                        bi.imported_height = import.height;
+                    } else if (compatible_format && direct_extent && compatible_device &&
                         (!depth_bits_import_eligible || !depth_import || depth_bits_extent)) {
                         if (depth_import && depth_bits_import_eligible) {
                             bi.depth_bits_source = true;
@@ -6824,7 +6842,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     break;
                 }
             }
-            if (renderer_owned && !bi.imported && !bi.seed_skip &&
+            if (renderer_owned && !bi.imported && !bi.color_bits_source && !bi.seed_skip &&
                 bi.seed_from_imported == SIZE_MAX) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
@@ -6979,6 +6997,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool same_backing_representation =
                     prior.imported == bi.imported &&
                     prior.depth_bits_source == bi.depth_bits_source &&
+                    prior.color_bits_source == bi.color_bits_source &&
+                    (!bi.color_bits_source || prior.color_bits_image == bi.color_bits_image) &&
                     prior.unorm_rtt_value_reuse == bi.unorm_rtt_value_reuse &&
                     (!bi.imported ||
                      (prior.image == bi.image &&
@@ -7243,7 +7263,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::getenv("PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS") != nullptr;
             static const bool sampled_dcc_fast_clear_disabled =
                 std::getenv("PROSPER_NO_COMPUTE_DCC_FAST_CLEAR") != nullptr;
-            if (!bi.depth_bits_source && compute_sampled_guest_prepare_required(
+            if (!bi.depth_bits_source && !bi.color_bits_source &&
+                compute_sampled_guest_prepare_required(
                     bi.storage, renderer_owned, bi.imported,
                     imported_guest_bypass_disabled)) {
                 // Resolve and validate the guest source before allocating staging. A proven cache
@@ -7639,14 +7660,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // directly. The old path first built a heap upload and then memcpy'd the complete result
             // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
             ScopedMappedMemory upload_mapping(ctx);
-            const size_t upload_size = (bi.imported || bi.depth_bits_source || bi.seed_skip ||
+            const size_t upload_size = (bi.imported || bi.depth_bits_source || bi.color_bits_source ||
+                                        bi.seed_skip ||
                                         bi.seed_from_imported != SIZE_MAX ||
                                         bi.compute_transfer_seed_borrowed)
                 ? size_t{0} : (size_t)sbytes;
             // A retained storage image still needs a fresh destination for its post-dispatch
             // transfer. Only a read-only sampled cache hit can omit staging altogether.
             const auto staging_start = ComputeClock::now();
-            if (!bi.imported &&
+            if (!bi.imported && !bi.color_bits_source &&
                 ((bi.storage && !bi.write_skip) || (!bi.compute_transfer_seed_borrowed &&
                                                     !(bi.persistent && bi.upload_skipped)))) {
                 VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
@@ -7681,6 +7703,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const auto prepare_upload_start = ComputeClock::now();
             if (bi.imported) {
                 // The renderer's sampled image is the source, so direct imports need no transfer.
+                bi.guest_bytes = 0;
+            } else if (bi.color_bits_source) {
+                // The command buffer copies the exact RGBA8 payload into a UINT image. Avoid
+                // both the lazy renderer readback and the CPU per-channel repacking/upload.
                 bi.guest_bytes = 0;
             } else if (bi.depth_bits_source) {
                 // The command buffer below copies the borrowed D32 depth plane through this
@@ -8676,7 +8702,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (image_timing)
                 std::fprintf(stderr,
                              "[compute-image] code=0x%llx hash=0x%016llx "
-                             "binding=%u class=%s imported=%u addr=0x%llx "
+                             "binding=%u class=%s imported=%u color-bits-copy=%u addr=0x%llx "
                              "persistent=%u allocation-reused=%u upload-skipped=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu "
                              "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u "
@@ -8686,6 +8712,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              (unsigned long long)item.code_addr,
                              (unsigned long long)timing_program_hash, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
+                             bi.color_bits_source ? 1u : 0u,
                              (unsigned long long)r->gpu_addr,
                              bi.persistent ? 1u : 0u,
                              bi.forced_seed_allocation_reused ? 1u : 0u,
@@ -9134,6 +9161,57 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                                      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
                                      1, &to_general);
+                continue;
+            }
+            if (bi.color_bits_source) {
+                // vkCmdCopyImage preserves bytes between size-compatible color formats. Unlike
+                // a sampled UNORM view, the destination's RGBA8_UINT view returns 0..255 integers,
+                // exactly as the CPU snapshot path does. No host staging allocation participates.
+                bool source_already_general = false;
+                for (size_t prior = 0; prior < i; ++prior) {
+                    const BoundImage& candidate = images[prior];
+                    if (candidate.imported && candidate.alias_of == SIZE_MAX &&
+                        candidate.image == bi.color_bits_image && imported_barrier_owner(prior))
+                        source_already_general = true;
+                }
+                const VkImageLayout source_saved = source_already_general
+                    ? VK_IMAGE_LAYOUT_GENERAL
+                    : static_cast<VkImageLayout>(bi.color_bits_saved_layout);
+                VkImageMemoryBarrier barriers[2]{};
+                for (auto& barrier : barriers) {
+                    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                    barrier.srcQueueFamilyIndex = barrier.dstQueueFamilyIndex =
+                        VK_QUEUE_FAMILY_IGNORED;
+                    barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                }
+                barriers[0].image = bi.color_bits_image;
+                barriers[0].oldLayout = source_saved;
+                barriers[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                barriers[0].srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+                barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                barriers[1].image = bi.image;
+                barriers[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                barriers[1].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barriers[1].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     2, barriers);
+                VkImageCopy copy{};
+                copy.srcSubresource = copy.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                copy.extent = {r->width, r->height, 1};
+                vkCmdCopyImage(command, bi.color_bits_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               bi.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+                barriers[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                barriers[0].newLayout = source_saved;
+                barriers[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                barriers[0].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+                barriers[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barriers[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                barriers[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barriers[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
+                                     2, barriers);
                 continue;
             }
             if (bi.depth_bits_source) {

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -1518,6 +1518,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             import.device = ctx.dev;
             import.layout = static_cast<uint32_t>(target->layout);
             import.transfer_dst = true;
+            import.transfer_src = true;
             return true;
         },
         [](uint64_t addr) {

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -1107,6 +1107,8 @@ struct LiveTargetImageImport {
     // Explicit image-creation contract: a sampled import is not otherwise guaranteed to carry
     // VK_IMAGE_USAGE_TRANSFER_DST_BIT, which the compute-result mirror requires.
     bool transfer_dst = false;
+    // A typed color copy may borrow only images created with TRANSFER_SRC usage.
+    bool transfer_src = false;
     bool valid() const { return image && device && width && height; }
 };
 struct LiveTargetImageRequest {

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -694,6 +694,26 @@ struct PersistentPipelineKey {
     }
 };
 
+inline VkPrimitiveTopology pipeline_topology_class(VkPrimitiveTopology topology) {
+    // Dynamic topology is core, but unrestricted changes BETWEEN topology classes are not.
+    // Retain the class on every device rather than depending on extended_dynamic_state3.
+    switch (topology) {
+    case VK_PRIMITIVE_TOPOLOGY_LINE_LIST:
+    case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP:
+    case VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY:
+    case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY:
+        return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
+    case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST:
+    case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP:
+    case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN:
+    case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY:
+    case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY:
+        return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    default:
+        return topology; // points, patches, and unknown values stay distinct
+    }
+}
+
 struct PersistentPipelineKeyHash {
     size_t operator()(const PersistentPipelineKey& key) const {
         return static_cast<size_t>(key.hash);
@@ -6328,6 +6348,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         float depth_bias_slope = 0.0f;
         VkStencilOpState stencil_front{};
         VkStencilOpState stencil_back{};
+        VkPrimitiveTopology topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        VkBool32 primitive_restart = VK_FALSE;
+        VkCullModeFlags cull_mode = VK_CULL_MODE_NONE;
+        VkFrontFace front_face = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+        VkBool32 depth_test = VK_FALSE, depth_write = VK_FALSE, stencil_test = VK_FALSE;
+        VkCompareOp depth_compare = VK_COMPARE_OP_NEVER;
         uint32_t n_sets = 1, vcount = 3, icount = 0, instance_count = 1;
         int32_t vertex_offset = 0;
         bool use_desc = false, ok = false, pipeline_cached = false;
@@ -7182,6 +7208,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // strip-restart sentinel index (0xFFFF/0xFFFFFFFF), and it has no effect on list topologies.
         ia.primitiveRestartEnable = VK_TRUE;
 #endif
+        v.topology = ia.topology;
+        v.primitive_restart = ia.primitiveRestartEnable;
         // Default: full-target viewport. When the resolved state carries the guest's PA_CL_VPORT transform,
         // honor it — a guest yscale < 0 arrives as a negative viewport_h (Vulkan core-1.1 flipped viewport),
         // reproducing the hardware's Y orientation (#38; each draw item keeps its own resolved viewport).
@@ -7206,6 +7234,15 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK,
             VK_DYNAMIC_STATE_STENCIL_WRITE_MASK,
             VK_DYNAMIC_STATE_STENCIL_REFERENCE,
+            VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE,
+            VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE,
+            VK_DYNAMIC_STATE_DEPTH_COMPARE_OP,
+            VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE,
+            VK_DYNAMIC_STATE_STENCIL_OP,
+            VK_DYNAMIC_STATE_CULL_MODE,
+            VK_DYNAMIC_STATE_FRONT_FACE,
+            VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY,
+            VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE,
         };
         VkPipelineDynamicStateCreateInfo dynamic_state{VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
         dynamic_state.dynamicStateCount = static_cast<uint32_t>(std::size(dynamic_states));
@@ -7234,6 +7271,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             rs.depthBiasClamp = render_vk_ctx().depth_bias_clamp_enabled ? ps->depth_bias_clamp : 0.0f;
         }
         v.line_width = rs.lineWidth;
+        v.cull_mode = rs.cullMode;
+        v.front_face = rs.frontFace;
         v.depth_bias_constant = rs.depthBiasConstantFactor;
         v.depth_bias_clamp = rs.depthBiasClamp;
         v.depth_bias_slope = rs.depthBiasSlopeFactor;
@@ -7319,7 +7358,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
         if (ps && ps->stencil_enable) {
             // Wire the front/back stencil op-state so masks clip (e.g. the title shimmer tests the
-            // stencil the logo draw wrote). ref/compareMask/writeMask are baked (not dynamic).
+            // stencil the logo draw wrote). All per-face values are recorded dynamically.
             dss.stencilTestEnable = VK_TRUE;
             auto mkop = [&](int fb) {
                 VkStencilOpState s{};
@@ -7371,6 +7410,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
         v.stencil_front = dss.front;
         v.stencil_back = dss.back;
+        v.depth_test = dss.depthTestEnable;
+        v.depth_write = dss.depthWriteEnable;
+        v.depth_compare = dss.depthCompareOp;
+        v.stencil_test = dss.stencilTestEnable;
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         const auto fixed_dss_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) res_fixed_depth_stencil_ms += setup_elapsed_ms(fixed_blend_ready, fixed_dss_ready);
@@ -8483,7 +8526,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         gp.pViewportState = &vpst; gp.pRasterizationState = &rs; gp.pMultisampleState = &ms;
         gp.pColorBlendState = &cb; gp.pDynamicState = &dynamic_state;
         gp.layout = v.layout; gp.renderPass = rp; gp.subpass = 0;
-        if (ps && (ps->depth_test_enable || ps->stencil_enable)) gp.pDepthStencilState = &dss;
+        // Every pipeline in a depth/stencil pass has the same static contract, including draws
+        // which disable both tests. Their enables are recorded with the other dynamic state.
+        if (use_ds) gp.pDepthStencilState = &dss;
         ++pipeline_stats.references;
         bool create_pipeline = true;
         PersistentPipelineKey pipeline_key;
@@ -8503,7 +8548,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 memcpy(&word, &value, sizeof word);
                 append(word);
             };
-            append(12); // dynamic viewport/bias/stencil values; descriptor arity #2471; MRT formats #1390
+            append(13); // core dynamic depth/stencil/cull/topology; retain topology class (#3419)
             append(W); append(H); append(color_count);
             for (uint32_t slot = 0; slot < color_count; ++slot)
                 append(static_cast<uint32_t>(color_formats[slot]));
@@ -8562,8 +8607,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     append(stage_flags);   // count already keyed above, for both branches
                 }
             }
-            append(ia.topology); append(ia.primitiveRestartEnable);
-            append(rs.polygonMode); append(rs.cullMode); append(rs.frontFace);
+            append(pipeline_topology_class(ia.topology));
+            append(rs.polygonMode);
             append(rs.depthBiasEnable);
             append(cb.logicOpEnable); append(cb.logicOp);
             for (uint32_t attachment = 0; attachment < color_count; ++attachment) {
@@ -8574,13 +8619,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             }
             append(gp.pDepthStencilState != nullptr);
             if (gp.pDepthStencilState) {
-                append(dss.depthTestEnable); append(dss.depthWriteEnable); append(dss.depthCompareOp);
-                append(dss.depthBoundsTestEnable); append(dss.stencilTestEnable);
-                auto append_stencil = [&](const VkStencilOpState& stencil) {
-                    append(stencil.failOp); append(stencil.passOp); append(stencil.depthFailOp);
-                    append(stencil.compareOp);
-                };
-                append_stencil(dss.front); append_stencil(dss.back);
+                append(dss.depthBoundsTestEnable);
                 append_float(dss.minDepthBounds); append_float(dss.maxDepthBounds);
             }
             auto found = pipeline_cache.find(pipeline_key);
@@ -9526,7 +9565,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                   return n;
                               }());   // #2333
     // Every dynamic state these pipelines declare, set once per draw. It is a lambda rather than
-    // eleven inline calls because the PROSPER_DRAW_ISO re-render below replays the SAME pipelines
+    // duplicated calls because the PROSPER_DRAW_ISO re-render below replays the SAME pipelines
     // into a second command buffer, and it set NONE of this (#3248): the isolation pass therefore
     // ran under undefined viewport, scissor, line width, depth bias and stencil state while
     // reporting which draw paints a pixel -- a diagnostic answering about a render that is not the
@@ -9556,6 +9595,21 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                  v.stencil_front.reference);
         vkCmdSetStencilReference(command, VK_STENCIL_FACE_BACK_BIT,
                                  v.stencil_back.reference);
+        // These commands and states are required by core Vulkan 1.3, below our 1.4 floor.
+        vkCmdSetDepthTestEnable(command, v.depth_test);
+        vkCmdSetDepthWriteEnable(command, v.depth_write);
+        vkCmdSetDepthCompareOp(command, v.depth_compare);
+        vkCmdSetStencilTestEnable(command, v.stencil_test);
+        vkCmdSetStencilOp(command, VK_STENCIL_FACE_FRONT_BIT, v.stencil_front.failOp,
+                          v.stencil_front.passOp, v.stencil_front.depthFailOp,
+                          v.stencil_front.compareOp);
+        vkCmdSetStencilOp(command, VK_STENCIL_FACE_BACK_BIT, v.stencil_back.failOp,
+                          v.stencil_back.passOp, v.stencil_back.depthFailOp,
+                          v.stencil_back.compareOp);
+        vkCmdSetCullMode(command, v.cull_mode);
+        vkCmdSetFrontFace(command, v.front_face);
+        vkCmdSetPrimitiveTopology(command, v.topology);
+        vkCmdSetPrimitiveRestartEnable(command, v.primitive_restart);
     };
     vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
     for (size_t di = 0; di < dv.size(); di++) {

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -1049,6 +1049,9 @@ struct RenderVkCtx {
     // Non-null only under PROSPER_VK_VALIDATION; without it the layer has no output sink.
     VkDebugUtilsMessengerEXT debug_messenger = VK_NULL_HANDLE;
     VkDevice dev = VK_NULL_HANDLE; VkQueue queue = VK_NULL_HANDLE; uint32_t qfi = UINT32_MAX;
+    // Driver compilation data, distinct from the map retaining prosper's VkPipeline handles.
+    // Retained with this process-lifetime device. All users hold BackendPersistentResourceGuard.
+    VkPipelineCache driver_pipeline_cache = VK_NULL_HANDLE;
     VkDeviceSize storage_buffer_alignment = 1;
     double timestamp_period_ns = 0.0;
     uint32_t timestamp_valid_bits = 0;
@@ -1493,6 +1496,14 @@ inline const RenderVkCtx& render_vk_ctx() {
         dci.enabledExtensionCount = (uint32_t)dev_exts.size();
         dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
         if (vkCreateDevice(r.phys, &dci, nullptr, &r.dev) != VK_SUCCESS || !r.dev) return r;
+        VkPipelineCacheCreateInfo cache_info{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
+        const VkResult cache_result = vkCreatePipelineCache(
+            r.dev, &cache_info, nullptr, &r.driver_pipeline_cache);
+        if (cache_result != VK_SUCCESS) {
+            r.driver_pipeline_cache = VK_NULL_HANDLE;
+            fprintf(stderr, "[render] driver pipeline cache unavailable (%d); compiling uncached\n",
+                    static_cast<int>(cache_result));
+        }
         vkGetDeviceQueue(r.dev, r.qfi, 0, &r.queue);
         // Present unification (#1270): resolve the queue prosper-app will use to present. A dedicated
         // second queue (when the family has >=2) avoids contending the render queue; otherwise the app
@@ -8653,7 +8664,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 fflush(stderr);
             }
             const VkResult pipeline_result = vkCreateGraphicsPipelines(
-                    dev, VK_NULL_HANDLE, 1, &gp, nullptr, &v.pipe);
+                    dev, ctx.driver_pipeline_cache, 1, &gp, nullptr, &v.pipe);
             if (backend_trace) {
                 fprintf(stderr,
                         "[backend-trace] draw=%zu create-pipeline end result=%d pipeline=%p\n",

--- a/prosper/tests/gpu/execute/test_renderer_uint_copy.cpp
+++ b/prosper/tests/gpu/execute/test_renderer_uint_copy.cpp
@@ -1,0 +1,161 @@
+// #3407: a renderer-owned RGBA8 UNORM target sampled as UINT must preserve all byte values.
+// Exercise the live compute backend, including pin release, typed sampling and guest writeback.
+#include "fixtures/render_runner.h"
+#include "fixtures/spirv_triangle.h"
+#include "shared/live/live_compute.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include <memory>
+
+using namespace prosper::gpu;
+static int failures = 0;
+#define CHECK(c, m) do { if (!(c)) { std::fprintf(stderr, "FAIL: %s\n", m); ++failures; } } while (0)
+
+int main() {
+    constexpr uint32_t width = 256;
+    std::vector<uint8_t> stale(width * 4, 0), output(width * 4, 0xee);
+    auto expected = std::make_shared<std::vector<uint8_t>>(width * 4);
+    const uint64_t address = reinterpret_cast<uint64_t>(stale.data());
+    const auto& ctx = prosper::test::render_vk_ctx(); // publish before compute adopts a device
+    if (!ctx.ok) return 1;
+
+    ResolvedPipelineState state{};
+    state.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    state.color_write_mask = 0; // retain the seeded pattern across the harmless draw
+    prosper::test::BackendDraw draw;
+    draw.vs.assign(std::begin(kTriVertSpv), std::end(kTriVertSpv));
+    draw.fs.assign(std::begin(kTriFragSpv), std::end(kTriFragSpv));
+    draw.ps = &state;
+    draw.vcount = 3;
+    prosper::test::BackendColorTarget target{address, false, true};
+
+    unsigned reads = 0, imports = 0, releases = 0;
+    bool transfer_source = true, matching_extent = true;
+    set_live_target_query([&](uint64_t addr) { return addr == address; });
+    set_live_target_reader([&](uint64_t addr, LiveTargetSnapshot& snapshot) {
+        if (addr != address) return false;
+        ++reads;
+        snapshot.width = width; snapshot.height = 1;
+        snapshot.format = LiveTargetPixelFormat::Rgba8Unorm;
+        snapshot.pixels = expected;
+        return true;
+    });
+    set_live_target_image_importer(
+        [&](uint64_t addr, const LiveTargetImageRequest&, LiveTargetImageImport& result) {
+            if (addr != address) return false;
+            prosper::test::BackendPersistentResourceGuard guard;
+            auto* image = prosper::test::find_persistent_color_target(
+                address, width, 1, VK_FORMAT_R8G8B8A8_UNORM);
+            if (!image || !prosper::test::pin_persistent_color_target(
+                    address, width, 1, VK_FORMAT_R8G8B8A8_UNORM)) return false;
+            ++imports;
+            result.width = matching_extent ? width : width / 2;
+            result.height = 1;
+            result.format = LiveTargetPixelFormat::Rgba8Unorm;
+            result.image = image->image; result.device = ctx.dev;
+            result.layout = image->layout;
+            result.transfer_src = transfer_source;
+            return true;
+        },
+        [&](uint64_t addr) {
+            CHECK(addr == address, "release names the pinned renderer target");
+            ++releases;
+            prosper::test::BackendPersistentResourceGuard guard;
+            prosper::test::unpin_persistent_color_target(
+                address, width, 1, VK_FORMAT_R8G8B8A8_UNORM);
+        });
+
+    std::vector<uint32_t> indices(width), dummy(4, 0);
+    for (uint32_t i = 0; i < width; ++i) indices[i] = i;
+    ShaderResourceTable resources;
+    for (uint32_t binding = 0; binding < 4; ++binding) {
+        ShaderResource buffer{};
+        buffer.cls = ResourceClass::ConstantBuffer;
+        buffer.binding = binding;
+        buffer.gpu_addr = reinterpret_cast<uint64_t>(binding ? dummy.data() : indices.data());
+        buffer.size = binding ? 16 : width * sizeof(uint32_t);
+        resources.resources.push_back(buffer);
+    }
+    for (uint32_t binding : {4u, 5u}) {
+        ShaderResource image{};
+        image.cls = binding == 4 ? ResourceClass::Texture : ResourceClass::StorageImage;
+        image.binding = binding; image.sgpr_base = binding == 4 ? 0 : 8;
+        image.img_dim = 1; image.width = width; image.height = image.depth = 1;
+        image.format = DataFormat::Uint8; image.num_components = 4;
+        image.gpu_addr = binding == 4 ? address : reinterpret_cast<uint64_t>(output.data());
+        image.size = width * 4;
+        for (uint32_t c = 0; c < 4; ++c) image.swizzle[c] = 4 + c;
+        resources.resources.push_back(image);
+    }
+    // v4 = input[gid] (x), v5 = 0; image_load RGBA from s[0:7]; image_store to s[8:15].
+    const uint32_t code[] = {
+        0x7e080300u, 0x7e0a0280u, 0xf0000f08u, 0x00000004u, 0xbf8c3f70u,
+        0xf0200f08u, 0x00020004u, 0xbf810000u,
+    };
+    ComputeItem item;
+    item.spirv = recompile_valu(code, std::size(code), 1, 0, &resources);
+    CHECK(!item.spirv.empty(), "UINT image copy kernel recompiles");
+    item.resources = std::make_shared<ShaderResourceTable>(resources);
+    item.launch.threads_x = width;
+    item.launch.local_x = 64; item.launch.groups_x = width / 64;
+    item.launch.local_y = item.launch.local_z = 1;
+    item.launch.groups_y = item.launch.groups_z = 1;
+    item.code_addr = 0x3407;
+
+    for (unsigned round = 0; round < 4; ++round) {
+        for (uint32_t i = 0; i < width * 4; ++i)
+            (*expected)[i] = static_cast<uint8_t>((i / 4) * 37 + (i % 4) * 23 + round * 113 + 11);
+        const auto rendered = prosper::test::render_draws_rgba(
+            {draw}, width, 1, expected->data(), nullptr, false, &target);
+        CHECK(rendered == *expected, "renderer holds the exact nontrivial RGBA8 pattern");
+        // First two rounds replace content at the same identity. The remaining arms require the
+        // old CPU route: neither a missing transfer usage nor a scaled image is an exact copy.
+        transfer_source = round != 2;
+        matching_extent = round != 3;
+        std::fill(output.begin(), output.end(), 0xee);
+        const unsigned reads_before = reads;
+        const unsigned imports_before = imports;
+        CHECK(prosper::frontend::execute_live_compute_items({item}), "live UINT copy executes");
+        CHECK(output == *expected, "all 256 byte values survive UINT sampling and guest writeback");
+        CHECK(imports > imports_before && imports == releases, "every acquired image pin is released");
+        CHECK(round < 2 ? reads == reads_before : reads == reads_before + 1,
+              "eligible copies avoid CPU readback; incompatible imports use the snapshot fallback");
+    }
+    // Two descriptors can pin the same renderer image. Check folded UINT aliases, then each
+    // ordering of a direct UNORM borrow beside the UINT copy. The latter must preserve GENERAL
+    // while the direct borrower owns it, then restore the renderer's original layout on release.
+    transfer_source = matching_extent = true;
+    for (unsigned order = 0; order < 3; ++order) {
+        auto paired = resources;
+        auto second = paired.resources[4];
+        second.binding = 6; second.sgpr_base = 16;
+        if (order == 1) paired.resources[4].format = DataFormat::Unorm8;
+        if (order == 2) second.format = DataFormat::Unorm8;
+        paired.resources.push_back(second);
+        const uint32_t paired_code[] = {
+            0x7e080300u, 0x7e0a0280u,
+            0xf0000f08u, order == 2 ? 0x00040004u : 0x00000004u, 0xbf8c3f70u,
+            0xf0000f08u, order == 2 ? 0x00000004u : 0x00040004u, 0xbf8c3f70u,
+            0xf0200f08u, 0x00020004u, 0xbf810000u,
+        };
+        item.spirv = recompile_valu(paired_code, std::size(paired_code), 1, 0, &paired);
+        CHECK(!item.spirv.empty(), "paired UNORM/UINT copy kernel recompiles");
+        item.resources = std::make_shared<ShaderResourceTable>(paired);
+        const unsigned reads_before = reads, imports_before = imports;
+        std::fill(output.begin(), output.end(), 0xee);
+        CHECK(prosper::frontend::execute_live_compute_items({item}), "paired image imports execute");
+        CHECK(output == *expected, "alias folding and mixed view order preserve UINT values");
+        CHECK(reads == reads_before && imports == imports_before + 2 && imports == releases,
+              "both borrowed descriptors release their pins without a CPU snapshot");
+        std::vector<uint8_t> retained;
+        std::string error;
+        prosper::test::BackendPersistentResourceGuard guard;
+        CHECK(prosper::test::readback_persistent_color_target(
+                  address, width, 1, VK_FORMAT_R8G8B8A8_UNORM, retained, error) && retained == *expected,
+              "the renderer source retains its pixels and usable layout after both imports");
+    }
+    set_live_target_image_importer({}, {});
+    set_live_target_reader({});
+    set_live_target_query({});
+    std::printf("renderer UINT copy: %d failures\n", failures);
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/state/test_multidraw_render.cpp
+++ b/prosper/tests/gpu/state/test_multidraw_render.cpp
@@ -256,6 +256,67 @@ int main() {
               "pipeline-cache disable A/B bypasses every lookup");
     }
 
+    // Core dynamic state changes must reuse ONE pipeline and still change coverage. The priming
+    // draw is culled completely, so only the second draw can colour the center. It also retains
+    // the depth attachment when the second draw disables depth, testing the mixed-enable pass.
+    {
+        ResolvedPipelineState prime = opaque;
+        prime.depth_test_enable = true;
+        prime.depth_compare_op = VK_COMPARE_OP_ALWAYS;
+        // Keep the attachment format D32+S8 in every arm; switching D32 to D32+S8 is a valid
+        // pipeline compatibility difference even when stencil operations themselves are dynamic.
+        prime.stencil_enable = true;
+        prime.stencil_compare_op[0] = prime.stencil_compare_op[1] = VK_COMPARE_OP_ALWAYS;
+        prime.cull_mode = VK_CULL_MODE_FRONT_AND_BACK;
+        prosper::test::BackendDraw d;
+        d.vs = vs; d.fs = red; d.ps = &prime; d.vcount = 3;
+        CHECK(!prosper::test::render_draws_rgba({d}, W, H).empty(),
+              "warm the shared depth/stencil pipeline");
+        for (unsigned axis = 0; axis < 10; ++axis) {
+            ResolvedPipelineState state = prime;
+            state.cull_mode = VK_CULL_MODE_NONE;
+            bool visible = true;
+            switch (axis) {
+            case 0: state.depth_test_enable = false; state.stencil_enable = false; break;
+            case 1: state.depth_write_enable = true; break;
+            case 2: state.depth_compare_op = VK_COMPARE_OP_NEVER; visible = false; break;
+            case 3:
+                state.stencil_enable = true;
+                state.stencil_compare_op[0] = state.stencil_compare_op[1] = VK_COMPARE_OP_NEVER;
+                visible = false;
+                break;
+            case 4:
+                state.stencil_enable = true;
+                for (unsigned face = 0; face < 2; ++face) {
+                    state.stencil_compare_op[face] = VK_COMPARE_OP_ALWAYS;
+                    state.stencil_fail_op[face] = VK_STENCIL_OP_REPLACE;
+                    state.stencil_pass_op[face] = VK_STENCIL_OP_INCREMENT_AND_CLAMP;
+                    state.stencil_depth_fail_op[face] = VK_STENCIL_OP_DECREMENT_AND_CLAMP;
+                }
+                break;
+            case 5: state.cull_mode = VK_CULL_MODE_FRONT_AND_BACK; visible = false; break;
+            case 6: state.front_face = VK_FRONT_FACE_CLOCKWISE; break;
+            case 7: state.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP; break;
+            case 8: state.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN; break;
+            default: break; // restore all defaults after the preceding changes
+            }
+            auto changed = d; changed.ps = &state;
+            const auto pixels = prosper::test::render_draws_rgba({d, changed}, W, H);
+            const auto cache = prosper::test::backend_pipeline_cache_stats();
+            printf("  dynamic-state axis %u\n", axis);
+            CHECK(cache.references == 2 && cache.hits == 2 && cache.misses == 0,
+                  "depth/stencil/cull/topology values reuse the warmed pipeline");
+            CHECK(pixels.size() == static_cast<size_t>(W) * H * 4,
+                  "dynamic state render produced a complete frame");
+            if (const auto* c = center(pixels))
+                CHECK((c[0] > 0xC0) == visible,
+                      "cached pipeline honours the current draw's coverage state");
+        }
+        CHECK(prosper::test::pipeline_topology_class(VK_PRIMITIVE_TOPOLOGY_LINE_STRIP) !=
+                  prosper::test::pipeline_topology_class(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP),
+              "line and triangle classes cannot alias on restricted dynamic-topology devices");
+    }
+
     // Hundreds of Evergate draws repeat identical constant/vertex payloads and descriptor contracts.
     // A synchronous backend call may share those immutable objects after exact comparison, while the
     // disable switch provides a byte-identical one-object-per-reference control.

--- a/prosper/tests/gpu/test_pipeline_render.cpp
+++ b/prosper/tests/gpu/test_pipeline_render.cpp
@@ -9,7 +9,23 @@
 // by resolve_pipeline_state from a real register value — not hand-set — so this exercises the whole path.
 #include "gpu/state/render_state.hpp"
 #include "gpu/pm4/pm4_registers.hpp"
+#include <vulkan/vulkan.h>
+
+// Pixels cannot reveal whether the driver received reusable compilation data. Observe the real
+// API boundary while still executing every pipeline creation on the device.
+static unsigned driver_cache_calls = 0;
+static bool driver_cache_missing = false;
+static VkResult observe_graphics_pipeline_cache(
+    VkDevice device, VkPipelineCache cache, uint32_t count,
+    const VkGraphicsPipelineCreateInfo* info, const VkAllocationCallbacks* allocator,
+    VkPipeline* pipelines) {
+    ++driver_cache_calls;
+    driver_cache_missing |= cache == VK_NULL_HANDLE;
+    return vkCreateGraphicsPipelines(device, cache, count, info, allocator, pipelines);
+}
+#define vkCreateGraphicsPipelines observe_graphics_pipeline_cache
 #include "fixtures/render_runner.h"
+#undef vkCreateGraphicsPipelines
 #include "fixtures/spirv_triangle.h"
 #include <cstdio>
 #include <cstring>
@@ -260,6 +276,8 @@ int main() {
         } else { CHECK(false, "FACE=1 cull render produced a frame"); }
     }
 
+    CHECK(driver_cache_calls > 1 && !driver_cache_missing,
+          "distinct graphics pipelines receive the device's driver compilation cache");
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Graphics pipeline creation discarded driver compilation data and treated several per-draw states as distinct pipelines. Renderer-owned RGBA8 targets sampled as unsigned integers also incurred a CPU readback and upload. This change reuses a device-lifetime graphics `VkPipelineCache`, records core depth/stencil/cull/topology state dynamically, and copies eligible RGBA8 UNORM targets into typed UINT images on the GPU.

The pipeline key retains attachment formats and topology classes. GPU copies require an ordinary 2D unsigned view, matching dimensions, the same device and explicit transfer-source usage; incompatible imports retain their existing fallback. Borrowed source layouts and pin lifetimes are preserved across duplicate and mixed-format descriptors. No experimental driver flags or disk pipeline-cache loading are introduced.

Validation:

- Full Linux Release build and all 370 configured tests passed.
- All 370 tests passed again under core and synchronization validation, with the deliberate-hazard probe confirming synchronization validation was armed. Only existing test-scoped allowlisted findings remain; no new validation findings.
- Regression tests check every byte value in each channel, repeated renderer updates, mixed descriptor ordering, alias pin balance, source preservation and fallback behavior. Deliberately restoring the wrong UNORM destination, dropping the driver cache, or restoring a dynamic field to the pipeline key makes the corresponding guard fail.
- Joe & Mac reached correctly rendered gameplay. Sonic exercised both hot GPU copy inputs. One pair of startup capture windows showed mean compute setup falling from 1.040 ms to 0.432 ms; this is not a whole-game FPS benchmark or a demonstrated audio-underrun fix. The user also confirmed the current Sonic and GTA visuals look good, with low FPS still present.

The investigation and measurement limits are recorded in `prosper/docs/GRAPHICS_PIPELINES_AND_RTT_2026_09.md`. Cross-run cache persistence and general GPU detiling remain outside this change. Based on current `main` at `88aba88c1`.

Refs #3378, #3419, #3407.
