### PR TITLE
Persist graphics pipeline caches across app launches

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3172,6 +3172,24 @@ if(TARGET prosper_core)
       target_link_libraries(test_pipeline_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME pipeline_render COMMAND test_pipeline_render)
 
+      add_executable(test_pipeline_cache_file frontends/shared/tests/test_pipeline_cache_file.cpp)
+      target_include_directories(test_pipeline_cache_file PRIVATE frontends)
+      target_link_libraries(test_pipeline_cache_file PRIVATE Vulkan::Vulkan Threads::Threads)
+      if(Python3_Interpreter_FOUND)
+        add_test(NAME pipeline_cache_file COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/frontends/shared/tests/run_pipeline_cache_file.py
+          $<TARGET_FILE:test_pipeline_cache_file>)
+      endif()
+
+      add_executable(test_graphics_cache_persistence tests/gpu/test_graphics_cache_persistence.cpp)
+      target_include_directories(test_graphics_cache_persistence PRIVATE tests frontends)
+      target_link_libraries(test_graphics_cache_persistence PRIVATE prosper_core Vulkan::Vulkan)
+      if(Python3_Interpreter_FOUND)
+        add_test(NAME graphics_cache_persistence COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/tests/gpu/test_graphics_cache_persistence.py
+          $<TARGET_FILE:test_graphics_cache_persistence>)
+      endif()
+
       # Full back-half spine: a GpuState -> recompile shaders from their PGM addresses -> resolve
       # pipeline state -> rendered frame (the path a real submitted Dcb will drive).
       add_executable(test_gpustate_render tests/gpu/test_gpustate_render.cpp)

