### PR TITLE
Measure SDL consumption demand separately from input queue gaps

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3571,6 +3571,17 @@ if(PROSPER_AUDIO_SDL3 AND TARGET SDL3::SDL3)
   target_link_libraries(test_audio_sdl3 PRIVATE prosper_audio_sdl3)
   add_test(NAME audio_sdl3 COMMAND test_audio_sdl3)
   set_tests_properties(audio_sdl3 PROPERTIES ENVIRONMENT "SDL_AUDIO_DRIVER=dummy")
+  add_executable(test_audio_demand frontends/audio_sdl3/test_audio_demand.cpp)
+  target_link_libraries(test_audio_demand PRIVATE prosper_audio_sdl3)
+  add_test(NAME audio_demand COMMAND test_audio_demand)
+  set_tests_properties(audio_demand PROPERTIES ENVIRONMENT "SDL_AUDIO_DRIVER=dummy")
+  add_test(NAME audio_demand_return_open COMMAND test_audio_demand return-open)
+  add_test(NAME audio_demand_ordered_quit COMMAND test_audio_demand ordered-quit)
+  set_tests_properties(audio_demand_return_open audio_demand_ordered_quit PROPERTIES
+    ENVIRONMENT "SDL_AUDIO_DRIVER=dummy;PROSPER_AUDIO_DEMAND=1")
+  add_test(NAME audio_demand_external_quit COMMAND test_audio_demand external-quit)
+  set_tests_properties(audio_demand_external_quit PROPERTIES
+    ENVIRONMENT "SDL_AUDIO_DRIVER=dummy;PROSPER_AUDIO_DEMAND=0;PROSPER_AUDIO_QUEUE_TIMELINE=0")
 
   # Route the live game's audio to the host when the runner is built (guarded by the macro).
   if(TARGET boot_trace)

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -21,6 +21,28 @@ owned; no grain is replayed to conceal late production. FLOW diagnostics also re
 and pending-grain replacements. These startup measurements establish the clock-related deficit;
 they do not establish that every title or every later gameplay interval is free of underruns.
 
+## SDL consumption measurements (#3432)
+
+`PROSPER_AUDIO_DEMAND=1` installs a bounded per-stream consumption callback. It counts SDL
+requests and requests needing additional input, separately for startup, active playback and
+host pause. First successful PCM publication begins the active phase; a close/reopen starts a
+new generation. Intentional silent PCM counts as supplied data. Output/channel ownership and
+pacing are unchanged. Input format and the device's reported format/quantum are logged at open.
+
+The existing sampler prints cumulative snapshots once per second, outside the audio callback.
+`tools/perf/audio_delivery_report.py LOG` reads the final snapshot of each phase/generation;
+use one process run per log file. Missing diagnostics are unavailable, and a phase with no
+callbacks is unobserved. The final partial second before process exit may not be logged.
+SDL's additional-byte estimate can overestimate demand under resampling; it is neither a
+physical backend XRUN counter nor a measured duration of inserted silence.
+
+`SDL_GetAudioStreamQueued` counts unconverted **input** bytes. An empty input queue can follow
+successful consumption while its audio is still buffered downstream. Delivery and timeline
+reports therefore name input queue gaps and leave downstream continuity unknown. Correlate
+consumption demand with guest FLOW, scheduling and backend measurements before changing pacing.
+Frontend owners must stop guest producers and call `shutdown_sdl3_audio_sink()` before SDL teardown;
+it joins the sampler and destroys streams before their callback state goes away.
+
 ## Layers
 
 | Layer | File | In `prosper_core`? |
