### PR TITLE
Remove unused color-readback waits and detect stale session instructions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3",
+            "args": [
+              "${CLAUDE_PROJECT_DIR}/prosper/tools/session_start.py",
+              "--repo",
+              "${CLAUDE_PROJECT_DIR}",
+              "--hook"
+            ],
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Session startup
+
+Read `CLAUDE.md`, `LOCAL.md` if present, and `CONTRIBUTING.md` before working here.
+Run `python3 prosper/tools/session_start.py` from the checkout root at the start of a session
+and after changing worktrees. This read-only check compares the actual checkout and instruction
+files with current `origin/main`; do not treat an unavailable remote as proof of freshness.
+If it reports a difference, inspect current instructions with `git show origin/main:CLAUDE.md`
+and preserve intentional local changes. Fetch stale refs in your own worktree and rerun the check.
+Do not switch or reset someone else's worktree to silence a warning.
+
+Follow the applicable nested `AGENTS.md` files for the area being changed. The startup check is
+automatic in Claude Code through `.claude/settings.json`; other agents run the command above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,13 @@
 > starting work. It is gitignored and holds per-computer facts (hardware, paths, installed tools)
 > that must not be written into this committed charter.
 
+**At session start and after changing worktrees**, run `python3 prosper/tools/session_start.py`
+from the checkout root. It compares this checkout and its actual instruction files against
+`origin/main`, including a bounded remote-ref freshness check (#2710). A difference may be an
+intentional local edit; inspect it before trusting the session's loaded charter. An unavailable
+remote is unverified, not current. The check never fetches or switches branches. Claude Code runs
+it through the checked-in SessionStart hook; other agents follow root `AGENTS.md`.
+
 ## What this project is
 
 **prosper is a PS5→PC compatibility layer — "Wine/Proton for PS5."** It runs PS5 games natively on

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -382,6 +382,8 @@ if(Python3_Interpreter_FOUND)
   # guards a state this repository produces routinely, since every lane pushes after CI starts.
   add_test(NAME pr_merge_gate
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/ci/test_pr_merge_gate.py")
+  add_test(NAME session_start
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/test_session_start.py")
   # PROSPER_ENV_ON/_VALUE sample getenv once and return it forever. Applied to a name a TEST arms at
   # runtime, the arm becomes invisible -- and the test does not fail, it goes vacuous and keeps
   # printing [ok], which is why #2214 surfaced only as one unrelated-looking Vulkan binding error on

--- a/prosper/docs/SESSION_START.md
+++ b/prosper/docs/SESSION_START.md
@@ -1,0 +1,51 @@
+# Checkout and instruction freshness
+
+Issue [#2710](https://github.com/mattias800/prosper/issues/2710) reproduced with the shared
+checkout on an old feature branch. Its tracked charter was clean but differed from `origin/main`.
+The histories had diverged, so `git pull --ff-only` could not repair it. A clean working tree is
+not evidence that a session loaded current instructions.
+
+Run from the checkout root:
+
+```sh
+python3 prosper/tools/session_start.py
+```
+
+The check reports the branch and HEAD, commits ahead/behind `origin/main`, differences in the
+working `CLAUDE.md`, `AGENTS.md` and `CONTRIBUTING.md`, and local instruction edits. It then checks
+the advertised remote main tip against the tracking ref. A feature branch that includes current
+main and keeps the same instructions is valid; detached HEAD is reported explicitly. Intentional
+instruction changes still produce a difference to inspect. Windows CRLF checkout conversion is
+not an instruction change.
+
+Exit status is 0 for a verified current checkout, 1 for a difference, and 2 when verification
+cannot finish. `--offline` performs the local comparison but returns 2: it cannot establish remote
+freshness. Git operations have bounded timeouts, share a 12-second check deadline and disable
+interactive credential prompts. The
+tool does not fetch, change a branch, alter files, or print instruction contents or remote URLs.
+
+Claude Code invokes the check using the checked-in `.claude/settings.json` SessionStart hook.
+Its `--hook` mode returns exit 0 with JSON `additionalContext` for all verdicts, including errors,
+so failures become visible session context instead of disappearing into hook stderr. This follows
+the [SessionStart output contract](https://code.claude.com/docs/en/hooks#sessionstart-decision-control).
+The exec-form hook passes paths as separate arguments, including paths containing spaces. It
+requires Python 3 and Git on the agent host. Root `AGENTS.md` and `CLAUDE.md` instruct other agents
+to run the same command at startup and after moving to another worktree.
+
+When a tracking ref is stale, fetch in your own worktree and repeat the check. Compare instruction
+changes against `git show origin/main:CLAUDE.md`; do not replace another lane's work just to clear
+a warning. This guard reports the checkout being inspected, not the instructions already retained
+inside an older running conversation. That session must read the current files again.
+
+Refreshing a shared checkout is a separate, explicit maintenance action. Preserve its feature
+branch and untracked files first. If another worktree owns `main`, a detached checkout of current
+`origin/main` refreshes the instructions without moving that peer's branch. Do not force `main`
+into two worktrees or reset the peer's branch. Future startup checks still detect when that shared
+checkout falls behind again.
+
+`test_session_start.py` uses local Git repositories to exercise the actual configured hook argv
+and verify delivered context. Controls cover current and stale instructions, staged edits,
+divergence, stale/missing remote refs, unreachable remotes, offline checks, linked worktrees,
+detached HEAD, feature branches, Windows line endings and paths containing spaces. It is registered
+as the `session_start` CTest case. The contribution-shape gate allows only `.claude/settings.json`,
+keeping private settings and agent worktree contents outside the exception.

--- a/prosper/docs/UNREQUESTED_COLOR_FLUSH_2026_09.md
+++ b/prosper/docs/UNREQUESTED_COLOR_FLUSH_2026_09.md
@@ -1,0 +1,61 @@
+# Unrequested color-readback synchronization (2026-09-07)
+
+Issue [#2283](https://github.com/mattias800/prosper/issues/2283) has two distinct parts. The
+unused color copies were already removed. Their former readback predicate still forced a queue
+submit and fence wait even when the caller explicitly declined all CPU color results.
+
+The flush decision now uses the actual readback request. Standalone calls, explicit batch ends,
+and storage-image writeback still submit and wait. The live caller's existing union of bound MRT
+slots decides whether color pixels are wanted; this change does not infer that from color-0's
+format, color-0's address, a black image, or a draw write mask.
+
+Pending commands retain transient attachments, descriptors, uploads and command pools through
+`BackendSubmissionBatch`. Persistent depth/stencil state is published speculatively so later
+commands in the same batch can LOAD it. Existing failure callbacks revoke validity if that batch
+is discarded or fails. The implementation changes neither that ownership nor the publication
+contract; it allows additional passes to use it.
+
+## Regression guards
+
+`multidraw_render` now records a stencil producer with no color target and no requested color
+pixels. It verifies zero submits/waits, then checks that a persistent stencil consumer produces
+the expected green pixels with both commands behind one fence. Its discard arm first observes
+the speculative cache entry, then verifies layout/depth/stencil validity is revoked and a
+persistent consumer clears it instead of observing a write that never executed.
+
+Restoring the old flush predicate fails the pending-batch and combined-submit assertions.
+Removing the depth/stencil failure callback fails the explicit revocation assertion. Review
+caught an initial discard test whose consumer used a transient attachment; that test could not
+establish cache invalidation and was corrected before final verification.
+
+`texture_sample_render` verifies that no-readback standalone and explicit batch-end calls still
+complete, and that a storage-image atomic writes the expected guest value with color readback
+explicitly disabled. Existing offscreen pixel consumers and sparse-MRT coverage remain enabled.
+
+## Blue Prince measurement
+
+The native Linux/RADV baseline used a fresh save, `PROSPER_IME_AUTOKEY=1`, direct graphics mode,
+immediate presentation, timing and non-deferred pass logs, an F8 capture after 300 seconds, and
+an F9 capture after 310 seconds, outside the performance window. No compiler or other GPU workload
+ran during measurement. This is the opening cutscene, not a Day One gameplay measurement.
+
+The retained baseline executable contains the production source subsequently merged in #3420
+(`241a59342`); its embedded revision still names `e1ed278ce`, from before those working-tree
+changes were committed. The private run manifest records that distinction and the binary hash.
+
+Across 360 seconds, all 27,605 logged no-color-base passes had `raw_fmt=0`, `writes=0` and
+`bytes=0`. Later timing windows averaged 9.72–10.28 readback-driven waits per callback out of
+15.68–16.32 total submits, with no `no_batch` or storage-writeback contribution. The domain is
+present, and the already-removed copies are not the remaining work.
+
+The baseline F8 contains 20 pre-trigger and 21 post-trigger samples, 46 renderer records and 708
+compute records with zero drops. Over the full sampled interval it measured 4.48 guest flips/s,
+4.38 host presents/s and 1.82 process CPU cores. Renderer detail records cover only the five-second
+post-trigger window; their 759 callbacks total 3,886.69 ms, including 218.92 ms GPU waits.
+These scopes must not be mixed into a single frame-time budget.
+
+The captured cutscene also confirms the user's separately reported recent regression: world
+geometry appears in front of the FMV. The user identified recent GTA work as a possible lead;
+that causal link has not been established. It is present before this flush change and is not
+claimed fixed here. Review also noted a pre-existing DRAW_ISO empty-output indexing defect;
+that diagnostic issue is outside the flush change.

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -8748,17 +8748,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     }
 
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    // Persistent MRT0/MRT1 attachments retain their independent readback contracts. In particular,
-    // merely requesting the complete MRT shape must not materialize either GPU-resident image on the
-    // CPU. Slots 2+ are currently transient backend attachments, so a caller requesting them through
-    // BackendMrtOutputs still needs those planes copied before the images are released.
-    // #2283. Split into two questions that used to be one.
-    //
-    // WOULD a readback be requested -- unchanged, and it is what still drives the flush below. The
-    // scope of this change is the COPY only: `readback_requested` also feeds
-    // `synchronous_results_requested` and therefore `flush_now`, which gates persistent attachment
-    // publication. Removing a flush is a real win (each is a queue submit plus a full CPU-GPU fence
-    // wait) and it is a different change with different risk, so it is deliberately NOT taken here.
+    // Each bound color slot has its own readback contract. The caller can decline all CPU
+    // color results, including the transient color attachment used by a depth-only live pass.
     const bool readback_color0_wanted = prosper::frontend::is_color_target_readback_wanted(
         color_target != nullptr,
         color_target ? color_target->persistent_id : 0,
@@ -8785,13 +8776,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
         return false;
     }();
-    const bool readback_requested_for_flush =
-        readback_color0_wanted || readback_color1_wanted || readback_extra_wanted;
-
-    // ...and will one actually be PERFORMED. Blue Prince renders 457 depth-only passes with no
-    // colour base per route; every one reads back a fully black surface that the frontend then
-    // never looks at (`live_renderer.cpp:6082`/`:6118` consume the pixels only under `if (base ...)`,
-    // and there is no else). That is up to 8 MB copied and discarded per pass.
+    // #2283: the copy and its synchronization have the same consumer. When no color result
+    // is wanted, retain commands and resources in the existing submission batch. Persistent
+    // attachment state is published speculatively for later LOAD/sample commands in that batch;
+    // its failure cleanups invalidate the state if submission fails or the batch is discarded.
     const bool readback_color0 = want_color_readback && readback_color0_wanted;
     const bool readback_color1 = want_color_readback && readback_color1_wanted;
     const bool readback_requested = readback_color0 || readback_color1 ||
@@ -8801,10 +8789,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         [](const SharedTextureUpload& upload) {
             return !upload.storage_writebacks.empty();
         });
-    // Deliberately the WOULD-BE value, not the gated one: this change must not alter when the
-    // backend flushes. Verified by the flush-reason counters, which are unchanged in an A/B.
     const bool synchronous_results_requested =
-        readback_requested_for_flush || storage_writeback_requested;
+        readback_requested || storage_writeback_requested;
     const bool flush_now = !submission_batch || synchronous_results_requested ||
                            flush_submission_batch;
     // Attributed in the same order the condition above evaluates, so exactly one bucket is charged
@@ -8813,11 +8799,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     uint64_t flush_reason_storage = 0, flush_reason_explicit = 0;
     if (flush_now) {
         if (!submission_batch) flush_reason_no_batch = 1;
-        // The WOULD-BE value: this bucket answers "why did the backend flush", and the flush is
-        // still caused by a readback being wanted even when #2283 then skips performing it.
-        // Attributing it to `explicit` instead would silently move counts between buckets and make
-        // the flush-reason histogram lie about an unchanged synchronization path.
-        else if (readback_requested_for_flush) flush_reason_readback = 1;
+        else if (readback_requested) flush_reason_readback = 1;
         else if (storage_writeback_requested) flush_reason_storage = 1;
         else flush_reason_explicit = 1;
     }

--- a/prosper/tests/gpu/state/test_multidraw_render.cpp
+++ b/prosper/tests/gpu/state/test_multidraw_render.cpp
@@ -681,28 +681,73 @@ int main() {
               "persistent guest DS identity LOADs stencil written by an earlier renderer call");
 
         // The same dependency must survive when both calls are recorded before one queue submit.
-        // Give the calls GPU-only color targets so the stencil producer does not force an early CPU
-        // readback; the consumer's requested readback flushes both command buffers behind one fence.
+        // The live depth-only producer has no color target and explicitly declines CPU color
+        // pixels (#2283). Its stencil must survive until the consumer flushes both calls together.
         ResolvedPipelineState batched_writer = writer;
         batched_writer.stencil_read_base = batched_writer.stencil_write_base = 0x99410000;
         ResolvedPipelineState batched_reader = reader;
         batched_reader.stencil_read_base = batched_reader.stencil_write_base = 0x99410000;
         prosper::test::BackendDraw bw = w; bw.ps = &batched_writer;
         prosper::test::BackendDraw br = r; br.ps = &batched_reader;
-        prosper::test::BackendColorTarget batch_write_target{
-            0x9941000000000001ull, false, false};
         prosper::test::BackendColorTarget batch_read_target{
             0x9941000000000002ull, false, true};
         prosper::test::BackendSubmissionBatch ds_batch;
         const std::vector<uint8_t> pending = prosper::test::render_draws_rgba(
-            {bw}, W, H, nullptr, nullptr, true, &batch_write_target,
-            nullptr, nullptr, nullptr, &ds_batch, false);
+            {bw}, W, H, nullptr, nullptr, true, nullptr,
+            nullptr, nullptr, nullptr, &ds_batch, false, nullptr, false);
+        const auto writer_timing = prosper::test::backend_render_timing_stats();
+        CHECK(ds_batch.pending() && writer_timing.queue_submits == 0 &&
+                  writer_timing.fence_waits == 0 && writer_timing.flush_readback == 0,
+              "depth-only pass with no color consumer stays in the pending batch");
         const std::vector<uint8_t> batched_loaded = prosper::test::render_draws_rgba(
             {br}, W, H, nullptr, nullptr, true, &batch_read_target,
             nullptr, nullptr, nullptr, &ds_batch, true);
+        const auto reader_timing = prosper::test::backend_render_timing_stats();
+        CHECK(!ds_batch.pending() && reader_timing.command_buffers == 2 &&
+                  reader_timing.queue_submits == 1 && reader_timing.fence_waits == 1 &&
+                  reader_timing.flush_readback == 1,
+              "the actual color consumer flushes the stencil producer and reader together");
         const uint8_t* blc = center(batched_loaded);
         CHECK(pending.empty() && blc && blc[1] > 0xC0 && blc[0] < 0x40,
               "batched renderer calls publish persistent stencil before a later LOAD");
+
+        // A discarded batch never executed the stencil write. Its speculative validity must
+        // be revoked before a later consumer can LOAD it as if it had completed.
+        batched_writer.stencil_read_base = batched_writer.stencil_write_base = 0x99420000;
+        batched_reader.stencil_read_base = batched_reader.stencil_write_base = 0x99420000;
+        prosper::test::BackendSubmissionBatch discarded_ds_batch;
+        (void)prosper::test::render_draws_rgba(
+            {bw}, W, H, nullptr, nullptr, true, nullptr,
+            nullptr, nullptr, nullptr, &discarded_ds_batch, false, nullptr, false);
+        CHECK(discarded_ds_batch.pending(), "discard control contains an unsubmitted stencil write");
+        auto discarded_state = [&] {
+            prosper::test::BackendPersistentResourceGuard guard;
+            const auto& cache = prosper::test::persistent_ds_cache();
+            const auto entry = std::find_if(cache.begin(), cache.end(), [&](const auto& pair) {
+                return pair.first.sr == batched_writer.stencil_read_base &&
+                       pair.first.w == W && pair.first.h == H;
+            });
+            return std::array<bool, 4>{entry != cache.end(),
+                entry != cache.end() && entry->second.layout_initialized,
+                entry != cache.end() && entry->second.depth_valid,
+                entry != cache.end() && entry->second.stencil_valid};
+        };
+        const auto before_discard = discarded_state();
+        CHECK(before_discard[0] && before_discard[1] && before_discard[3],
+              "discard control first observes published speculative stencil state");
+        discarded_ds_batch.discard();
+        discarded_ds_batch.complete();
+        const auto revoked = discarded_state();
+        const bool invalidated = revoked[0] && !revoked[1] && !revoked[2] && !revoked[3];
+        CHECK(invalidated, "discard revokes cached layout, depth and stencil validity");
+        // Do not ask Vulkan to LOAD an uninitialized image if the invalidation guard failed.
+        if (invalidated) {
+            const auto after_discard = prosper::test::render_draws_rgba(
+                {br}, W, H, nullptr, nullptr, true);
+            const auto* discarded_center = center(after_discard);
+            CHECK(discarded_center && discarded_center[1] < 0x80,
+                  "persistent consumer clears discarded stencil instead of observing its write");
+        }
 
         ResolvedPipelineState fresh = reader;
         fresh.stencil_read_base = fresh.stencil_write_base = 0x22220000;

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -745,6 +745,25 @@ int main() {
             {producer}, W, H, nullptr, nullptr, false, &unbound_target,
             nullptr, nullptr, nullptr, &unbound_batch, false);
         const auto unbound_timing = prosper::test::backend_render_timing_stats();
+
+        // Declining color pixels removes only the readback reason. Standalone calls and an
+        // explicitly closed batch must still complete, even with no persistent color target.
+        const auto discarded_pixels = prosper::test::render_draws_rgba(
+            {producer}, W, H, nullptr, nullptr, false, nullptr,
+            nullptr, nullptr, nullptr, nullptr, false, nullptr, false);
+        const auto standalone_timing = prosper::test::backend_render_timing_stats();
+        prosper::test::BackendSubmissionBatch explicit_batch;
+        const auto explicit_pixels = prosper::test::render_draws_rgba(
+            {producer}, W, H, nullptr, nullptr, false, nullptr,
+            nullptr, nullptr, nullptr, &explicit_batch, true, nullptr, false);
+        const auto explicit_timing = prosper::test::backend_render_timing_stats();
+        CHECK(discarded_pixels.empty() && standalone_timing.queue_submits == 1 &&
+                  standalone_timing.fence_waits == 1 && standalone_timing.flush_no_batch == 1,
+              "standalone calls still complete when no CPU color pixels are requested");
+        CHECK(explicit_pixels.empty() && !explicit_batch.pending() &&
+                  explicit_timing.queue_submits == 1 && explicit_timing.fence_waits == 1 &&
+                  explicit_timing.flush_explicit == 1 && explicit_timing.flush_readback == 0,
+              "explicit end-of-batch flush is retained without a color consumer");
 #ifdef _WIN32
         _putenv_s("PROSPER_RENDER_TIMING", "");
 #else
@@ -1495,7 +1514,7 @@ int main() {
             const std::vector<uint8_t> storage_only =
                 prosper::test::render_draws_rgba(
                     {draw}, 1, 1, nullptr, nullptr, false, &storage_target,
-                    nullptr, nullptr, nullptr, &storage_batch, false);
+                    nullptr, nullptr, nullptr, &storage_batch, false, nullptr, false);
             const auto storage_stats = prosper::test::backend_color_target_stats();
             printf("  image_atomic_swap storage-only guest=%08x source=%08x\n",
                    guest_word, upload_word);

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -8,6 +8,11 @@ question-to-tool map. `doctor/` validates external instruments with bounded posi
 provides a small standalone sanitizer build of existing host tests, and verifies RenderDoc
 capture/replay without requiring an importable system Python module.
 
+- **`session_start.py`** — read-only checkout/instruction freshness signal for #2710. See
+  [Session startup](../docs/SESSION_START.md). Its hook mode must deliver failures as visible
+  SessionStart context; an unavailable remote must never be reported as current. The regression
+  executes the configured hook argv against both current and stale temporary repositories.
+
 - **`evidence/prerender_check.py`** - **run this before publishing a progression screenshot.** It
   answers whether the frame is the game's own PRE-RENDERED picture rather than something prosper
   rendered: a full-screen loading blit is the most convincing false evidence this project has

--- a/prosper/tools/ci/check_contribution_shape.py
+++ b/prosper/tools/ci/check_contribution_shape.py
@@ -78,6 +78,10 @@ def top_level(path):
 
 def is_allowed_addition(path):
     """Whether a newly ADDED file may live at `path`."""
+    # #2710: a reviewed project SessionStart hook is shipped metadata. Keep private settings,
+    # agent worktrees and every other .claude path outside this exception.
+    if path == ".claude/settings.json":
+        return True
     head = top_level(path)
     if head in ALLOWED_TOP_LEVEL:
         return True
@@ -144,6 +148,8 @@ def parse_name_status(text):
 def selftest():
     """Both rules, against inputs that must fail and inputs that must not."""
     must_fail = [
+        ("private agent settings", [("A", ".claude/settings.local.json")]),
+        ("agent worktree contents", [("A", ".claude/worktrees/feature/main.cpp")]),
         ("rule 1: header at the repo root (#2507)", [("A", "core/event_bus.hpp")]),
         ("rule 1: plugin dir at the repo root (#2508)", [("A", "plugins/boot_state_machine_plugin.hpp")]),
         ("rule 1: a new top-level directory", [("A", "framework/thing.hpp")]),
@@ -151,6 +157,7 @@ def selftest():
         ("both rules at once", [("A", "core/x.hpp"), ("A", "prosper/src/y.cpp")]),
     ]
     must_pass = [
+        ("project startup hook", [("A", ".claude/settings.json")]),
         ("source plus a test", [("A", "prosper/src/diagnostics/foo.cpp"),
                                 ("A", "prosper/tests/test_foo.cpp")]),
         ("source plus a MODIFIED test", [("A", "prosper/src/foo.cpp"),

--- a/prosper/tools/session_start.py
+++ b/prosper/tools/session_start.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Read-only checkout/instruction freshness signal (#2710).
+
+Exit 0: instructions match current origin/main and the checkout includes it.
+Exit 1: stale/divergent checkout or changed instructions. Exit 2: unable to verify.
+--hook always exits 0 and emits SessionStart context, including failures. It never
+fetches, edits files, changes branches, or treats an unavailable remote as current.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+REFERENCE = "refs/remotes/origin/main"
+INSTRUCTIONS = ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md")
+
+
+class Unverified(Exception):
+    pass
+
+
+def git(repo: Path, *args: str, allow_missing: bool = False, deadline: float) -> bytes:
+    env = dict(os.environ, GIT_TERMINAL_PROMPT="0", GIT_OPTIONAL_LOCKS="0")
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise Unverified("startup check deadline exceeded")
+    try:
+        result = subprocess.run(["git", "-C", str(repo), *args], env=env,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=min(5, remaining))
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise Unverified("Git unavailable or timed out while checking " + args[0]) from exc
+    if result.returncode and not allow_missing:
+        # Do not echo a remote URL, credential-helper output, or local instruction contents.
+        raise Unverified("Git could not verify " + args[0])
+    return result.stdout if result.returncode == 0 else b""
+
+
+def inspect(repo: Path, offline: bool = False) -> tuple[int, str]:
+    lines = []
+    deadline = time.monotonic() + 12  # leave time to emit context before the 20-second hook limit
+    def checked(*args, **kwargs):
+        return git(*args, deadline=deadline, **kwargs)
+    try:
+        root = Path(os.fsdecode(checked(repo, "rev-parse", "--show-toplevel").strip()))
+        head = checked(root, "rev-parse", "HEAD").decode().strip()
+        branch = checked(root, "symbolic-ref", "--quiet", "--short", "HEAD",
+                     allow_missing=True).decode().strip() or "(detached)"
+        lines.append(f"Checkout: branch={branch} HEAD={head[:12]}")
+        reference = checked(root, "rev-parse", "--verify", REFERENCE).decode().strip()
+        ahead, behind = map(int, checked(root, "rev-list", "--left-right", "--count",
+                                    f"HEAD...{REFERENCE}").split())
+        lines.append(f"origin/main={reference[:12]} ahead={ahead} behind={behind}")
+        different = behind != 0
+        if behind:
+            lines.append("WARNING: checkout lacks commits from origin/main; "
+                         "read current instructions before relying on this checkout.")
+        for name in INSTRUCTIONS:
+            # Missing AGENTS.md is legitimate on older references. Missing CLAUDE.md is not.
+            exists = checked(root, "ls-tree", "--name-only", REFERENCE, "--", name).strip()
+            if name == "CLAUDE.md" and not exists:
+                raise Unverified("origin/main has no CLAUDE.md")
+            expected = checked(root, "show", f"{REFERENCE}:{name}") if exists else None
+            path = root / name
+            actual = path.read_bytes() if path.exists() else None
+            # Git checkout may translate LF to CRLF on Windows; this is not a charter change.
+            normalize = lambda data: None if data is None else data.replace(b"\r\n", b"\n")
+            matches = normalize(actual) == normalize(expected)
+            status = checked(root, "status", "--porcelain", "--untracked-files=all", "--", name)
+            dirty = status.startswith(b"??") or bool(
+                checked(root, "diff", "--ignore-space-at-eol", "--name-only", "HEAD", "--", name) or
+                checked(root, "diff", "--cached", "--ignore-space-at-eol", "--name-only", "--", name))
+            if not matches or dirty:
+                different = True
+                lines.append(f"WARNING: {name}: reference={'matches' if matches else 'differs'}; "
+                             f"local edits={'yes' if dirty else 'no'}.")
+        if offline:
+            raise Unverified("remote freshness unchecked (--offline); local comparison only")
+        advertised = checked(root, "ls-remote", "--exit-code", "origin", "refs/heads/main")
+        rows = [row.split() for row in advertised.splitlines()]
+        tips = [row[0].decode() for row in rows
+                if len(row) == 2 and row[1] == b"refs/heads/main"]
+        if len(tips) != 1:
+            raise Unverified("origin did not advertise exactly one main branch")
+        if tips[0] != reference:
+            lines.append("WARNING: origin/main tracking ref is stale; fetch origin main "
+                         "in your own worktree and rerun this check.")
+            return 1, "\n".join(lines)
+        if different:
+            lines.append("Compare intentional instruction edits with git diff origin/main -- "
+                         "CLAUDE.md AGENTS.md CONTRIBUTING.md. Preserve other worktrees.")
+            return 1, "\n".join(lines)
+        lines.append("OK: checkout includes current origin/main; instruction files match.")
+        return 0, "\n".join(lines)
+    except (Unverified, OSError, ValueError) as exc:
+        lines.append("UNVERIFIED: " + str(exc))
+        return 2, "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--offline", action="store_true")
+    parser.add_argument("--hook", action="store_true")
+    args = parser.parse_args()
+    code, report = inspect(args.repo, args.offline)
+    report = "[session-start] " + report
+    if args.hook:
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "SessionStart", "additionalContext": report}}))
+        return 0
+    print(report)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prosper/tools/test_session_start.py
+++ b/prosper/tools/test_session_start.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Exercise startup context against real temporary Git repositories and the shipped hook."""
+import json
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "prosper/tools/session_start.py"
+HOOK = json.loads((ROOT / ".claude/settings.json").read_text())["hooks"]["SessionStart"][0]["hooks"][0]
+SPEC = importlib.util.spec_from_file_location("session_start", TOOL)
+PROBE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROBE)
+
+
+class StartupTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="session start ")
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = Path(self.tmp.name) / "checkout with spaces"
+        self.remote = Path(self.tmp.name) / "origin.git"
+        self.repo.mkdir()
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.name", "Test")
+        self.git("config", "user.email", "test@example.invalid")
+        for name in ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md"):
+            (self.repo / name).write_text("Current instruction\n")
+        dest = self.repo / "prosper/tools/session_start.py"
+        dest.parent.mkdir(parents=True)
+        shutil.copyfile(TOOL, dest)
+        self.commit("initial")
+        self.git("clone", "--bare", "-q", str(self.repo), str(self.remote))
+        self.git("remote", "add", "origin", str(self.remote))
+        self.git("fetch", "-q", "origin")
+
+    def git(self, *args):
+        return subprocess.check_output(["git", "-C", str(self.repo), *args],
+                                       stderr=subprocess.PIPE, text=True).strip()
+
+    def commit(self, message):
+        self.git("add", ".")
+        self.git("commit", "-qm", message)
+
+    def check(self, expected, *args, repo=None):
+        proc = subprocess.run([sys.executable, str(TOOL), "--repo", str(repo or self.repo), *args],
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, expected, proc.stdout + proc.stderr)
+        if expected:
+            self.assertNotIn("OK:", proc.stdout)
+        return proc.stdout
+
+    def hook(self, repo=None):
+        # Execute the actual exec-form hook argv, with the documented project-dir substitution.
+        # No shell is involved: project paths containing spaces stay one argument.
+        project = str(repo or self.repo)
+        argv = [HOOK["command"]] + [x.replace("${CLAUDE_PROJECT_DIR}", project) for x in HOOK["args"]]
+        proc = subprocess.run(argv, input="{}", capture_output=True, text=True,
+                              timeout=HOOK["timeout"])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        output = json.loads(proc.stdout)["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], "SessionStart")
+        return output["additionalContext"]
+
+    def advance_remote(self):
+        old = self.git("rev-parse", "HEAD")
+        (self.repo / "CLAUDE.md").write_text("New instruction\n")
+        self.commit("new charter")
+        self.git("push", "-q", "origin", "main")
+        self.git("reset", "--hard", old)
+        # A push updates tracking refs. Reset that ref to reproduce a session that never fetched.
+        self.git("update-ref", "refs/remotes/origin/main", old)
+
+    def test_current_and_hook_positive_control(self):
+        self.assertIn("OK:", self.check(0))
+        self.assertIn("OK:", self.hook())
+
+    def test_dirty_and_staged_instructions_reach_hook_context(self):
+        (self.repo / "CLAUDE.md").write_text("Local instruction\n")
+        self.assertIn("CLAUDE.md: reference=differs; local edits=yes", self.check(1))
+        self.assertIn("WARNING: CLAUDE.md", self.hook())
+        self.git("add", "CLAUDE.md")
+        self.assertIn("local edits=yes", self.check(1))
+
+    def test_missing_working_charter(self):
+        (self.repo / "CLAUDE.md").unlink()
+        self.assertIn("CLAUDE.md: reference=differs", self.check(1))
+
+    def test_stale_tracking_ref_is_not_current(self):
+        self.advance_remote()
+        self.assertIn("tracking ref is stale", self.check(1))
+        self.assertIn("tracking ref is stale", self.hook())
+
+    def test_fetched_new_charter_and_divergence(self):
+        self.advance_remote()
+        self.git("fetch", "-q", "origin")
+        self.assertIn("ahead=0 behind=1", self.check(1))
+        (self.repo / "feature.txt").write_text("Feature\n")
+        self.commit("feature")
+        self.assertIn("ahead=1 behind=1", self.check(1))
+
+    def test_feature_branch_and_detached_head(self):
+        self.git("switch", "-qc", "feature")
+        (self.repo / "feature.txt").write_text("Feature\n")
+        self.commit("feature")
+        self.assertIn("branch=feature", self.check(0))
+        self.git("checkout", "-q", "--detach", "origin/main")
+        self.assertIn("branch=(detached)", self.check(0))
+
+    def test_linked_worktree_checks_its_own_instructions(self):
+        linked = Path(self.tmp.name) / "linked worktree"
+        self.git("worktree", "add", "-q", "--detach", str(linked), "HEAD")
+        self.check(0, repo=linked)
+        (linked / "CLAUDE.md").write_text("Changed in linked tree\n")
+        self.assertIn("WARNING: CLAUDE.md", self.hook(repo=linked))
+        self.check(0)
+
+    def test_missing_reference_and_offline_are_unverified(self):
+        self.assertIn("UNVERIFIED:", self.check(2, "--offline"))
+        self.git("update-ref", "-d", "refs/remotes/origin/main")
+        self.assertIn("UNVERIFIED:", self.check(2))
+        self.assertIn("UNVERIFIED:", self.hook())
+
+    def test_unreachable_remote_is_unverified(self):
+        self.git("remote", "set-url", "origin", str(Path(self.tmp.name) / "absent.git"))
+        self.assertIn("UNVERIFIED:", self.check(2))
+        self.assertIn("UNVERIFIED:", self.hook())
+
+    def test_line_endings_are_not_instruction_changes(self):
+        self.git("config", "core.autocrlf", "true")
+        for name in ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md"):
+            (self.repo / name).write_bytes(b"Current instruction\r\n")
+        self.check(0)
+
+    def test_git_timeout_and_unavailable_are_unverified(self):
+        for error in (subprocess.TimeoutExpired("git", 5), FileNotFoundError("git")):
+            with self.subTest(error=type(error).__name__), patch.object(
+                    PROBE.subprocess, "run", side_effect=error):
+                status, report = PROBE.inspect(self.repo)
+                self.assertEqual(status, 2)
+                self.assertIn("UNVERIFIED:", report)
+                self.assertNotIn("OK:", report)
+
+    def test_whole_check_deadline_leaves_time_for_hook_output(self):
+        with patch.object(PROBE.time, "monotonic", side_effect=[0, 13]), patch.object(
+                PROBE.subprocess, "run") as run:
+            status, report = PROBE.inspect(self.repo)
+            self.assertEqual(status, 2)
+            self.assertIn("deadline exceeded", report)
+            run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Depth-only live passes already omit unused color copies, but still force a queue submit and fence wait for those omitted results. The shared checkout also remained on an old feature branch, silently supplying stale session instructions.

This PR addresses the two issues in separate commits:

- **#2283:** use actual requested color results in the flush decision. Standalone calls, explicit batch ends and storage-image writeback still synchronize. Existing batch ownership retains resources, and failure callbacks revoke speculative attachment state. The caller still considers every bound MRT slot.
- **#2710:** add a read-only startup check of working instruction files, checkout ancestry and remote-ref freshness. Wire the project SessionStart hook and root agent instructions. Missing/offline/timeout states report unverified; a 12-second deadline allows failures to reach context before the hook timeout. Only `.claude/settings.json` is allowed through the contribution-shape exception.

Validation on this final source tree:

- Full Linux Release build and all 371 configured tests pass under core and synchronization validation; the deliberate-hazard probe confirms synchronization validation is armed. Only the four existing scoped Vulkan findings remain.
- Restoring the old flush behavior fails the pending-batch/combined-submit guards. Removing the DS failure callback fails the direct cache-revocation guard. Persistent stencil consumption, discarded batches, standalone and explicit completion, and storage atomic writeback are covered.
- Twelve startup controls exercise real temporary Git repositories and the actual configured hook argv, including paths with spaces, local/staged changes, divergence, detached/feature/linked worktrees, stale/missing refs, offline/unreachable remotes, unavailable Git, timeouts and line endings. Contribution-shape controls keep private agent files excluded.
- Blue Prince's 360-second native baseline expressed 27,605 no-color-base passes, all with zero color bytes. Later windows averaged 9.72–10.28 readback-driven waits per callback. The comparison on this head reduced comparable late-window submits/waits by roughly 6% (15.68–16.32 to 14.72–15.28 per callback), while host presentation remained approximately 4.38 FPS. Many old readback-labelled flushes also satisfied the explicit-end condition, so the old reason count overstated the removable waits. No material FPS improvement is established. The user's recent geometry-over-FMV regression is present in the baseline and is not claimed fixed here.

Details: `docs/UNREQUESTED_COLOR_FLUSH_2026_09.md` and `docs/SESSION_START.md`. The shared checkout will be explicitly refreshed after merge, preserving its feature branch and private untracked files. Since another worktree owns `main`, it will be detached at current `origin/main`; the peer's branch will not be moved.

Refs #2283, #2710.
