### PR TITLE
Honor HTILE broadcast clears during Blue Prince FMV composition

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3248,6 +3248,13 @@ if(TARGET prosper_core)
   endif()
 endif()
 
+if(TARGET prosper_live_renderer AND TARGET Vulkan::Vulkan)
+  add_executable(test_broadcast_htile_clear tests/gpu/execute/test_broadcast_htile_clear.cpp)
+  target_include_directories(test_broadcast_htile_clear PRIVATE tests frontends)
+  target_link_libraries(test_broadcast_htile_clear PRIVATE prosper_live_renderer Vulkan::Vulkan)
+  add_test(NAME broadcast_htile_clear COMMAND test_broadcast_htile_clear)
+endif()
+
 # Normal sampled-render capture on every host with the live renderer. Unix writes PNG through zlib;
 # Windows uses its built-in WIC PNG encoder so the native tool needs no extra package.
 if(TARGET prosper_live_renderer AND TARGET Vulkan::Vulkan)

--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -1,9 +1,9 @@
 # Blue Prince (PPSA25009, Unity/IL2CPP) — status & investigation map
 
-Last revised: 2026-08-17 (ladder position reconciled against tracker #1808 and the checked-in guard;
-the investigation body below is unchanged and still dated 2026-08-03 — snapshot route/reference
-triage, see Ruled out). Prior history: #1216 (closed — boot/blank-frame era), #1264 (Day One hold
-investigation), #1287 (visuals umbrella, open).
+Last revised: 2026-09-07 (opening FMV regression #3423; see Ruled out). Ladder position was last
+reconciled against tracker #1808 and the checked-in guard on 2026-08-17; the older investigation
+sections retain their own dates. Prior history: #1216 (closed — boot/blank-frame era), #1264
+(Day One hold investigation), #1287 (visuals umbrella, open).
 
 ## Ladder position
 
@@ -430,6 +430,40 @@ not runtime caching — they say nothing about whether prosper re-uploads a text
 reading them that way is a trap.
 
 ## Ruled out (do-not-redo list)
+
+**2026-09-07 — opening FMV foreground geometry (#3423): adjacent-commit live bisect.**
+The exact parent `75f57457f79920c1e8c4cca96695eb183824984d` renders an unobstructed portrait;
+its immediate successor `03caaf19fb5a15d1efa278da066d0e9afdcc79b8` (#3281) puts a tree and
+balustrade in front of the same opening movie. Both used fresh saves, the native app with
+`PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_IME_AUTOKEY=1 PROSPER_RENDER=1`, immediate
+presentation, no pad input, and `PROSPER_GRAB_BUNDLE_AFTER_MS=310000` during a 350-second run.
+This is visual correctness evidence, not a timing comparison; compilation overlapped parts of the
+historical runs. The screenshots, manifests and detailed bisect are linked from #3423.
+
+The current bad capture contains 31 dispatches of one bounded indexed-buffer program across two
+adjacent submits. Every observed mask is zero: the shader broadcasts a separate four-byte source
+value over a destination HTILE range. All destination bytes happen to be zero already, but the
+operation is a logical clear, not an identity copy of the destination. In the strongest sequence,
+a depth-producing draw is followed by the broadcast into that same surface's HTILE, then a
+stencil-only clear draw. Preserving detached depth on the strength of equal guest metadata skips
+the depth reset. The count and mask come from the per-instruction scalar-load resource snapshots;
+the generic SGPR-8 resource is not the captured value source.
+
+The older neutral suppression experiment below measured a different black-frame/coverage claim;
+it does not rule out this visually bisected layering regression. A blanket reversion of #3281 is
+also insufficient: the identity-update preservation serves GTA's G-buffer-to-lighting path.
+The fix must distinguish an independently sourced broadcast from an actual identity update and
+retain the latter's rendered depth.
+
+The bounded broadcast path proves the full decoded instruction shape, runtime zero mask, linear
+UINT32 descriptors, launch extent and non-aliasing readable input ranges before filling the exact
+written range. It emits an ordinary guest-write notification even for zero-to-zero metadata.
+Identity updates keep the Vulkan path and its existing preservation behavior. The
+`broadcast_htile_clear` guard renders nonzero depth, verifies that a Vulkan identity update retains
+it, then sends a broadcast through capture serialization and replay and verifies the formerly
+occluded consumer becomes visible. Replay derives the proof from retained ISA and owns its
+snapshot bytes; an explicit SPIR-V override clears the guest-program shortcuts.
+
 
 **2026-08-29 — the HTILE byte-preserving suppression is NOT what keeps this title rendering.**
 #3093 removed that suppression to fix this title's black frame and recorded a fade-in to ~21% as the

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -4901,10 +4901,140 @@ void maybe_dump_traced_compute_raw(const prosper::gpu::ComputeItem& item, bool t
                  readable_bytes, path, ok ? "written" : "failed");
 }
 
+std::optional<bool> execute_cpu_broadcast_fill(const prosper::gpu::ComputeItem& item) {
+    using namespace prosper::gpu;
+    if (!item.resources || item.user_sgprs.size() != 12 || !item.recompile_config_available ||
+        !item.recompile_config.tgid_x_en || item.recompile_config.tgid_y_en ||
+        item.recompile_config.tgid_z_en || item.recompile_config.tidig_comp_cnt != 0 ||
+        item.recompile_config.local_x != 64 || item.recompile_config.local_y != 1 ||
+        item.recompile_config.local_z != 1 ||
+        item.launch.local_x != 64 || item.launch.local_y != 1 || item.launch.local_z != 1 ||
+        !item.launch.groups_x || item.launch.groups_y != 1 || item.launch.groups_z != 1 ||
+        item.launch.threads_y != 1 || item.launch.threads_z != 1)
+        return std::nullopt;
+
+    // SMEM realization may retain several snapshots of one descriptor. Use each instruction's
+    // actual resource, not the generic SGPR-8 binding (which need not contain captured bytes).
+    const auto* count_resource = item.resources->by_fetch_pc(3);
+    const auto* mask_resource = item.resources->by_fetch_pc(8);
+    const auto* source = item.resources->by_fetch_pc(12);
+    const auto* target = item.resources->by_fetch_pc(15);
+    auto scalar_shape = [](const ShaderResource* r) {
+        return r && !r->table_index_count && r->cls == ResourceClass::ConstantBuffer && r->format == DataFormat::Float32 &&
+            r->num_components == 4 && r->stride == 16;
+    };
+    auto uint_shape = [](const ShaderResource* r, uint32_t sgpr) {
+        return r && !r->table_index_count && r->cls == ResourceClass::ConstantBuffer && r->format == DataFormat::Uint32 &&
+            r->num_components == 1 && r->stride == 4 && r->sgpr_base == sgpr;
+    };
+    if (!scalar_shape(count_resource) || !scalar_shape(mask_resource) ||
+        !uint_shape(source, 0) || !uint_shape(target, 4))
+        return std::nullopt;
+    auto raw_shape = [&](const ShaderResource& r, uint32_t sgpr, bool typed) {
+        const uint32_t* v = item.user_sgprs.data() + sgpr;
+        const uint64_t base = v[0] | (static_cast<uint64_t>(v[1] & 0xffffu) << 32);
+        const uint32_t stride = (v[1] >> 16) & 0x3fffu;
+        const uint64_t size = static_cast<uint64_t>(v[2]) * stride;
+        DataFormat format = DataFormat::Unknown;
+        uint32_t components = 0;
+        rdna2_buffer_format((v[3] >> 12) & 0x7fu, &format, &components);
+        // Normalization drops addressing controls. Prove a linear V# from the actual user SGPRs;
+        // a typed load also needs X=select-X, whereas SMEM consumes raw bytes regardless of DST_SEL.
+        return !(v[1] & 0xc0000000u) && !(v[3] & 0xfff80000u) &&
+            base == r.gpu_addr && stride == r.stride && size == r.size &&
+            (!typed || ((v[3] & 7u) == 4u && format == r.format && components == r.num_components));
+    };
+    if (!raw_shape(*source, 0, true) || !raw_shape(*target, 4, true) ||
+        !raw_shape(*count_resource, 8, false) || !raw_shape(*mask_resource, 8, false))
+        return std::nullopt;
+    auto read_pointer = [](const ShaderResource& r, uint32_t offset) -> const uint8_t* {
+        const uint32_t required = offset + sizeof(uint32_t);
+        if (r.size < required) return nullptr;
+        if (r.host_data)
+            return r.host_data_size >= required ? r.host_data + offset : nullptr;
+        if (!r.gpu_addr || r.gpu_addr > UINT64_MAX - required ||
+            !guest_readable(r.gpu_addr, required)) return nullptr;
+        return reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(r.gpu_addr)) + offset;
+    };
+    const uint8_t* count_ptr = read_pointer(*count_resource, 0);
+    const uint8_t* mask_ptr = read_pointer(*mask_resource, 4);
+    const uint8_t* source_ptr = read_pointer(*source, 0);
+    if (!count_ptr || !mask_ptr || !source_ptr) return std::nullopt;
+    uint32_t count = 0, mask = 0, value = 0;
+    std::memcpy(&count, count_ptr, sizeof(count));
+    std::memcpy(&mask, mask_ptr, sizeof(mask));
+    std::memcpy(&value, source_ptr, sizeof(value));
+    if (mask != 0 || count == 0) return std::nullopt;
+    const uint64_t launched = static_cast<uint64_t>(item.launch.groups_x) * 64u;
+    if (launched > UINT32_MAX) return std::nullopt;
+    if ((item.recompile_config.exact_thread_extent &&
+         (!item.launch.threads_x || item.recompile_config.threads_x != item.launch.threads_x ||
+          item.recompile_config.threads_y != 1 || item.recompile_config.threads_z != 1)) ||
+        (!item.recompile_config.exact_thread_extent && item.launch.threads_x &&
+         item.launch.threads_x != launched))
+        return std::nullopt;
+    const uint64_t threads = item.recompile_config.exact_thread_extent
+        ? std::min<uint64_t>(item.launch.threads_x, launched) : launched;
+    const uint64_t records = std::min<uint64_t>(count, threads);
+    const uint64_t bytes = records * sizeof(uint32_t);
+    if (!bytes || bytes > target->size || bytes > SIZE_MAX ||
+        !target->gpu_addr || target->gpu_addr > UINT64_MAX - bytes)
+        return std::nullopt;
+    uint8_t* destination = nullptr;
+    if (target->host_data) {
+        if (target->host_data_size < bytes) return std::nullopt;
+        destination = target->host_data;
+    } else if (bytes <= UINT32_MAX && guest_writable(target->gpu_addr, static_cast<uint32_t>(bytes))) {
+        destination = reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(target->gpu_addr));
+    }
+    if (!destination) return std::nullopt;
+    auto overlaps = [](uint64_t a, uint64_t n, uint64_t b, uint64_t m) {
+        if (!a || !b || !n || !m) return false;
+        return a <= b ? b - a < n : a - b < m;
+    };
+    // Readonly inputs may alias each other (a fill value often lives beside count/mask). A source
+    // aliasing the destination would be a different operation, even if all current bytes are zero.
+    const ShaderResource* reads[] = {count_resource, mask_resource, source};
+    const uint8_t* pointers[] = {count_ptr, mask_ptr, source_ptr};
+    const uint32_t offsets[] = {0, 4, 0};
+    for (size_t n = 0; n < 3; ++n) {
+        if ((reads[n]->gpu_addr &&
+             (reads[n]->gpu_addr > UINT64_MAX - offsets[n] ||
+              overlaps(target->gpu_addr, bytes, reads[n]->gpu_addr + offsets[n], 4))) ||
+            overlaps(reinterpret_cast<uintptr_t>(destination), bytes,
+                     reinterpret_cast<uintptr_t>(pointers[n]), 4))
+            return std::nullopt;
+    }
+
+    notify_compute_authority_boundary({ComputeAuthorityBoundaryKind::Compute,
+        item.submit_no, item.command_order, target->gpu_addr, bytes, true});
+    if (!target->host_data)
+        prosper::host::guest_write_watch_notify_host_write(target->gpu_addr, static_cast<size_t>(bytes));
+    if (!value) {
+        std::memset(destination, 0, static_cast<size_t>(bytes));
+    } else {
+        for (size_t offset = 0; offset < bytes; offset += sizeof(value))
+            std::memcpy(destination + offset, &value, sizeof(value));
+    }
+    // This writes logical contents, including a zero-to-zero HTILE clear. Byte equality must not
+    // suppress invalidation of renderer-owned depth written earlier in the same present.
+    const char* previous_origin = guest_gpu_write_origin();
+    set_guest_gpu_write_origin("compute-writeback(cpu-broadcast)");
+    notify_guest_gpu_write(target->gpu_addr, bytes);
+    set_guest_gpu_write_origin(previous_origin);
+    if (!target->host_data && writer_provenance_enabled())
+        record_guest_write(GuestWriterKind::ComputeBuffer, target->gpu_addr, bytes,
+                           item.submit_no, item.dispatch_index, item.command_order, item.code_addr);
+    g_cpu_fill_dispatches.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
 std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item) {
     using prosper::gpu::ComputeCpuFastPath;
     using prosper::gpu::ResourceClass;
     if (item.cpu_fast_path == ComputeCpuFastPath::None) return std::nullopt;
+    if (item.cpu_fast_path == ComputeCpuFastPath::BroadcastBufferU32)
+        return execute_cpu_broadcast_fill(item);
     if (item.cpu_fast_path != ComputeCpuFastPath::FillSgprUvec4 ||
         !item.resources || item.resources->resources.size() != 1 ||
         item.user_sgprs.size() != 8 || !item.recompile_config_available ||

--- a/prosper/src/gpu/capture/gpu_capture.cpp
+++ b/prosper/src/gpu/capture/gpu_capture.cpp
@@ -5396,6 +5396,11 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         if (compute.resources && compute.recompile_config_available &&
             compute.raw_shader_index < c.raw_shader_versions.size()) {
             const auto& raw = c.raw_shader_versions[compute.raw_shader_index].words;
+            // Rebuild this semantic proof from retained guest ISA, never from a serialized enum.
+            // Replay still checks the captured descriptors, launch and owned backing at execution.
+            if (classify_compute_cpu_fast_path(raw.data(), raw.size()) ==
+                    ComputeCpuFastPath::BroadcastBufferU32)
+                compute.cpu_fast_path = ComputeCpuFastPath::BroadcastBufferU32;
             if (has_cf9200_no_backing) {
                 if (!rdna2_gta5_cf9200_no_backing_dispatch(
                         raw.data(), raw.size(), compute.recompile_config,

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -444,6 +444,7 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& dispatc
 enum class ComputeCpuFastPath : uint8_t {
     None,
     FillSgprUvec4,
+    BroadcastBufferU32,
 };
 
 ComputeCpuFastPath classify_compute_cpu_fast_path(const uint32_t* code, size_t dwords);

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -7892,17 +7892,20 @@ ComputeCpuFastPath classify_compute_cpu_fast_path(const uint32_t* code, size_t d
         operand(index.src[1], OperandKind::InlineInt, 6) &&
         operand(index.src[2], OperandKind::VGPR, 0) &&
         scalar_load(2, 3, 0) && shape(3, Rdna2Format::SOPP, 0x0c, 5, 1) &&
+        static_cast<uint16_t>(ins[3].simm16) == 0xc07fu &&
         shape(4, Rdna2Format::VOPC, 0xd4, 6, 1) &&
         operand(compare.src[0], OperandKind::Special, 106) &&
         operand(compare.src[1], OperandKind::VGPR, 0) &&
         shape(5, Rdna2Format::SOPP, 0x08, 7, 1) && ins[5].simm16 == 9 &&
         scalar_load(6, 8, 4) && shape(7, Rdna2Format::SOPP, 0x0c, 10, 1) &&
+        static_cast<uint16_t>(ins[7].simm16) == 0xc07fu &&
         shape(8, Rdna2Format::VOP2, 0x1b, 11, 1) &&
         operand(mask.dst, OperandKind::VGPR, 1) &&
         operand(mask.src[0], OperandKind::Special, 106) &&
         operand(mask.src[1], OperandKind::VGPR, 0) &&
         buffer_access(9, 12, 0x00, 1, 0) &&
         shape(10, Rdna2Format::SOPP, 0x0c, 14, 1) &&
+        static_cast<uint16_t>(ins[10].simm16) == 0x3f70u &&
         buffer_access(11, 15, 0x04, 0, 4) && shape(12, Rdna2Format::SOPP, 0x01, 17, 1))
         return ComputeCpuFastPath::BroadcastBufferU32;
     return ComputeCpuFastPath::None;

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -7839,6 +7839,72 @@ ComputeCpuFastPath classify_compute_cpu_fast_path(const uint32_t* code, size_t d
     if (code && dwords >= std::size(kFillSgprUvec4) &&
         std::equal(std::begin(kFillSgprUvec4), std::end(kFillSgprUvec4), code))
         return ComputeCpuFastPath::FillSgprUvec4;
+
+    // Bounded indexed copy: i=(tgid.x<<6)+tid.x; if (i<count) dst[i]=src[i&mask].
+    // A zero live mask makes this a broadcast fill. It is not an identity update merely because
+    // guest destination bytes already equal the source: detached rendered depth can differ (#3423).
+    // Classify the complete instruction/operand shape here; execution proves the live mask, numeric
+    // formats, dispatch extent, readable snapshots and non-aliasing before taking the CPU path.
+    if (!code || dwords < 18 || code[0] != (0xbf800000u | (0x20u << 16) | 1u))
+        return ComputeCpuFastPath::None;
+    std::vector<Rdna2Inst> ins;
+    if (rdna2_walk(code, 18, ins) != 18 || ins.size() != 13 || !ins.back().is_end)
+        return ComputeCpuFastPath::None;
+    for (const auto& in : ins) {
+        if (in.has_modifier || in.has_sdwa || in.has_dpp || in.clamp || in.omod)
+            return ComputeCpuFastPath::None;
+        for (unsigned n = 0; n < 4; ++n)
+            if (in.src_neg[n] || in.src_abs[n]) return ComputeCpuFastPath::None;
+    }
+    auto operand = [](const Operand& op, OperandKind kind, int value) {
+        return op.kind == kind && op.value == value;
+    };
+    auto shape = [&](size_t index, Rdna2Format fmt, uint32_t op, uint32_t pc, uint32_t len) {
+        const auto& in = ins[index];
+        return in.fmt == fmt && in.opcode == op && in.pc == pc && in.len_dwords == len;
+    };
+    auto scalar_load = [&](size_t index, uint32_t pc, uint32_t offset) {
+        const auto& in = ins[index];
+        return shape(index, Rdna2Format::SMEM, 0x08, pc, 2) &&
+            operand(in.dst, OperandKind::SGPR, 106) &&
+            operand(in.src[0], OperandKind::SGPR, 8) &&
+            operand(in.src[1], OperandKind::Special, 125) && in.literal == offset &&
+            !(in.words[0] & 0x0003e000u) && !(in.words[1] & 0x01e00000u);
+    };
+    auto buffer_access = [&](size_t index, uint32_t pc, uint32_t op, int addr_vgpr, int descriptor) {
+        const auto& in = ins[index];
+        return shape(index, Rdna2Format::MUBUF, op, pc, 2) &&
+            operand(in.dst, OperandKind::VGPR, 1) &&
+            operand(in.src[0], OperandKind::VGPR, addr_vgpr) &&
+            operand(in.src[1], OperandKind::SGPR, descriptor) &&
+            operand(in.src[2], OperandKind::InlineInt, 0) && in.literal == 0x2000u &&
+            !in.mubuf_glc && !in.mubuf_dlc && !in.mubuf_lds && !in.mubuf_tfe &&
+            !(in.words[0] & 0x00020000u) &&
+            !(in.words[1] & 0x00600000u);
+    };
+    const auto& index = ins[1];
+    const auto& compare = ins[4];
+    const auto& mask = ins[8];
+    if (shape(0, Rdna2Format::SOPP, 0x20, 0, 1) &&
+        shape(1, Rdna2Format::VOP3, 0x346, 1, 2) &&
+        operand(index.dst, OperandKind::VGPR, 0) &&
+        operand(index.src[0], OperandKind::SGPR, 12) &&
+        operand(index.src[1], OperandKind::InlineInt, 6) &&
+        operand(index.src[2], OperandKind::VGPR, 0) &&
+        scalar_load(2, 3, 0) && shape(3, Rdna2Format::SOPP, 0x0c, 5, 1) &&
+        shape(4, Rdna2Format::VOPC, 0xd4, 6, 1) &&
+        operand(compare.src[0], OperandKind::Special, 106) &&
+        operand(compare.src[1], OperandKind::VGPR, 0) &&
+        shape(5, Rdna2Format::SOPP, 0x08, 7, 1) && ins[5].simm16 == 9 &&
+        scalar_load(6, 8, 4) && shape(7, Rdna2Format::SOPP, 0x0c, 10, 1) &&
+        shape(8, Rdna2Format::VOP2, 0x1b, 11, 1) &&
+        operand(mask.dst, OperandKind::VGPR, 1) &&
+        operand(mask.src[0], OperandKind::Special, 106) &&
+        operand(mask.src[1], OperandKind::VGPR, 0) &&
+        buffer_access(9, 12, 0x00, 1, 0) &&
+        shape(10, Rdna2Format::SOPP, 0x0c, 14, 1) &&
+        buffer_access(11, 15, 0x04, 0, 4) && shape(12, Rdna2Format::SOPP, 0x01, 17, 1))
+        return ComputeCpuFastPath::BroadcastBufferU32;
     return ComputeCpuFastPath::None;
 }
 

--- a/prosper/tests/gpu/execute/test_broadcast_htile_clear.cpp
+++ b/prosper/tests/gpu/execute/test_broadcast_htile_clear.cpp
@@ -1,0 +1,301 @@
+// A semantic zero fill must discard rendered depth even when guest HTILE was already zero.
+// The adjacent negative arm copies each destination value back unchanged through the Vulkan path.
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/capture/gpu_capture.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "shared/live/live_compute.hpp"
+#include "fixtures/render_runner.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper::gpu;
+static int failures = 0;
+static void check(bool ok, const char* message) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; }
+}
+
+// Hand-assembled bounded broadcast/copy, built from ISA fields rather than captured shader data.
+static std::array<uint32_t, 18> broadcast_program() {
+    auto sopp = [](uint32_t op, uint32_t imm) { return 0xbf800000u | (op << 16) | imm; };
+    auto smem = [](uint32_t op, uint32_t dst, uint32_t base) {
+        return 0xf4000000u | (op << 18) | (dst << 6) | (base / 2);
+    };
+    auto mubuf = [](uint32_t op) { return 0xe0000000u | (op << 18) | (1u << 13); };
+    auto args = [](uint32_t data, uint32_t addr, uint32_t descriptor) {
+        return (128u << 24) | ((descriptor / 4) << 16) | (data << 8) | addr;
+    };
+    return {sopp(0x20, 1),                                  // prefetch
+        0xd4000000u | (0x346u << 16), 12u | (134u << 9) | (256u << 18), // i=(s12<<6)+v0
+        smem(8, 106, 8), 125u << 25, sopp(12, 0xc07f),       // count=CB[0]
+        0x7c000000u | (0xd4u << 17) | 106u, sopp(8, 9),      // active=count>i; skip to end
+        smem(8, 106, 8), (125u << 25) | 4u, sopp(12, 0xc07f),// mask=CB[1]
+        (0x1bu << 25) | (1u << 17) | 106u,                  // src_index=mask&i
+        mubuf(0), args(1, 1, 0), sopp(12, 0x3f70),          // value=src[src_index]
+        mubuf(4), args(1, 0, 4), sopp(1, 0)};               // dst[i]=value
+}
+
+static void descriptor(std::vector<uint32_t>& sgprs, unsigned slot,
+                       uint64_t address, uint32_t stride, uint32_t records, uint32_t format) {
+    sgprs[slot] = static_cast<uint32_t>(address);
+    sgprs[slot + 1] = static_cast<uint32_t>(address >> 32) | (stride << 16);
+    sgprs[slot + 2] = records;
+    sgprs[slot + 3] = (format << 12) | 4u;
+}
+
+int main() {
+    const auto code = broadcast_program();
+    check(classify_compute_cpu_fast_path(code.data(), code.size()) ==
+              ComputeCpuFastPath::BroadcastBufferU32, "complete bounded broadcast is recognized");
+    check(classify_compute_cpu_fast_path(code.data(), code.size() - 1) == ComputeCpuFastPath::None,
+          "truncated broadcast is refused");
+    for (const auto [word, bit] : {std::pair{15u, 0u}, {15u, 17u}, {16u, 0u}, {7u, 0u}}) {
+        auto altered = code; altered[word] ^= 1u << bit;
+        check(classify_compute_cpu_fast_path(altered.data(), altered.size()) == ComputeCpuFastPath::None,
+              "changed store offset, address controls, address register or branch is refused");
+    }
+
+    constexpr uint64_t cb_address = 0x20000000u, target_address = 0x21000000u;
+    std::array<uint32_t, 4> constants{128, 0, 0, 0};
+    std::array<uint32_t, 128> metadata{};
+    ShaderResourceTable table;
+    auto resource = [&](uint32_t binding, uint32_t pc, uint32_t sgpr, uint64_t addr,
+                        uint32_t size, uint32_t stride, DataFormat fmt, uint32_t nc, void* host) {
+        ShaderResource r;
+        r.binding = binding; r.fetch_pc = pc; r.sgpr_base = sgpr; r.gpu_addr = addr;
+        r.size = size; r.stride = stride; r.format = fmt; r.num_components = nc;
+        r.host_data = static_cast<uint8_t*>(host); r.host_data_size = size;
+        table.resources.push_back(r);
+    };
+    resource(3, 15, 4, target_address, sizeof(metadata), 4, DataFormat::Uint32, 1, metadata.data());
+    resource(4, 12, 0, cb_address + 8, 4, 4, DataFormat::Uint32, 1, constants.data() + 2);
+    resource(5, 3, UINT32_MAX, cb_address, 16, 16, DataFormat::Float32, 4, constants.data());
+    resource(6, 8, UINT32_MAX, cb_address, 16, 16, DataFormat::Float32, 4, constants.data());
+    ComputeItem item;
+    item.user_sgprs.resize(12);
+    descriptor(item.user_sgprs, 0, cb_address + 8, 4, 1, 20); // 32_UINT
+    descriptor(item.user_sgprs, 4, target_address, 4, metadata.size(), 20);
+    descriptor(item.user_sgprs, 8, cb_address, 16, 1, 77); // scalar loads ignore numeric format
+    item.launch.local_x = 64; item.launch.local_y = item.launch.local_z = 1;
+    item.launch.groups_x = 2; item.launch.groups_y = item.launch.groups_z = 1;
+    item.launch.threads_x = 128; item.launch.threads_y = item.launch.threads_z = 1;
+    item.recompile_config_available = true;
+    item.recompile_config.user_sgprs = item.user_sgprs;
+    item.recompile_config.local_x = 64;
+    item.recompile_config.local_y = item.recompile_config.local_z = 1;
+    item.recompile_config.tgid_x_en = true;
+    item.recompile_config.tgid_y_en = item.recompile_config.tgid_z_en = false;
+    item.recompile_config.tidig_comp_cnt = 0;
+    item.recompile_config.threads_x = item.launch.threads_x;
+    item.recompile_config.threads_y = item.launch.threads_y;
+    item.recompile_config.threads_z = item.launch.threads_z;
+    item.cpu_fast_path = classify_compute_cpu_fast_path(code.data(), code.size());
+    item.resources = std::make_shared<ShaderResourceTable>(table);
+    item.spirv = recompile_compute(code.data(), code.size(), item.resources.get(), item.recompile_config);
+    check(!item.spirv.empty(), "broadcast shader independently recompiles for Vulkan control");
+    if (item.spirv.empty()) return 1;
+
+    auto run = [&](ComputeItem candidate, uint32_t expected_fills) {
+        const uint64_t before = prosper::frontend::live_compute_cpu_fill_dispatches();
+        const bool ok = prosper::frontend::execute_live_compute_items({candidate});
+        check(prosper::frontend::live_compute_cpu_fill_dispatches() == before + expected_fills,
+              "CPU admission counter matches expected execution path");
+        return ok;
+    };
+    // Use the live renderer's device before compute initializes, matching the shared-device route.
+    // Creating an independent compute device first also changes layer teardown ordering at exit.
+    check(prosper::test::render_vk_ctx().ok, "shared renderer device initializes");
+    if (!prosper::test::render_vk_ctx().ok) return 1;
+    constants[2] = 0x12345678;
+    check(run(item, 1) && std::all_of(metadata.begin(), metadata.end(),
+          [](uint32_t v) { return v == 0x12345678; }), "broadcast carries nonzero runtime source value");
+    constants[0] = 65; metadata.fill(0xa5a5a5a5);
+    check(run(item, 1) && metadata[64] == constants[2] && metadata[65] == 0xa5a5a5a5,
+          "shader count bounds writes independently of the full workgroup extent");
+    constants[0] = 128;
+    metadata.fill(0xa5a5a5a5);
+    ComputeItem partial = item;
+    partial.recompile_config.exact_thread_extent = true;
+    partial.launch.threads_x = partial.recompile_config.threads_x = 65;
+    partial.recompile_config.threads_y = partial.recompile_config.threads_z = 1;
+    check(run(partial, 1) && metadata[64] == constants[2] && metadata[65] == 0xa5a5a5a5,
+          "exact partial workgroup leaves padded lanes untouched");
+
+    // Admission-only probes use a valid terminating fallback instead of sending deliberately
+    // altered descriptors to a shader that accesses them. A declined shortcut must neither touch
+    // bytes nor increment its counter; the fallback succeeds without any external memory access.
+    const uint32_t no_op_code[] = {0xbf810000u};
+    const auto no_op_spirv = recompile_compute(no_op_code, std::size(no_op_code), nullptr,
+                                              item.recompile_config);
+    check(!no_op_spirv.empty(), "admission probes have a valid terminating fallback");
+    if (no_op_spirv.empty()) return 1;
+    auto reject = [&](ComputeItem candidate) {
+        candidate.spirv = no_op_spirv;
+        candidate.terminator_only_program_validated = true;
+        metadata.fill(0xa5a5a5a5);
+        check(run(candidate, 0) && std::all_of(metadata.begin(), metadata.end(),
+              [](uint32_t v) { return v == 0xa5a5a5a5; }),
+              "unsafe shortcut declines without writing destination");
+    };
+    for (auto [word, bit] : {std::pair{1u, 30u}, {3u, 23u}, {3u, 0u}, {5u, 31u}, {7u, 21u}}) {
+        auto bad = item; bad.user_sgprs[word] ^= 1u << bit; reject(bad);
+    }
+    auto inexact = partial; inexact.recompile_config.exact_thread_extent = false; reject(inexact);
+    auto short_source = item;
+    short_source.resources = std::make_shared<ShaderResourceTable>(table);
+    short_source.resources->resources[1].host_data_size = 3; reject(short_source);
+    auto host_alias = item;
+    host_alias.resources = std::make_shared<ShaderResourceTable>(table);
+    host_alias.resources->resources[1].host_data = reinterpret_cast<uint8_t*>(metadata.data());
+    reject(host_alias);
+
+    // Render real nonzero depth, then test its consumer before and after the semantic metadata clear.
+    #include "../tools/boot_trace/refvs.inc"
+    std::vector<uint32_t> vs(kRefVs, kRefVs + std::size(kRefVs));
+    auto with_depth = [&](uint32_t bits) {
+        auto words = vs;
+        for (size_t i = 5; i < words.size(); i += words[i] >> 16)
+            if ((words[i] & 0xffffu) == 43 && (words[i] >> 16) == 4 &&
+                words[i + 1] == 6 && words[i + 2] == 0x25) words[i + 3] = bits;
+        return words;
+    };
+    const uint32_t red_code[] = {0x7e0002f2, 0x7e020280, 0x7e040280, 0x7e0602f2,
+                                 0xf800180f, 0x03020100, 0xbf810000};
+    const uint32_t green_code[] = {0x7e000280, 0x7e0202f2, 0x7e040280, 0x7e0602f2,
+                                   0xf800180f, 0x03020100, 0xbf810000};
+    ResolvedPipelineState writer;
+    writer.topology = 3; writer.color_write_mask = 15;
+    writer.depth_test_enable = writer.depth_write_enable = true;
+    writer.depth_compare_op = 7; writer.has_depth_clear = true; writer.depth_clear_value = 0;
+    writer.depth_read_base = writer.depth_write_base = 0x22000000;
+    writer.htile_data_base = target_address;
+    ResolvedPipelineState reader = writer;
+    reader.depth_write_enable = false; reader.depth_compare_op = 6; // GREATER_OR_EQUAL, reverse-Z
+    prosper::test::BackendDraw w, r;
+    w.vs = with_depth(0x3f400000); w.fs = recompile_fragment(red_code, std::size(red_code), nullptr);
+    w.ps = &writer; w.vcount = 3;
+    r.vs = with_depth(0x3f000000); r.fs = recompile_fragment(green_code, std::size(green_code), nullptr);
+    r.ps = &reader; r.vcount = 3;
+    auto green_visible = [&]() {
+        auto pixels = prosper::test::render_draws_rgba({r}, 64, 64, nullptr, nullptr, true);
+        return pixels.size() == 64 * 64 * 4 && pixels[(32 * 64 + 32) * 4 + 1] > 192;
+    };
+    auto produced = prosper::test::render_draws_rgba({w}, 64, 64, nullptr, nullptr, true);
+    check(produced.size() == 64 * 64 * 4 && !green_visible(),
+          "rendered nearer depth rejects the green consumer before a clear");
+    uint32_t preserving = 0, overwrites = 0;
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t bytes, const char* origin) {
+        if (std::strcmp(origin, "gpu-preserving") == 0) ++preserving; else ++overwrites;
+        const char* previous = guest_gpu_write_origin();
+        set_guest_gpu_write_origin(origin);
+        prosper::test::invalidate_persistent_ds_guest_write(addr, bytes);
+        set_guest_gpu_write_origin(previous);
+    });
+    constants[2] = 0; metadata.fill(0);
+    // Source aliases destination and i&~0 selects the same element: a real Vulkan identity copy.
+    auto identity = item;
+    constants[1] = UINT32_MAX;
+    identity.resources = std::make_shared<ShaderResourceTable>(table);
+    auto& identity_source = identity.resources->resources[1];
+    identity_source.gpu_addr = target_address; identity_source.size = sizeof(metadata);
+    identity_source.host_data = reinterpret_cast<uint8_t*>(metadata.data());
+    identity_source.host_data_size = sizeof(metadata);
+    descriptor(identity.user_sgprs, 0, target_address, 4, metadata.size(), 20);
+    identity.recompile_config.user_sgprs = identity.user_sgprs;
+    identity.spirv = recompile_compute(code.data(), code.size(), identity.resources.get(), identity.recompile_config);
+    check(!identity.spirv.empty() && run(identity, 0) && preserving > 0 && !green_visible(),
+          "Vulkan identity metadata update preserves current-present rendered depth");
+    constants[1] = 0;
+    // Exercise the same clear through the public capture roundtrip: replay owns the snapshots
+    // and must rederive the semantic proof from retained ISA, rather than losing it or trusting
+    // a serialized shortcut. The fake guest addresses are served only by this bounded reader.
+    item.code_addr = 0x23000000u;
+    const CaptureMemoryReader memory = [&](uint64_t address, uint8_t* out, size_t bytes) {
+        const void* source = nullptr;
+        size_t available = 0;
+        auto region = [&](uint64_t base, const void* data, size_t size) {
+            if (address >= base && address - base < size) {
+                const size_t offset = static_cast<size_t>(address - base);
+                source = static_cast<const uint8_t*>(data) + offset;
+                available = size - offset;
+            }
+        };
+        region(cb_address, constants.data(), sizeof(constants));
+        region(target_address, metadata.data(), sizeof(metadata));
+        region(item.code_addr, code.data(), sizeof(code));
+        const size_t copied = std::min(bytes, available);
+        if (copied) std::memcpy(out, source, copied);
+        return copied;
+    };
+    GpuCaptureMetadata capture_metadata;
+    capture_metadata.width = capture_metadata.height = 64;
+    GpuCaptureFile captured, loaded;
+    GpuReplayFrame replay;
+    std::vector<uint8_t> serialized;
+    std::string error;
+    const bool roundtrip = capture_submit_items({}, {item}, {}, capture_metadata, memory,
+                                                captured, error) &&
+        serialize_gpu_capture(captured, serialized, error) &&
+        deserialize_gpu_capture(serialized, loaded, error) &&
+        materialize_gpu_replay(loaded, replay, error);
+    if (!roundtrip) std::fprintf(stderr, "capture roundtrip: %s\n", error.c_str());
+    check(roundtrip && replay.computes.size() == 1,
+          "bounded broadcast capture serializes and materializes");
+    if (roundtrip && replay.computes.size() == 1) {
+        const auto& restored = replay.computes[0];
+        check(restored.cpu_fast_path == ComputeCpuFastPath::BroadcastBufferU32,
+              "replay rederives the broadcast proof from retained raw ISA");
+        const auto* destination = restored.resources ? restored.resources->by_fetch_pc(15) : nullptr;
+        check(destination && destination->host_data &&
+              destination->host_data != reinterpret_cast<uint8_t*>(metadata.data()),
+              "replay destination uses owned captured backing");
+        // Poison live bytes after capture: the replay must consume its independent snapshots.
+        metadata.fill(0xa5a5a5a5);
+        check(run(restored, 1) && overwrites > 0 && green_visible(),
+              "replayed zero-to-zero broadcast invalidates depth and restores the green consumer");
+        check(std::all_of(metadata.begin(), metadata.end(),
+                         [](uint32_t v) { return v == 0xa5a5a5a5; }),
+              "replayed broadcast does not mutate the live source allocation");
+        check(destination && destination->host_data &&
+              destination->host_data_size >= sizeof(metadata) &&
+              std::all_of(destination->host_data, destination->host_data + sizeof(metadata),
+                          [](uint8_t v) { return v == 0; }),
+              "replayed clear writes the captured destination bytes");
+        auto refused_proof = [&](GpuCaptureFile candidate) {
+            GpuReplayFrame without_proof;
+            const bool materialized = materialize_gpu_replay(candidate, without_proof, error);
+            const bool refused = materialized &&
+                  without_proof.computes.size() == 1 &&
+                  without_proof.computes[0].cpu_fast_path == ComputeCpuFastPath::None;
+            if (!refused)
+                std::fprintf(stderr, "refused proof: materialized=%u computes=%zu fast-path=%d error=%s\n",
+                             materialized, without_proof.computes.size(),
+                             without_proof.computes.empty() ? -1 :
+                                 static_cast<int>(without_proof.computes[0].cpu_fast_path), error.c_str());
+            check(refused,
+                  "replay does not infer a broadcast shortcut without complete matching ISA and config");
+        };
+        auto missing = loaded;
+        missing.computes[0].raw_shader_index = UINT32_MAX;
+        missing.raw_shader_versions.clear(); // No orphaned version: reach the materializer.
+        refused_proof(std::move(missing));
+        auto altered = loaded;
+        auto& altered_raw = altered.raw_shader_versions[altered.computes[0].raw_shader_index];
+        altered_raw.words[15] ^= 1u;
+        // Keep the container valid so changed ISA, rather than a stale hash, refuses the shortcut.
+        altered_raw.content_hash = gpu_capture_hash(
+            reinterpret_cast<const uint8_t*>(altered_raw.words.data()),
+            altered_raw.words.size() * sizeof(uint32_t));
+        refused_proof(std::move(altered));
+        auto no_config = loaded;
+        no_config.computes[0].recompile_config_available = false;
+        GpuReplayFrame without_config;
+        check(!materialize_gpu_replay(no_config, without_config, error) &&
+              error == "compute raw shader has no recompile state" && without_config.computes.empty(),
+              "capture validation refuses retained raw ISA without the required compute config");
+    }
+    set_guest_gpu_write_observer({});
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/execute/test_broadcast_htile_clear.cpp
+++ b/prosper/tests/gpu/execute/test_broadcast_htile_clear.cpp
@@ -51,10 +51,11 @@ int main() {
               ComputeCpuFastPath::BroadcastBufferU32, "complete bounded broadcast is recognized");
     check(classify_compute_cpu_fast_path(code.data(), code.size() - 1) == ComputeCpuFastPath::None,
           "truncated broadcast is refused");
-    for (const auto [word, bit] : {std::pair{15u, 0u}, {15u, 17u}, {16u, 0u}, {7u, 0u}}) {
+    for (const auto [word, bit] : {std::pair{15u, 0u}, {15u, 17u}, {16u, 0u}, {7u, 0u},
+                                   {5u, 8u}, {10u, 8u}, {14u, 0u}}) {
         auto altered = code; altered[word] ^= 1u << bit;
         check(classify_compute_cpu_fast_path(altered.data(), altered.size()) == ComputeCpuFastPath::None,
-              "changed store offset, address controls, address register or branch is refused");
+              "changed store addressing, branch or memory-completion waits are refused");
     }
 
     constexpr uint64_t cb_address = 0x20000000u, target_address = 0x21000000u;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -2927,7 +2927,11 @@ int main(int argc, char** argv) {
             return 2;
         }
         std::fclose(file);
-        replay.computes[static_cast<size_t>(index)].spirv = std::move(words);
+        auto& overridden = replay.computes[static_cast<size_t>(index)];
+        overridden.spirv = std::move(words);
+        // Guest-ISA shortcuts cannot stand in for an explicitly substituted SPIR-V program.
+        overridden.cpu_fast_path = prosper::gpu::ComputeCpuFastPath::None;
+        overridden.terminator_only_program_validated = false;
         allow_mismatch = true;
         std::fprintf(stderr, "[gpureplay] override compute %ld with %ld bytes from %s\n",
                      index, byte_count, compute_override_path.c_str());


### PR DESCRIPTION
Blue Prince broadcasts a separate zero source into HTILE to clear depth during its opening FMV. Because guest metadata was already zero, the byte-preserving writeback path retained renderer-owned depth written earlier in the present, leaving trees and balustrades in front of the movie. Adjacent live captures bisect the regression to #3281: parent 75f57457f is good and 03caaf19fb is bad. A current-main native-window capture reproduces the same layering defect after the guest-clock correction.

Recognize the complete bounded indexed-buffer program and prove its live zero mask, descriptor layout, launch bounds, input backing and non-aliasing before executing a broadcast fill. Notify the exact written range as a logical overwrite, including zero-to-zero writes. Actual identity updates retain their Vulkan path and depth preservation, which GTA's lighting needs. Replay rederives this proof from retained ISA; explicit SPIR-V overrides discard guest-program execution shortcuts.

The regression test renders depth, preserves it through a Vulkan identity update, then captures/serializes/reloads a broadcast clear and verifies the previously hidden consumer becomes visible. It also checks independent replay storage, full/partial dispatch bounds, raw descriptor refusal, and absent/altered capture evidence. A forced preserving notification makes the visible-depth assertion fail.

Validation and merge gates are recorded in follow-up comments: full build, full tests and synchronization validation, exact-commit independent review, paired live Blue Prince movie captures, GTA performance-route correctness, and required Linux/general CI. Blue Prince and GTA native visual checks passed at 71558fdd; the final wait-admission narrowing at c6600ed4 has a fresh registered approval, full build, 375/375 plain tests and 375/375 core+sync tests. All seven required Linux/general CI checks subsequently passed; merged as 610eb839738c4ab58456174e74c9469ddb2c824f. Exact revisions, commands, controls and limitations are recorded in the final validation comment. No FPS improvement is claimed.

Fixes #3423.