@@ -59,8 +81,8 @@ cmake -S prosper -B build -DPROSPER_AUDIO_SDL3=ON   # uses system SDL3 if presen
 ```
 - Uses a system SDL3 (`find_package(SDL3)`) if available, otherwise fetches and builds an
   **audio-only** SDL3 (video/render/joystick/etc. disabled — no X11/Wayland needed).
-- One `SDL_AudioStream` per PS5 port; `output()` pushes PCM and blocks while the device queue is full
-  (matching hardware pacing). Per-channel volumes are mapped to the stream gain.
+- One `SDL_AudioStream` per PS5 port; `output()` pushes PCM and paces the guest by each
+  grain’s wall-clock duration. Per-channel volumes are mapped to the stream gain.
 - When enabled, `boot_trace` calls `install_sdl3_audio_sink()` at startup automatically.
 
 ## AudioOut2 submission ownership (#3411)
@@ -403,6 +425,11 @@ PCM sampling, signal-bearing ports only) and `PROSPER_AUDIO2_CONTROL_PROBE=1` (c
 Note that the first two fall silent in cases 1 **and** 2, which is why `PROSPER_AUDIO_FLOW` exists.
 
 ## Ruled out — do not re-derive these
+
+- **Empty SDL input means a playback underrun.** The real unbound-stream test consumes a complete
+  known grain, checks exact PCM, then observes an empty input queue with zero demand shortfalls.
+  A subsequent read without new PCM produces a shortfall. Bracketing queue zeros with nonzero
+  samples cannot substitute for observing consumption (#3432).
 
 - **"A silent AudioOut2 port might be pushing its PCM through `sceAudioOut2ContextBedWrite`, which
   prosper stubs."** The stub is real — `audio2_ctx_bed_write` in `hle_audio.cpp` validates the

--- a/prosper/frontends/audio_sdl3/AGENTS.md
+++ b/prosper/frontends/audio_sdl3/AGENTS.md
@@ -1,0 +1,9 @@
+# SDL audio frontend
+
+This optional frontend adapts the core AudioSink interface to one SDL stream per output.
+Keep SDL device ownership, stream lifetime, host pacing and playback diagnostics here;
+guest ABI decoding and independently owned output/channel PCM belong in the HLE.
+Diagnostics must distinguish queued input, SDL consumption demand and backend XRUNs.
+Callbacks run under SDL's stream lock: never take the sink mutex or log from them.
+The dummy-device tests cover lifecycle; unbound stream tests can verify consumption without
+depending on a physical device or scheduler timing.

--- a/prosper/frontends/audio_sdl3/audio_demand.hpp
+++ b/prosper/frontends/audio_sdl3/audio_demand.hpp
@@ -1,0 +1,59 @@
+#pragma once
+#include "audio_sdl3.hpp"
+#include <SDL3/SDL.h>
+#include <atomic>
+
+namespace prosper {
+
+// The callback owns no samples and supplies none. SDL calls it while holding the
+// stream lock, before consuming queued input. Its additional byte estimate can
+// include resampler padding, so this is demand accounting, not inserted silence.
+class AudioDemandMeter {
+public:
+    static_assert(std::atomic<uint64_t>::is_always_lock_free);
+    void reset(AudioDemandPhase phase) {
+        // Only before attaching the callback, after any previous stream is destroyed.
+        for (auto& c : counts_) {
+            c.calls = 0; c.requested = 0; c.short_calls = 0; c.additional = 0;
+            c.first = 0; c.last = 0;
+        }
+        set_phase(phase);
+    }
+    void set_phase(AudioDemandPhase phase) { phase_.store(phase, std::memory_order_relaxed); }
+
+    static void SDLCALL consume(void* userdata, SDL_AudioStream*, int additional, int total) {
+        auto& self = *static_cast<AudioDemandMeter*>(userdata);
+        auto& c = self.counts_[static_cast<unsigned>(self.phase_.load(std::memory_order_relaxed))];
+        const auto now = SDL_GetTicksNS();
+        if (!c.calls.load(std::memory_order_relaxed)) c.first.store(now, std::memory_order_relaxed);
+        c.calls.fetch_add(1, std::memory_order_relaxed);
+        c.requested.fetch_add(total > 0 ? uint64_t(total) : 0, std::memory_order_relaxed);
+        if (additional > 0) {
+            c.short_calls.fetch_add(1, std::memory_order_relaxed);
+            c.additional.fetch_add(uint64_t(additional), std::memory_order_relaxed);
+        }
+        c.last.store(now, std::memory_order_relaxed);
+    }
+
+    bool snapshot(SDL_AudioStream* stream, Sdl3AudioDemandSnapshot& out) const {
+        // The caller protects stream lifetime. This lock makes the set of atomic
+        // counters consistent; the callback never acquires the outer sink lock.
+        if (!SDL_LockAudioStream(stream)) return false;
+        for (unsigned i = 0; i < counts_.size(); ++i) {
+            const auto& c = counts_[i];
+            out.phases[i] = {c.calls.load(std::memory_order_relaxed),
+                c.requested.load(std::memory_order_relaxed), c.short_calls.load(std::memory_order_relaxed),
+                c.additional.load(std::memory_order_relaxed), c.first.load(std::memory_order_relaxed),
+                c.last.load(std::memory_order_relaxed)};
+        }
+        SDL_UnlockAudioStream(stream);
+        return true;
+    }
+private:
+    struct Counts {
+        std::atomic<uint64_t> calls{0}, requested{0}, short_calls{0}, additional{0}, first{0}, last{0};
+    };
+    std::array<Counts, 3> counts_{};
+    std::atomic<AudioDemandPhase> phase_{AudioDemandPhase::Startup};
+};
+} // namespace prosper

--- a/prosper/frontends/audio_sdl3/audio_sdl3.hpp
+++ b/prosper/frontends/audio_sdl3/audio_sdl3.hpp
@@ -4,8 +4,25 @@
 // audio actually plays out of the host's default device. The core HLE (src/hle/audio/hle_audio.cpp)
 // has no knowledge of SDL — this frontend lives outside prosper_core and plugs in at runtime.
 #pragma once
+#include <array>
+#include <cstdint>
 
 namespace prosper {
+
+enum class AudioDemandPhase : unsigned { Startup, Active, Paused };
+struct AudioDemandCounts {
+    uint64_t calls = 0, requested_bytes = 0, shortfall_calls = 0, additional_bytes = 0;
+    uint64_t first_ns = 0, last_ns = 0;
+};
+struct Sdl3AudioDemandSnapshot {
+    uint64_t generation = 0; // changes when this port is reopened
+    std::array<AudioDemandCounts, 3> phases{};
+};
+
+// Optional PROSPER_AUDIO_DEMAND=1 diagnostic. Counts SDL's input-format demand at
+// consumption, not hardware underruns; resampling can overestimate additional bytes.
+// False means unavailable/closed, never a measurement of zero shortfalls.
+bool sdl3_audio_demand_snapshot(int port, Sdl3AudioDemandSnapshot& snapshot);
 
 // Initialise SDL audio and install the SDL3 AudioSink as the active backend. Idempotent.
 // Returns true on success; false (and leaves the default silent sink active) if SDL audio
@@ -26,7 +43,9 @@ void set_sdl3_audio_paused(bool paused);
 // changing the default; see kDefaultVolumePercent in prosper-app/main.cpp.
 void set_sdl3_audio_gain(float gain);
 
-// Uninstall the SDL3 sink (restores the default), closing any open streams and SDL audio.
+// Uninstall the SDL3 sink (restores the default), joining diagnostics and closing streams.
+// Call after guest audio producers stop, BEFORE SDL_Quit/SDL_QuitSubSystem(AUDIO).
+// Concurrent external SDL teardown and quit/reinit with retained streams are unsupported.
 void shutdown_sdl3_audio_sink();
 
 } // namespace prosper

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -2,9 +2,9 @@
 //
 // Enabled with -DPROSPER_AUDIO_SDL3=ON. Bridges the headless AudioSink interface (audio.hpp)
 // to SDL3's audio-stream API: one SDL_AudioStream per PS5 audio port, fed the guest's PCM
-// grains. output() blocks while the device's queue is full, reproducing the pacing that
-// sceAudioOutOutput has on real hardware (it blocks until the audio ring has room).
+// grains. output() paces the guest on a wall-clock grid using each grain's duration.
 #include "audio_sdl3.hpp"
+#include "audio_demand.hpp"
 #include "hle/audio/audio.hpp"
 #include "host/platform/lifecycle.hpp"
 #include "host/platform/precise_sleep.hpp"   // the grain pacer must not quantize to the winpthreads tick (#3016)
@@ -57,6 +57,13 @@ bool audio_debug() {
     static const bool on = getenv("PROSPER_AUDIO_DEBUG") != nullptr;
     return on;
 }
+bool audio_demand() {
+    static const bool on = [] {
+        const char* value = getenv("PROSPER_AUDIO_DEMAND");
+        return value && std::string(value) == "1";
+    }();
+    return on;
+}
 bool queue_trace() {
     static const bool on = getenv("PROSPER_AUDIO_QUEUE_TRACE") != nullptr;
     return on;
@@ -75,10 +82,11 @@ bool queue_trace() {
 // the queue is below the target, which is the property under test -- but a reader should know the
 // arm is the property, not the diff.
 //
-// Measured on Blasphemous 2 (PPSA13579), Windows/RTX 4090, 150 s from launch per arm, underrun
+// Measured on Blasphemous 2 (PPSA13579), Windows/RTX 4090, 150 s from launch per arm, input-queue
 // episodes from tools/perf/audio_queue_timeline_report.py (#3070), two runs per arm (#3033).
 //
-// "dry" here means the percentage of 1 ms SAMPLES at which the device queue held ZERO bytes while
+// These historical queue figures do not measure consumption shortfalls or backend XRUNs (#3432).
+// "dry" here means the percentage of 1 ms SAMPLES at which the INPUT queue held ZERO bytes while
 // the port was being fed -- pinned because the word became ambiguous on 2026-08-27: #3046 found
 // audio_delivery_report.py's "below one grain" thresholds were computed in FRAMES, so that tool
 // was reporting "completely empty" under a much weaker label, and a figure from it had already
@@ -231,7 +239,7 @@ public:
             SDL_Log("prosper-audio: SDL_InitSubSystem(AUDIO) failed: %s", SDL_GetError());
             return false;
         }
-        start_queue_timeline();   // no-op unless PROSPER_AUDIO_QUEUE_TIMELINE is set
+        start_queue_timeline();   // no-op unless queue or demand diagnostics are enabled
         return true;
     }
 
@@ -261,6 +269,16 @@ public:
         s.grain_bytes = audio_grain_bytes(info);
         s.freq = info.freq;
         s.put_failed = false;
+        s.demand_started = false;
+        s.demand_enabled = false;
+        ++s.generation;
+        if (audio_demand()) {
+            s.demand.reset(paused_ ? AudioDemandPhase::Paused : AudioDemandPhase::Startup);
+            s.demand_enabled = SDL_SetAudioStreamGetCallback(s.stream, AudioDemandMeter::consume,
+                                                           &s.demand);
+            if (!s.demand_enabled)
+                SDL_Log("[audio-demand-error] port=%d callback unavailable: %s", port, SDL_GetError());
+        }
         s.next = {};   // (re)start the per-grain pacing clock on the first output()
         SDL_SetAudioStreamGain(s.stream, gain_);
         const bool stream_ready = paused_ ? SDL_PauseAudioStreamDevice(s.stream)
@@ -273,6 +291,17 @@ public:
             return false;
         }
         const SDL_AudioDeviceID device = SDL_GetAudioStreamDevice(s.stream);
+        if (s.demand_enabled) {
+            SDL_AudioSpec device_spec{};
+            int quantum = 0;
+            const bool available = SDL_GetAudioDeviceFormat(device, &device_spec, &quantum);
+            SDL_Log("[audio-demand-open] port=%d generation=%llu input_hz=%d input_channels=%d "
+                    "input_format=%u device_available=%d device_hz=%d device_channels=%d "
+                    "device_format=%u device_quantum_frames=%d",
+                    port, (unsigned long long)s.generation, spec.freq, spec.channels,
+                    unsigned(spec.format), int(available), device_spec.freq, device_spec.channels,
+                    unsigned(device_spec.format), quantum);
+        }
         if (const char* dump = getenv("PROSPER_AUDIO_DUMP_WAV"); dump && *dump) {
             std::string path(dump);
             const auto dot = path.rfind('.');
@@ -355,16 +384,24 @@ public:
             // the lock let close()/open()/quit() destroy it immediately before this call (#855).
             // The pacing sleep remains outside the lock, so lifecycle calls wait only for SDL's
             // synchronous queue copy rather than for an entire audio grain.
-            if (!SDL_PutAudioStreamData(s.stream, pcm, frames * s.frame_bytes) && !s.put_failed) {
+            // Publish the first PCM and its phase under the same recursive SDL stream lock.
+            // Otherwise the consumer can pull that grain before Startup changes to Active.
+            const bool transition = s.demand_enabled && !s.demand_started;
+            const bool locked = transition && SDL_LockAudioStream(s.stream);
+            const bool put_ok = SDL_PutAudioStreamData(s.stream, pcm, frames * s.frame_bytes);
+            if (!put_ok && !s.put_failed) {
                 SDL_Log("prosper-audio: PutAudioStreamData failed on port %d: %s", port, SDL_GetError());
                 s.put_failed = true;
             }
+            if (put_ok && s.demand_enabled && !s.demand_started) {
+                s.demand_started = true;
+                s.demand.set_phase(paused_ ? AudioDemandPhase::Paused : AudioDemandPhase::Active);
+            }
+            if (locked) SDL_UnlockAudioStream(s.stream);
             s.dump.write(pcm, frames, s.channels, s.f32);
-            // PROSPER_AUDIO_QUEUE_TRACE=1: the device queue depth AT each grain handoff, reported
-            // as a per-second MINIMUM rather than a mean. A mean cannot see this defect -- #3016
-            // averaged 100% of real time while the queue emptied in every gap -- so the minimum is
-            // the whole point, together with the count of handoffs that found less than one grain
-            // buffered, which is the moment a real device would underrun.
+            // PROSPER_AUDIO_QUEUE_TRACE=1: input queue depth after each handoff.
+            // The minimum exposes queue variation hidden by averages, but converted
+            // audio may already be playing downstream. This does not measure XRUNs.
             if (queue_trace()) {
                 const int queued = SDL_GetAudioStreamQueued(s.stream);
                 if (queued >= 0) {
@@ -423,8 +460,8 @@ public:
     // samples AT each grain handoff, so a queue that drains to zero BETWEEN handoffs is
     // invisible to it -- which is why `below-one-grain=0` appeared in both arms of that A/B and
     // could not settle it. Sampling on a clock instead makes the drain slope, the refill bursts
-    // and the zero crossings all directly visible, so an underrun can be established without
-    // an ear in the room.
+    // and sampled zero crossings visible. Only input occupancy is measured: downstream
+    // playback and hardware XRUNs remain unknown. Use demand accounting for consumption.
     //
     // Paced with host::sleep_until_steady_ns on an ABSOLUTE grid, and that is not incidental:
     // as recovered from #2984 this loop used std::this_thread::sleep_for(1ms), which on Windows
@@ -443,7 +480,13 @@ public:
         // queued, not available: SDL_GetAudioStreamAvailable reports DEVICE-format bytes while
         // grain_bytes, the [audio-dbg] field name and the #3016 sibling meter are all guest
         // format. Mixing them is benign on an F32 title by luck and silently 2x out on an S16 one.
-        struct Sample { int port; int queued; int grain; };
+        struct Sample {
+            int port = 0, queued = -1, grain = 0;
+            bool demand_available = false;
+            Sdl3AudioDemandSnapshot demand{};
+        };
+        const bool queue_enabled = queue_timeline_ms() > 0;
+        auto demand_last = t0;
         // Counted and reported, because review could not reconcile the measured median with an
         // exactly-honoured grid and neither could I: on a strict grid the median delta telescopes
         // to the interval, yet =2 measured 2.041 ms -- 41 us high, which would suggest the resync
@@ -458,13 +501,22 @@ public:
         while (timeline_running_.load(std::memory_order_relaxed)) {
             passes++;
             int n = 0;
+            const auto report_now = std::chrono::steady_clock::now();
+            const bool report_demand = audio_demand() && report_now - demand_last >= std::chrono::seconds(1);
+            if (report_demand) demand_last = report_now;
             {
                 std::lock_guard<std::mutex> lk(mx_);
                 for (int i = 0; i < kMaxPorts; i++) {
                     if (!slots_[i].stream) continue;
-                    const int q = SDL_GetAudioStreamQueued(slots_[i].stream);
-                    if (q < 0) continue;          // an errored stream reports -1; do not log it as a level
-                    samples[n++] = { i + 1, q, slots_[i].grain_bytes };
+                    auto& sample = samples[n++];
+                    sample = {};
+                    sample.port = i + 1;
+                    sample.grain = slots_[i].grain_bytes;
+                    if (queue_enabled) sample.queued = SDL_GetAudioStreamQueued(slots_[i].stream);
+                    if (report_demand && slots_[i].demand_enabled) {
+                        sample.demand.generation = slots_[i].generation;
+                        sample.demand_available = slots_[i].demand.snapshot(slots_[i].stream, sample.demand);
+                    }
                 }
             }
             const uint64_t t_us = (uint64_t)std::chrono::duration_cast<std::chrono::microseconds>(
@@ -473,10 +525,25 @@ public:
             // exactly the sampling interval, so a 1 ms sampler could only ever print gaps of
             // 1.000/2.000/3.000 -- the honesty figures quoted for this instrument were partly an
             // artifact of its own format string.
-            for (int i = 0; i < n; i++)
-                SDL_Log("[audio-queue] t_us=%llu port=%d queued=%d grain=%d",
-                        (unsigned long long)t_us, samples[i].port, samples[i].queued,
-                        samples[i].grain);
+            for (int i = 0; i < n; i++) {
+                if (queue_enabled && samples[i].queued >= 0)
+                    SDL_Log("[audio-queue] t_us=%llu port=%d queued=%d grain=%d",
+                            (unsigned long long)t_us, samples[i].port, samples[i].queued, samples[i].grain);
+                if (samples[i].demand_available) {
+                    const char* phases[] = {"startup", "active", "paused"};
+                    for (unsigned phase = 0; phase < 3; ++phase) {
+                        const auto& c = samples[i].demand.phases[phase];
+                        SDL_Log("[audio-demand] t_us=%llu port=%d generation=%llu phase=%s "
+                                "calls=%llu requested_bytes=%llu shortfall_calls=%llu additional_bytes=%llu "
+                                "first_ns=%llu last_ns=%llu",
+                                (unsigned long long)t_us, samples[i].port,
+                                (unsigned long long)samples[i].demand.generation, phases[phase],
+                                (unsigned long long)c.calls, (unsigned long long)c.requested_bytes,
+                                (unsigned long long)c.shortfall_calls, (unsigned long long)c.additional_bytes,
+                                (unsigned long long)c.first_ns, (unsigned long long)c.last_ns);
+                    }
+                }
+            }
             // Advance the grid, but RESYNC if a pass overran it. Without this, one slow pass
             // leaves every subsequent deadline in the past, sleep_until_steady_ns returns
             // immediately by contract, and the loop becomes a busy spin hammering mx_ at full
@@ -503,32 +570,44 @@ public:
     }
 
     void start_queue_timeline() {
-        const int ms = queue_timeline_ms();
+        const int ms = queue_timeline_ms() > 0 ? queue_timeline_ms() : (audio_demand() ? 1000 : 0);
         if (ms <= 0 || timeline_running_.exchange(true)) return;
         timeline_thread_ = std::thread(&Sdl3AudioSink::queue_timeline_loop, this, ms);
-        SDL_Log("prosper-audio: queue-level timeline started at %d ms", ms);
+        SDL_Log("prosper-audio: diagnostic sampler started at %d ms (queue=%d demand=%d)",
+                ms, int(queue_timeline_ms() > 0), int(audio_demand()));
     }
 
-    // JOINED, not detached, and joined from both places that can actually run.
-    //
-    // The first version cleared a flag at the top of quit() and called that sufficient. Review
-    // found the argument was about dead code: shutdown_sdl3_audio_sink() -- the only caller of
-    // quit() -- is invoked ONLY from test_audio_sdl3.cpp. prosper-app and boot_trace install the
-    // sink and never shut it down, so on neither path where this instrument is used did the flag
-    // ever get cleared.
-    //
-    // What that leaves per path: prosper-app ends in std::_Exit, which runs no destructors at all,
-    // so a sampler alive at exit is harmless by construction. boot_trace returns from main and
-    // drops into static destruction of mx_ and slots_ WITH the sampler live -- that one was a real
-    // use-after-free, and the destructor below is what closes it. A detached thread cannot be made
-    // safe here by any flag, because the flag only says "please stop" and static destruction does
-    // not wait to be asked.
+    // Explicit frontend shutdown and static destruction both join the sampler before
+    // releasing its mutex/slots. The app's guest-running _Exit path skips destructors,
+    // so periodic reporting must not rely on a final destructor flush.
     void stop_queue_timeline() {
         timeline_running_.store(false, std::memory_order_relaxed);
         if (timeline_thread_.joinable()) timeline_thread_.join();
     }
 
-    ~Sdl3AudioSink() override { stop_queue_timeline(); }
+    ~Sdl3AudioSink() override {
+        stop_queue_timeline();
+        // Stop SDL callbacks before their per-port userdata is destroyed, including
+        // frontends that return from main without calling shutdown_sdl3_audio_sink.
+        if (SDL_WasInit(SDL_INIT_AUDIO)) {
+            for (int port = 1; port <= kMaxPorts; ++port) close(port);
+        } else {
+            // A sequential external SDL_Quit already destroyed every stream. Never
+            // dereference those stale pointers. Frontends with a running sampler must
+            // explicitly shut down this sink BEFORE SDL_Quit (see audio_sdl3.hpp).
+            for (auto& s : slots_) s.stream = nullptr;
+        }
+    }
+
+    bool demand_snapshot(int port, Sdl3AudioDemandSnapshot& out) {
+        out = {};
+        if (port < 1 || port > kMaxPorts) return false;
+        std::lock_guard<std::mutex> lk(mx_);
+        auto& s = slots_[port - 1];
+        if (!s.stream || !s.demand_enabled) return false;
+        out.generation = s.generation;
+        return s.demand.snapshot(s.stream, out);
+    }
 
     void set_volume(int port, uint32_t mask, const int* vols) override {
         if (port < 1 || port > kMaxPorts || !vols) return;
@@ -544,6 +623,7 @@ public:
         std::lock_guard<std::mutex> lk(mx_);
         Slot& s = slots_[port - 1];
         if (s.stream) { SDL_DestroyAudioStream(s.stream); s.stream = nullptr; }
+        s.demand_enabled = false;
         s.frame_bytes = s.grain_bytes = 0;
         s.dump.finalize();   // a closed port's capture is complete
     }
@@ -566,6 +646,9 @@ public:
         for (Slot& s : slots_) {
             if (!s.stream) continue;
             ++active_streams;
+            if (s.demand_enabled)
+                s.demand.set_phase(paused ? AudioDemandPhase::Paused :
+                    (s.demand_started ? AudioDemandPhase::Active : AudioDemandPhase::Startup));
             const bool ok = paused ? SDL_PauseAudioStreamDevice(s.stream)
                                    : SDL_ResumeAudioStreamDevice(s.stream);
             if (!ok)
@@ -579,6 +662,9 @@ public:
 
 private:
     struct Slot { SDL_AudioStream* stream = nullptr; int frame_bytes = 0; int grain_bytes = 0;
+                  AudioDemandMeter demand;
+                  uint64_t generation = 0;
+                  bool demand_enabled = false, demand_started = false;
                   bool put_failed = false;
                   int freq = 0;                                     // port sample rate for pacing
                   std::chrono::steady_clock::time_point next{};     // per-grain pacing deadline
@@ -626,6 +712,10 @@ bool install_sdl3_audio_sink() {
     g_installed = true;
     SDL_Log("prosper-audio: SDL3 audio backend installed");
     return true;
+}
+
+bool sdl3_audio_demand_snapshot(int port, Sdl3AudioDemandSnapshot& snapshot) {
+    return g_sink.demand_snapshot(port, snapshot);
 }
 
 void set_sdl3_audio_gain(float gain) {

--- a/prosper/frontends/audio_sdl3/test_audio_demand.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_demand.cpp
@@ -1,0 +1,110 @@
+#include "audio_demand.hpp"
+#include "hle/audio/audio.hpp"
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+using namespace prosper;
+static int failures = 0;
+#define CHECK(c) do { if (!(c)) { std::printf("FAIL line %d: %s\n", __LINE__, #c); ++failures; } } while (0)
+
+int main(int argc, char** argv) {
+    // Separate processes exercise static destruction, which cannot be tested by
+    // explicitly shutting down the same sink earlier in the ordinary test.
+    if (argc == 2) {
+        CHECK(install_sdl3_audio_sink());
+        CHECK(audio_sink()->open(1, AudioPortInfo{}));
+        if (std::strcmp(argv[1], "external-quit") == 0) SDL_Quit();
+        else if (std::strcmp(argv[1], "ordered-quit") == 0) {
+            shutdown_sdl3_audio_sink();
+            SDL_Quit();
+        } else CHECK(std::strcmp(argv[1], "return-open") == 0);
+        return failures ? 1 : 0;
+    }
+    if (!std::getenv("PROSPER_AUDIO_DEMAND")) {
+#ifdef _WIN32
+        _putenv_s("PROSPER_AUDIO_DEMAND", "1");
+#else
+        setenv("PROSPER_AUDIO_DEMAND", "1", 1);
+#endif
+    }
+    CHECK(install_sdl3_audio_sink());
+    const SDL_AudioSpec spec{SDL_AUDIO_F32, 2, 48000};
+    SDL_AudioStream* a = SDL_CreateAudioStream(&spec, &spec);
+    SDL_AudioStream* b = SDL_CreateAudioStream(&spec, &spec);
+    CHECK(a && b);
+    AudioDemandMeter ma, mb;
+    if (a && b) {
+        ma.reset(AudioDemandPhase::Active); mb.reset(AudioDemandPhase::Active);
+        CHECK(SDL_SetAudioStreamGetCallback(a, AudioDemandMeter::consume, &ma));
+        CHECK(SDL_SetAudioStreamGetCallback(b, AudioDemandMeter::consume, &mb));
+        float pcm[16], out[16]{};
+        for (unsigned i = 0; i < 16; ++i) pcm[i] = float(i) / 32;
+        CHECK(SDL_PutAudioStreamData(a, pcm, sizeof(pcm)));
+        CHECK(SDL_PutAudioStreamData(b, pcm, sizeof(pcm)));
+        CHECK(SDL_GetAudioStreamData(a, out, sizeof(out)) == sizeof(out));
+        CHECK(std::memcmp(pcm, out, sizeof(out)) == 0);
+        CHECK(SDL_GetAudioStreamQueued(a) == 0);
+        Sdl3AudioDemandSnapshot sa{}, sb{};
+        CHECK(ma.snapshot(a, sa));
+        // Empty input after a successful pull is not a shortage: its full PCM is
+        // now in the consumer's output buffer and can still be playing downstream.
+        CHECK(sa.phases[1].calls == 1 && sa.phases[1].requested_bytes == sizeof(out));
+        CHECK(sa.phases[1].shortfall_calls == 0 && sa.phases[1].additional_bytes == 0);
+        CHECK(SDL_GetAudioStreamData(a, out, sizeof(out)) == 0); // deliberate producer gap
+        CHECK(ma.snapshot(a, sa));
+        CHECK(sa.phases[1].calls == 2 && sa.phases[1].shortfall_calls == 1);
+        CHECK(sa.phases[1].additional_bytes == sizeof(out));
+        CHECK(sa.phases[1].first_ns > 0 && sa.phases[1].last_ns >= sa.phases[1].first_ns);
+        CHECK(SDL_GetAudioStreamData(b, out, sizeof(out)) == sizeof(out));
+        CHECK(mb.snapshot(b, sb));
+        CHECK(sb.phases[1].calls == 1 && sb.phases[1].additional_bytes == 0);
+        CHECK(std::memcmp(pcm, out, sizeof(out)) == 0); // independent stream retained its PCM
+        ma.set_phase(AudioDemandPhase::Paused);
+        CHECK(SDL_GetAudioStreamData(a, out, sizeof(out)) == 0);
+        CHECK(ma.snapshot(a, sa));
+        CHECK(sa.phases[2].shortfall_calls == 1 && sa.phases[1].shortfall_calls == 1);
+    }
+    SDL_DestroyAudioStream(a); SDL_DestroyAudioStream(b); // before callback userdata dies
+
+    // The meter must also be wired into the actual sink, not only a test stream.
+    auto* sink = audio_sink();
+    AudioPortInfo info;
+    CHECK(sink->open(1, info));
+    Sdl3AudioDemandSnapshot before{}, after{};
+    const bool wired = sdl3_audio_demand_snapshot(1, before);
+    CHECK(wired);
+    if (wired) {
+        auto wait_for = [&](auto predicate) {
+            const auto end = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+            do {
+                CHECK(sdl3_audio_demand_snapshot(1, after));
+                if (predicate(after)) return true;
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            } while (std::chrono::steady_clock::now() < end);
+            return false;
+        };
+        CHECK(wait_for([](const auto& s) { return s.phases[0].calls > 0; }));
+        int16_t pcm[256 * 2]{};
+        sink->output(1, pcm, 256); // intentional silent PCM is still a supplied grain
+        CHECK(wait_for([](const auto& s) { return s.phases[1].shortfall_calls > 0; }));
+        set_sdl3_audio_paused(true);
+        CHECK(sdl3_audio_demand_snapshot(1, before));
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+        CHECK(sdl3_audio_demand_snapshot(1, after));
+        CHECK(after.phases[1].calls == before.phases[1].calls);
+        sink->close(1);
+        CHECK(!sdl3_audio_demand_snapshot(1, after));
+        CHECK(sink->open(1, info)); // still paused: no background reads can race the reset
+        CHECK(sdl3_audio_demand_snapshot(1, after));
+        CHECK(after.generation > before.generation);
+        for (const auto& phase : after.phases) CHECK(phase.calls == 0);
+        set_sdl3_audio_paused(false);
+    }
+    sink->close(1);
+    shutdown_sdl3_audio_sink();
+    CHECK(!sdl3_audio_demand_snapshot(1, after));
+    return failures ? 1 : 0;
+}

--- a/prosper/frontends/prosper-app/AGENTS.md
+++ b/prosper/frontends/prosper-app/AGENTS.md
@@ -1,0 +1,7 @@
+# Desktop frontend
+
+`main.cpp` owns the SDL window, Vulkan presentation and application lifecycle.
+Library UI, settings, gamepad input and FPS overlays live alongside it; guest APIs and
+shared rendering implementations belong in their existing core/shared directories.
+Stop frontend workers and release SDL-dependent objects before calling SDL_Quit.
+Keep performance displays explicit about guest flips, presentations and fresh render work.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -3259,6 +3259,9 @@ int main(int argc, char** argv) {
     if (vk.sampleBuf)    vkDestroyBuffer(vk.device, vk.sampleBuf, nullptr);
     if (vk.sampleMem)    vkFreeMemory(vk.device, vk.sampleMem, nullptr);
 
+#ifdef PROSPER_AUDIO_SDL3
+    shutdown_sdl3_audio_sink(); // join diagnostics and destroy streams while SDL is alive
+#endif
     SDL_DestroyWindow(win); SDL_Quit();
     return exitCode;
 }

--- a/prosper/tools/perf/audio_delivery_report.py
+++ b/prosper/tools/perf/audio_delivery_report.py
@@ -1,44 +1,14 @@
 #!/usr/bin/env python3
 """Aggregate `[audio-dbg]` lines into an audio-delivery health report.
 
-WHY THIS EXISTS
----------------
-Audio underrun hunts on Windows dev boxes have been ear-driven: "it stutters like a small
-buffer", then a cycle of pacing changes and listen tests. `PROSPER_AUDIO_DEBUG=1` makes the
-SDL sink log every guest grain delivery (arrival gap, frames, queued bytes); this tool turns
-that log into the numbers that name the failure mode, offline, without listening:
-
-  * delivery cadence -- mean/median/p99/max inter-arrival gap per port, and the fraction of
-    gaps beyond one and two grain periods;
-  * queue health -- mean/min queued bytes, and the share of arrivals that found the queue
-    below one grain and below a quarter grain -- a THIN CUSHION, which for a pacer that hands
-    over one grain at a time is the normal steady state rather than a fault -- plus the share
-    that arrived to a COMPLETELY EMPTY queue, which is the starvation case;
-  * effective delivery rate vs the device rate -- a persistent deficit is a CLOCK DRIFT
-    between the guest's budgeted audio clock and the device crystal; no cushion survives it,
-    and the fix is drift compensation, not deeper buffering;
-  * burst clustering -- the fraction of arrivals whose inter-arrival GAP exceeds two grain
-    periods (#3061: earlier wording here promised a stronger conjunct -- "carries more than
-    one grain of audio" -- that the code has never tested; frames-per-arrival is available in
-    the log but is not examined, so this is gap-only, same as the code). This shape is
-    CONSISTENT WITH a quantized mixer wake, but the cadence alone cannot prove it -- and, being
-    gap-only, it does not distinguish a real multi-grain flush from a producer simply
-    delivering audio below real time, which also arrives in clusters, spaced by production
-    rather than by a wait (#3080 -- the verdict named the wrong cause on a title where a
-    `PROSPER_TIMEDWAIT_CENSUS=1` measurement, in the same log, showed the guest's only timed
-    wait resolving at x1.02, i.e. not quantized at all; the -55% delivery-rate deficit already
-    explained the clustering). So if `[timedwait Ns]` census lines are present in the same
-    input, their ratio for the dominant wait primitive SETTLES which cause applies; if they are
-    absent, the report says so and names the census as the discriminator instead of asserting a
-    mechanism it cannot see.
-
-WHAT THIS TOOL DOES NOT SEE
----------------------------
-`[audio-dbg]` is emitted per accepted `output()` call from the guest. Grains the guest never
-delivers (a mixer that skipped a period) appear only as a longer gap. Content-level defects
-(a mixer that produced silence or repeated samples) are invisible here; the queue level and
-the delivery rate are most of the report's world -- the one exception is the wait-primitive
-census below, read from the SAME log when the run captured both diagnostics together.
+Reports delivery cadence, input queue occupancy and rate relative to --device-hz.
+An empty SDL input queue is not proof of a playback underrun: converted audio may
+already be playing downstream. Rate differences do not identify their own cause.
+Optional PROSPER_AUDIO_DEMAND=1 records measure consumption requests per stream and
+phase. Their additional input bytes are approximate under resampling and are not
+hardware XRUNs or a count of silence inserted. Counters are cumulative per open;
+only the last snapshot is used, never the sum of periodic reports. Use one process
+run per log file. Content correctness and physical backend XRUNs need other evidence.
 
 Usage:
     audio_delivery_report.py [LOG ...] [--port P] [--device-hz H] [--channels C] [--bytes-per-frame N]
@@ -53,26 +23,17 @@ RECORD = re.compile(
     r"\[audio-dbg\] port=(\d+) gap=([0-9.]+)ms frames=(\d+) queued_before=(\d+)"
     r"(?: \(grain=(\d+)\))?")
 
-# `report_timedwait_census()` (src/hle/kernel/timedwait_census.hpp) prints one of these per
-# primitive every 5 s when PROSPER_TIMEDWAIT_CENSUS=1. It is a DIRECT measurement of how coarse
-# a wait primitive actually is -- requested vs actual, as a ratio -- which is exactly the
-# question the burst-clustering verdict below cannot answer from cadence alone. A primitive with
-# no requested interval (an absolute-clock deadline, e.g. cond_timedwait) prints "?" instead of a
-# ratio and is skipped: no ratio, no evidence either way.
+DEMAND = re.compile(
+    r"\[audio-demand\] t_us=(\d+) port=(\d+) generation=(\d+) phase=(startup|active|paused) "
+    r"calls=(\d+) requested_bytes=(\d+) shortfall_calls=(\d+) additional_bytes=(\d+) "
+    r"first_ns=(\d+) last_ns=(\d+)")
+DEMAND_OPEN = re.compile(r"\[audio-demand-open\] port=(\d+) generation=(\d+) (.*)")
+
+# Process-wide wait context; no producer thread/caller identity is present.
 TIMEDWAIT_RECORD = re.compile(
     r"\[timedwait \S+\]\s+(\S+)\s+calls=(\d+)\s+requested=\s*(?:[0-9.]+\s*ms|\?)"
     r"\s+actual=\s*[0-9.]+\s*ms(?:\s+x([0-9.]+))?")
-
-# A ratio comfortably above 1.0 means the wait genuinely overshot what the guest asked for (the
-# "coarse tick" the burst verdict describes); a ratio near 1.0 means the wait resolved close to
-# on time and cannot be the cause of clustered arrivals. #3013 measured ~x2.9 for a primitive that
-# WAS the cause; #3080 measured x1.02 for one that was not, on a title whose clustering was fully
-# explained by a -55% delivery-rate deficit instead. The threshold sits well clear of both.
 QUANTIZED_RATIO_THRESHOLD = 1.3
-
-# The device consumes `device_hz * channels * bytes_per_frame` bytes per second. The guest's
-# delivery rate against THAT number is the clock-drift measurement; a persistent deficit
-# drains any cushion at the deficit rate no matter how deep the buffer is.
 
 
 def parse_streams(paths):
@@ -92,7 +53,26 @@ def analyze(paths, port_filter, device_hz, channels, bytes_per_frame):
     # Weighted by calls (not averaged line-to-line) so a primitive with many more calls in one
     # 5 s window is not diluted by a quiet window reporting the same primitive.
     census = {}
+    demand, formats = {}, {}
     for path, line in parse_streams(paths):
+        dm = DEMAND.search(line)
+        om = DEMAND_OPEN.search(line)
+        if dm:
+            t, port, generation = map(int, dm.groups()[:3])
+            if port_filter is None or port == port_filter:
+                key = (path, port, generation, dm.group(4))
+                values = tuple(map(int, dm.groups()[4:]))
+                prior = demand.get(key)
+                # Reject reset/concatenated runs; otherwise the last row could hide
+                # an earlier shortfall and falsely report a clean run.
+                valid = (not prior or (prior[2] and t >= prior[0] and
+                         all(x >= y for x, y in zip(values[:4], prior[1][:4]))))
+                valid = valid and values[2] <= values[0] and values[5] >= values[4]
+                if prior and prior[1][0]:
+                    valid = valid and values[4] == prior[1][4] and values[5] >= prior[1][5]
+                demand[key] = (t, values, valid)
+        elif om:
+            formats[(path, int(om.group(1)), int(om.group(2)))] = om.group(3)
         m = RECORD.search(line)
         if not m:
             tm = TIMEDWAIT_RECORD.search(line)
@@ -126,18 +106,13 @@ def analyze(paths, port_filter, device_hz, channels, bytes_per_frame):
         slot["gaps"].append(gap_ms)
         slot["frames"].append(frames)
         slot["queued"].append(queued)
-    return per_port, census
+    return per_port, census, demand, formats
 
 
 def dominant_census(census):
-    """The most-called wait primitive's mean overshoot ratio, or None if no census was present.
+    """Most-called process-wide wait primitive and its call-weighted mean ratio.
 
-    Global to the process, not per port -- the census counts every timed wait regardless of which
-    audio port (if any) it paces -- so this is the best available evidence for a burst-clustering
-    verdict on any port, not a per-port measurement. Most-called rather than worst-ratio: on a
-    title that uses exactly one primitive (the common case -- see #3080, where usleep was the
-    ONLY one that ever appeared), that is the same primitive either way, and on a title using
-    several, the one actually driving the pacing is more likely the one called the most.
+    These records do not identify the audio producer or establish its wake cadence.
     """
     if not census:
         return None
@@ -220,13 +195,13 @@ def report_port(port, slot, device_hz, channels, bytes_per_frame, census=None):
         # the fixture added with this change prints 100% of them beside 0% empty. The old wording,
         # "the device starved between deliveries", was true only while the threshold was
         # accidentally testing queued == 0; widening it 256x to a real grain left the words
-        # describing a condition they no longer match. Starvation is the EMPTY row.
+        # describing a condition they no longer match. Even the EMPTY row cannot establish downstream starvation.
         print(f"  arrivals with under 1 grain buffered: {under_one}"
               f" ({100 * under_one / len(queued):.1f}%) -- thin cushion")
         print(f"  arrivals below 1/4 grain:          {under_quarter}"
               f" ({100 * under_quarter / len(queued):.1f}%) -- very thin")
         print(f"  arrivals with an EMPTY queue:         {empty}"
-              f" ({100 * empty / len(queued):.1f}%) -- STARVED: nothing left to play")
+              f" ({100 * empty / len(queued):.1f}%) -- input empty; downstream playback unknown")
 
     if span_s > 0 and device_hz:
         # The emitter logs gap=0.00ms for a port's FIRST arrival -- there is no previous arrival
@@ -259,58 +234,49 @@ def report_port(port, slot, device_hz, channels, bytes_per_frame, census=None):
         print(f"  effective delivery: {delivered_hz:.0f} frames/s vs device {device_hz_total}"
               f" -> drift {drift_pct:+.2f}%")
         if drift_pct < -0.3:
-            print("  VERDICT: the guest's audio clock runs below the device rate -- a clock"
-                  " deficit, not a buffering defect. No cushion survives it; fix the guest"
-                  " audio clock or compensate the drift in the sink.")
+            print("  VERDICT: measured delivery deficit relative to the configured rate;"
+                  " investigate guest production, scheduling and pacing to establish the cause.")
         elif drift_pct > 0.3:
-            print("  VERDICT: the guest's audio clock runs above the device rate -- the"
-                  " cushion grows until the depth cap; drift compensation should slow the"
-                  " delivery.")
+            print("  VERDICT: measured delivery exceeds the configured rate;"
+                  " check the selected rate and production/pacing before changing buffering.")
         else:
-            print("  VERDICT: delivery matches the device rate -- a stutter at this rate is"
-                  " a burst/quantization problem, not a clock deficit. See the cadence and"
-                  " burst rows above.")
+            print("  VERDICT: delivery matches the device rate on average;"
+                  " consumption continuity and audible correctness remain unmeasured by arrivals.")
 
     if grain_ms > 0:
-        # GAP-ONLY, deliberately (#3061): this counts arrivals separated from the previous one by
-        # more than two grain periods, not arrivals that themselves carry more than one grain of
-        # frames -- the emitter logs frames= per record, so that conjunct could be tested, but
-        # doing so would make this gate blind to exactly the case #3080 needed it for: a producer
-        # delivering ordinary single-grain arrivals, delayed by a clock deficit rather than a
-        # quantized wake, which never carries more than a grain per arrival. The three-way verdict
-        # below (present since #3168) already exists to tell that case apart from a real multi-grain
-        # burst using the timedwait census; narrowing the gate here to frames > grain would silence
-        # that verdict for the scenario it was built to diagnose instead.
         bursts = sum(1 for g in gaps if g > 2 * grain_ms)
         if bursts > len(gaps) * 0.2 and mean_gap > 1.5 * grain_ms:
-            # This cadence shape (clustering beyond two grain periods) is what a quantized mixer
-            # wake looks like -- but it is also what a producer simply running below real time
-            # looks like, since its arrivals are spaced by production rather than by a wait. #3080:
-            # this exact code path asserted the wait-primitive cause on a title where the census
-            # measured the opposite (x1.02, i.e. not quantized) and a -55% delivery-rate deficit
-            # already explained the clustering. So the verdict is only as strong as the evidence
-            # available for THIS run: earned when a census is present, a named hypothesis when not.
+            print("  Cadence clusters beyond two grain periods: late production and delayed wakes"
+                  " can both cause this; arrivals cannot tell them apart.")
             if census is not None and census["ratio"] is not None:
-                if census["ratio"] < QUANTIZED_RATIO_THRESHOLD:
-                    print("  VERDICT: the inter-arrival cadence clusters beyond two grain periods,"
-                          f" but the timedwait census RULES OUT a quantized wake -- {census['name']}"
-                          f" resolves at x{census['ratio']:.2f} ({census['calls']} calls), not a"
-                          " coarse tick. The clustering has some other cause -- see the delivery-rate"
-                          " verdict above if it fired -- and the wait primitive is not it.")
-                else:
-                    print("  VERDICT: the inter-arrival cadence clusters beyond two grain periods,"
-                          f" and the timedwait census CONFIRMS a coarse wait -- {census['name']}"
-                          f" resolves at x{census['ratio']:.2f} ({census['calls']} calls) against its"
-                          " requested interval. The mixer's wake is quantized, not a buffering"
-                          " defect. Fix the wait primitive's resolution.")
+                timing = ("near requested duration" if census["ratio"] < QUANTIZED_RATIO_THRESHOLD
+                          else "longer than requested duration")
+                print(f"  Process wait context: {census['name']} x{census['ratio']:.2f}"
+                      f" ({census['calls']} calls), {timing}.")
+                print("  This aggregate does not identify the audio producer's thread/caller;"
+                      " it neither proves nor excludes delayed mixer wakes.")
             else:
-                print("  VERDICT: the inter-arrival cadence clusters beyond two grain periods --"
-                      " consistent with EITHER a quantized mixer wake (a timed wait resolving on a"
-                      " coarse tick) OR a producer delivering audio below real time (which also"
-                      " arrives in clusters). This cadence alone cannot tell them apart. Re-run with"
-                      " PROSPER_TIMEDWAIT_CENSUS=1 captured into the same log and check the dominant"
-                      " wait primitive's ratio: near 1.0 rules out quantization, well above it"
-                      " confirms the wait is the cause.")
+                print("  PROSPER_TIMEDWAIT_CENSUS=1 can add process wait context;"
+                      " correlate producer thread/caller and scheduling before assigning a cause.")
+
+
+def report_demand(demand, formats):
+    if not demand:
+        print("SDL consumption demand: unavailable (run with PROSPER_AUDIO_DEMAND=1)")
+        return
+    print("SDL consumption demand: cumulative input-format requests; not hardware XRUNs")
+    for (path, port, generation, phase), (t, values, valid) in sorted(demand.items()):
+        calls, requested, shortfalls, additional, first, last = values
+        print(f"  source={path} port={port} generation={generation} phase={phase} snapshot_us={t}")
+        print("    " + formats.get((path, port, generation), "input/device format context unavailable"))
+        if not valid:
+            print("    INVALID counter sequence: use one process run per log file")
+        elif not calls:
+            print("    UNOBSERVED: no consumption callbacks in this phase")
+        else:
+            print(f"    calls={calls} requested_bytes={requested} shortfall_calls={shortfalls}"
+                  f" additional_bytes={additional} first_ns={first} last_ns={last}")
+            print("    Additional bytes are approximate under resampling; no silence duration inferred.")
 
 
 def main():
@@ -328,14 +294,17 @@ def main():
     args = parser.parse_args()
 
     paths = args.logs if args.logs else ["-"]
-    per_port, census = analyze(paths, args.port, args.device_hz, args.channels, args.bytes_per_frame)
+    per_port, census, demand, formats = analyze(paths, args.port, args.device_hz, args.channels, args.bytes_per_frame)
     if not per_port:
         print("no [audio-dbg] records found (run with PROSPER_AUDIO_DEBUG=1)")
-        return 1
+        if not demand:
+            report_demand(demand, formats)
+            return 1
     census_summary = dominant_census(census)
     for port in sorted(per_port):
         report_port(port, per_port[port], args.device_hz, args.channels, args.bytes_per_frame,
                     census_summary)
+    report_demand(demand, formats)
     return 0
 
 

--- a/prosper/tools/perf/audio_queue_timeline_report.py
+++ b/prosper/tools/perf/audio_queue_timeline_report.py
@@ -1,64 +1,19 @@
 #!/usr/bin/env python3
-"""Read a PROSPER_AUDIO_QUEUE_TIMELINE log and report how close each audio port came to dry.
+"""Report SDL input queue occupancy from PROSPER_AUDIO_QUEUE_TIMELINE logs.
 
-The metric this exists for is the ZERO-CROSSING EPISODE, not the mean and not the sample
-percentage. A device queue that empties for 3 ms and refills is the condition an underrun is made
-of, and it is invisible to both of the obvious summaries: the one-second delivery average stays at ~100% of real
-time (that is exactly how #3016 hid), and a percentage-of-samples figure buries a burst of
-contiguous dry samples in a large denominator. So an episode -- a maximal run of consecutive
-samples at zero on one port -- is counted once, and its duration is reported.
+Usage: audio_queue_timeline_report.py LOG [--min-episode-us N] [--active-window-ms N]
 
-  usage: audio_queue_timeline_report.py <log> [--min-episode-us N] [--active-window-ms N]
-         both `--opt N` and `--opt=N` are accepted; an unknown option is an error
+A zero queue means no unconverted input bytes remain. Converted audio can still be
+playing downstream, even when the zero is bracketed by positive queue samples.
+These episodes are INPUT QUEUE GAPS, not measured consumption shortfalls or hardware
+XRUNs. Use PROSPER_AUDIO_DEMAND=1 with audio_delivery_report.py for SDL consumption.
 
-Input lines come from the sampler in audio_sink_sdl3.cpp:
-
-  [audio-queue] t_us=123456 port=17 queued=2048 grain=2048
-
-`queued` and `grain` are both GUEST-format bytes (the sampler uses SDL_GetAudioStreamQueued, not
-Available, for exactly that reason), so grain-relative thresholds here need no format flags.
-
-## An empty queue is not an underrun, and the timeline alone cannot tell the difference
-
-A port that is OPEN but not being fed reads `queued=0` forever, and that is silence, not
-starvation. A discriminator that cannot tell the two apart would decide a pacer A/B on whichever
-arm happened to idle more.
-
-Worth recording precisely, because the first run analysed here is a case where the confound was
-suspected and turned out NOT to be the explanation. That run reported a median queue depth of
-0.00 grains and 53% of samples dry on Blasphemous 2, which looked like exactly this artefact. It
-was not: with the gate in place only **6 samples** out of 588,705 reclassify as idle, so the 53%
-is real underrunning. (The other half of that first reading was mine, not the tool's -- I read the
-longest episode's `40248 us` as 40 seconds. It is 40 ms, which is an underrun, not silence.)
-
-So the gate exists on principle rather than on that evidence, and the evidence it was built to
-explain away survived it. Both halves are stated because a plausible instrument artefact is a very
-comfortable explanation for an inconvenient measurement, and this one would have retired a real
-defect.
-
-So a dry sample counts as an underrun only when the port was actively streaming across it. The
-gate is taken from the sampler's OWN series and needs no second source:
-
-    a dry EPISODE is an UNDERRUN if audio was seen anywhere before it, audio is seen anywhere
-    after it, it is no longer than --active-window-ms, and it does not abut a gap in the
-    sample series. Otherwise it is not counted.
-
-The first two conditions are GLOBAL, not a local window. An earlier version of this line said
-"within --active-window-ms on BOTH sides", which is not what the code does and disagrees with it
-on real input -- the window is a maximum DIP DURATION. Found in review of #3070, and worth the
-space because a docstring that describes a rule the code does not implement is the most citable
-kind of wrong.
-
-Deliberately not cross-correlated with the per-arrival `[audio-dbg]` emitter, which would be the
-obvious richer gate. That emitter logs only the GAP since the previous arrival, so arrival times
-have to be reconstructed by accumulation and their origin is the first arrival, while the
-sampler's `t_us` origin is sink construction. The two clocks cannot be aligned from the log, and a
-gate resting on a mis-aligned clock would be exactly the kind of instrument this tool exists to
-avoid. When [audio-dbg] lines are present they are used only for CONTEXT -- arrival count and
-median cadence -- and are labelled as such.
-
-Both figures are always printed. A tool that silently drops samples reports an improvement that is
-really a filter, so IDLE time is shown next to underrun time rather than subtracted out of sight.
+The historical activity filter retains episodes bracketed by positive samples,
+shorter than --active-window-ms, and not adjacent to a sampling discontinuity.
+It is a heuristic queue filter, not proof of activity or idleness. All excluded
+samples remain visible. Durations estimate one median sampling interval per sample;
+zero between samples is unobserved. Arrival records supply cadence context only:
+their relative gap clock cannot be aligned to the sampler's absolute t_us clock.
 """
 import re
 import sys
@@ -102,31 +57,10 @@ def arrival_context(gaps):
 
 
 def classify_dry_episodes(samples, dry_eps, interval_us, max_dip_us):
-    """Split dry EPISODES into underruns and idleness, using only this port's own series.
+    """Return (bracketed input-queue episodes, excluded sample count).
 
-    A dry episode is an UNDERRUN when all four hold:
-
-      * audio was seen BEFORE it   -- otherwise the port had not started feeding yet;
-      * audio is seen AFTER it     -- otherwise the port stopped, and the tail is silence;
-      * it is no longer than max_dip_us -- otherwise it is silence between two fed stretches,
-        not a dip in a stream. This is the condition that matters, and the reason the first two
-        are not sufficient: a 5000 ms gap between two songs IS bracketed by audio on both sides,
-        so bracketing alone would call it one enormous underrun;
-      * it does not abut a DISCONTINUITY in the sample series. This condition is DEFLATIONARY by
-        design -- a real dip that happens to follow a lost-sample hole is not counted either, and
-        that is the intended trade: the coverage figure in the header is what tells a reader the
-        window was not fully observed, and under-reporting a defect we cannot substantiate is
-        preferable to attributing unobserved time to one. The bracketing samples are then
-        on the far side of an interval nobody observed, so "the port was being fed across this"
-        is exactly what the data cannot say. Counting it would attribute unobserved time to a
-        defect -- and the common case, a port closing and reopening, is idleness.
-
-    Per EPISODE rather than per sample, deliberately. A per-sample version of the same rule
-    silently turns into a pure duration cap -- the samples at the edges of a long silence fail
-    the far-side test and get excluded too -- so the bracketing half of the rule stops meaning
-    anything while still appearing in the code. Measured while writing the tests for it.
-
-    Returns (underrun_episodes, idle_sample_count).
+    Bracketing, duration and continuity are heuristic filters. None establish a
+    consumer shortage or prove that an excluded interval was intentional silence.
     """
     if not dry_eps:
         return [], 0
@@ -252,11 +186,11 @@ def report(ports, gaps=None, min_episode_us=0, active_window_us=200000):
             return sum(e[2] * iv for e in eps)
 
         kept = [e for e in dry if e[2] * iv >= min_episode_us]
-        print(f"  NOT COUNTED (idle, or unobservable): {n_idle} samples,"
+        print(f"  EXCLUDED (outside queue-gap filter): {n_idle} samples,"
               f" {n_idle * iv / 1000.0:.1f} ms"
               f", {100.0 * n_idle / len(samples):.2f}% of samples"
               f"  [excluded below; max dip {active_window_us // 1000} ms]")
-        print(f"  UNDERRUN (dry while streaming): {len(kept)} episodes"
+        print(f"  INPUT QUEUE GAP (bracketed): {len(kept)} episodes"
               + (f" (of {len(dry)}; {len(dry) - len(kept)} shorter than"
                  f" {min_episode_us} us)" if min_episode_us else "")
               + f", {total_us(kept) / 1000:.1f} ms total"
@@ -268,18 +202,8 @@ def report(ports, gaps=None, min_episode_us=0, active_window_us=200000):
               f" {total_us(thin) / 1000:.1f} ms total,"
               f" {100.0 * sum(e[2] for e in thin) / len(samples):.2f}% of samples")
 
-        # The verdict names the UNDERRUN episode count, because that is the quantity an A/B between
-        # two pacers can actually separate; a mean cannot, and this tool exists because of that.
-        if not kept:
-            # Two different facts, and the old wording conflated them: "no underrun found" is
-            # not "the queue never emptied" when dry stretches were excluded by the gate.
-            print("  verdict: the queue never emptied" if not n_idle else
-                  "  verdict: no underrun -- every dry stretch was idle, over the dip bound,\n"
-                  "           or across a gap in sampling (see NOT COUNTED above)")
-        elif len(kept) < 5:
-            print(f"  verdict: {len(kept)} isolated underruns")
-        else:
-            print(f"  verdict: STARVED -- {len(kept)} underruns")
+        print(f"  verdict: {len(kept)} retained input queue gaps; "
+              "SDL consumption shortfalls and hardware XRUNs are unknown")
     return 0
 
 
@@ -317,7 +241,7 @@ def main(argv):
             # detection while still printing a report. That is the one value whose effect a
             # reader would not predict from the name, so it is refused rather than echoed.
             print("error: --active-window-ms 0 would classify every dry stretch as idle, "
-                  "disabling underrun detection entirely", file=sys.stderr)
+                  "disabling queue-gap detection entirely", file=sys.stderr)
             return 2
         if name == "--min-episode-us":
             min_ep = n

--- a/prosper/tools/perf/test_audio_delivery_report.py
+++ b/prosper/tools/perf/test_audio_delivery_report.py
@@ -121,7 +121,7 @@ def main():
     #    name the clock deficit -- this is exactly the Blasphemous 2 signature.
     log = "".join(dbg(gap=15.7, queued=64) for _ in range(300))
     out, _ = run(log)
-    expect(out, "clock deficit", "case 2 verdict")
+    expect(out, "measured delivery deficit", "case 2 verdict")
     # A NUMBER, not the row label. This assertion used to be `expect(out, "the device starved
     # between deliveries")` -- a string printed on every run regardless of the count, so review
     # confirmed that hardwiring under_one = 0 left it green. queued=64 is under one 2048 B grain
@@ -137,7 +137,8 @@ def main():
                   for _ in range(300))
     out, _ = run(log)
     expect(out, "delivery matches the device rate", "case 3 drift verdict")
