### PR TITLE
Keep guest clocks advancing during graphics stalls

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -860,6 +860,12 @@ if(TARGET prosper_core)
   add_executable(test_audio tests/hle/audio/test_audio.cpp)
   target_link_libraries(test_audio PRIVATE prosper_core)
   add_test(NAME audio_hle COMMAND test_audio)
+  if(Python3_Interpreter_FOUND)
+    add_test(NAME audio_flow_publication
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_SOURCE_DIR}/tests/hle/audio/test_audio_flow_publication.py"
+                     $<TARGET_FILE:test_audio>)
+  endif()
 
   # NGS2 waveform-block streaming (#1059/#1060 part 3): a fed block makes the voice Playing and advances
   # num_decoded_samples across renders (the Dead Cells music stream clock). POSIX-gated (needs a fixed
@@ -957,8 +963,8 @@ if(TARGET prosper_core)
   target_link_libraries(test_det_clock PRIVATE prosper_core)
   add_test(NAME det_clock COMMAND test_det_clock)
 
-  # Synchronous host-GPU work must not become a giant guest frame delta. The clock retains one
-  # caller-supplied frame budget, stays monotonic under concurrent reads, and leaves realtime alone.
+  # Guest clocks continue through host GPU stalls; only the internal dependency-watchdog clock
+  # discounts excess backend time, retaining its hold/resume and concurrent-reader guarantees.
   add_executable(test_gpu_time_compensation tests/hle/kernel/test_gpu_time_compensation.cpp)
   target_link_libraries(test_gpu_time_compensation PRIVATE prosper_core)
   add_test(NAME gpu_time_compensation COMMAND test_gpu_time_compensation)

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -6,6 +6,21 @@ into a port lifecycle plus interleaved PCM "grains" and forwards them to an inst
 This keeps `prosper_core` dependency-free and unit-testable, and lets any frontend (SDL3, a file
 recorder, a network sink, …) be swapped in at runtime.
 
+## Sonic clock starvation (#3422, 2026-09-07)
+
+A matched startup A–B–A on the same binary identified graphics clock compensation as a cause of
+missing AudioOut2 grains. With fresh saves, no input and 65-second native app runs, the default
+compensated clock produced median MAIN rates of 108 and 108.5 fresh grains/s, versus the sink's
+roughly 188 grains/s. Disabling compensation produced 188 fresh grains/s and zero median
+missing-grain intervals (80 and 79.5 in the two default arms). Earlier publication diagnostics
+showed no unconsumed grain replacements. Commands and measurement limits are recorded in #3422.
+
+Guest monotonic/process-time/TSC clocks now continue through graphics stalls. Only prosper's
+internal GPU dependency watchdog retains compensation. Output/channel buffers remain independently
+owned; no grain is replayed to conceal late production. FLOW diagnostics also report publications
+and pending-grain replacements. These startup measurements establish the clock-related deficit;
+they do not establish that every title or every later gameplay interval is free of underruns.
+
 ## Layers
 
 | Layer | File | In `prosper_core`? |

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -315,15 +315,17 @@ The complete manual PowerShell recipe is in `WINDOWS_PORT_HANDOFF.md`.
 
 ### Guest time during synchronous GPU work
 
