### PR TITLE
Quantize renderer-owned FP16 compute uploads directly

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6481,6 +6481,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             double image_allocation_ms = 0.0;
             double view_ms = 0.0;
             double sampler_ms = 0.0;
+            bool rtt_half_unorm = false;
             const ShaderResource* r = item.resources->by_binding(image_descriptors[i].binding);
             if (!r || !r->width || !r->height) { skip_image(r, "no/degenerate resource"); break; }
             BoundImage& bi = images[i];
@@ -8327,31 +8328,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             });
                     } else if (sampled_unorm8x2) {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        // #3407: per-texel and independent -- every write is upload[t*n+c],
-                        // disjoint across t -- so this is the same shape as the arm below that
-                        // already uses the helper. Leaving it scalar is why a 4K conversion took
-                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
-                        // on bytes touched per texel; the helper uses it only to size the pool.
-                        parallel_compute_texels(
-                            texels, texels * 16u, [&](size_t begin, size_t end) {
-                        for (size_t t = begin; t < end; ++t) {
-                            for (uint32_t c = 0; c < 2; ++c) {
-                                if (source_rg8) {
-                                    upload[t * 2 + c] = pixels[t * 2 + c];
-                                } else if (source_unorm8) {
-                                    upload[t * 2 + c] = pixels[t * 4 + c];
-                                } else {
-                                    uint16_t half = 0;
-                                    std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
-                                    float value = half_to_float(half);
-                                    if (!std::isfinite(value) || value <= 0.0f) value = 0.0f;
-                                    else if (value >= 1.0f) value = 1.0f;
-                                    upload[t * 2 + c] = static_cast<uint8_t>(
-                                        std::lround(value * 255.0f));
-                                }
-                            }
-                        }
+                        if (source_float16) {
+                            renderer_float16_to_unorm8_range(pixels.data(), 2, texels, upload);
+                            rtt_half_unorm = true;
+                        } else {
+                            parallel_compute_texels(
+                                texels, texels * 16u, [&](size_t begin, size_t end) {
+                                for (size_t t = begin; t < end; ++t)
+                                    for (uint32_t c = 0; c < 2; ++c)
+                                        upload[t * 2 + c] = source_rg8
+                                            ? pixels[t * 2 + c] : pixels[t * 4 + c];
                             });
+                        }
                     } else if (sampled_unorm16_native) {
                         const size_t texels = static_cast<size_t>(volume_texels);
                         // #3407: per-texel and independent -- every write is upload[t*n+c],
@@ -8429,26 +8417,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             break;
                         }
                     } else {
-                        const size_t texels = static_cast<size_t>(volume_texels);
-                        // #3407: per-texel and independent -- every write is upload[t*n+c],
-                        // disjoint across t -- so this is the same shape as the arm below that
-                        // already uses the helper. Leaving it scalar is why a 4K conversion took
-                        // 25 ms on one core while 31 others idled. work_bytes is an upper bound
-                        // on bytes touched per texel; the helper uses it only to size the pool.
-                        parallel_compute_texels(
-                            texels, texels * 16u, [&](size_t begin, size_t end) {
-                        for (size_t t = begin; t < end; ++t) {
-                            for (uint32_t c = 0; c < 4; ++c) {
-                                uint16_t half = 0;
-                                std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
-                                float value = half_to_float(half);
-                                if (!std::isfinite(value) || value <= 0.0f) value = 0.0f;
-                                else if (value >= 1.0f) value = 1.0f;
-                                upload[t * 4 + c] = static_cast<uint8_t>(
-                                    std::lround(value * 255.0f));
-                            }
-                        }
-                            });
+                        // The layout guard above leaves only an RGBA16F snapshot here. Preserve
+                        // its historical nonfinite-to-zero normalization, distinct from the
+                        // guest-backed sampled fallback (which maps positive infinity to 255).
+                        renderer_float16_to_unorm8_range(
+                            pixels.data(), 4, static_cast<size_t>(volume_texels), upload);
+                        rtt_half_unorm = true;
                     }
                     if (trace) {
                         const uint64_t snapshot_hash = fnv1a(live_target.pixels->data(),
@@ -8836,6 +8810,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              "persistent=%u allocation-reused=%u upload-skipped=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu "
                              "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u "
+                             "rtt-format=%s rtt-half-unorm=%u "
                              "query_ms=%.3f import_ms=%.3f cache_ms=%.3f "
                              "staging_ms=%.3f prepare_ms=%.3f allocation_ms=%.3f "
                              "view_ms=%.3f sampler_ms=%.3f ms=%.3f\n",
@@ -8853,6 +8828,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              image_descriptors[i].texel_access ? 1u : 0u,
                              image_descriptors[i].sampled_float ? 1u : 0u,
                              bi.unorm_rtt_value_reuse ? 1u : 0u,
+                             renderer_owned
+                                 ? prosper::frontend::live_target_pixel_format_name(live_target.format)
+                                 : "none",
+                             rtt_half_unorm ? 1u : 0u,
                              query_ms, import_ms, cache_lookup_ms,
                              staging_ms, prepare_upload_ms, image_allocation_ms,
                              view_ms, sampler_ms,
@@ -11738,6 +11717,34 @@ void sampled_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
                 }
             }
         });
