### PR TITLE
Convert packed sampled render targets on the GPU

### DIFF
--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -27,6 +27,35 @@ aggregate frame metric was used to make the call. Checked-in capture:
 ticked as a rendered-gameplay milestone: the route reaches gameplay, and a rendering defect stands
 between that and a gameplay screenshot.
 
+## Packed render-target GPU conversion (2026-09-07, #3437)
+
+The selected sampled input is now verified against the live imported image: binding 10 of
+`0x200599c900` / hash `0xe3c2229a45c7807c` requests packed 10-bit UNORM, while 200 selected
+available imports reported a same-device 3840×2160 RGBA8 UNORM color target with transfer-source
+usage. Other declarations occur at the same code address; this is the exact packed-input population.
+The compute backend now copies that authoritative image through an integer quantization shader into
+the requested packed image, within the existing submission. It preserves filtering after 10-bit RGB /
+2-bit alpha quantization, source pins and layouts; incompatible views retain the CPU fallback.
+
+An exploratory same-binary comparison on `a4e3757b5115` used fresh saves/caches, the committed
+route and immediate presentation. Only `PROSPER_NO_GPU_PACKED_RTT=1` differed in the normalized
+launch environment. F8 at 300 seconds recorded 26 CPU-fallback / 27 GPU-converted target dispatches,
+all successful, all with GPU timestamps and complete capture footers. Their mean total cost was
+**14.502 / 6.717 ms per dispatch** (53.7% lower in this pair), including setup, dispatch/wait,
+writeback and cleanup. Setup was 8.923 / 1.059 ms; GPU preparation was 0.500 / 0.693 ms,
+including the new conversion. Writeback still cost 3.836 / 3.616 ms, while cleanup rose from
+0.009 to 0.575 ms. The standalone shader interval excludes the conversion and is not its cost.
+
+Guest presentations were 5.19 / 5.39 per second, host presentations 5.19 / 5.19, and CPU use
+1.91 / 1.61 cores. Newly rendered-frame rates were unavailable; this is not an FPS improvement
+claim. Extra compositor screenshots/focus changes investigated the user-reported menu defect before
+the timing windows (last baseline intervention about 217 seconds). They did not overlap F8, but
+subsequent effects are unproven: the pair is exploratory and whole-prefix audio comparison is excluded.
+The later F9s show the known black Cyber Space world with visible HUD at 00:26.95 / 00:27.33;
+HUD colors/icon poses differ at these different guest instants, so they are not pixel-equivalence proof.
+The blank modal, absent menu clouds and wrong title artwork remain open in #2206; cutscene
+corruption remains in #3436. Independent execution tests cover exact values and filtered precision.
+
 ## Mapped GPU detile inputs (2026-09-07, #3434)
 
 A same-binary native `prosper-app` comparison on `f0fb9f112998` used the committed