-    expect(out, "burst/quantization problem", "case 3 burst verdict")
+    expect(out, "consumption continuity and audible correctness remain unmeasured", "case 3 limits")
+    reject(out, "burst/quantization problem", "average rate does not prove a mechanism")
     reject(out, "the guest's audio clock runs below the device rate", "case 3 must not miscall a clock deficit")
 
     # 4. Port filter: records for another port must not leak into the report.
@@ -176,7 +177,7 @@ def main():
     census_low = ("[timedwait 5s] usleep           calls=488       requested= 20.143 ms"
                   "  actual= 20.503 ms  x1.02\n")
     out, _ = run(deficit_log + census_low)
-    expect(out, "RULES OUT a quantized wake", "case 7: census rules out quantization")
+    expect(out, "near requested duration", "case 7: process wait context")
     expect(out, "x1.02", "case 7: reports the measured ratio")
     reject(out, "Fix the wait primitive's resolution",
            "case 7: must not issue the imperative when the census contradicts it")
@@ -187,10 +188,10 @@ def main():
     census_high = ("[timedwait 5s] sem_timedwait    calls=488       requested=  5.330 ms"
                    "  actual= 15.457 ms  x2.90\n")
     out, _ = run(deficit_log + census_high)
-    expect(out, "CONFIRMS a coarse wait", "case 8: census confirms quantization")
+    expect(out, "longer than requested duration", "case 8: process wait context")
     expect(out, "x2.90", "case 8: reports the measured ratio")