--- a/prosper/docs/GRAPHICS_PIPELINE_CACHE.md
+++ b/prosper/docs/GRAPHICS_PIPELINE_CACHE.md
@@ -1,0 +1,45 @@
+# Graphics pipeline cache persistence
+
+The renderer shares one device-lifetime `VkPipelineCache` across graphics pipeline creation.
+Disk persistence is opt-in, as for the compute cache:
+
+- `PROSPER_DISK_PIPELINE_CACHE=1` selects the platform cache directory.
+- `PROSPER_GRAPHICS_PIPELINE_CACHE_PATH=<FILE>` selects an explicit graphics cache file and
+  also opts in. An empty path disables graphics persistence.
+- `PROSPER_NO_DISK_PIPELINE_CACHE=1` overrides both and disables disk access.
+
+Graphics and compute files are separate. Graphics filenames include vendor/device identity,
+driver version and pipeline-cache UUID. The graphics file wraps the original driver data with
+a versioned length/checksum envelope and records driver version and process pointer width.
+Damaged, truncated or incompatible files become cache misses. Only the original driver bytes
+are passed to Vulkan. A driver returning an error for cached creation is retried with empty data;
+failure to create even an empty cache retains uncached graphics pipeline creation.
+
+These checks do **not** establish that a driver can safely load every blob it produced. Repeated
+GTA V runs previously crashed in NVIDIA's cache-load path; the cause remains unresolved. That is
+why loading remains opt-in, including on NVIDIA. No experimental Vulkan feature is required.
+
+`prosper-app` explicitly requests a snapshot before its deliberate `_Exit`. The initialized
+renderer context is published atomically and lives for the process lifetime. The snapshot uses
+the same mutex as graphics pipeline creation; a busy renderer skips the save rather than waiting
+for guest work. Queue draining alone does not serialize pipeline compilation. Disk I/O occurs
+after the snapshot releases the mutex. Guest-triggered abrupt exits may still bypass this path.
+
+Each writer reserves a unique sibling temporary directory, closes the complete file, then
+replaces the destination atomically. A failed replacement preserves the existing destination.
+Concurrent writers produce complete files; the last successful replacement wins. This is a
+rebuildable cache, not a promise of durability after power loss.
+
+The `pipeline_cache_file` test covers identity checks, concurrent writers and failed replacement.
+`graphics_cache_persistence` runs separate processes: render/save/`_Exit`, load/render, disabled
+loading, corrupted/truncated data and driver rejection with an empty-cache retry. It observes
+the actual Vulkan creation argument, so a cached file alone cannot make loading pass. It also
+checks that a held renderer mutex causes a save to skip. Both tests require Python for their
+temporary-directory/process orchestration; the Vulkan test additionally requires a device.
+
+Successful persistence proves cross-launch reuse is available. It does not establish that
+pipeline compilation causes a particular game's stutter or promises an FPS improvement.
+
+References: [#3378](https://github.com/mattias800/prosper/issues/3378),
+[Vulkan cache input](https://docs.vulkan.org/refpages/latest/refpages/source/VkPipelineCacheCreateInfo.html),
+[cache extraction](https://docs.vulkan.org/refpages/latest/refpages/source/vkGetPipelineCacheData.html).

--- a/prosper/docs/GRAPHICS_PIPELINE_CACHE.md
+++ b/prosper/docs/GRAPHICS_PIPELINE_CACHE.md
@@ -21,8 +21,9 @@ why loading remains opt-in, including on NVIDIA. No experimental Vulkan feature 
 
 `prosper-app` explicitly requests a snapshot before its deliberate `_Exit`. The initialized
 renderer context is published atomically and lives for the process lifetime. The snapshot uses
-the same mutex as graphics pipeline creation; a busy renderer skips the save rather than waiting
-for guest work. Queue draining alone does not serialize pipeline compilation. Disk I/O occurs
+a dedicated mutex shared with graphics pipeline creation, independent of the whole-pass resource
+lock. It waits up to one second to acquire that mutex; a compilation still holding it then skips
+the save. Queue draining alone does not serialize pipeline compilation. Disk I/O occurs
 after the snapshot releases the mutex. Guest-triggered abrupt exits may still bypass this path.
 
 Each writer reserves a unique sibling temporary directory, closes the complete file, then
@@ -34,7 +35,8 @@ The `pipeline_cache_file` test covers identity checks, concurrent writers and fa
 `graphics_cache_persistence` runs separate processes: render/save/`_Exit`, load/render, disabled
 loading, corrupted/truncated data and driver rejection with an empty-cache retry. It observes
 the actual Vulkan creation argument, so a cached file alone cannot make loading pass. It also
-checks that a held renderer mutex causes a save to skip. Both tests require Python for their
+checks that a held renderer mutex permits saving while a held compilation mutex prevents it.
+Both tests require Python for their
 temporary-directory/process orchestration; the Vulkan test additionally requires a device.
 
 Successful persistence proves cross-launch reuse is available. It does not establish that

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -3231,6 +3231,7 @@ int main(int argc, char** argv) {
         // _Exit skips RuntimeComputeTimingSelector's destructor. Publish its validity verdict here;
         // the report is idempotent so a future cooperative teardown cannot duplicate it.
         prosper::frontend::report_live_compute_timing_selector_summary();
+        prosper::frontend::flush_live_graphics_pipeline_cache();
 #endif
         // The bounded dmem writer trace also has a destructor/atexit fallback, which _Exit skips.
         prosper::host::guest_dmem_write_trace_report();

--- a/prosper/frontends/shared/device/AGENTS.md
+++ b/prosper/frontends/shared/device/AGENTS.md
@@ -1,0 +1,6 @@
+# Shared Vulkan device policy
+
+Loader/device requirements and selection shared by live frontends and execution tests.
+Pipeline-cache files belong here: they store opaque driver data, not guest shaders or game assets.
+Cache compatibility checks reject damaged or mismatched files; they cannot guarantee a driver
+accepts its own data safely. Keep disk loading opt-in while the recorded NVIDIA failure remains.

--- a/prosper/frontends/shared/device/pipeline_cache_file.hpp
+++ b/prosper/frontends/shared/device/pipeline_cache_file.hpp
@@ -1,0 +1,147 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <span>
+#include <vector>
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace prosper::frontend {
+
+// Store the original driver bytes inside a checked envelope. Only those original bytes may be
+// supplied to VkPipelineCacheCreateInfo; a compatible header alone cannot detect a truncated body.
+struct PipelineCacheFile {
+    static constexpr size_t max_bytes = 256u * 1024u * 1024u;
+    std::filesystem::path path;
+    VkPhysicalDeviceProperties device{};
+
+    static uint64_t checksum(std::span<const uint8_t> bytes) {
+        uint64_t h = 14695981039346656037ull;
+        for (uint8_t b : bytes) { h ^= b; h *= 1099511628211ull; }
+        return h;
+    }
+    static uint64_t read_le(const uint8_t* p, size_t n) {
+        uint64_t v = 0;
+        for (size_t i = 0; i < n; ++i) v |= uint64_t(p[i]) << (8 * i);
+        return v;
+    }
+    static void write_le(uint8_t* p, uint64_t v, size_t n) {
+        for (size_t i = 0; i < n; ++i) p[i] = uint8_t(v >> (8 * i));
+    }
+    bool compatible(std::span<const uint8_t> blob) const {
+        return blob.size() >= 32 && blob.size() <= max_bytes &&
+            read_le(blob.data(), 4) >= 32 && read_le(blob.data(), 4) <= blob.size() &&
+            read_le(blob.data() + 4, 4) == VK_PIPELINE_CACHE_HEADER_VERSION_ONE &&
+            read_le(blob.data() + 8, 4) == device.vendorID &&
+            read_le(blob.data() + 12, 4) == device.deviceID &&
+            std::memcmp(blob.data() + 16, device.pipelineCacheUUID, VK_UUID_SIZE) == 0;
+    }
+    static PipelineCacheFile graphics(const VkPhysicalDeviceProperties& properties) {
+        PipelineCacheFile file;
+        file.device = properties;
+        if (std::getenv("PROSPER_NO_DISK_PIPELINE_CACHE")) return file;
+        // Explicit paths also count as opt-in, matching the existing compute policy. This is
+        // deliberately not default-on: identity checks do not cure the NVIDIA blob-load crash.
+        if (const char* p = std::getenv("PROSPER_GRAPHICS_PIPELINE_CACHE_PATH")) {
+            file.path = p;
+            return file;
+        }
+        if (!std::getenv("PROSPER_DISK_PIPELINE_CACHE")) return file;
+#ifdef _WIN32
+        const char* base = std::getenv("LOCALAPPDATA");
+        if (!base || !*base) return file;
+        std::filesystem::path directory(base);
+#else
+        const char* base = std::getenv("XDG_CACHE_HOME");
+        std::filesystem::path directory;
+        if (base && *base) directory = base;
+        else {
+            base = std::getenv("HOME");
+            if (!base || !*base) return file;
+            directory = std::filesystem::path(base) / ".cache";
+        }
+#endif
+        char name[160];
+        std::snprintf(name, sizeof(name), "graphics-vkcache-v1-%08x-%08x-%08x-",
+                      properties.vendorID, properties.deviceID, properties.driverVersion);
+        std::string identity(name);
+        for (uint8_t b : properties.pipelineCacheUUID) {
+            char hex[3]; std::snprintf(hex, sizeof(hex), "%02x", b); identity += hex;
+        }
+        file.path = directory / "prosper" / identity;
+        return file;
+    }
+    std::vector<uint8_t> load() const {
+        if (path.empty()) return {};
+        std::ifstream in(path, std::ios::binary | std::ios::ate);
+        if (!in) return {};
+        const auto bytes = in.tellg();
+        if (bytes < 64 || bytes > std::streamoff(max_bytes + 32)) return {};
+        in.seekg(0);
+        std::array<uint8_t, 32> header{};
+        in.read(reinterpret_cast<char*>(header.data()), header.size());
+        if (!in || std::memcmp(header.data(), "PRVKC01\0", 8) ||
+            read_le(header.data() + 8, 4) != device.driverVersion ||
+            read_le(header.data() + 12, 4) != sizeof(void*) ||
+            read_le(header.data() + 16, 8) != uint64_t(bytes) - header.size()) return {};
+        std::vector<uint8_t> blob(size_t(bytes) - header.size());
+        in.read(reinterpret_cast<char*>(blob.data()), blob.size());
+        if (!in || !compatible(blob) ||
+            checksum(blob) != read_le(header.data() + 24, 8)) return {};
+        return blob;
+    }
+    bool save(std::span<const uint8_t> blob) const {
+        if (path.empty() || !compatible(blob)) return false;
+        std::error_code ec;
+        auto parent = path.parent_path();
+        if (parent.empty()) parent = ".";
+        std::filesystem::create_directories(parent, ec);
+        if (ec) return false;
+        // Atomically reserve a private sibling directory, including across concurrent processes.
+        // No writer truncates another writer's temporary or deletes the previous good cache.
+        static std::atomic<uint64_t> serial{0};
+        std::filesystem::path temporary;
+        for (unsigned attempt = 0; attempt < 16; ++attempt) {
+            temporary = path;
+            temporary += ".tmp-" + std::to_string(
+                std::chrono::steady_clock::now().time_since_epoch().count()) + "-" +
+                std::to_string(serial.fetch_add(1));
+            if (std::filesystem::create_directory(temporary, ec)) break;
+            if (ec || attempt == 15) return false;
+        }
+        struct Cleanup {
+            std::filesystem::path directory;
+            ~Cleanup() { std::error_code ignored; std::filesystem::remove_all(directory, ignored); }
+        } cleanup{temporary};
+        auto payload = temporary / "cache";
+        std::array<uint8_t, 32> header{};
+        std::memcpy(header.data(), "PRVKC01\0", 8);
+        write_le(header.data() + 8, device.driverVersion, 4);
+        write_le(header.data() + 12, sizeof(void*), 4);
+        write_le(header.data() + 16, blob.size(), 8);
+        write_le(header.data() + 24, checksum(blob), 8);
+        std::ofstream out(payload, std::ios::binary | std::ios::trunc);
+        out.write(reinterpret_cast<const char*>(header.data()), header.size());
+        out.write(reinterpret_cast<const char*>(blob.data()), blob.size());
+        out.close();
+        if (!out) return false;
+#ifdef _WIN32
+        return MoveFileExW(payload.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING) != 0;
+#else
+        std::filesystem::rename(payload, path, ec);
+        return !ec;
+#endif
+    }
+};
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -85,6 +85,10 @@ extern "C" uint64_t prosper_vo_flip_count();
 
 namespace prosper::frontend {
 
+bool flush_live_graphics_pipeline_cache() {
+    return prosper::test::flush_graphics_pipeline_cache();
+}
+
 // Render-to-texture surface cache (#167): CB_COLOR0_BASE -> the RGBA pixels we last rendered into it.
 // The game renders its scene into a color target then samples that address as a texture in a later
 // composite pass. Guest memory at that address is never populated on our (CPU-read) side, so without

--- a/prosper/frontends/shared/live/live_renderer.hpp
+++ b/prosper/frontends/shared/live/live_renderer.hpp
@@ -19,6 +19,10 @@
 
 namespace prosper::frontend {
 
+// Snapshot the initialized graphics driver cache before an _Exit frontend terminates. A busy
+// renderer skips the save; this never destroys resources or waits for guest compilation.
+bool flush_live_graphics_pipeline_cache();
+
 // The decoded-texture identity map lives for one SUBMIT (#1691). A submit is cut into a new graphics
 // span at every interleaved compute/DMA operation, and that split is exactly what could rewrite guest
 // texture bytes mid-submit, so an entry crossing a span boundary must carry proof that nothing wrote

--- a/prosper/frontends/shared/live/live_renderer.hpp
+++ b/prosper/frontends/shared/live/live_renderer.hpp
@@ -19,8 +19,9 @@
 
 namespace prosper::frontend {
 
-// Snapshot the initialized graphics driver cache before an _Exit frontend terminates. A busy
-// renderer skips the save; this never destroys resources or waits for guest compilation.
+// Snapshot the initialized graphics driver cache before an _Exit frontend terminates.
+// Waits up to one second to acquire the compilation lock; cache extraction and disk I/O
+// are not time-bounded. Never initializes a renderer or destroys resources.
 bool flush_live_graphics_pipeline_cache();
 
 // The decoded-texture identity map lives for one SUBMIT (#1691). A submit is cut into a new graphics

--- a/prosper/frontends/shared/tests/run_pipeline_cache_file.py
+++ b/prosper/frontends/shared/tests/run_pipeline_cache_file.py
@@ -1,0 +1,6 @@
+import subprocess
+import sys
+import tempfile
+
+with tempfile.TemporaryDirectory(prefix="pipeline-cache-file-") as directory:
+    subprocess.run([sys.argv[1], directory], check=True, timeout=30)

--- a/prosper/frontends/shared/tests/test_pipeline_cache_file.cpp
+++ b/prosper/frontends/shared/tests/test_pipeline_cache_file.cpp
@@ -1,0 +1,50 @@
+#include "shared/device/pipeline_cache_file.hpp"
+#include <thread>
+#include <cassert>
+
+// Keep assertions active in Release, like the surrounding standalone policy checks.
+#undef assert
+#define assert(condition) do { if (!(condition)) { std::fprintf(stderr, "failed: %s\n", #condition); return 1; } } while (0)
+
+int main(int argc, char** argv) {
+    if (argc != 2) return 2;
+    using prosper::frontend::PipelineCacheFile;
+    PipelineCacheFile file;
+    file.path = std::filesystem::path(argv[1]) / "cache";
+    file.device.vendorID = 123;
+    file.device.deviceID = 456;
+    file.device.driverVersion = 789;
+    file.device.pipelineCacheUUID[0] = 42;
+    std::vector<uint8_t> blob(64, 0);
+    PipelineCacheFile::write_le(blob.data(), 32, 4);
+    PipelineCacheFile::write_le(blob.data() + 4, 1, 4);
+    PipelineCacheFile::write_le(blob.data() + 8, 123, 4);
+    PipelineCacheFile::write_le(blob.data() + 12, 456, 4);
+    blob[16] = 42;
+    assert(file.save(blob));
+    assert(file.load() == blob);
+    auto other = file;
+    other.device.driverVersion++;
+    assert(other.load().empty());
+    other = file; other.device.deviceID++;
+    assert(other.load().empty());
+    other = file; other.device.pipelineCacheUUID[0]++;
+    assert(other.load().empty());
+    auto second = blob; second.back() = 17;
+    bool a = false, b = false;
+    std::thread first([&] { a = file.save(blob); });
+    std::thread last([&] { b = file.save(second); });
+    first.join(); last.join();
+    assert(a && b);
+    auto loaded = file.load();
+    assert(loaded == blob || loaded == second);
+    // A failed replacement must leave the destination intact, including non-file destinations.
+    auto obstructed = file; obstructed.path += ".directory";
+    std::filesystem::create_directories(obstructed.path);
+    std::ofstream(obstructed.path / "marker") << "keep";
+    assert(!obstructed.save(blob));
+    assert(std::filesystem::exists(obstructed.path / "marker"));
+    for (const auto& entry : std::filesystem::directory_iterator(file.path.parent_path()))
+        assert(entry.path().filename().string().find(".tmp-") == std::string::npos);
+    return 0;
+}

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -776,6 +776,13 @@ inline std::mutex& backend_persistent_resource_mutex() {
     return mutex;
 }
 
+// Separate from the whole-pass resource domain: saving must not wait on guest rendering or
+// fence waits. Lock order is resource domain -> driver cache; snapshots take only this lock.
+inline std::timed_mutex& graphics_driver_cache_mutex() {
+    static std::timed_mutex mutex;
+    return mutex;
+}
+
 inline std::atomic<int>& backend_persistent_resource_in_flight() {
     static std::atomic<int> in_flight{0};
     return in_flight;
@@ -1071,7 +1078,7 @@ struct RenderVkCtx {
     VkDebugUtilsMessengerEXT debug_messenger = VK_NULL_HANDLE;
     VkDevice dev = VK_NULL_HANDLE; VkQueue queue = VK_NULL_HANDLE; uint32_t qfi = UINT32_MAX;
     // Driver compilation data, distinct from the map retaining prosper's VkPipeline handles.
-    // Retained with this process-lifetime device. All users hold BackendPersistentResourceGuard.
+    // Retained with this process-lifetime device. Access uses graphics_driver_cache_mutex().
     VkPipelineCache driver_pipeline_cache = VK_NULL_HANDLE;
     prosper::frontend::PipelineCacheFile driver_cache_file;
     size_t driver_cache_loaded_bytes = 0;
@@ -1669,16 +1676,18 @@ inline const RenderVkCtx& render_vk_ctx() {
 
 // Explicit snapshot for frontends that use _Exit. Do not initialize a renderer during shutdown
 // or wait for a guest holding its resource lock. The queue drain does not serialize compilation.
-inline bool flush_graphics_pipeline_cache() {
+// Bound lock acquisition if a driver compilation is still in flight during shutdown.
+inline bool flush_graphics_pipeline_cache(
+        std::chrono::milliseconds lock_budget = std::chrono::milliseconds(1000)) {
     const RenderVkCtx* context = published_render_cache_context().load(std::memory_order_acquire);
     if (!context || context->driver_cache_file.path.empty() || !context->driver_pipeline_cache)
         return false;
     try {
         std::vector<uint8_t> blob;
         {
-            std::unique_lock<std::mutex> lock(backend_persistent_resource_mutex(), std::try_to_lock);
-            if (!lock.owns_lock()) {
-                fprintf(stderr, "[render] disk pipeline cache save skipped: renderer busy\n");
+            std::unique_lock<std::timed_mutex> lock(graphics_driver_cache_mutex(), std::defer_lock);
+            if (!lock.try_lock_for(lock_budget)) {
+                fprintf(stderr, "[render] disk pipeline cache save skipped: compilation busy\n");
                 return false;
             }
             size_t bytes = 0;
@@ -8765,8 +8774,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 fprintf(stderr, "[backend-trace] draw=%zu create-pipeline begin\n", di);
                 fflush(stderr);
             }
-            const VkResult pipeline_result = vkCreateGraphicsPipelines(
+            VkResult pipeline_result;
+            {
+                std::lock_guard<std::timed_mutex> cache_lock(graphics_driver_cache_mutex());
+                pipeline_result = vkCreateGraphicsPipelines(
                     dev, ctx.driver_pipeline_cache, 1, &gp, nullptr, &v.pipe);
+            }
             if (backend_trace) {
                 fprintf(stderr,
                         "[backend-trace] draw=%zu create-pipeline end result=%d pipeline=%p\n",

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -19,6 +19,7 @@
 #include "host/platform/gpu_submit_gate.hpp"   // refuse submits once the frontend shuts down (#3225)
 #include "shared/rtt/rtt_scale.hpp"
 #include "shared/device/vulkan_device_select.hpp"
+#include "shared/device/pipeline_cache_file.hpp"
 #include "shared/perf/performance_timing_gate.hpp"
 #include "shared/perf/performance_timing_policy.hpp"
 #include "shared/present/readback_policy.hpp"
@@ -1072,6 +1073,8 @@ struct RenderVkCtx {
     // Driver compilation data, distinct from the map retaining prosper's VkPipeline handles.
     // Retained with this process-lifetime device. All users hold BackendPersistentResourceGuard.
     VkPipelineCache driver_pipeline_cache = VK_NULL_HANDLE;
+    prosper::frontend::PipelineCacheFile driver_cache_file;
+    size_t driver_cache_loaded_bytes = 0;
     VkDeviceSize storage_buffer_alignment = 1;
     double timestamp_period_ns = 0.0;
     uint32_t timestamp_valid_bits = 0;
@@ -1113,6 +1116,10 @@ struct RenderVkCtx {
     VkQueue present_queue = VK_NULL_HANDLE; // dedicated 2nd queue when the family has >=2, else == queue
     bool present_queue_shared = false;      // present_queue aliases the render queue -> submits need a mutex
 };
+inline std::atomic<const RenderVkCtx*>& published_render_cache_context() {
+    static std::atomic<const RenderVkCtx*> context{nullptr};
+    return context;
+}
 inline const RenderVkCtx& render_vk_ctx() {
     static RenderVkCtx c = [] {
         RenderVkCtx r;
@@ -1517,8 +1524,30 @@ inline const RenderVkCtx& render_vk_ctx() {
         dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
         if (vkCreateDevice(r.phys, &dci, nullptr, &r.dev) != VK_SUCCESS || !r.dev) return r;
         VkPipelineCacheCreateInfo cache_info{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
-        const VkResult cache_result = vkCreatePipelineCache(
+        std::vector<uint8_t> initial_cache;
+        try {
+            VkPhysicalDeviceProperties properties{};
+            vkGetPhysicalDeviceProperties(r.phys, &properties);
+            r.driver_cache_file = prosper::frontend::PipelineCacheFile::graphics(properties);
+            initial_cache = r.driver_cache_file.load();
+        } catch (const std::exception&) {
+            fprintf(stderr, "[render] disk pipeline cache unavailable; starting empty\n");
+        }
+        cache_info.initialDataSize = initial_cache.size();
+        cache_info.pInitialData = initial_cache.empty() ? nullptr : initial_cache.data();
+        VkResult cache_result = vkCreatePipelineCache(
             r.dev, &cache_info, nullptr, &r.driver_pipeline_cache);
+        if (cache_result != VK_SUCCESS && !initial_cache.empty()) {
+            cache_info.initialDataSize = 0;
+            cache_info.pInitialData = nullptr;
+            initial_cache.clear();
+            cache_result = vkCreatePipelineCache(
+                r.dev, &cache_info, nullptr, &r.driver_pipeline_cache);
+        }
+        if (cache_result == VK_SUCCESS) r.driver_cache_loaded_bytes = initial_cache.size();
+        if (!r.driver_cache_file.path.empty())
+            fprintf(stderr, "[render] disk pipeline cache %s (%zu bytes)\n",
+                    r.driver_cache_loaded_bytes ? "loaded" : "cold", r.driver_cache_loaded_bytes);
         if (cache_result != VK_SUCCESS) {
             r.driver_pipeline_cache = VK_NULL_HANDLE;
             fprintf(stderr, "[render] driver pipeline cache unavailable (%d); compiling uncached\n",
@@ -1634,7 +1663,41 @@ inline const RenderVkCtx& render_vk_ctx() {
         }
         return r;
     }();
+    published_render_cache_context().store(&c, std::memory_order_release);
     return c;
+}
+
+// Explicit snapshot for frontends that use _Exit. Do not initialize a renderer during shutdown
+// or wait for a guest holding its resource lock. The queue drain does not serialize compilation.
+inline bool flush_graphics_pipeline_cache() {
+    const RenderVkCtx* context = published_render_cache_context().load(std::memory_order_acquire);
+    if (!context || context->driver_cache_file.path.empty() || !context->driver_pipeline_cache)
+        return false;
+    try {
+        std::vector<uint8_t> blob;
+        {
+            std::unique_lock<std::mutex> lock(backend_persistent_resource_mutex(), std::try_to_lock);
+            if (!lock.owns_lock()) {
+                fprintf(stderr, "[render] disk pipeline cache save skipped: renderer busy\n");
+                return false;
+            }
+            size_t bytes = 0;
+            if (vkGetPipelineCacheData(context->dev, context->driver_pipeline_cache,
+                    &bytes, nullptr) != VK_SUCCESS || !bytes ||
+                bytes > prosper::frontend::PipelineCacheFile::max_bytes) return false;
+            blob.resize(bytes);
+            if (vkGetPipelineCacheData(context->dev, context->driver_pipeline_cache,
+                    &bytes, blob.data()) != VK_SUCCESS) return false;
+            blob.resize(bytes);
+        }
+        const bool saved = context->driver_cache_file.save(blob);
+        fprintf(stderr, "[render] disk pipeline cache %s (%zu bytes)\n",
+                saved ? "saved" : "save failed", blob.size());
+        return saved;
+    } catch (const std::exception&) {
+        fprintf(stderr, "[render] disk pipeline cache save failed\n");
+        return false;
+    }
 }
 
 // Present unification (#1270): serialize a single queue CALL against prosper-app's present submits when

--- a/prosper/tests/gpu/test_graphics_cache_persistence.cpp
+++ b/prosper/tests/gpu/test_graphics_cache_persistence.cpp
@@ -2,6 +2,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
+#include <thread>
 
 static size_t observed_initial_bytes = 0;
 static bool reject_cached = false;
@@ -13,9 +15,24 @@ static VkResult observe_cache_create(VkDevice device, const VkPipelineCacheCreat
     if (reject_cached && info->initialDataSize) return VK_ERROR_INITIALIZATION_FAILED;
     return vkCreatePipelineCache(device, info, allocator, cache);
 }
+namespace prosper::test { std::timed_mutex& graphics_driver_cache_mutex(); }
+static bool compilation_was_locked = false;
+static VkResult observe_pipeline_create(VkDevice device, VkPipelineCache cache, uint32_t count,
+        const VkGraphicsPipelineCreateInfo* info, const VkAllocationCallbacks* allocator,
+        VkPipeline* pipelines) {
+    std::thread observer([] {
+        auto& mutex = prosper::test::graphics_driver_cache_mutex();
+        compilation_was_locked = !mutex.try_lock();
+        if (!compilation_was_locked) mutex.unlock();
+    });
+    observer.join();
+    return vkCreateGraphicsPipelines(device, cache, count, info, allocator, pipelines);
+}
+#define vkCreateGraphicsPipelines observe_pipeline_create
 #define vkCreatePipelineCache observe_cache_create
 #include "fixtures/render_runner.h"
 #undef vkCreatePipelineCache
+#undef vkCreateGraphicsPipelines
 #include "fixtures/spirv_triangle.h"
 
 int main(int argc, char** argv) {
@@ -32,19 +49,37 @@ int main(int argc, char** argv) {
         return 4;
     }
     if (reject_cached && cache_create_calls != 2) return 7;
-    // A held resource domain must skip immediately, not deadlock during _Exit.
-    std::atomic<bool> ready{false}, release{false};
-    std::thread owner([&] {
-        prosper::test::BackendPersistentResourceGuard guard;
-        ready.store(true);
-        while (!release.load()) std::this_thread::yield();
-    });
-    while (!ready.load()) std::this_thread::yield();
-    const bool saved_while_busy = prosper::test::flush_graphics_pipeline_cache();
-    release.store(true);
-    owner.join();
-    if (saved_while_busy) return 5;
-    if (save && !prosper::test::flush_graphics_pipeline_cache()) return 6;
+    if (!compilation_was_locked) return 9;
+    if (save) {
+        // Reproduce app shutdown during a pass: the broad resource lock must not block saving.
+        std::atomic<bool> ready{false}, release{false};
+        std::thread owner([&] {
+            prosper::test::BackendPersistentResourceGuard guard;
+            ready.store(true);
+            while (!release.load()) std::this_thread::yield();
+        });
+        while (!ready.load()) std::this_thread::yield();
+        const bool saved_during_pass = prosper::test::flush_graphics_pipeline_cache();
+        release.store(true);
+        owner.join();
+        if (!saved_during_pass) return 5;
+
+        // In-flight driver compilation does serialize extraction, with a bounded wait.
+        ready.store(false);
+        release.store(false);
+        std::thread compiler([&] {
+            std::lock_guard<std::timed_mutex> lock(prosper::test::graphics_driver_cache_mutex());
+            ready.store(true);
+            while (!release.load()) std::this_thread::yield();
+        });
+        while (!ready.load()) std::this_thread::yield();
+        const bool saved_while_compiling = prosper::test::flush_graphics_pipeline_cache(
+            std::chrono::milliseconds(1));
+        release.store(true);
+        compiler.join();
+        if (saved_while_compiling) return 6;
+        if (!prosper::test::flush_graphics_pipeline_cache()) return 8;
+    }
     std::fflush(nullptr);
     std::_Exit(0); // destructor-only persistence must not pass this test
 }

--- a/prosper/tests/gpu/test_graphics_cache_persistence.cpp
+++ b/prosper/tests/gpu/test_graphics_cache_persistence.cpp
@@ -1,0 +1,50 @@
+#include <vulkan/vulkan.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+
+static size_t observed_initial_bytes = 0;
+static bool reject_cached = false;
+static unsigned cache_create_calls = 0;
+static VkResult observe_cache_create(VkDevice device, const VkPipelineCacheCreateInfo* info,
+                                    const VkAllocationCallbacks* allocator, VkPipelineCache* cache) {
+    observed_initial_bytes = info->initialDataSize;
+    ++cache_create_calls;
+    if (reject_cached && info->initialDataSize) return VK_ERROR_INITIALIZATION_FAILED;
+    return vkCreatePipelineCache(device, info, allocator, cache);
+}
+#define vkCreatePipelineCache observe_cache_create
+#include "fixtures/render_runner.h"
+#undef vkCreatePipelineCache
+#include "fixtures/spirv_triangle.h"
+
+int main(int argc, char** argv) {
+    if (argc != 2) return 2;
+    const bool load = std::strcmp(argv[1], "load") == 0;
+    const bool save = std::strcmp(argv[1], "save") == 0;
+    reject_cached = std::strcmp(argv[1], "reject") == 0;
+    std::vector<uint32_t> vert(std::begin(kTriVertSpv), std::end(kTriVertSpv));
+    std::vector<uint32_t> frag(std::begin(kTriFragSpv), std::end(kTriFragSpv));
+    auto pixels = prosper::test::render_triangle_rgba(vert, frag, 32, 32);
+    if (pixels.size() != 32 * 32 * 4 || pixels[(16 * 32 + 16) * 4] < 200) return 3;
+    if (load != (observed_initial_bytes > 0)) {
+        std::fprintf(stderr, "initial cache bytes=%zu expected load=%d\n", observed_initial_bytes, load);
+        return 4;
+    }
+    if (reject_cached && cache_create_calls != 2) return 7;
+    // A held resource domain must skip immediately, not deadlock during _Exit.
+    std::atomic<bool> ready{false}, release{false};
+    std::thread owner([&] {
+        prosper::test::BackendPersistentResourceGuard guard;
+        ready.store(true);
+        while (!release.load()) std::this_thread::yield();
+    });
+    while (!ready.load()) std::this_thread::yield();
+    const bool saved_while_busy = prosper::test::flush_graphics_pipeline_cache();
+    release.store(true);
+    owner.join();
+    if (saved_while_busy) return 5;
+    if (save && !prosper::test::flush_graphics_pipeline_cache()) return 6;
+    std::fflush(nullptr);
+    std::_Exit(0); // destructor-only persistence must not pass this test
+}

--- a/prosper/tests/gpu/test_graphics_cache_persistence.py
+++ b/prosper/tests/gpu/test_graphics_cache_persistence.py
@@ -1,0 +1,31 @@
+"""Separate processes prove driver data survives _Exit and actually reaches Vulkan at startup."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+with tempfile.TemporaryDirectory(prefix="graphics-cache-") as directory:
+    path = Path(directory) / "cache"
+    env = os.environ.copy()
+    env.pop("PROSPER_NO_DISK_PIPELINE_CACHE", None)
+    env["PROSPER_GRAPHICS_PIPELINE_CACHE_PATH"] = str(path)
+
+    def run(mode, extra=None):
+        subprocess.run([sys.argv[1], mode], env=env | (extra or {}), check=True, timeout=60)
+
+    run("save")
+    original = path.read_bytes()
+    assert len(original) > 32
+    run("load")
+    run("reject")
+    run("empty", {"PROSPER_NO_DISK_PIPELINE_CACHE": "1"})
+    assert path.read_bytes() == original
+    damaged = bytearray(original)
+    damaged[-1] ^= 1
+    path.write_bytes(damaged)
+    run("empty")
+    path.write_bytes(original[:-1])
+    run("empty")
+    path.write_bytes(original)
+    run("load")


### PR DESCRIPTION
Graphics pipelines already share an in-process driver cache, but the app lost that cache at `_Exit`. This adds opt-in cross-launch persistence with device/driver/UUID and pointer-width checks, bounded file parsing, integrity checks, an empty-cache retry after driver rejection, and atomic replacement that preserves the previous file on failure.

The app snapshots the initialized cache before `_Exit`. Extraction shares a dedicated mutex with pipeline compilation and waits up to one second to acquire it. It does not depend on the whole-pass renderer lock: an actual Sonic run exposed that the original broad-lock try-lock skipped saving. Vulkan extraction and file I/O themselves are not time-bounded.

Disk loading remains opt-in, including on NVIDIA; compatibility checks do not resolve the documented NVIDIA blob-loading crash. No experimental Vulkan feature is needed. See `prosper/docs/GRAPHICS_PIPELINE_CACHE.md` for controls and limits. The separate compute `_Exit` persistence gap is tracked in #3425.

Validation at `b4c2cd8627e8cad18b135e0e2c81012ac5aa4479`:

- Full Release build passed. Focused file/Vulkan tests passed 2/2; restoring the old broad lock makes the save regression fail with exit 5.
- Tests cover separate-process save/load through `_Exit`, observed Vulkan initial data, disabled/corrupt/truncated inputs, driver rejection and empty retry, concurrent writers, failed replacement, compilation serialization and saving during a held render pass.
- Two actual 45-second Sonic app launches: cold launch saved 140,180 driver bytes; warm launch loaded 140,180 and saved again. Each reached 574 presentations. This proves persistence, not a speedup.
- Independent exact-head review approved. All 373 tests passed (99.44s); full core/synchronization scan passed all 373 tests (97.06s), with only the existing scoped findings and the scanner's deliberate-hazard control armed. Required Linux/general CI remains the merge gate.

Addresses the remaining graphics persistence scope of #3378. No claim that pipeline compilation caused the original stutter or that this raises FPS.