@@ -674,6 +703,7 @@ to remember to update it. The last one did not (review of #2820).
 
 | Hypothesis | Verdict and evidence |
 | --- | --- |
+| The packed GPU conversion in #3437 or mapped detile inputs in #3434 first introduced the black title-menu background | **Falsified as first introduction.** Retained user F9 `frame_grab_PPSA03831_20260907-153044-350`, written at guest present 1285 on source `0927f6d3a8a8` (tree-identical to pre-#3434 main `92f0e7368e48`) with `PROSPER_NO_GPU_DETILE=1`, already shows black behind the menu and incorrect TIME UP artwork. New #3437 compositor screenshots after route f1700/f1940 show the same visible failure class at different selections. The earlier run was excluded from the cutscene comparison for capturing a menu; that does not invalidate this menu evidence. This establishes prior occurrence, not unchanged frequency or a shared root cause. #2206 remains open. |
 | The mapped GPU detile input reuse in #3434 introduced the alternating opening-cutscene corruption | **Falsified as an introducing change.** The retained pre-PR main binary (source `0927f6d3a8a8`, tree identical to main `92f0e7368e48`) renders a normal stone-tower frame at guest flip 2810 and green/red UI artwork at 2812 without F9. A same-binary, same-route control with only `PROSPER_NO_GPU_DETILE=1` changed also reaches the cutscene and renders green corruption at 2812. This excludes GPU detiling as necessary for the green flicker; the sampled CPU-detile frames did not reproduce the separate red artwork and do not exonerate that symptom. These are sampled readback snapshots (15 main / 19 CPU-control deliveries), not complete or timing-neutral frame sequences. Root cause remains open in #3436. |
 | Making `gpu_replay` materialize the declared mip chain needs a new capture-format version, because the placement the reader must know is not in the file | **Falsified.** The placement *is* in the file, and had been since before v57: `collect_intervals` anchors a resource's captured range at an interval whose `begin` may sit below `gpu_addr`, and `assign_blob_range` already serializes `blob_offset = gpu_addr - interval.begin` — which is exactly the count of owned bytes preceding the descriptor's address, because a blob's byte *i* is the guest byte at `blob.guest_addr + i` by construction. Only the *writer* had to change (own the allocation, not the selected level); the reader publishes an existing serialized number as `host_data_prefix_bytes`. Pre-#3202 capsules fail closed on the same number without a version gate. #3202 |
 | All three scene-target-width kernels are blocked by `s_cbranch_execz` — a stronger claim than #2790's census, which records it for two of the three | **Partly falsified — two of the three moved, one never did.** The `V_LSHL_ADD_U32` allowlist entry the census predates has landed, and re-measuring on `33417dca` shows `0x2005717e00` and `0x200571bd00` no longer rejecting on `s_cbranch_execz` at pc=28 but on `image_load_mip` at **pc=81** — "a reject PC names where a fact was consumed, not where it was lost", exactly as that commit predicted. `0x2005714000` did **not** move: the census already recorded it at pc=33 `image_load_mip`, byte-identical. So all three of THESE THREE kernels now stop on the SAME instruction — which narrows this particular group to one unimplemented operation, and is **not** a claim that the title's world needs only that: `image_load_mip` is the first blocker of at least two (see the section above, and #2859 for the `s_getpc_b64` half that has since landed). Their `[mimg-mip]` profiles are identical too — `img_dim=5/1 mips=12 addr=0x2026900000 2048x2048`. Note `image_get_resinfo` at pc=73 belongs to `0x2005a13f00` / `0x2006e24000`, **not** to any of these three; an earlier revision of this row mis-attributed it by pairing separately-collected program and reject lists. #2790, #3048 |

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -14,6 +14,9 @@ found Vulkan.
   pipeline cache, descriptor pools, memory pool and command buffers, and does not include
   `render_runner.h` at all. Reflected storage buffers and storage images are materialized from guest
   memory, dispatched, and written back into guest memory synchronously.
+- `packed_rtt_conversion.hpp` — device-owned RGBA8→packed-10-bit sampled conversion.
+  Records transfers and conversion into the guest compute submission; setup failures retain their
+  `VkResult` so optional fallback cannot hide device loss.
 - `live_target_format.hpp` — the guest↔Vulkan pixel-format mapping. Compiled with `-Werror=switch`
   on purpose: a silent RGBA8 fallback has cost two titles a whole render layer.
 - `decode_scratch.hpp` — the pooled full-surface intermediates that both the texture decode branches

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -7,6 +7,7 @@
 #include "shared/compute/storage_image_alias_plan.hpp"
 #include "shared/live/decode_scratch.hpp"  // pooled full-surface intermediates (#3309's mechanism)
 #include "shared/live/live_target_format.hpp"
+#include "shared/live/packed_rtt_conversion.hpp"
 #include "shared/rtt/rtt_scale.hpp"
 #include "shared/rtt/rtt_authority.hpp"
 #include "shared/texture/seed_reprove.hpp"
@@ -423,6 +424,7 @@ std::atomic<bool> g_zero_next_cold_storage_snapshot_minimum_for_test{false};
 std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
 std::atomic<bool> g_fail_next_image_result_buffer_retain_for_test{false};
 std::atomic<bool> g_force_next_queue_submit_device_lost_for_test{false};
+std::atomic<VkResult> g_next_packed_rtt_setup_result_for_test{VK_SUCCESS};
 std::atomic<uint64_t> g_live_compute_queue_submit_attempts{0};
 thread_local uint64_t g_perf_compute_gpu_timestamp_samples = 0;
 thread_local double g_perf_compute_gpu_device_ms = 0.0;
@@ -1408,6 +1410,7 @@ struct VulkanComputeContext {
     VkShaderModule compare_shader = VK_NULL_HANDLE;
     VkPipelineLayout compare_pipeline_layout = VK_NULL_HANDLE;
     VkPipeline compare_pipeline = VK_NULL_HANDLE;
+    PackedRttConversion packed_rtt_conversion;
     // Storage-image support (#590): the recompiler's storage path declares the
     // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
     // tests/fixtures/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
@@ -1590,6 +1593,7 @@ struct VulkanComputeContext {
         if (command_pool) vkDestroyCommandPool(device, command_pool, nullptr);
         if (descriptor_pool) vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
         if (compare_pool) vkDestroyDescriptorPool(device, compare_pool, nullptr);
+        packed_rtt_conversion.destroy();
         if (compare_pipeline) vkDestroyPipeline(device, compare_pipeline, nullptr);
         if (compare_pipeline_layout)
             vkDestroyPipelineLayout(device, compare_pipeline_layout, nullptr);
@@ -3303,6 +3307,9 @@ struct BoundImage {
     uint32_t depth_bits_saved_layout = 0;
     // RGBA8 UNORM -> UINT preserves the CPU snapshot's bytes, but must sample an INTEGER
     // image. Copy into an owned UINT image; no mutable image or mismatched UNORM view is needed.
+    bool packed10_source = false;
+    VkDescriptorPool packed10_pool = VK_NULL_HANDLE;
+    VkDescriptorSet packed10_set = VK_NULL_HANDLE;
     bool color_bits_source = false;
     VkImage color_bits_image = VK_NULL_HANDLE;
     uint32_t color_bits_saved_layout = 0;
@@ -6000,9 +6007,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         return decline(stage);
     };
     // NON-declining forms, for setup whose failure disables an OPTIONAL feature and lets the
-    // dispatch run anyway. The GPU result-comparison path is the only such caller: a false
-    // `compare_ready` merely clears `compare_targets` and drops each `compare_flag_index`, after
-    // which the dispatch proceeds and can succeed.
+    // dispatch run anyway. Conversion setup can fall back to a CPU snapshot; a false
+    // `compare_ready` clears `compare_targets` and drops each `compare_flag_index`.
+    // Device loss remains fatal, including in these optional paths.
     //
     // Routing those through the declining form would make `[compute-decline]` fire — with a running
     // count — for a dispatch that then executed, which is precisely the class of misread instrument
@@ -6049,8 +6056,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             // A pin is taken per successful import, so it is released per import -- including for a
             // binding that a later alias check folded into an earlier one (#1095).
-            if (images[i].imported || images[i].depth_bits_source || images[i].color_bits_source)
+            if (images[i].imported || images[i].depth_bits_source || images[i].color_bits_source ||
+                images[i].packed10_source)
                 release_live_render_target_image(images[i].imported_addr);
+            if (images[i].packed10_pool)
+                vkDestroyDescriptorPool(ctx.device, images[i].packed10_pool, nullptr);
             if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
             if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
@@ -6820,8 +6830,36 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // transfer below copies exact texels and deliberately performs no resampling.
                     const bool depth_bits_extent =
                         import.width == r->width && import.height == r->height;
-                    if (color_bits_copy) {
-                        bi.color_bits_source = true;
+                    bool packed10_copy = ordinary_2d_view && !depth_import &&
+                        compatible_device && import.transfer_src &&
+                        shader_resource_compute_mip_chain_levels(*r) == 1 &&
+                        import.width == r->width && import.height == r->height &&
+                        import.format == LiveTargetPixelFormat::Rgba8Unorm &&
+                        r->format == DataFormat::Unorm2_10_10_10 && r->num_components == 4 &&
+                        image_descriptors[i].sampled_float &&
+                        std::getenv("PROSPER_NO_GPU_PACKED_RTT") == nullptr;
+                    if (packed10_copy) {
+                        std::lock_guard<std::mutex> cache_lock(ctx.pipeline_cache_mutex);
+                        auto& conversion = ctx.packed_rtt_conversion;
+                        const VkResult injected = g_next_packed_rtt_setup_result_for_test.exchange(
+                            VK_SUCCESS, std::memory_order_acq_rel);
+                        packed10_copy = vk_soft_ok(injected != VK_SUCCESS ? injected :
+                            conversion.initialize(ctx.physical, ctx.device, ctx.pipeline_cache),
+                                                   "packed-rtt-pipeline") &&
+                            conversion.fits(uint64_t(r->width) * r->height) &&
+                            vk_soft_ok(conversion.allocate_binding(bi.packed10_pool, bi.packed10_set),
+                                       "packed-rtt-descriptors");
+                        if (ctx.device_lost) {
+                            // Admission owns a pin, but no conversion commands have been recorded.
+                            release_live_render_target_image(r->gpu_addr);
+                            images_ready = false;
+                            decline("packed-rtt-device-lost");
+                            break;
+                        }
+                    }
+                    if (color_bits_copy || packed10_copy) {
+                        bi.color_bits_source = color_bits_copy;
+                        bi.packed10_source = packed10_copy;
                         bi.color_bits_image = static_cast<VkImage>(import.image);
                         bi.color_bits_saved_layout = import.layout;
                         bi.imported_addr = r->gpu_addr;
@@ -6978,7 +7016,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     break;
                 }
             }
-            if (renderer_owned && !bi.imported && !bi.color_bits_source && !bi.seed_skip &&
+            if (renderer_owned && !bi.imported && !bi.color_bits_source &&
+                !bi.packed10_source && !bi.seed_skip &&
                 bi.seed_from_imported == SIZE_MAX) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
@@ -7134,7 +7173,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     prior.imported == bi.imported &&
                     prior.depth_bits_source == bi.depth_bits_source &&
                     prior.color_bits_source == bi.color_bits_source &&
-                    (!bi.color_bits_source || prior.color_bits_image == bi.color_bits_image) &&
+                    prior.packed10_source == bi.packed10_source &&
+                    (!(bi.color_bits_source || bi.packed10_source) ||
+                     prior.color_bits_image == bi.color_bits_image) &&
                     prior.unorm_rtt_value_reuse == bi.unorm_rtt_value_reuse &&
                     (!bi.imported ||
                      (prior.image == bi.image &&
@@ -7399,7 +7440,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::getenv("PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS") != nullptr;
             static const bool sampled_dcc_fast_clear_disabled =
                 std::getenv("PROSPER_NO_COMPUTE_DCC_FAST_CLEAR") != nullptr;
-            if (!bi.depth_bits_source && !bi.color_bits_source &&
+            if (!bi.depth_bits_source && !bi.color_bits_source && !bi.packed10_source &&
                 compute_sampled_guest_prepare_required(
                     bi.storage, renderer_owned, bi.imported,
                     imported_guest_bypass_disabled)) {
@@ -7796,7 +7837,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // directly. The old path first built a heap upload and then memcpy'd the complete result
             // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
             ScopedMappedMemory upload_mapping(ctx);
-            const size_t upload_size = (bi.imported || bi.depth_bits_source || bi.color_bits_source ||
+            const size_t upload_size = (bi.imported || bi.depth_bits_source || bi.color_bits_source || bi.packed10_source ||
                                         bi.seed_skip ||
                                         bi.seed_from_imported != SIZE_MAX ||
                                         bi.compute_transfer_seed_borrowed)
@@ -7824,7 +7865,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     images_ready = false; break;
                 }
                 upload_mapping.memory = staging_memory[i];
-                if (!bi.depth_bits_source && !bi.seed_skip &&
+                if (!bi.depth_bits_source && !bi.packed10_source && !bi.seed_skip &&
                     bi.seed_from_imported == SIZE_MAX &&
                     !bi.compute_transfer_seed_borrowed &&
                     !(bi.persistent && bi.upload_skipped) &&
@@ -7840,6 +7881,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (bi.imported) {
                 // The renderer's sampled image is the source, so direct imports need no transfer.
                 bi.guest_bytes = 0;
+            } else if (bi.packed10_source) {
+                bi.guest_bytes = 0;
+                ctx.packed_rtt_conversion.bind_buffer(bi.packed10_set, staging[i], sbytes);
             } else if (bi.color_bits_source) {
                 // The command buffer copies the exact RGBA8 payload into a UINT image. Avoid
                 // both the lazy renderer readback and the CPU per-channel repacking/upload.
@@ -8838,7 +8882,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (image_timing)
                 std::fprintf(stderr,
                              "[compute-image] code=0x%llx hash=0x%016llx "
-                             "binding=%u class=%s imported=%u color-bits-copy=%u addr=0x%llx "
+                             "binding=%u class=%s imported=%u color-bits-copy=%u packed10-copy=%u addr=0x%llx "
                              "persistent=%u allocation-reused=%u upload-skipped=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu format=%u components=%u "
                              "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u "
@@ -8848,7 +8892,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              (unsigned long long)item.code_addr,
                              (unsigned long long)timing_program_hash, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
-                             bi.color_bits_source ? 1u : 0u,
+                             bi.color_bits_source ? 1u : 0u, bi.packed10_source ? 1u : 0u,
                              (unsigned long long)r->gpu_addr,
                              bi.persistent ? 1u : 0u,
                              bi.forced_seed_allocation_reused ? 1u : 0u,
@@ -9300,10 +9344,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      1, &to_general);
                 continue;
             }
-            if (bi.color_bits_source) {
-                // vkCmdCopyImage preserves bytes between size-compatible color formats. Unlike
-                // a sampled UNORM view, the destination's RGBA8_UINT view returns 0..255 integers,
-                // exactly as the CPU snapshot path does. No host staging allocation participates.
+            if (bi.color_bits_source || bi.packed10_source) {
+                // Preserve GENERAL while an earlier direct borrower owns the source.
                 bool source_already_general = false;
                 for (size_t prior = 0; prior < i; ++prior) {
                     const BoundImage& candidate = images[prior];
@@ -9314,6 +9356,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const VkImageLayout source_saved = source_already_general
                     ? VK_IMAGE_LAYOUT_GENERAL
                     : static_cast<VkImageLayout>(bi.color_bits_saved_layout);
+                if (bi.packed10_source) {
+                    ctx.packed_rtt_conversion.record(command, bi.color_bits_image, source_saved,
+                        bi.image, staging[i], bi.packed10_set, r->width, r->height);
+                    continue;
+                }
+                // The UINT arm preserves bytes between size-compatible color formats;
+                // the packed arm above instead reconstructs normalized numeric values.
                 VkImageMemoryBarrier barriers[2]{};
                 for (auto& barrier : barriers) {
                     barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -11592,6 +11641,12 @@ void live_compute_force_next_image_result_host_fallback_for_test() {
 
 void live_compute_fail_next_image_result_buffer_retain_for_test() {
     g_fail_next_image_result_buffer_retain_for_test.store(true, std::memory_order_release);
+}
+
+void live_compute_fail_next_packed_rtt_setup_for_test(bool device_lost) {
+    g_next_packed_rtt_setup_result_for_test.store(
+        device_lost ? VK_ERROR_DEVICE_LOST : VK_ERROR_OUT_OF_DEVICE_MEMORY,
+        std::memory_order_release);
 }
 
 void live_compute_force_next_queue_submit_device_lost_for_test() {

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -6774,18 +6774,24 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     r->gpu_addr, import_request, import);
                 import_ms = std::chrono::duration<double, std::milli>(
                     ComputeClock::now() - import_start).count();
-                if (trace)
+                if (trace || image_timing)
                     std::fprintf(stderr,
                                  "[compute]   direct RTT candidate binding=%u addr=0x%llx "
                                  "requested=f%u/c%u dim=%u extent=%ux%u available=%u "
-                                 "imported=%ux%u/%u kind=%s native=%u\n",
+                                 "imported=%ux%u/%u kind=%s native=%u "
+                                 "same-device=%u transfer-src=%u layout=%u "
+                                 "code=0x%llx hash=0x%016llx\n",
                                  bi.binding, (unsigned long long)r->gpu_addr,
                                  (unsigned)r->format, r->num_components, r->img_dim,
                                  r->width, r->height, import_available ? 1u : 0u,
                                  import.width, import.height, (unsigned)import.format,
                                  import.kind == LiveTargetImageImport::Kind::Depth
                                      ? "depth" : "color",
-                                 import.native_format);
+                                 import.native_format,
+                                 import.device == static_cast<void*>(ctx.device) ? 1u : 0u,
+                                 import.transfer_src ? 1u : 0u, import.layout,
+                                 (unsigned long long)item.code_addr,
+                                 (unsigned long long)timing_program_hash);
                 if (import_available) {
                     const bool depth_import =
                         import.kind == LiveTargetImageImport::Kind::Depth;

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -365,6 +365,8 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 // Deterministic failure injection for the storage-image recovery regression test. The next storage
 // readback fails after dispatch, exercising retained-image invalidation without a Vulkan fault.
 void live_compute_fail_next_storage_readback_for_test();
+// Inject an optional conversion-admission result; does not fail an actual driver call.
+void live_compute_fail_next_packed_rtt_setup_for_test(bool device_lost);
 
 // Deterministic controls for post-DCC cache-promotion regressions. The first leaves the next
 // writable metadata plane unresolved, exercising the final all-0xff recheck. The second disables

--- a/prosper/frontends/shared/live/packed_rtt_conversion.hpp
+++ b/prosper/frontends/shared/live/packed_rtt_conversion.hpp
@@ -1,0 +1,155 @@
+// Device conversion of an authoritative RGBA8 image into the sampled packed-10-bit layout.
+#pragma once
+#include "gpu/recompiler/spirv_builder.hpp"
+#include "gpu/execute/host_read_barrier.hpp"
+#include <vulkan/vulkan.h>
+#include <cstdint>
+
+namespace prosper::frontend {
+// Owned by the compute context, which destroys it before releasing its device.
+struct PackedRttConversion {
+    VkDevice device = VK_NULL_HANDLE;
+    VkDescriptorSetLayout descriptors = VK_NULL_HANDLE;
+    VkPipelineLayout layout = VK_NULL_HANDLE;
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    VkPhysicalDeviceLimits limits{};
+    bool attempted = false;
+    VkResult setup_result = VK_ERROR_FORMAT_NOT_SUPPORTED;
+
+    void destroy() {
+        if (pipeline) vkDestroyPipeline(device, pipeline, nullptr);
+        if (layout) vkDestroyPipelineLayout(device, layout, nullptr);
+        if (descriptors) vkDestroyDescriptorSetLayout(device, descriptors, nullptr);
+        pipeline = VK_NULL_HANDLE; layout = VK_NULL_HANDLE; descriptors = VK_NULL_HANDLE;
+    }
+    VkResult initialize(VkPhysicalDevice physical, VkDevice dev, VkPipelineCache cache) {
+        if (attempted) return setup_result;
+        attempted = true; device = dev;
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(physical, &properties);
+        limits = properties.limits;
+        VkFormatProperties format{};
+        vkGetPhysicalDeviceFormatProperties(physical, VK_FORMAT_A2B10G10R10_UNORM_PACK32, &format);
+        const auto needed = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
+        if ((format.optimalTilingFeatures & needed) != needed ||
+            limits.maxComputeWorkGroupSize[0] < 128 || limits.maxComputeWorkGroupInvocations < 128)
+            return setup_result;
+        const VkDescriptorSetLayoutBinding binding{
+            0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr};
+        VkDescriptorSetLayoutCreateInfo dci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+        dci.bindingCount = 1; dci.pBindings = &binding;
+        setup_result = vkCreateDescriptorSetLayout(device, &dci, nullptr, &descriptors);
+        if (setup_result != VK_SUCCESS) return setup_result;
+        const VkPushConstantRange push{VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t)};
+        VkPipelineLayoutCreateInfo lci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+        lci.setLayoutCount = 1; lci.pSetLayouts = &descriptors;
+        lci.pushConstantRangeCount = 1; lci.pPushConstantRanges = &push;
+        setup_result = vkCreatePipelineLayout(device, &lci, nullptr, &layout);
+        if (setup_result != VK_SUCCESS) {
+            destroy(); return setup_result;
+        }
+        const auto words = prosper::gpu::build_compute_rgba8_to_packed10();
+        VkShaderModuleCreateInfo sci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+        sci.codeSize = words.size() * sizeof(uint32_t); sci.pCode = words.data();
+        VkShaderModule shader = VK_NULL_HANDLE;
+        setup_result = vkCreateShaderModule(device, &sci, nullptr, &shader);
+        if (setup_result != VK_SUCCESS) {
+            destroy(); return setup_result;
+        }
+        VkComputePipelineCreateInfo pci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+        pci.stage = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+        pci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        pci.stage.module = shader; pci.stage.pName = "main"; pci.layout = layout;
+        setup_result = vkCreateComputePipelines(device, cache, 1, &pci, nullptr, &pipeline);
+        vkDestroyShaderModule(device, shader, nullptr);
+        if (setup_result != VK_SUCCESS) destroy();
+        return setup_result;
+    }
+    bool fits(uint64_t texels) const {
+        return texels && texels <= UINT32_MAX - 127u &&
+            texels * 4 <= limits.maxStorageBufferRange &&
+            (texels + 127) / 128 <= limits.maxComputeWorkGroupCount[0];
+    }
+    VkResult allocate_binding(VkDescriptorPool& pool, VkDescriptorSet& set) const {
+        const VkDescriptorPoolSize size{VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1};
+        VkDescriptorPoolCreateInfo pci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+        pci.maxSets = 1; pci.poolSizeCount = 1; pci.pPoolSizes = &size;
+        VkResult result = vkCreateDescriptorPool(device, &pci, nullptr, &pool);
+        if (result != VK_SUCCESS) return result;
+        VkDescriptorSetAllocateInfo ai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+        ai.descriptorPool = pool; ai.descriptorSetCount = 1; ai.pSetLayouts = &descriptors;
+        result = vkAllocateDescriptorSets(device, &ai, &set);
+        if (result == VK_SUCCESS) return result;
+        vkDestroyDescriptorPool(device, pool, nullptr); pool = VK_NULL_HANDLE;
+        return result;
+    }
+    void bind_buffer(VkDescriptorSet set, VkBuffer buffer, VkDeviceSize bytes) const {
+        const VkDescriptorBufferInfo info{buffer, 0, bytes};
+        VkWriteDescriptorSet write{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
+        write.dstSet = set; write.descriptorCount = 1;
+        write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; write.pBufferInfo = &info;
+        vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
+    }
+    void record(VkCommandBuffer command, VkImage source, VkImageLayout saved,
+                VkImage destination, VkBuffer scratch, VkDescriptorSet set,
+                uint32_t width, uint32_t height) const {
+        VkImageMemoryBarrier images[2]{};
+        for (auto& b : images) {
+            b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.srcQueueFamilyIndex = b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        }
+        images[0].image = source; images[0].oldLayout = saved;
+        images[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        images[0].srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+        images[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        images[1].image = destination; images[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        images[1].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        images[1].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        // The allocation may contain a prior dispatch's device writes under another
+        // buffer handle. Order those writes before overwriting the recycled storage.
+        VkMemoryBarrier recycled{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
+        recycled.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+        recycled.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &recycled, 0, nullptr, 2, images);
+        VkBufferImageCopy copy{};
+        copy.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        copy.imageExtent = {width, height, 1};
+        vkCmdCopyImageToBuffer(command, source, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                              scratch, 1, &copy);
+        VkBufferMemoryBarrier buffer{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+        buffer.srcQueueFamilyIndex = buffer.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        buffer.buffer = scratch; buffer.size = VK_WHOLE_SIZE;
+        buffer.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        buffer.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 1, &buffer, 0, nullptr);
+        const uint32_t count = width * height;
+        vkCmdBindPipeline(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+        vkCmdBindDescriptorSets(command, VK_PIPELINE_BIND_POINT_COMPUTE, layout,
+                                0, 1, &set, 0, nullptr);
+        vkCmdPushConstants(command, layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(count), &count);
+        vkCmdDispatch(command, (count + 127u) / 128u, 1, 1);
+        buffer.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        buffer.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 1, &buffer, 0, nullptr);
+        vkCmdCopyBufferToImage(command, scratch, destination,
+                              VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+        images[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        images[0].newLayout = saved; images[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        images[0].dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+        images[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        images[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        images[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        images[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr, 2, images);
+        // The scratch allocation returns to the host-visible memory pool. Its next
+        // owner can map and read it even though this binding never maps it.
+        prosper::gpu::record_host_read_barrier(command, scratch,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_ACCESS_SHADER_WRITE_BIT);
+    }
+};
+} // namespace prosper::frontend

--- a/prosper/src/gpu/recompiler/AGENTS.md
+++ b/prosper/src/gpu/recompiler/AGENTS.md
@@ -6,9 +6,10 @@ Takes a guest shader's instruction bytes and emits a SPIR-V module.
   makes it the cheapest thing in the stack to unit-test.
 - `rdna2_to_spirv` (+ `_internal`, `emit_alu`, `emit_cfg`, `alu_support`, `cfg_support`) — the
   translator: register state, control-flow structurization, and per-instruction lowering.
-- `spirv_builder` — small hand-built SPIR-V modules. **One of them SHIPS**:
+- `spirv_builder` — small hand-built SPIR-V modules. **These include shipped shaders**:
   `frontends/shared/live/live_compute.cpp`'s `prepare_compare_pipeline()` feeds
-  `build_compute_compare_uvec4()` straight to `vkCreateShaderModule` on the live path. Treating
+  `build_compute_compare_uvec4()` straight to `vkCreateShaderModule` on the live path. The GPU
+  texture detiler and `packed_rtt_conversion.hpp` also use modules built here. Treating
   them as test fixtures is what let an invalid `OpAccessChain` reach real devices (#1711), and
   `tools/spv_validate` exists to stop exactly that — so a change here is a change to shipped
   shader code, not to a fixture. It is not a general emitter either.

--- a/prosper/src/gpu/recompiler/spirv_builder.cpp
+++ b/prosper/src/gpu/recompiler/spirv_builder.cpp
@@ -433,4 +433,83 @@ std::vector<uint32_t> build_compute_detile_rgba16f() {
   return e.assemble();
 }
 
+std::vector<uint32_t> build_compute_rgba8_to_packed10() {
+    Emitter e;
+    const auto void_t = e.id(), fn_t = e.id(), uint_t = e.id(), bool_t = e.id();
+    const auto vec_t = e.id(), input_ptr = e.id(), gid = e.id();
+    const auto array_t = e.id(), block_t = e.id(), block_ptr = e.id(), word_ptr = e.id();
+    const auto words = e.id(), push_t = e.id(), push_ptr = e.id(), push_word = e.id();
+    const auto push = e.id(), main = e.id(), entry = e.id(), body = e.id(), done = e.id();
+    Emitter::put(e.caps, Op_Capability, {Cap_Shader});
+    Emitter::put(e.mem, Op_MemoryModel, {Addr_Logical, Mem_GLSL450});
+    std::vector<uint32_t> ep{Exec_GLCompute, main};
+    push_string(ep, "main"); ep.push_back(gid);
+    Emitter::putv(e.entry, Op_EntryPoint, ep);
+    Emitter::put(e.exec, Op_ExecutionMode, {main, EM_LocalSize, 128, 1, 1});
+    Emitter::put(e.deco, Op_Decorate, {gid, Dec_BuiltIn, BI_GlobalInvocationId});
+    Emitter::put(e.deco, Op_Decorate, {array_t, Dec_ArrayStride, 4});
+    for (auto block : {block_t, push_t}) {
+        Emitter::put(e.deco, Op_Decorate, {block, Dec_Block});
+        Emitter::put(e.deco, Op_MemberDecorate, {block, 0, Dec_Offset, 0});
+    }
+    Emitter::put(e.deco, Op_Decorate, {words, Dec_DescriptorSet, 0});
+    Emitter::put(e.deco, Op_Decorate, {words, Dec_Binding, 0});
+    Emitter::put(e.types, Op_TypeVoid, {void_t});
+    Emitter::put(e.types, Op_TypeFunction, {fn_t, void_t});
+    Emitter::put(e.types, Op_TypeInt, {uint_t, 32, 0});
+    Emitter::put(e.types, Op_TypeBool, {bool_t});
+    Emitter::put(e.types, Op_TypeVector, {vec_t, uint_t, 3});
+    Emitter::put(e.types, Op_TypePointer, {input_ptr, SC_Input, vec_t});
+    Emitter::put(e.types, Op_Variable, {input_ptr, gid, SC_Input});
+    Emitter::put(e.types, Op_TypeRuntimeArray, {array_t, uint_t});
+    Emitter::put(e.types, Op_TypeStruct, {block_t, array_t});
+    Emitter::put(e.types, Op_TypePointer, {block_ptr, SC_StorageBuffer, block_t});
+    Emitter::put(e.types, Op_TypePointer, {word_ptr, SC_StorageBuffer, uint_t});
+    Emitter::put(e.types, Op_Variable, {block_ptr, words, SC_StorageBuffer});
+    Emitter::put(e.types, Op_TypeStruct, {push_t, uint_t});
+    Emitter::put(e.types, Op_TypePointer, {push_ptr, SC_PushConstant, push_t});
+    Emitter::put(e.types, Op_TypePointer, {push_word, SC_PushConstant, uint_t});
+    Emitter::put(e.types, Op_Variable, {push_ptr, push, SC_PushConstant});
+    auto constant = [&](uint32_t value) {
+        auto id = e.id();
+        Emitter::put(e.types, Op_Constant, {uint_t, id, value});
+        return id;
+    };
+    auto binary = [&](uint32_t op, uint32_t a, uint32_t b) {
+        auto id = e.id();
+        Emitter::put(e.code, op, {uint_t, id, a, b});
+        return id;
+    };
+    Emitter::put(e.code, Op_Function, {void_t, main, FC_None, fn_t});
+    Emitter::put(e.code, Op_Label, {entry});
+    const auto xyz = e.id(), index = e.id(), count_ptr = e.id(), count = e.id(), valid = e.id();
+    Emitter::put(e.code, Op_Load, {vec_t, xyz, gid});
+    Emitter::put(e.code, Op_CompositeExtract, {uint_t, index, xyz, 0});
+    Emitter::put(e.code, Op_AccessChain, {push_word, count_ptr, push, constant(0)});
+    Emitter::put(e.code, Op_Load, {uint_t, count, count_ptr});
+    Emitter::put(e.code, Op_ULessThan, {bool_t, valid, index, count});
+    Emitter::put(e.code, Op_SelectionMerge, {done, 0});
+    Emitter::put(e.code, Op_BranchConditional, {valid, body, done});
+    Emitter::put(e.code, Op_Label, {body});
+    const auto texel_ptr = e.id(), rgba = e.id();
+    Emitter::put(e.code, Op_AccessChain, {word_ptr, texel_ptr, words, constant(0), index});
+    Emitter::put(e.code, Op_Load, {uint_t, rgba, texel_ptr});
+    auto packed = constant(0);
+    for (uint32_t c = 0; c < 4; ++c) {
+        const auto byte = binary(Op_BitwiseAnd,
+            binary(Op_ShiftRightLogical, rgba, constant(c * 8)), constant(255));
+        // Nearest integer to byte * scale / 255. The odd denominator has no ties.
+        const auto q = binary(Op_UDiv, binary(Op_IAdd,
+            binary(Op_IMul, byte, constant(c == 3 ? 3 : 1023)), constant(127)), constant(255));
+        packed = binary(Op_BitwiseOr, packed,
+            binary(Op_ShiftLeftLogical, q, constant(c * 10)));
+    }
+    Emitter::put(e.code, Op_Store, {texel_ptr, packed});
+    Emitter::put(e.code, Op_Branch, {done});
+    Emitter::put(e.code, Op_Label, {done});
+    Emitter::put(e.code, Op_Return, {});
+    Emitter::put(e.code, Op_FunctionEnd, {});
+    return e.assemble();
+}
+
 } // namespace prosper::gpu

--- a/prosper/src/gpu/recompiler/spirv_builder.hpp
+++ b/prosper/src/gpu/recompiler/spirv_builder.hpp
@@ -33,4 +33,8 @@ std::vector<uint32_t> build_compute_compare_uvec4();
 // completes. Only excess invocations are checked by the shader itself.
 std::vector<uint32_t> build_compute_detile_rgba16f();
 
+// Reconstruct packed R10G10B10A2 UNORM from canonical RGBA8 bytes in place.
+// Binding 0: storage buffer of uint32 texels; push constant: texel count.
+std::vector<uint32_t> build_compute_rgba8_to_packed10();
+
 } // namespace prosper::gpu

--- a/prosper/tests/gpu/execute/test_renderer_uint_copy.cpp
+++ b/prosper/tests/gpu/execute/test_renderer_uint_copy.cpp
@@ -5,6 +5,8 @@
 #include "shared/live/live_compute.hpp"
 #include "gpu/recompiler/rdna2_to_spirv.hpp"
 #include <memory>
+#include <cmath>
+#include <algorithm>
 
 using namespace prosper::gpu;
 static int failures = 0;
@@ -153,9 +155,180 @@ int main() {
                   address, width, 1, VK_FORMAT_R8G8B8A8_UNORM, retained, error) && retained == *expected,
               "the renderer source retains its pixels and usable layout after both imports");
     }
+    // Observe the sampled values in FLOAT32 output. Packed-to-packed output would
+    // hide a wrong direct RGBA8 borrow by quantizing the values during storage.
+    std::vector<float> floats(width * 4), second_floats(width * 4);
+    auto packed_resources = resources;
+    packed_resources.resources[4].format = DataFormat::Unorm2_10_10_10;
+    auto& float_output = packed_resources.resources[5];
+    float_output.format = DataFormat::Float32;
+    float_output.gpu_addr = reinterpret_cast<uint64_t>(floats.data());
+    float_output.size = floats.size() * sizeof(float);
+    auto compile = [&](const ShaderResourceTable& table, const uint32_t* words, size_t n) {
+        item.spirv = recompile_valu(words, n, 1, 0, &table);
+        CHECK(!item.spirv.empty(), "packed UNORM sample into float output recompiles");
+        item.resources = std::make_shared<ShaderResourceTable>(table);
+    };
+    auto check_values = [&](const std::vector<float>& values, bool quantized) {
+        for (size_t i = 0; i < values.size(); ++i) {
+            const uint32_t byte = (*expected)[i];
+            const uint32_t scale = i % 4 == 3 ? 3u : 1023u;
+            const uint32_t q = (byte * scale + 127u) / 255u;
+            const float oracle = quantized ? float(q) / float(scale) : float(byte) / 255.0f;
+            // Independent arithmetic plus an exact CPU-path comparison below. This
+            // tolerance allows float normalization rounding, not an 8-bit-value bypass.
+            CHECK(std::isfinite(values[i]) && std::abs(values[i] - oracle) <= 0.000001f,
+                  "the guest observes the requested UNORM precision in every channel");
+            CHECK(q == uint32_t(std::lround((float(byte) / 255.0f) * float(scale))),
+                  "integer packing agrees with existing CPU reconstruction for every byte");
+        }
+    };
+    compile(packed_resources, code, std::size(code));
+    std::fill(stale.begin(), stale.end(), 0xa5);
+    const auto poison = stale;
+    for (unsigned round = 0; round < 2; ++round) {
+        for (uint32_t i = 0; i < width * 4; ++i)
+            (*expected)[i] = uint8_t((i / 4) * 37 + (i % 4) * 23 + round * 113 + 11);
+        CHECK(prosper::test::render_draws_rgba(
+            {draw}, width, 1, expected->data(), nullptr, false, &target) == *expected,
+            "packed conversion source refreshes at the same renderer address");
+        transfer_source = matching_extent = true;
+        unsigned reads_before = reads, imports_before = imports;
+        std::fill(floats.begin(), floats.end(), -99.0f);
+        CHECK(prosper::frontend::execute_live_compute_items({item}), "GPU packed conversion executes");
+        check_values(floats, true);
+        const auto gpu_values = floats;
+        CHECK(reads == reads_before && imports > imports_before && imports == releases,
+              "packed conversion avoids CPU snapshots and releases every pin");
+        CHECK(stale == poison, "renderer authority does not read or overwrite poisoned guest backing");
+        for (unsigned refusal = 0; refusal < 2; ++refusal) {
+            transfer_source = refusal != 0; matching_extent = refusal != 1;
+            reads_before = reads;
+            std::fill(floats.begin(), floats.end(), -99.0f);
+            CHECK(prosper::frontend::execute_live_compute_items({item}), "packed CPU fallback executes");
+            CHECK(floats == gpu_values, "GPU reconstruction exactly matches sampled CPU fallback values");
+            CHECK(reads == reads_before + 1 && imports == releases,
+                  "incompatible packed import uses one snapshot and balances its pin");
+        }
+    }
+    transfer_source = matching_extent = true;
+    for (unsigned order = 0; order < 3; ++order) {
+        auto paired = packed_resources;
+        auto second = paired.resources[4]; second.binding = 6; second.sgpr_base = 16;
+        if (order == 1) paired.resources[4].format = DataFormat::Unorm8;
+        if (order == 2) second.format = DataFormat::Unorm8;
+        paired.resources.push_back(second);
+        auto second_output = float_output;
+        second_output.binding = 7; second_output.sgpr_base = 24;
+        second_output.gpu_addr = reinterpret_cast<uint64_t>(second_floats.data());
+        paired.resources.push_back(second_output);
+        const uint32_t both_observed[] = {
+            0x7e080300u, 0x7e0a0280u,
+            0xf0000f08u, 0x00000004u, 0xbf8c3f70u,
+            0xf0200f08u, 0x00020004u,
+            0xf0000f08u, 0x00040004u, 0xbf8c3f70u,
+            0xf0200f08u, 0x00060004u, 0xbf810000u,
+        };
+        compile(paired, both_observed, std::size(both_observed));
+        const unsigned reads_before = reads, imports_before = imports;
+        std::fill(floats.begin(), floats.end(), -99.0f);
+        std::fill(second_floats.begin(), second_floats.end(), -99.0f);
+        CHECK(prosper::frontend::execute_live_compute_items({item}), "paired packed/direct views execute");
+        check_values(floats, order != 1); check_values(second_floats, order != 2);
+        CHECK(reads == reads_before && imports == imports_before + 2 && imports == releases,
+              "paired packed/direct views avoid snapshots and release both pins");
+        std::vector<uint8_t> retained; std::string error;
+        prosper::test::BackendPersistentResourceGuard guard;
+        CHECK(prosper::test::readback_persistent_color_target(
+            address, width, 1, VK_FORMAT_R8G8B8A8_UNORM, retained, error) && retained == *expected,
+            "mixed packed/direct imports restore the renderer image and layout");
+    }
+    compile(packed_resources, code, std::size(code));
+    std::fill(floats.begin(), floats.end(), -99.0f);
+    const auto untouched = floats;
+    prosper::frontend::live_compute_fail_next_storage_readback_for_test();
+    CHECK(!prosper::frontend::execute_live_compute_items({item}), "packed readback failure is reported");
+    CHECK(floats == untouched && imports == releases,
+          "failure after completed GPU work preserves guest output and releases pins");
+    CHECK(prosper::frontend::execute_live_compute_items({item}), "packed conversion retries after failure");
+    check_values(floats, true);
+    // Match the measured normalized-sampling contract, including filtering AFTER
+    // quantization. Alpha42/43 straddles the 2-bit boundary: quarter interpolation
+    // yields 1/12, while incorrectly filtering the original bytes yields42.25/255.
+    (*expected)[3] = 42; (*expected)[7] = 43;
+    CHECK(prosper::test::render_draws_rgba(
+        {draw}, width, 1, expected->data(), nullptr, false, &target) == *expected,
+        "filtered packed source retains the alpha boundary pattern");
+    auto sampled = packed_resources;
+    auto& sampled_source = sampled.resources[4];
+    sampled_source.sampler_sgpr_base = 8;
+    sampled_source.unnormalized = 0;
+    sampled_source.min_filter = sampled_source.mag_filter = 1;
+    sampled_source.mip_filter = 0;
+    sampled_source.addr_uvw[0] = sampled_source.addr_uvw[1] = 2;
+    sampled_source.min_lod = sampled_source.max_lod = sampled_source.lod_bias = 0;
+    sampled.resources[5].sgpr_base = 16;
+    const uint32_t filtered_code[] = {
+        0x7e020280u, 0x7e0802ffu, 0x3b400000u, 0x7e0a02ffu, 0x3f000000u,
+        0xf09c0f08u, 0x00400c04u, 0xbf8c3f70u,
+        0xf0200f08u, 0x00040c00u, 0xbf810000u,
+    };
+    compile(sampled, filtered_code, std::size(filtered_code));
+    const auto reflected = validate_spirv_descriptor_interface(
+        item.spirv, &sampled, 0, SpirvShaderStage::Compute, false);
+    const auto* binding = find_spirv_descriptor_binding(reflected, 0, 4);
+    CHECK(reflected.ok() && binding && binding->kind == SpirvDescriptorKind::CombinedImageSampler &&
+        binding->sampled_float && binding->normalized_sampling && !binding->texel_access,
+        "packed filter guard exercises normalized float sampling, not texel fetch");
+    transfer_source = true;
+    unsigned reads_before_filter = reads;
+    std::fill(floats.begin(), floats.end(), -99.0f);
+    CHECK(prosper::frontend::execute_live_compute_items({item}), "packed normalized filtering executes");
+    const auto filtered_gpu = floats;
+    for (size_t i = 3; i < floats.size(); i += 4)
+        CHECK(std::abs(floats[i] - 1.0f / 12.0f) < 0.000002f,
+              "linear filtering observes quantized 2-bit alpha, not original8-bit alpha");
+    CHECK(reads == reads_before_filter && imports == releases,
+          "normalized packed filtering avoids readback and balances pins");
+    transfer_source = false;
+    const unsigned reads_before_fallback = reads;
+    std::fill(floats.begin(), floats.end(), -99.0f);
+    CHECK(prosper::frontend::execute_live_compute_items({item}), "filtered packed CPU fallback executes");
+    CHECK(floats == filtered_gpu, "all filtered channels exactly match the CPU reconstruction path");
+    CHECK(reads == reads_before_fallback + 1 && imports == releases,
+          "filtered CPU fallback takes one snapshot and balances its pin");
+    transfer_source = true;
+    const unsigned reads_before_oom = reads;
+    prosper::frontend::live_compute_fail_next_packed_rtt_setup_for_test(false);
+    std::fill(floats.begin(), floats.end(), -99.0f);
+    CHECK(prosper::frontend::execute_live_compute_items({item}) && floats == filtered_gpu,
+          "recoverable conversion admission failure uses the correct CPU fallback");
+    CHECK(reads == reads_before_oom + 1 && imports == releases,
+          "recoverable admission failure takes one snapshot and releases its pin");
+    std::fill(floats.begin(), floats.end(), -99.0f);
+    CHECK(prosper::frontend::execute_live_compute_items({item}) && floats == filtered_gpu &&
+          reads == reads_before_oom + 1 && imports == releases,
+          "conversion can be used again after recoverable admission failure");
+    // Last: simulated device loss permanently latches this process's compute context.
+    // Inject the admission result, not an actual failing driver allocation.
+    const unsigned imports_before_loss = imports, reads_before_loss = reads;
+    const uint64_t submits_before_loss = prosper::frontend::live_compute_queue_submit_attempts();
+    std::fill(floats.begin(), floats.end(), -99.0f);
+    const auto before_loss = floats;
+    prosper::frontend::live_compute_fail_next_packed_rtt_setup_for_test(true);
+    CHECK(!prosper::frontend::execute_live_compute_items({item}),
+          "device loss in optional conversion admission stops execution");
+    CHECK(floats == before_loss && reads == reads_before_loss &&
+          imports == imports_before_loss + 1 && imports == releases &&
+          prosper::frontend::live_compute_queue_submit_attempts() == submits_before_loss,
+          "lost-device admission releases the pin without snapshot, submit or writeback");
+    CHECK(!prosper::frontend::execute_live_compute_items({item}) &&
+          imports == imports_before_loss + 1 && reads == reads_before_loss &&
+          prosper::frontend::live_compute_queue_submit_attempts() == submits_before_loss,
+          "latched device loss rejects later work before imports and submission");
     set_live_target_image_importer({}, {});
     set_live_target_reader({});
     set_live_target_query({});
-    std::printf("renderer UINT copy: %d failures\n", failures);
+    std::printf("renderer UINT/packed copy: %d failures\n", failures);
     return failures ? 1 : 0;
 }

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -760,6 +760,8 @@ int main(int argc, char** argv) {
          "build_compute_compare_uvec4");
     dump(dir, "builder_detile_rgba16f", build_compute_detile_rgba16f(),
          "build_compute_detile_rgba16f");
+    dump(dir, "builder_rgba8_to_packed10", build_compute_rgba8_to_packed10(),
+         "build_compute_rgba8_to_packed10");
 
     // --- Recompiler entry points beyond the four main stage functions ---
     // Wave32 fragment lowering (s_wqm_b32 through the low-half EXEC/VCC mask path).


### PR DESCRIPTION
Sonic’s measured 4K packed-UNORM sampled input read its authoritative RGBA8 renderer target back to the CPU and repacked every texel. Convert it in the existing compute command buffer: image-to-buffer copy, integer quantization, then copy into the requested packed image. This preserves 10-bit RGB and 2-bit alpha precision, including filtering after quantization.

Admission requires an exact one-mip 2D color view, the same device, transfer-source usage, supported destination format and dispatch/storage bounds. Source pins, descriptor ownership and layout restoration cover mixed direct imports. Optional setup failures retain Vulkan results; device loss remains fatal. `PROSPER_NO_GPU_PACKED_RTT=1` selects the existing CPU fallback.

A same-binary Sonic pair observed the selected program fall from **14.502 to 6.717 ms/dispatch (53.7%)**, including setup, GPU work/wait, writeback and cleanup. Host presentation rate stayed about 5.19/s; newly rendered-frame rate is unavailable. This is an exploratory component result: early asymmetric menu screenshots/focus changes preceded the timing windows, with unproven downstream effects. Whole-prefix Sonic audio comparison is excluded. Renderer resource preparation and guest writeback remain expensive.

**Validation:** 381/381 ctests pass. The focused Vulkan execution test covers all 256 channel values into Float32 outputs, normalized filtering, fresh same-address source contents, mixed aliases, incompatible-view fallback and failure recovery. Wrong direct-RGBA8 borrowing and dropped device-loss handling both fail regression assertions. Strict SPIR-V validation passes; core/synchronization validation passes with zero messages after layer-load and deliberate-hazard controls. Independent exact-head source and evidence reviews are registered.

Sonic F9s retain the known black Cyber Space world and visible HUD at different guest instants; they do not establish pixel equivalence. GTA’s Performance Story bank scene retains geometry, characters, textures and HUD. Its packed-path coverage was not measured. The blank modal, black menu background and incorrect title artwork remain in #2206; prior captures establish that the black-menu symptom predates this change. Alternating cutscene corruption remains in #3436.

[Author verification, exact launch manifests, commands and limitations](https://github.com/mattias800/prosper/pull/3437#issuecomment-5572633836). Refs #3407; remaining conversions/writeback stay open. Required Linux/general CI must pass on the final head before merge.