-    expect(out, "Fix the wait primitive's resolution",
-           "case 8: the imperative IS earned when the census supports it")
+    reject(out, "Fix the wait primitive's resolution", "aggregate cannot prove the audio cause")
+    expect(out, "neither proves nor excludes delayed mixer wakes", "thread identity remains unknown")
 
     # 9. Drift bias hand-check (#3061). The `[audio-dbg]` emitter logs gap=0.00ms for a port's
     #    FIRST arrival -- no previous arrival to measure from -- so `span_s = sum(gaps)` covers
@@ -224,6 +225,32 @@ def main():
            "case 9: the true rate must read as matching, not as a clock excess")
     reject(out, "runs above the device rate",
            "case 9: the pre-fix +1/(N-1) bias (+10.00% at N=11) must not survive")
+
+    # Cumulative snapshots must not be added; startup and reopen counts must remain separate.
+    def demand(t, generation=1, phase="active", calls=2, shortfalls=1, additional=64):
+        return (f"[audio-demand] t_us={t} port=17 generation={generation} phase={phase} "
+                f"calls={calls} requested_bytes={calls * 64} shortfall_calls={shortfalls} "
+                f"additional_bytes={additional} first_ns=10 last_ns=20\n")
+    log = (demand(100, calls=1, shortfalls=0, additional=0) + demand(200) +
+           demand(200, phase="startup", calls=10, shortfalls=10, additional=640) +
+           demand(300, generation=2, calls=0, shortfalls=0, additional=0))
+    out, rc = run(log)
+    expect(out, "calls=2 requested_bytes=128 shortfall_calls=1 additional_bytes=64", "last cumulative row")
+    reject(out, "calls=3 requested_bytes=192", "never sum snapshots")
+    expect(out, "generation=2", "reopen is independent")
+    expect(out, "UNOBSERVED: no consumption callbacks", "zero callbacks is not healthy playback")
+    expect(out, "phase=startup", "startup remains separately visible")
+    if rc != 0: failures.append("demand-only input should be accepted")
+    out, _ = run(demand(200) + demand(300, calls=1, shortfalls=0, additional=0))
+    expect(out, "INVALID counter sequence", "reject counters reset within the same stream generation")
+    out, _ = run(demand(100) + demand(200).replace("first_ns=10", "first_ns=11"))
+    expect(out, "INVALID counter sequence", "reject timestamp reset even if counts match")
+    out, _ = run(demand(100) + demand(200).replace("last_ns=20", "last_ns=19"))
+    expect(out, "INVALID counter sequence", "reject backwards last callback time")
+    out, _ = run(dbg(queued=0))
+    expect(out, "input empty; downstream playback unknown", "empty input does not prove underrun")
+    expect(out, "SDL consumption demand: unavailable", "missing observer must be visible")
+    reject(out, "STARVED", "arrival-only record cannot prove starvation")
 
     if failures:
         print("FAILURES:")