+}
+
+// Only renderer-owned RGBA16F snapshots use this contract: the source stride remains
+// eight bytes even when the guest samples two normalized channels. Its scalar control leaves
+// the graphics layered conversion unchanged, isolating this compute preparation cost.
+void renderer_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
+                                      size_t texels, uint8_t* packed) {
+    if (!source || !packed || (components != 2 && components != 4) ||
+        texels > SIZE_MAX / 16u) return;
+    static const bool old_half_quantization =
+        std::getenv("PROSPER_NO_RTT_HALF_QUANTIZATION") != nullptr;
+    parallel_compute_texels(texels, texels * 16u, [&](size_t begin, size_t end) {
+        for (size_t t = begin; t < end; ++t) {
+            for (uint32_t c = 0; c < components; ++c) {
+                uint16_t half = 0;
+                std::memcpy(&half, source + t * 8 + c * 2, sizeof(half));
+                if (old_half_quantization) {
+                    float value = prosper::gpu::half_to_float(half);
+                    if (!std::isfinite(value) || value <= 0.0f) value = 0.0f;
+                    else if (value >= 1.0f) value = 1.0f;
+                    packed[t * components + c] = static_cast<uint8_t>(
+                        std::lround(value * 255.0f));
+                } else {
+                    packed[t * components + c] = prosper::gpu::half_to_unorm8(half);
+                }
+            }
+        }
+    });
 }
 
 // TripBoundWitnessScope lives in trip_bound_witness.hpp so its save/restore contract can be

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -122,6 +122,10 @@ void storage_unpack_float16x4_range(const uint8_t* rgba16f, size_t texels, uint3
 uint8_t sampled_float16_to_unorm8(uint16_t half_bits);
 void sampled_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
                                      size_t texels, uint8_t* rgba);
+// Normalize renderer-owned RGBA16F snapshots into tightly packed RG8/RGBA8. Unlike the
+// guest-backed sampled conversion, all nonfinite inputs become zero. Source stride is always 8.
+void renderer_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
+                                      size_t texels, uint8_t* packed);
 // Pack tightly-strided RGBA32F channel bits to RGBA16F. Uses a runtime-dispatched F16C path where
 // available and preserves float_to_half's exact NaN payload/rounding contract.
 void storage_pack_float16x4_range(const uint32_t* channels, size_t texels, uint8_t* rgba16f);

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -335,6 +335,61 @@ int main() {
               true, 27, false, true),
           "the recovery switch restores the copied writeback path");
 
