### PR TITLE
Quantize layered FP16 texture channels directly to UNORM8

### DIFF
--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -5727,22 +5727,29 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                         slice_short[slice_short_count++] = fface;
                                     if (f16) {
                                         const uint32_t nc = source_bpt / 2;
+                                        // Same-build performance control for the scalar float path.
+                                        static const bool old_half_quantization =
+                                            PROSPER_ENV_ON("PROSPER_NO_HALF_QUANTIZATION");
                                         for (size_t texel = 0; texel < (size_t)tw * th; ++texel) {
                                             uint8_t* pixel = slice + texel * 4;
                                             for (uint32_t c = 0; c < 4; ++c) {
-                                                float value = c == 3 ? 1.0f : 0.0f;
+                                                uint16_t half = c == 3 ? 0x3c00u : 0u;
                                                 if (c < nc) {
-                                                    uint16_t half = 0;
                                                     std::memcpy(
                                                         &half,
                                                         linear.data() + texel * source_bpt + c * 2,
                                                         sizeof(half));
-                                                    value = prosper::gpu::half_to_float(half);
                                                 }
-                                                pixel[c] = !std::isfinite(value) || value <= 0.0f
-                                                    ? 0u : (value >= 1.0f
-                                                        ? 255u
-                                                        : static_cast<uint8_t>(value * 255.0f + 0.5f));
+                                                if (old_half_quantization) {
+                                                    const float value = c < nc
+                                                        ? prosper::gpu::half_to_float(half)
+                                                        : (c == 3 ? 1.0f : 0.0f);
+                                                    pixel[c] = !std::isfinite(value) || value <= 0.0f
+                                                        ? 0u : (value >= 1.0f ? 255u
+                                                            : static_cast<uint8_t>(value * 255.0f + 0.5f));
+                                                } else {
+                                                    pixel[c] = prosper::gpu::half_to_unorm8(half);
+                                                }
                                             }
                                         }
                                     } else if (source_bpt == 4) {

--- a/prosper/src/gpu/resources/shader_resources.hpp
+++ b/prosper/src/gpu/resources/shader_resources.hpp
@@ -182,6 +182,17 @@ constexpr uint32_t kNativeStorageFormatSupportMask = (1u << 25) - 1u;
 // convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
 float half_to_float(uint16_t h);
 
+// The RGBA8 texture fallback's finite, clamped, nearest-value conversion, directly from binary16.
+// Preserve its non-finite policy: even positive infinity maps to zero. Values below exponent 6
+// cannot round up to one UNORM8 step; the remaining finite fraction is (1024+mantissa)*2^(exp-25).
+constexpr uint8_t half_to_unorm8(uint16_t h) {
+    if (h < 0x1800u || h >= 0x7c00u) return 0;
+    if (h >= 0x3c00u) return 255;
+    const uint32_t shift = 25u - (h >> 10);
+    return static_cast<uint8_t>(
+        (((h & 0x3ffu) + 1024u) * 255u + (1u << (shift - 1u))) >> shift);
+}
+
 // IEEE-754 binary32 -> binary16, round-to-nearest-even. This is the inverse conversion needed when
 // a format-free storage-image write targets an R16_FLOAT/R16G16B16A16_FLOAT guest surface.
 uint16_t float_to_half(float f);

--- a/prosper/tests/gpu/resources/test_shader_resources.cpp
+++ b/prosper/tests/gpu/resources/test_shader_resources.cpp
@@ -6,6 +6,7 @@
 #include "gpu/execute/gpu_execute.hpp"
 #include "shared/live/live_compute.hpp"
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <initializer_list>
@@ -472,6 +473,17 @@ int main() {
     }
     CHECK(unorm16_reversals == 0,
           "UNORM16 -> UNORM8 remains monotonic instead of wrapping at byte boundaries");
+
+    uint32_t half_quantization_mismatches = 0;
+    for (uint32_t bits = 0; bits <= 0xffffu; ++bits) {
+        const float value = half_to_float(static_cast<uint16_t>(bits));
+        const uint8_t reference = !std::isfinite(value) || value <= 0.0f ? 0u
+            : value >= 1.0f ? 255u : static_cast<uint8_t>(value * 255.0f + 0.5f);
+        if (half_to_unorm8(static_cast<uint16_t>(bits)) != reference)
+            ++half_quantization_mismatches;
+    }
+    CHECK(half_quantization_mismatches == 0,
+          "binary16 -> UNORM8 matches the original float conversion for all 65536 encodings");
 
     // A table as the front-half would build it: a float32×4 constant buffer (descriptor at SRT 0x20)
     // and a unorm8×4 vertex buffer (descriptor at SRT 0x40).


### PR DESCRIPTION
Sonic's layered RGBA16F cube fallback repeatedly expands every half component to float and clamps it. Quantize these channels directly with exact integer rounding. In a same-binary Sonic comparison, uncached texture conversion cost fell from 9.643 to 4.758 ms per texture reference (50.7%); the slowest 512×512×6 FP16 cube fell from 15.346 to 8.923 ms.

The output remains byte-identical across all 65,536 half encodings, including negative values, absent channels and existing non-finite-to-zero behavior. `PROSPER_NO_HALF_QUANTIZATION=1` restores the original scalar path for comparisons.

Validation at ed5d9e994be9d9ecd82cee7d86618daa6d601768: full Release build; 374/374 tests; 374/374 under core plus synchronization validation, with no new messages beyond the four documented allowlisted IDs. Removing integer rounding makes the exhaustive comparison fail at 0x1805. Independent exact-commit review approved. Required Linux/general CI is green.

Both Sonic arms ran the same 380-second route with fresh saves and the same executable; GTA ran its 360-second performance route. Paired Sonic images retain the existing #2790 black Cyber Space world/HUD, and GTA still renders the bank scene correctly. The observed Sonic presentation rate was 3.99 versus 4.79/s, but game progress differed and fresh-frame counts were unavailable: this is not a demonstrated general FPS speedup. Detailed captures, commands and limitations are recorded in the validation comment.

Refs #3407. GPU detiling, broader conversion caching and guest writeback work remain open.