--- a/prosper/tools/perf/test_audio_queue_timeline_report.py
+++ b/prosper/tools/perf/test_audio_queue_timeline_report.py
@@ -72,8 +72,8 @@ def main():
     log = "".join(sample(i * 1000, 6144) for i in range(2000))
     out, rc = run(log)
     expect(out, "= 3.00 grains", "healthy: the cushion is reported in grains")
-    expect(out, "the queue never emptied", "healthy: no starvation claimed")
-    expect(out, "UNDERRUN (dry while streaming): 0 episodes", "healthy: zero underruns")
+    expect(out, "0 retained input queue gaps", "healthy: no starvation claimed")
+    expect(out, "INPUT QUEUE GAP (bracketed): 0 episodes", "healthy: zero underruns")
     expect_rc(rc, 0, "healthy: a clean log exits 0")
 
     # 2. THE CONFOUND ARM, and the reason the gate exists. A port that is OPEN but never fed reads
@@ -82,9 +82,9 @@ def main():
     #    decided a pacer A/B on whichever arm happened to idle more.
     log = "".join(sample(i * 1000, 0) for i in range(2000))
     out, _ = run(log)
-    expect(out, "NOT COUNTED (idle, or unobservable): 2000 samples",
+    expect(out, "EXCLUDED (outside queue-gap filter): 2000 samples",
            "confound: a never-fed port is IDLE for every sample")
-    expect(out, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "confound: ...and reports ZERO underruns, not 2000")
     expect_not(out, "STARVED", "confound: a silent port is never called STARVED")
     # 3. Idle time is REPORTED, not silently dropped. A filter that hides what it removed reports
@@ -95,11 +95,11 @@ def main():
     #    both sides, is ONE underrun episode of 8 ms -- not 8 episodes, and not idle.
     log = "".join(sample(i * 1000, 0 if 500 <= i < 508 else 6144) for i in range(2000))
     out, _ = run(log)
-    expect(out, "UNDERRUN (dry while streaming): 1 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 1 episodes",
            "burst: 8 contiguous dry samples bracketed by audio are ONE underrun")
     expect(out, "8.0 ms total", "burst: charged one sampling interval per dry sample")
     expect(out, "longest 8000 us at t=500000 us", "burst: the longest episode is located")
-    expect(out, "NOT COUNTED (idle, or unobservable): 0 samples",
+    expect(out, "EXCLUDED (outside queue-gap filter): 0 samples",
            "burst: a bracketed dip is not idle")
 
     # 5. A LONG silence BETWEEN two fed stretches -- bracketed by audio on both sides, and still
@@ -108,11 +108,11 @@ def main():
     #    enormous underrun without the duration condition.
     log = "".join(sample(i * 1000, 0 if 200 <= i < 5200 else 6144) for i in range(5400))
     out, _ = run(log)
-    expect(out, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "long silence: a 5 s bracketed gap is not an underrun")
-    expect(out, "NOT COUNTED (idle, or unobservable): 5000 samples",
+    expect(out, "EXCLUDED (outside queue-gap filter): 5000 samples",
            "long silence: ...it is idle, all 5000 samples of it")
-    expect(out, "no underrun -- every dry stretch was idle",
+    expect(out, "0 retained input queue gaps",
            "long silence: the verdict says no underrun, not \"never emptied\"")
 
     # 6. --active-window-ms is the max-dip boundary, and must be shown to bite in BOTH directions
@@ -120,12 +120,12 @@ def main():
     #    A knob that cannot be shown to move the answer is a knob whose default nobody can justify.
     log8 = "".join(sample(i * 1000, 0 if 500 <= i < 508 else 6144) for i in range(2000))
     out_big, _ = run(log8)
-    expect(out_big, "UNDERRUN (dry while streaming): 1 episodes",
+    expect(out_big, "INPUT QUEUE GAP (bracketed): 1 episodes",
            "max dip: an 8 ms dip counts at the 200 ms default")
     out_small, _ = run(log8, "--active-window-ms=2")
-    expect(out_small, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out_small, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "max dip: the same 8 ms dip is idleness at a 2 ms bound")
-    expect(out_small, "NOT COUNTED (idle, or unobservable): 8 samples",
+    expect(out_small, "EXCLUDED (outside queue-gap filter): 8 samples",
            "max dip: ...and the eight samples are accounted for, not dropped")
     expect(out_small, "max dip 2 ms", "max dip: the bound in force is stated in the output")
 
@@ -136,9 +136,9 @@ def main():
     log_lead = ("".join(sample(i * 1000, 0) for i in range(60)) +
                 "".join(sample((60 + i) * 1000, 6144) for i in range(500)))
     out, _ = run(log_lead)
-    expect(out, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "leading dry: a port dry before its first audio is not an underrun")
-    expect(out, "NOT COUNTED (idle, or unobservable): 60 samples",
+    expect(out, "EXCLUDED (outside queue-gap filter): 60 samples",
            "leading dry: ...it is start-up idleness")
 
     # 6c. TRAILING dry: the port stops being fed and stays dry to the end of the log. Symmetric to
@@ -147,9 +147,9 @@ def main():
     log_tail = ("".join(sample(i * 1000, 6144) for i in range(500)) +
                 "".join(sample((500 + i) * 1000, 0) for i in range(60)))
     out, _ = run(log_tail)
-    expect(out, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "trailing dry: a port that stops feeding is not underrunning")
-    expect(out, "NOT COUNTED (idle, or unobservable): 60 samples",
+    expect(out, "EXCLUDED (outside queue-gap filter): 60 samples",
            "trailing dry: ...it is shutdown idleness")
 
     # 6d. THE WELDING CASE, and the reason episodes() takes a gap threshold. The sampler emits
@@ -164,9 +164,9 @@ def main():
                 "".join(sample(30_120_000 + i * 1000, 0) for i in range(20)) +
                 "".join(sample(30_140_000 + i * 1000, 6144) for i in range(100)))
     out, _ = run(log_weld)
-    expect(out, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "welding: two dry stretches across a sampling gap are NOT one underrun")
-    expect(out, "NOT COUNTED (idle, or unobservable): 40 samples",
+    expect(out, "EXCLUDED (outside queue-gap filter): 40 samples",
            "welding: both stretches are accounted for as unobservable, not dropped")
 
     # 6e. And the gap must be VISIBLE, not merely handled. Coverage -- samples x interval against
@@ -188,7 +188,7 @@ def main():
                   "".join(sample(107_000 + i * 1000, 0) for i in range(5)) +
                   "".join(sample(112_000 + i * 1000, 6144) for i in range(100)))
     out_j, _ = run(log_jitter)
-    expect(out_j, "UNDERRUN (dry while streaming): 1 episodes",
+    expect(out_j, "INPUT QUEUE GAP (bracketed): 1 episodes",
            "jitter: a 2 ms hiccup inside a dry stretch does not split the episode")
 
     # 6g. Argument parsing is STRICT, and both spellings work. The usage line documented
@@ -199,7 +199,7 @@ def main():
     log_sp = "".join(sample(i * 1000, 0 if 500 <= i < 508 else 6144) for i in range(2000))
     out_sp, rc_sp = run(log_sp, "--active-window-ms", "2")
     expect(out_sp, "max dip 2 ms", "args: the SPACE-separated form is honoured, not ignored")
-    expect(out_sp, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out_sp, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "args: ...and it actually changes the answer")
     out_eq, _ = run(log_sp, "--active-window-ms=2")
     expect(out_eq, "max dip 2 ms", "args: the = form still works")
@@ -235,7 +235,7 @@ def main():
                  "".join(sample(811_000 + i * 1000, 0) for i in range(5)) +   # 5 ms hole
                  "".join(sample(816_000 + i * 1000, 6144) for i in range(100)))
     out_rs, _ = run(log_reseg)
-    expect(out_rs, "UNDERRUN (dry while streaming): 0 episodes",
+    expect(out_rs, "INPUT QUEUE GAP (bracketed): 0 episodes",
            "resegmentation: a 5 ms hole splits under the median threshold, so neither half counts")
 
     # 6i. grain=0. The emitter can log it before a port's format is known, and the header divides
@@ -245,7 +245,7 @@ def main():
     out_g0, rc_g0 = run(log_g0)
     expect(out_g0, "grain UNKNOWN (0)", "grain 0: reported as unknown rather than dividing by it")
     expect_rc(rc_g0, 0, "grain 0: still produces a report")
-    expect(out_g0, "NOT COUNTED", "grain 0: dryness is still classified without a grain")
+    expect(out_g0, "EXCLUDED", "grain 0: dryness is still classified without a grain")
 
     # 6j. Coverage counts INTERVALS, not samples: n samples span (n-1) intervals. A two-sample
     #      port read 200% before this was fixed, which is the kind of figure that discredits the
@@ -262,20 +262,21 @@ def main():
     log = "".join(sample(i * 1000, 0 if i in (100, 101, 300, 700, 701, 702) else 6144)
                   for i in range(2000))
     out, _ = run(log)
-    expect(out, "UNDERRUN (dry while streaming): 3 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 3 episodes",
            "three separated bursts are three underruns")
-    # Pin the STARVED threshold from BOTH sides -- a one-sided assertion cannot tell a correct
-    # threshold from one that fires always or never.
+    # Neither a few nor many empty-input episodes establish playback starvation.
     expect_not(out, "STARVED", "three underruns is below the STARVED threshold")
-    expect(out, "3 isolated underruns", "...and is reported as isolated instead")
+    expect(out, "3 retained input queue gaps", "...and is reported as isolated instead")
     log5 = "".join(sample(i * 1000, 0 if i in (100, 300, 500, 700, 900) else 6144)
                    for i in range(2000))
     out5, _ = run(log5)
-    expect(out5, "STARVED -- 5 underruns", "five underruns crosses into STARVED")
+    expect(out5, "5 retained input queue gaps", "five gaps remain visible")
+    expect_not(out5, "STARVED", "even frequent queue gaps do not prove playback starvation")
+    expect(out5, "hardware XRUNs are unknown", "backend state is explicitly unobserved")
 
     # 8. --min-episode-us drops only the short ones and must SAY how many it dropped.
     out, _ = run(log, "--min-episode-us=2000")
-    expect(out, "UNDERRUN (dry while streaming): 2 episodes",
+    expect(out, "INPUT QUEUE GAP (bracketed): 2 episodes",
            "filter keeps the two multi-sample episodes")
     expect(out, "1 shorter than 2000 us", "filter reports what it dropped")
 
@@ -290,9 +291,9 @@ def main():
     #     not be conflated with it: half a grain has not emptied.
     log = "".join(sample(i * 1000, 1024) for i in range(500))
     out, _ = run(log)
-    expect(out, "UNDERRUN (dry while streaming): 0 episodes", "half a grain is not an underrun")
+    expect(out, "INPUT QUEUE GAP (bracketed): 0 episodes", "half a grain is not an underrun")
     expect(out, "THIN (under one grain, ungated): 1 episodes", "...but it is thin, as one episode")
-    expect(out, "verdict: the queue never emptied",
+    expect(out, "verdict: 0 retained input queue gaps",
            "and the verdict keys on dry, not thin -- with nothing excluded, it may say so")
 
     # 11. Two ports are reported independently. Blasphemous 2 plays through two, and interleaving
@@ -302,7 +303,7 @@ def main():
     out, _ = run(log)
     expect(out, "port 17:", "two ports: the first is reported")
     expect(out, "port 18:", "two ports: the second is reported")
-    expect(out, "NOT COUNTED (idle, or unobservable): 300 samples",
+    expect(out, "EXCLUDED (outside queue-gap filter): 300 samples",
            "two ports: the never-fed one is idle, not merged into the fed one")
 
     # 12. [audio-dbg] context is parsed and LABELLED as context. The docstring explains why it


### PR DESCRIPTION
An empty SDL input queue can follow successful consumption while audio is still buffered downstream. The previous delivery/timeline reports called this an underrun and inferred mixer wake causes from aggregate timing data.

Add optional per-stream SDL consumption-demand counters with separate startup, active and paused phases, stream generations, and input/device format context. Preserve PCM, independent output/channel buffers and pacing. Keep callbacks bounded and join diagnostics before SDL teardown. Reports retain the last cumulative snapshot and leave unavailable or unobserved playback explicit; additional-byte estimates are not hardware XRUN counts.

Validation: 11/11 focused audio tests pass, including exact independent PCM and a deliberate unmet SDL read, actual sink wiring and three teardown process paths. Disabling production diagnostic wiring makes the guard fail. Independent source review approved the exact head; all seven required Linux/general CI checks are green.

Same-binary Sonic/GTA controls with F9 disabled retain only small consumption shortfalls, despite 20.3% / 18.8% empty-input arrivals. The F9 runs have larger late delivery disturbances around bundle work. Detailed exact-head evidence distinguishes startup, stopped-producer tails and later shortfalls; it does not claim a playback improvement from instrumentation or a hardware XRUN rate. Sonic's known black Cyber Space HUD and GTA's established bank scene were visually checked. “Active” counters mean first PCM has arrived and the stream is not paused, not proof of ongoing production; periodic snapshots can omit a closing stream's final partial interval.

Refs #3432. This adds consumption evidence for the ongoing audio investigation; it does not claim that all audible underruns are fixed.