+    // Exercise the range routine used by the renderer-owned RTT upload branches, including
+    // their fixed RGBA16F source stride when the guest requests only RG8. Every channel sees
+    // every binary16 code; unaligned buffers and an odd tail catch stride/alignment shortcuts.
+    {
+        constexpr size_t texels = 65536u + 7u;
+        std::vector<uint8_t> source(texels * 8u + 2u, 0xa5u);
+        for (size_t t = 0; t < texels; ++t)
+            for (uint32_t c = 0; c < 4; ++c) {
+                const uint16_t half = static_cast<uint16_t>(t + c * 9973u);
+                std::memcpy(source.data() + 1u + t * 8u + c * 2u, &half, sizeof(half));
+            }
+        const auto original_source = source;
+        for (const uint32_t components : {2u, 4u}) {
+            std::vector<uint8_t> actual(texels * components + 2u, 0xcdu);
+            prosper::frontend::renderer_float16_to_unorm8_range(
+                source.data() + 1u, components, texels, actual.data() + 1u);
+            bool matches = actual.front() == 0xcdu && actual.back() == 0xcdu;
+            for (size_t t = 0; t < texels && matches; ++t)
+                for (uint32_t c = 0; c < components; ++c) {
+                    uint16_t half = 0;
+                    std::memcpy(&half, source.data() + 1u + t * 8u + c * 2u, sizeof(half));
+                    float value = half_to_float(half);
+                    if (!std::isfinite(value) || value <= 0.0f) value = 0.0f;
+                    else if (value >= 1.0f) value = 1.0f;
+                    const auto expected = static_cast<uint8_t>(std::lround(value * 255.0f));
+                    if (actual[1u + t * components + c] != expected) {
+                        std::printf("Renderer FP16 normalization mismatch components=%u "
+                                    "texel=%zu channel=%u half=0x%04x expected=%u actual=%u\n",
+                                    components, t, c, static_cast<unsigned>(half),
+                                    static_cast<unsigned>(expected),
+                                    static_cast<unsigned>(actual[1u + t * components + c]));
+                        matches = false;
+                        break;
+                    }
+                }
+            CHECK(matches, "renderer RTT FP16 normalization matches all 65536 lround inputs "
+                           "with RGBA16F source stride, packed destination and canaries");
+        }
+        CHECK(source == original_source, "renderer RTT conversion preserves its owned snapshot");
+        std::array<uint8_t, 16> untouched;
+        untouched.fill(0x5au);
+        const auto before = untouched;
+        for (const uint32_t components : {0u, 1u, 3u, 5u})
+            prosper::frontend::renderer_float16_to_unorm8_range(
+                source.data() + 1u, components, 1u, untouched.data());
+        prosper::frontend::renderer_float16_to_unorm8_range(
+            source.data(), 4u, 0u, untouched.data());
+        prosper::frontend::renderer_float16_to_unorm8_range(
+            nullptr, 4u, 1u, untouched.data());
+        prosper::frontend::renderer_float16_to_unorm8_range(
+            source.data(), 4u, SIZE_MAX, untouched.data());
+        CHECK(untouched == before, "renderer RTT conversion refuses unsupported shapes "
+                                   "and overflowing or empty ranges before writing");
+    }
+
     bool half_luts_match = true;
     for (uint32_t bits = 0; bits <= 0xffffu; ++bits) {
         const uint16_t half = static_cast<uint16_t>(bits);


### PR DESCRIPTION
Renderer-owned FP16 snapshots used by compute still expand each channel to float before clamping and rounding it to UNORM8. Reuse the exact integer quantizer for normalized RG and RGBA uploads, preserving the existing all-nonfinite-to-zero behavior and RGBA16F source stride. UINT8 conversion and target ownership decisions are unchanged. Refs #3407.

`PROSPER_NO_RTT_HALF_QUANTIZATION=1` restores the scalar conversion in the same binary while leaving the graphics optimization enabled. Existing opt-in `PROSPER_COMPUTE_IMAGE_TIMING` records now include the RTT source format and whether this conversion ran, so subsequent captures can establish the actual route. No live performance improvement is claimed yet.

Validation on the committed source before the commit was created:

- Release targets `test_game_compute` and `prosper-app` built successfully with `cmake --build <WORKTREE>/prosper/build-linux --target test_game_compute prosper-app -j4`.
- The production range-conversion test covers all 65,536 binary16 codes in every channel, RG/RGBA packing, unaligned buffers, an odd tail, canaries, source preservation and invalid inputs against the previous `lround` reference. `test_game_compute` passed with **705 assertions**, both normally and with `PROSPER_NO_RTT_HALF_QUANTIZATION=1`.
- A deliberate mutation in the production helper changed input `0x1805` from the correct output 1 to 0. The retained mutant executable exited 1 with **exactly two failures**, identifying that input in the RG and RGBA arms. Production source was restored byte-for-byte and rebuilt before both passing runs. Local logs: `prosper/build-linux/evidence/goal-rtt-half-{default,scalar,negative}.log`.

The full Release build subsequently passed at exact head `1c7d437f76affe32124c721116a6459ecc33452a` with `cmake --build <WORKTREE>/prosper/build-linux -j4` (local log `prosper/build-linux/evidence/goal-rtt-half-full-build.log`).

Draft gates still pending: full test suite, synchronization validation, live source-layout witness and controlled same-binary performance comparison, and a registered independent review of the exact PR head. The focused tests exercise the production conversion routine; they do not establish a live-game performance result.