-Prosper currently realizes and executes an AGC submit synchronously on the guest submitter. The
-guest monotonic clock discounts host GPU time beyond the refresh interval represented by that
-submit's completed VideoOut flips. This keeps shader compilation, resource conversion, execution,
-and readback stalls from becoming multi-second frame deltas that skip time-based guest states. Wall
-clock/RTC surfaces remain tied to host time, and monotonic time continues normally outside the
-backend scope, including while media or wait loops prepare the next frame. This is intentionally
-narrower than the opt-in `PROSPER_DET_CLOCK`, which holds monotonic time between every pair of flips.
+Guest process-time counters, TSC and monotonic clocks advance on one real steady timeline,
+including during synchronous shader compilation, resource conversion and GPU waits. GPU EOP
+timestamps use that same timeline. Slowing it globally starved Sonic's clock-paced PCM producer
+while the host audio device continued consuming samples in real time (#3422).
 
-Set `PROSPER_NO_GPU_TIME_COMPENSATION=1` only for a diagnostic A/B against the old behavior.
+The internal PM4 dependency watchdog uses a separate progress clock that discounts excess host
+backend time. A synchronous submit holds the queue mutex, so its queued producer cannot satisfy
+a dependency during that interval; charging it to the watchdog can force a healthy barrier through.
+This compensation never changes guest-visible timestamps. `PROSPER_NO_GPU_TIME_COMPENSATION=1`
+disables only that internal compensation and is a diagnostic control, not an audio setting.
+Explicit `PROSPER_DET_CLOCK` still selects the separate flip-paced diagnostic guest clock.
 
 ### Live renderer performance diagnostics
 

--- a/prosper/docs/PLUCKY_SQUIRE_STATUS.md
+++ b/prosper/docs/PLUCKY_SQUIRE_STATUS.md
@@ -18,11 +18,16 @@ checked-in `scripts/plucky-squire/reach-first-gameplay.pad` route, t = 1080 s.*
 
 **This is not rung 3.** A cutscene is not gameplay.
 
-**The frontier was re-measured on 2026-08-21 (master `f29f46c0`) and it is not what this section
+**Clock update (2026-09-07, #3422):** guest monotonic time now advances in real time even
+through synchronous graphics work. The historical per-flip slowdown below describes the old
+clock policy and no longer predicts current intro duration. The internal GPU dependency watchdog
+still excludes backend stalls. A new live progression measurement is needed for this title.
+
+**The frontier was measured on 2026-08-21 (master `f29f46c0`) and it is not what this section
 originally guessed.** "The route stops driving input at 525 s" is true and irrelevant: the guest reads
 the input it is given and the cutscene is not waiting on a button. The cutscene is not waiting at all —
-it is *advancing about 300x too slowly to finish*, because the guest runs at ~0.19 flips/s once the 3D
-world is up and prosper's guest clock advances in-game time **per flip**. See
+it is *advancing about 300x too slowly to finish*, because the guest ran at ~0.19 flips/s once the 3D
+world is up and prosper's guest clock advanced in-game time **per flip**. See
 [**## The wall is guest THROUGHPUT**](#the-wall-is-guest-throughput-and-the-reason-is-the-guest-clock-2026-08-21-master-f29f46c0)
 below and [#2839](https://github.com/mattias800/prosper/issues/2839); raising the flip rate alone
 carries the guest past the intro to the `Book_MAIN` storybook camera with no other change.
@@ -124,6 +129,9 @@ anchors are invariant to that, and to the sampling cadence — the same file dri
 through to `FinishDeskLevelLoad`.
 
 ## The wall is guest THROUGHPUT, and the reason is the guest clock (2026-08-21, master `f29f46c0`)
+
+Historical measurement: the global guest-clock compensation discussed here was superseded by
+#3422 on 2026-09-07. These observations remain evidence for the old build, not the current clock.
 
 The chapter-one intro cutscene is **not stuck** — it advances, roughly 300x too slowly to finish. What
 makes that fatal rather than merely slow is prosper's own guest-clock contract, so the two have to be

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -1,6 +1,7 @@
 // command_processor.cpp — see command_processor.hpp.
 #include "gpu/pm4/command_processor.hpp"
 #include "hle/memory/guest_memory_topology.hpp"
+#include "hle/kernel/hle_kernel_time.hpp"
 #include "gpu/diagnostics/diag_ratelimit.hpp"   // #1761: single-sourced ordinal + sparse-tail rule for capped logs
 #include "gpu/execute/mb3_freelist.hpp"
 #include "diagnostics/env_numeric.hpp"   // #3267: a typo must not switch a default-ON guard off
@@ -3450,12 +3451,12 @@ uint64_t defer_now_ms() {
     // The submit path executes shader translation, pipeline creation, dispatches, and rendering
     // synchronously while holding the queue mutex. Real hardware performs that work after returning
     // from submit, so another guest submit cannot deliver a WAIT_REG_MEM producer during this host-
-    // only interval. The shared guest/GPU clock excludes excess HostGpuClockScope time; using raw
+    // only interval. The internal progress clock excludes excess HostGpuClockScope time; using raw
     // steady_clock here aged a healthy barrier past the liveness timeout while its producer was
     // prevented from entering the queue, then deliberately violated ordering as soon as rendering
     // returned (Plucky's first gameplay scene needed 1-2 s of first-use pipeline work). Keep the
-    // timeout on the emulated timeline where the guest and producer can actually make progress.
-    return prosper_guest_tsc_ns() / 1000000ull;
+    // timeout on that internal timeline. Guest clocks and EOP timestamps still advance in real time.
+    return prosper::host_gpu_progress_ns() / 1000000ull;
 }
 struct DeferItem {
     Pm4Command cmd;                    // barrier (WaitRegMem) or effect (ReleaseMem/EventWrite/WriteData/Flip)

--- a/prosper/src/hle/audio/hle_audio.cpp
+++ b/prosper/src/hle/audio/hle_audio.cpp
@@ -575,7 +575,7 @@ void a2_dump(const char* tag, uint64_t p, size_t n) {
 void a2_log(const char* name, uint64_t a0, uint64_t a1, uint64_t a2,
             uint64_t a3, uint64_t a4, uint64_t a5, void* ra) {
     if (!audio2log()) return;
-    fprintf(stderr, "[audio2] %s(0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx) ra=eboot+0x%llx\n",
+    fprintf(stderr, "[audio2] %s(0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx) ra=%s+0x%llx\n",
             name, (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
             (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5,
             prosper::guest_module_name((uint64_t)ra),
@@ -684,6 +684,7 @@ using FlowSignal = AudioSignalStats;
 
 struct FlowPort {
     uint64_t reads = 0, mixed = 0, frames = 0, bytes = 0;
+    uint64_t publications = 0, replacements = 0;
     uint64_t no_pcm = 0, no_grain = 0, skip_fmt = 0, skip_not_main = 0, short_read = 0;
     uint16_t type = 0;
     uint32_t data_format = 0;
@@ -800,7 +801,7 @@ void audio_flow_report(uint32_t slot) {
         fprintf(stderr,
                 "[audio-flow]   port%u type=0x%x fmt=0x%x reads=%llu mixed=%llu frames=%llu bytes=%llu"
                 " peak=%.5f rms=%.5f nonzero=%llu/%llu nan=%llu no-pcm=%llu skip-fmt=%llu"
-                " skip-not-main=%llu short=%llu no-grain=%llu"
+                " skip-not-main=%llu short=%llu no-grain=%llu published=%llu replaced-pending=%llu"
                 " | LIFE: nonzero=%llu/%llu peak=%.5f rms=%.5f nan=%llu\n",
                 i + 1, p.type, p.data_format, (unsigned long long)p.reads,
                 (unsigned long long)p.mixed, (unsigned long long)p.frames,
@@ -810,11 +811,13 @@ void audio_flow_report(uint32_t slot) {
                 (unsigned long long)p.no_pcm, (unsigned long long)p.skip_fmt,
                 (unsigned long long)p.skip_not_main, (unsigned long long)p.short_read,
                 (unsigned long long)p.no_grain,
+                (unsigned long long)p.publications, (unsigned long long)p.replacements,
                 (unsigned long long)p.life.nonzero, (unsigned long long)p.life.samples,
                 p.life.peak, p.life.rms(), (unsigned long long)p.life_nan);
         // Per-interval counters: reset so each line describes the LAST second, not the whole run.
         // The `life:` totals above are deliberately NOT reset.
         p.reads = p.mixed = p.frames = p.bytes = 0;
+        p.publications = p.replacements = 0;
         p.no_pcm = p.no_grain = p.skip_fmt = p.skip_not_main = p.short_read = p.nan_samples = 0;
         p.seen = false;
         p.sig.reset();
@@ -1889,6 +1892,18 @@ HLE(audio2_port_set_attr) {
         if (at.id == 0 && at.vsize == 8) {
             uint64_t pcm = 0;
             if (audio_read_bytes(at.vptr, &pcm, 8)) {
+                if (audio_flow()) {
+                    uint32_t context_slot = 0;
+                    if (audio2_context_locked(port->context, &context_slot)) {
+                        std::lock_guard<std::mutex> flk(g_flow_mx);
+                        FlowPort& fp = g_flow_port[port_slot];
+                        flow_tag_port(fp, context_slot, port->type, port->data_format);
+                        if (pcm) ++fp.publications;
+                        // Count replacement before changing pending state, including a null
+                        // publication discarding a grain. This is an observation, not a FIFO policy.
+                        if (port->pcm_pending) ++fp.replacements;
+                    }
+                }
                 port->pcm_ptr = pcm;
                 port->pcm_frames = 0;
                 port->pcm_pending = pcm != 0;

--- a/prosper/src/hle/graphics/hle_agc.cpp
+++ b/prosper/src/hle/graphics/hle_agc.cpp
@@ -1921,9 +1921,9 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
     // Native-speed semantic capture happens before renderer sampling. PROSPER_RENDER_EVERY and
     // warmup may skip Vulkan work, but must not erase submit/present history from the timeline.
     gpu::record_gpu_timeline_submit(st, submit_no);
-    // Account at most one requested refresh interval per flip while the host performs synchronous
-    // GPU work. A real console returns from submission without charging shader compilation,
-    // resource conversion, execution, or readback latency to the guest's next frame delta.
+    // Account at most one requested refresh interval per flip in the internal dependency-watchdog
+    // clock. The host's synchronous backend holds the queue mutex and prevents other submissions
+    // from satisfying a dependency. This budget does not alter guest clocks or audio pacing.
     static uint64_t accounted_flips = 0;
     const uint64_t flips = prosper_vo_flip_count();
     const uint64_t flip_delta = flips >= accounted_flips ? flips - accounted_flips : flips;

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -56,16 +56,10 @@ namespace {
         return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(clk::now() - g_start).count();
     }
 
-    // The live GPU backend is synchronous today: the guest submitter performs shader realization,
-    // Vulkan execution, and readback before its HLE call returns. On hardware that work runs on the
-    // GPU after a cheap CPU submission. Without compensation, a one-off host pipeline/resource
-    // warmup is incorrectly exposed as a giant guest frame delta and can skip entire animations.
-    //
-    // During a host-GPU scope, monotonic time advances only through the caller-supplied display
-    // budget, then holds. At scope exit the excess is permanently removed from process-time/TSC.
-    // Ordinary guest execution and all realtime/RTC surfaces keep advancing from the host clocks.
-    // This is deliberately narrower than PROSPER_DET_CLOCK: time-gated media and wait loops can
-    // continue between flips, so a title cannot deadlock waiting to produce its next frame.
+    // Internal GPU dependency-watchdog time excludes excess synchronous host backend work:
+    // while the submit mutex is held, a queued producer cannot make progress. This must NOT
+    // slow guest process-time/TSC/monotonic clocks. Audio producers use those clocks while the
+    // physical sink consumes samples in real time; global compensation starved Sonic's PCM (#3422).
     struct HostGpuClockState {
         std::mutex writer_mutex;
         std::atomic<uint64_t> sequence{0};
@@ -84,7 +78,7 @@ namespace {
     }
 
     uint64_t host_gpu_compensated_ns(uint64_t mono) {
-        // Process-time reads are hot and may come from many guest threads. Writers publish their
+        // Watchdog reads may come from concurrent queue users. Writers publish their
         // handful of atomic fields under a seqlock, giving readers one consistent snapshot without
         // serializing every clock query on the scope-management mutex.
         uint64_t total_excess;
@@ -146,7 +140,7 @@ namespace {
     uint64_t ns_now() {
         static const bool det = getenv("PROSPER_DET_CLOCK") != nullptr;
         uint64_t mono = real_ns();
-        if (!det) return host_gpu_compensated_ns(mono);
+        if (!det) return mono;
         uint64_t flip = prosper_vo_flip_count();
         std::lock_guard<std::mutex> lock(g_det_clock.mutex);
         if (!g_det_clock.anchored) {
@@ -186,6 +180,10 @@ namespace {
     // RTC epoch: SceRtcTick counts microseconds since 0001-01-01 00:00:00 UTC; the unix epoch is
     // 62135596800 s after it (the documented Orbis RTC convention, also shadPS4 UNIX_EPOCH_TICKS).
     constexpr uint64_t kRtcUnixEpochOffsetUs = 62135596800ull * 1000000ull;
+}
+
+uint64_t host_gpu_progress_ns() {
+    return host_gpu_compensated_ns(real_ns());
 }
 
 uint64_t guest_clock_host_gpu_begin(uint64_t budget_ns) {

--- a/prosper/src/hle/kernel/hle_kernel_time.hpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.hpp
@@ -4,11 +4,12 @@
 
 namespace prosper {
 
-// Exclude excess time spent in Prosper's synchronous host GPU backend from the guest monotonic
-// clock. Real hardware submits this work asynchronously; charging a multi-second host translation
-// or pipeline warmup to the next guest frame makes time-based state machines skip visible states.
-// `budget_ns` is the amount of that interval that may legitimately belong to completed display
-// flips. A zero token means the scope was not installed (disabled or another scope is active).
+// Internal GPU dependency-watchdog clock, never a guest-visible timestamp. A synchronous host
+// submit holds the queue mutex and prevents its producer from advancing. Exclude excess backend
+// time only from that watchdog, retaining budget_ns for completed display flips. Guest clocks and
+// EOP timestamps continue on one real steady timeline, including during these scopes (#3422).
+uint64_t host_gpu_progress_ns();
+// A zero token means the scope was not installed (disabled or another scope is active).
 uint64_t guest_clock_host_gpu_begin(uint64_t budget_ns);
 void guest_clock_host_gpu_end(uint64_t token);
 

--- a/prosper/tests/gpu/pm4/test_wait_barrier.cpp
+++ b/prosper/tests/gpu/pm4/test_wait_barrier.cpp
@@ -241,6 +241,7 @@ int main() {
         run_cb(buf, 15, st);
         flush_deferred_streams();
         const uint64_t guest_before_host_work = prosper_guest_tsc_ns();
+        const uint64_t progress_before_host_work = prosper::host_gpu_progress_ns();
         {
             prosper::HostGpuClockScope host_gpu_work(0);
             std::this_thread::sleep_for(std::chrono::milliseconds(1100));
@@ -249,12 +250,23 @@ int main() {
         const uint64_t guest_after_host_work = prosper_guest_tsc_ns();
         CHECK(label == 0,
               "host GPU work longer than the timeout does not violate a blocked queue wait");
-        CHECK(guest_after_host_work - guest_before_host_work < 100000000ull,
-              "host GPU work is excluded from the guest queue clock");
+        CHECK(guest_after_host_work - guest_before_host_work >= 1000000000ull,
+              "guest time continues through the long host GPU interval");
+        CHECK(prosper::host_gpu_progress_ns() - progress_before_host_work < 100000000ull,
+              "host GPU work is excluded only from the internal dependency clock");
         cond = 1;
         flush_deferred_streams();
         CHECK(label == 1 && !deferred_pending(),
               "barrier still releases normally after compensated host GPU work");
+        uint64_t timestamp = 0;
+        uint32_t timestamp_cb[7];
+        emit_release(timestamp_cb, (uint64_t)(uintptr_t)&timestamp, 0);
+        timestamp_cb[3] = 3; // GPU timestamp, not an immediate value
+        const uint64_t tsc_before = prosper_guest_tsc_ns();
+        run_cb(timestamp_cb, 7, st);
+        const uint64_t tsc_after = prosper_guest_tsc_ns();
+        CHECK(timestamp >= tsc_before && timestamp <= tsc_after,
+              "EOP timestamps share guest TSC time, not the compensated watchdog epoch");
     }
 
     // 6: liveness backstop — a condition NOBODY ever satisfies releases via the bounded timeout.

--- a/prosper/tests/hle/audio/test_audio.cpp
+++ b/prosper/tests/hle/audio/test_audio.cpp
@@ -501,9 +501,57 @@ static void test_bed_routing_matrix() {
     audio_reset();
 }
 
-int main() {
+// Separate-process diagnostic control: same-port replacement and publication after consumption.
+// The Python driver verifies the actual FLOW log, including its nonzero replacement arm.
+static int test_flow_publication() {
+    audio_reset();
+    CapturingSink sink;
+    audio_set_sink(&sink);
+    uint8_t context_param[0x40]{};
+    CHECK(call("sceAudioOut2ContextResetParam", PTR(context_param)) == 0);
+    *(uint32_t*)(context_param + 0x10) = 64;
+    uint64_t context = 0, port = 0;
+    CHECK(call("sceAudioOut2ContextCreate", PTR(context_param), 0, 0, PTR(&context)) == 0);
+    struct PortParam {
+        uint16_t type, pad;
+        uint32_t format, rate, flags;
+        uint64_t user;
+        uint32_t reserved[10];
+    } param{};
+    param.format = 0x200;
+    param.rate = 48000;
+    CHECK(call("sceAudioOut2PortCreate", context, PTR(&param), PTR(&port)) == 0);
+    CHECK(call("sceAudioOut2ContextAdvance", context) == 0); // anchor the report interval
+    std::this_thread::sleep_for(std::chrono::milliseconds(1010));
+    std::vector<float> pcm(128, 0.25f);
+    uint64_t pointer = PTR(pcm.data());
+    struct Attribute { uint32_t id, reserved; uint64_t value, size; } attr{
+        0, 0, PTR(&pointer), sizeof(pointer)};
+    CHECK(call("sceAudioOut2PortSetAttributes", port, PTR(&attr), 1) == 0);
+    std::fill(pcm.begin(), pcm.end(), 0.5f);
+    CHECK(call("sceAudioOut2PortSetAttributes", port, PTR(&attr), 1) == 0);
+    CHECK(call("sceAudioOut2ContextPush", context, 1) == 0);
+    CHECK(sink.outs.size() == 1);
+    if (!sink.outs.empty()) CHECK(std::memcmp(sink.outs.back().pcm.data(), pcm.data(), 512) == 0);
+    // The first pending grain was consumed, so this publication must not count as replacement.
+    std::fill(pcm.begin(), pcm.end(), 0.75f);
+    CHECK(call("sceAudioOut2PortSetAttributes", port, PTR(&attr), 1) == 0);
+    CHECK(call("sceAudioOut2ContextPush", context, 1) == 0);
+    CHECK(sink.outs.size() == 2);
+    if (sink.outs.size() == 2) CHECK(std::memcmp(sink.outs.back().pcm.data(), pcm.data(), 512) == 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1010));
+    CHECK(call("sceAudioOut2ContextAdvance", context) == 0);
+    CHECK(call("sceAudioOut2PortDestroy", port) == 0);
+    CHECK(call("sceAudioOut2ContextDestroy", context) == 0);
+    audio_reset();
+    return fails ? 1 : 0;
+}
+
+int main(int argc, char** argv) {
     printf("== test_audio ==\n");
     register_builtin_hle();
+    if (argc == 2 && std::strcmp(argv[1], "--flow-publication") == 0)
+        return test_flow_publication();
     test_signal_stats();
     test_stereo_downmix();
     test_stamped_grain_verdicts();

--- a/prosper/tests/hle/audio/test_audio_flow_publication.py
+++ b/prosper/tests/hle/audio/test_audio_flow_publication.py
@@ -1,0 +1,13 @@
+"""Calibrate publication/replacement diagnostics through actual HLE calls and FLOW output."""
+import os
+import re
+import subprocess
+import sys
+
+result = subprocess.run([sys.argv[1], "--flow-publication"],
+                        env=os.environ | {"PROSPER_AUDIO_FLOW": "1"},
+                        capture_output=True, text=True, timeout=30, check=True)
+rows = [(int(a), int(b)) for a, b in re.findall(
+    r"\[audio-flow\]   port1 .*?published=(\d+) replaced-pending=(\d+)", result.stderr)]
+assert [row for row in rows if row[0]] == [(2, 1), (1, 0)], result.stderr
+print("FLOW calibrated: same-port replacement detected; consumed grain is not a replacement")

--- a/prosper/tests/hle/kernel/test_gpu_time_compensation.cpp
+++ b/prosper/tests/hle/kernel/test_gpu_time_compensation.cpp
@@ -1,4 +1,4 @@
-// test_gpu_time_compensation - discount synchronous host-GPU overhead from guest monotonic time.
+// Guest clocks advance in real time; only the internal GPU dependency watchdog discounts stalls.
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/kernel/hle_kernel_time.hpp"
 #include "hle/dispatch/nid.hpp"
@@ -20,33 +20,56 @@ int main() {
     register_builtin_hle();
     auto ptc = Hle::lookup(nid_hash("sceKernelGetProcessTimeCounter"));
     auto clock_gettime_fn = Hle::lookup(nid_hash("sceKernelClockGettime"));
-    CHECK(ptc && clock_gettime_fn, "monotonic and realtime entry points registered");
+    auto tsc = Hle::lookup(nid_hash("sceKernelReadTsc"));
+    CHECK(ptc && tsc && clock_gettime_fn, "monotonic, TSC and realtime entry points registered");
     if (fails) return 1;
 
     constexpr uint64_t kBudgetNs = 8'000'000;
-    uint64_t before = ptc(0, 0, 0, 0, 0, 0);
+    const uint64_t guest_before = ptc(0, 0, 0, 0, 0, 0);
+    uint64_t before = host_gpu_progress_ns();
     int64_t rt0[2] = {};
     clock_gettime_fn(0, (uint64_t)(uintptr_t)rt0, 0, 0, 0, 0);
     {
         HostGpuClockScope scope(kBudgetNs);
         std::this_thread::sleep_for(std::chrono::milliseconds(35));
-        uint64_t held0 = ptc(0, 0, 0, 0, 0, 0);
+        uint64_t held0 = host_gpu_progress_ns();
         std::this_thread::sleep_for(std::chrono::milliseconds(15));
-        uint64_t held1 = ptc(0, 0, 0, 0, 0, 0);
+        uint64_t held1 = host_gpu_progress_ns();
         CHECK(held0 >= before + 4'000'000 && held0 <= before + 25'000'000,
-              "host-GPU interval retains its bounded guest frame budget");
-        CHECK(held1 == held0, "guest monotonic time holds after the GPU budget is exhausted");
+              "host-GPU interval retains its bounded internal progress budget");
+        CHECK(held1 == held0, "internal progress time holds after the GPU budget is exhausted");
+
+        const uint64_t guest_now = ptc(0, 0, 0, 0, 0, 0);
+        CHECK(guest_now >= guest_before + 35'000'000,
+              "guest process time advances while the internal GPU budget is exhausted");
+        std::atomic<bool> guest_clocks_consistent{true};
+        std::vector<std::thread> guest_readers;
+        for (unsigned i = 0; i < 8; ++i) {
+            guest_readers.emplace_back([&] {
+                const uint64_t first = ptc(0, 0, 0, 0, 0, 0);
+                const uint64_t cycles = tsc(0, 0, 0, 0, 0, 0);
+                int64_t mono[2]{};
+                clock_gettime_fn(4, (uint64_t)(uintptr_t)mono, 0, 0, 0, 0);
+                const uint64_t nanos = uint64_t(mono[0]) * 1'000'000'000 + mono[1];
+                const uint64_t last = ptc(0, 0, 0, 0, 0, 0);
+                if (first < guest_now || cycles < first || nanos < cycles || last < nanos)
+                    guest_clocks_consistent.store(false);
+            });
+        }
+        for (auto& reader : guest_readers) reader.join();
+        CHECK(guest_clocks_consistent.load(),
+              "concurrent guest process-time, TSC and monotonic reads share one advancing epoch");
 
         std::vector<uint64_t> concurrent(8);
         std::vector<std::thread> readers;
         for (size_t i = 0; i < concurrent.size(); ++i)
-            readers.emplace_back([&, i] { concurrent[i] = ptc(0, 0, 0, 0, 0, 0); });
+            readers.emplace_back([&, i] { concurrent[i] = host_gpu_progress_ns(); });
         for (auto& reader : readers) reader.join();
         CHECK(*std::min_element(concurrent.begin(), concurrent.end()) == held0 &&
                   *std::max_element(concurrent.begin(), concurrent.end()) == held0,
-              "concurrent readers share one held monotonic value");
+              "internal readers share one held progress value");
     }
-    uint64_t after_scope = ptc(0, 0, 0, 0, 0, 0);
+    uint64_t after_scope = host_gpu_progress_ns();
     CHECK(after_scope - before <= 25'000'000,
           "scope exit permanently removes excess synchronous GPU time");
 
@@ -57,9 +80,9 @@ int main() {
           "CLOCK_REALTIME continues through a compensated host-GPU interval");
 
     std::this_thread::sleep_for(std::chrono::milliseconds(15));
-    uint64_t resumed = ptc(0, 0, 0, 0, 0, 0);
+    uint64_t resumed = host_gpu_progress_ns();
     CHECK(resumed >= after_scope + 8'000'000,
-          "guest monotonic time resumes after the host-GPU scope");
+          "internal progress time resumes after the host-GPU scope");
 
     // A rejected overlapping begin returns zero, and ending that token must not truncate the
     // active outer scope. This pins the fail-open behavior used if serialization ever regresses.
@@ -69,9 +92,9 @@ int main() {
     guest_clock_host_gpu_end(inner);
     guest_clock_host_gpu_end(outer + 1);
     std::this_thread::sleep_for(std::chrono::milliseconds(8));
-    uint64_t overlap_held = ptc(0, 0, 0, 0, 0, 0);
+    uint64_t overlap_held = host_gpu_progress_ns();
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    CHECK(ptc(0, 0, 0, 0, 0, 0) == overlap_held,
+    CHECK(host_gpu_progress_ns() == overlap_held,
           "rejected and mismatched ends cannot release the outer clock hold");
     guest_clock_host_gpu_end(outer);
 
@@ -82,9 +105,9 @@ int main() {
     std::vector<std::thread> racing_readers;
     for (unsigned i = 0; i < 4; ++i) {
         racing_readers.emplace_back([&] {
-            uint64_t previous = ptc(0, 0, 0, 0, 0, 0);
+            uint64_t previous = host_gpu_progress_ns();
             while (!stop_readers.load(std::memory_order_relaxed)) {
-                const uint64_t current = ptc(0, 0, 0, 0, 0, 0);
+                const uint64_t current = host_gpu_progress_ns();
                 if (current < previous)
                     readers_monotonic.store(false, std::memory_order_relaxed);
                 previous = current;
@@ -101,10 +124,10 @@ int main() {
     for (auto& reader : racing_readers) reader.join();
     CHECK(writer_tokens_valid && readers_monotonic.load(std::memory_order_relaxed),
           "lock-free readers stay monotonic across scope publication races");
-    const uint64_t stress_end = ptc(0, 0, 0, 0, 0, 0);
+    const uint64_t stress_end = host_gpu_progress_ns();
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    CHECK(ptc(0, 0, 0, 0, 0, 0) >= stress_end + 2'000'000,
-          "guest monotonic time resumes after rapid scope transitions");
+    CHECK(host_gpu_progress_ns() >= stress_end + 2'000'000,
+          "internal progress time resumes after rapid scope transitions");
 
     if (fails) std::printf("== FAIL (%d) ==\n", fails);
     else       std::printf("== PASS ==\n");


### PR DESCRIPTION
Sonic's AudioOut2 producer follows guest time while its physical sink follows real time. Globally discounting graphics stalls from guest clocks caused sustained missing PCM: a matched 65-second startup A–B–A measured median 108/80, 188/0, 108.5/79.5 fresh/missing MAIN grains per second when compensation was enabled, disabled, and enabled again.

Guest process-time, TSC, monotonic reads and GPU EOP timestamps now advance on one real steady timeline. The PM4 dependency watchdog retains a separate compensated clock: its queued producer cannot make progress while synchronous backend work holds the submit mutex. This avoids reintroducing the Plucky long-compilation timeout/ordering defect. Animation and cutscene timing intentionally follows real elapsed time; matched scene checks remain necessary.

Independent output/channel buffers and consumed-once PCM remain intact. FLOW diagnostics now count publications and pending replacements, with a positive same-port overwrite/control through the actual HLE and log. The caller diagnostic format is corrected. Plucky's historical per-flip explanation is marked superseded without discarding its measurements.

Validation:

- Focused audio/guest-clock/internal-watchdog tests passed 5/5; audio plus new FLOW calibration passed 2/2.
- Three independent source mutations fail distinct guards: restore guest clock freezing; age the watchdog with real guest time; use internal time for EOP timestamps.
- Independent exact-head review found no blocking issues. Release build, 374/374 tests, 374/374 core plus synchronization validation, fresh Sonic/GTA captures and all seven required Linux/general CI checks passed. Detailed author evidence is recorded in the PR comments.
- Reproducible A–B–A commands/manifests and measurement limits are recorded in #3422; captures stay private. Default full-route captures additionally delivered 71,058/67,296 fresh MAIN grains with zero missing in Sonic/GTA. These establish the observed production deficit is fixed, not zero physical device underruns or an FPS speedup.

Refs #3422. Broader graphics performance and Blue Prince work continues separately.
