### PR TITLE
Preserve primary compute buffers under result-cache pressure

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3076,6 +3076,18 @@ if(TARGET prosper_core)
       target_link_libraries(test_renderer_uint_copy PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
       add_test(NAME renderer_uint_copy COMMAND test_renderer_uint_copy)
 
+      if(Python3_Interpreter_FOUND)
+        add_executable(test_compute_buffer_timing tests/gpu/execute/test_compute_buffer_timing.cpp)
+        target_include_directories(test_compute_buffer_timing PRIVATE tests frontends)
+        target_link_libraries(test_compute_buffer_timing PRIVATE
+                             prosper_live_renderer prosper_core Vulkan::Vulkan)
+        add_test(NAME compute_buffer_timing_runtime
+                 COMMAND "${Python3_EXECUTABLE}"
+                         "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_buffer_timing_runtime.py"
+                         $<TARGET_FILE:test_compute_buffer_timing>)
+        set_tests_properties(compute_buffer_timing_runtime PROPERTIES TIMEOUT 180)
+      endif()
+
       # #3180: a failed color-target vkCreateImage must name its site and the real VkResult. Same
       # block as the other render_runner.h tests -- it needs the `tests` and `frontends` include
       # roots and a real Vulkan device.

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3086,6 +3086,15 @@ if(TARGET prosper_core)
                          "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_buffer_timing_runtime.py"
                          $<TARGET_FILE:test_compute_buffer_timing>)
         set_tests_properties(compute_buffer_timing_runtime PROPERTIES TIMEOUT 180)
+        add_executable(test_compute_buffer_residency tests/gpu/execute/test_compute_buffer_residency.cpp)
+        target_include_directories(test_compute_buffer_residency PRIVATE tests frontends)
+        target_link_libraries(test_compute_buffer_residency PRIVATE
+                             prosper_live_renderer prosper_core Vulkan::Vulkan)
+        add_test(NAME compute_buffer_residency_runtime
+                 COMMAND "${Python3_EXECUTABLE}"
+                         "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_buffer_residency_runtime.py"
+                         $<TARGET_FILE:test_compute_buffer_residency>)
+        set_tests_properties(compute_buffer_residency_runtime PROPERTIES TIMEOUT 180)
       endif()
 
       # #3180: a failed color-target vkCreateImage must name its site and the real VkResult. Same

--- a/prosper/frontends/shared/compute/compute_buffer_timing.hpp
+++ b/prosper/frontends/shared/compute/compute_buffer_timing.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace prosper::frontend {
+
+// Per unique allocation owner, never per alias. Byte counts are the lengths supplied to exact
+// comparisons/copies, not an assertion about how far an early-exiting memcmp actually read.
+// States start unobserved so an interrupted dispatch cannot masquerade as a successful skip.
+struct ComputeBufferTiming {
+    bool enabled = false;
+    bool owner_resolved = false;
+    const char* cache = "unobserved";
+    const char* validation = "unobserved";
+    const char* baseline = "unobserved";
+    const char* gpu_compare = "unobserved";
+    const char* writeback = "unobserved";
+    uint64_t compared_bytes = 0;
+    uint64_t uploaded_bytes = 0;
+    uint64_t result_compared_bytes = 0;
+    uint64_t guest_copied_bytes = 0;
+    double setup_ms = 0;
+    double validation_ms = 0;
+    double upload_compare_ms = 0;
+    double upload_copy_ms = 0;
+    double upload_map_ms = 0;
+    double upload_watch_ms = 0;
+    double writeback_ms = 0;
+    double result_compare_ms = 0;
+    double guest_copy_ms = 0;
+    double guest_layout_ms = 0;
+    double result_map_ms = 0;
+    double result_watch_ms = 0;
+    double baseline_ms = 0;
+    double notify_ms = 0;
+    double source_validation_ms = 0;
+    double provenance_ms = 0;
+};
+
+// No clock reads when disabled. A scope includes failure exits and does not include log I/O.
+class ComputeBufferCostScope {
+public:
+    ComputeBufferCostScope(bool enabled, double& milliseconds)
+        : enabled_(enabled), milliseconds_(milliseconds),
+          start_(enabled ? Clock::now() : Clock::time_point{}) {}
+    ~ComputeBufferCostScope() {
+        if (enabled_)
+            milliseconds_ += std::chrono::duration<double, std::milli>(
+                Clock::now() - start_).count();
+    }
+    ComputeBufferCostScope(const ComputeBufferCostScope&) = delete;
+    ComputeBufferCostScope& operator=(const ComputeBufferCostScope&) = delete;
+private:
+    using Clock = std::chrono::steady_clock;
+    bool enabled_;
+    double& milliseconds_;
+    Clock::time_point start_;
+};
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -59,6 +59,14 @@ production backend without a frontend or a game dump.
 
 ## Measuring buffer setup and writeback
 
+The persistent buffer budget charges primary allocations and optional exact-result baselines.
+Primary admission first proves that enough unpinned storage can be reclaimed, then drops unpinned
+baselines before evicting primary entries. Baseline admission uses spare capacity only. One owner
+pin protects both handles through completion; a failed submission without completion proof keeps
+that pin. Reclaiming a baseline preserves the primary's guest-content validation and write watches.
+Unchanged writeback preserves watch-promotion progress already earned by exact source validation;
+it neither resets that progress nor counts it a second time. Changed content resets progress.
+
 `PROSPER_COMPUTE_BUFFER_TIMING=1` emits `[compute-buffer-timing]` records after cleanup. Use
 `PROSPER_COMPUTE_TIMING_CODE` / `PROSPER_COMPUTE_TIMING_HASH` to select a program and
 `PROSPER_COMPUTE_TIMING_CAPTURE_ONLY=1` to bound records to F8; the existing `TRACE_ONLY` selector
@@ -79,6 +87,12 @@ prepared, recorded and a completed changed/unchanged result; `no-result` means c
 but the flag was not read, and `setup-failed` retains the CPU fallback. Check `ok` before treating a
 row as a completed dispatch. `host-key` is the existing cache-key pointer, whereas `host-backed`
 describes effective source selection (a short host mirror falls back to guest memory).
+
+`cache-bytes` and `cache-limit` report end-of-dispatch requested residency. The owner's
+`primary-allocation-bytes` and `result-allocation-bytes` report the surviving cache entry's separate
+charges (zero if absent). These use Vulkan resource memory requirements, as the existing budget
+does; the underlying allocation pool can supply a larger allocation. They are not a physical
+device-memory usage measurement or cap.
 
 Byte counters are lengths passed to comparisons and copies, not actual CPU bytes read by an
 early-exiting comparison. `compared-bytes` includes the initial exact comparison against pooled

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -56,3 +56,39 @@ can verify:
 `execute_live_compute_items()` is the one entry point exposed for tests, which is how
 `game_compute_exec`, `live_compute_descriptor_array` and `live_compute_host_read_barrier` drive the
 production backend without a frontend or a game dump.
+
+## Measuring buffer setup and writeback
+
+`PROSPER_COMPUTE_BUFFER_TIMING=1` emits `[compute-buffer-timing]` records after cleanup. Use
+`PROSPER_COMPUTE_TIMING_CODE` / `PROSPER_COMPUTE_TIMING_HASH` to select a program and
+`PROSPER_COMPUTE_TIMING_CAPTURE_ONLY=1` to bound records to F8; the existing `TRACE_ONLY` selector
+also applies. No guest-content hashes or extra comparisons are added, and the added timers read no
+clocks when disabled. Keep `PROSPER_COMPUTELOG` off when measuring: its additional scans and output
+are included in enclosing timers.
+
+Each resolved allocation owner gets one row, including read-only owners. `owner-index` identifies
+the flattened descriptor-table entry; `bindings` includes the owner and exact aliases, and `aliases`
+counts only the additional entries. Writability is combined across aliases. On setup failure, later
+descriptors may have `owner-resolved=0`; exclude those placeholders from allocation counts. Join
+records using submit/dispatch/order/program identity. CPU fast paths, proven no-ops and declines
+before materialization produce no buffer rows; these records are not the whole F8 population.
+
+`cache`, `validation`, `baseline`, `gpu-compare` and `writeback` report decisions already made by the
+backend. `unobserved` means the stage was not reached. GPU comparison progresses through eligible,
+prepared, recorded and a completed changed/unchanged result; `no-result` means completion occurred
+but the flag was not read, and `setup-failed` retains the CPU fallback. Check `ok` before treating a
+row as a completed dispatch. `host-key` is the existing cache-key pointer, whereas `host-backed`
+describes effective source selection (a short host mirror falls back to guest memory).
+
+Byte counters are lengths passed to comparisons and copies, not actual CPU bytes read by an
+early-exiting comparison. `compared-bytes` includes the initial exact comparison against pooled
+allocation contents. `upload-skipped` is the existing cached-source authority bit: zero upload bytes
+on a cold, already-equal pooled allocation does not set it. Atomic image writeback uses
+`guest_layout_ms`; `guest-copied-bytes` counts only the ordinary contiguous buffer copy.
+
+Timers are nested, not additive: `setup_ms` covers owner materialization after resource/alias checks;
+`validation_ms` includes upload compare/copy/map/watch on cache hits. `writeback_ms` encloses result
+comparison, guest copy/layout, map, host-write-watch notification, baseline creation, architectural
+notification, source validation/watch rearming and provenance. Those last two have separate
+`source_validation_ms` and `provenance_ms` fields. Use the existing dispatch phase totals for the
+remaining setup checks and loop overhead; do not claim the sum of owner timers covers all setup.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -918,6 +918,12 @@ struct ComputeBufferWriteWatchChunk {
     prosper::host::GuestWriteWatch watch;
 };
 
+enum class ComputeBufferSourceProof {
+    Changed,
+    ExactUnchanged,
+    PublishedUnchanged,
+};
+
 struct CachedComputeBuffer {
     VkBuffer buffer = VK_NULL_HANDLE;
     VkDeviceMemory memory = VK_NULL_HANDLE;
@@ -940,6 +946,7 @@ struct CachedComputeBuffer {
     VkBuffer result_buffer = VK_NULL_HANDLE;
     VkDeviceMemory result_memory = VK_NULL_HANDLE;
     VkDeviceSize result_bytes = 0;
+    VkDeviceSize result_allocation_bytes = 0;
 };
 
 struct ComputeImageCacheKey {
@@ -2052,22 +2059,46 @@ struct VulkanComputeContext {
     bool make_buffer_cache_room(VkDeviceSize bytes) {
         const VkDeviceSize limit = persistent_compute_buffer_limit();
         if (bytes > limit) return false;
+        if (buffer_cache_bytes <= limit - bytes) return true;
+        // A refusal must not destroy reusable entries first. Pins cover both the primary buffer
+        // and any result-baseline handle borrowed by an in-flight BoundBuffer.
+        const VkDeviceSize needed = buffer_cache_bytes - (limit - bytes);
+        VkDeviceSize reclaimable = 0;
+        for (const auto& [key, cached] : buffer_cache) {
+            if (cached.pins) continue;
+            reclaimable += cached.allocation_bytes;
+            if (reclaimable >= needed) break;
+        }
+        if (reclaimable < needed) return false;
         while (buffer_cache_bytes > limit - bytes) {
             auto victim = buffer_cache.end();
             for (auto it = buffer_cache.begin(); it != buffer_cache.end(); ++it) {
                 if (it->second.pins) continue;
+                // Optional comparisons must not displace the input/result allocation they exist
+                // to accelerate. Reclaim the oldest unpinned baseline before an entire primary.
+                const bool has_result = it->second.result_buffer != VK_NULL_HANDLE;
                 if (victim == buffer_cache.end() ||
-                    it->second.last_use < victim->second.last_use)
+                    (has_result && !victim->second.result_buffer) ||
+                    (has_result == (victim->second.result_buffer != VK_NULL_HANDLE) &&
+                     it->second.last_use < victim->second.last_use))
                     victim = it;
             }
             if (victim == buffer_cache.end()) return false;
+            if (victim->second.result_buffer) {
+                auto& cached = victim->second;
+                vkDestroyBuffer(device, cached.result_buffer, nullptr);
+                release_memory(cached.result_memory);
+                buffer_cache_bytes -= cached.result_allocation_bytes;
+                cached.allocation_bytes -= cached.result_allocation_bytes;
+                cached.result_buffer = VK_NULL_HANDLE;
+                cached.result_memory = VK_NULL_HANDLE;
+                cached.result_bytes = 0;
+                cached.result_allocation_bytes = 0;
+                continue;
+            }
             victim->second.write_watches.clear();
             if (victim->second.buffer) vkDestroyBuffer(device, victim->second.buffer, nullptr);
             if (victim->second.memory) release_memory(victim->second.memory);
-            if (victim->second.result_buffer)
-                vkDestroyBuffer(device, victim->second.result_buffer, nullptr);
-            if (victim->second.result_memory)
-                release_memory(victim->second.result_memory);
             buffer_cache_bytes -= victim->second.allocation_bytes;
             buffer_cache.erase(victim);
         }
@@ -2184,7 +2215,9 @@ struct VulkanComputeContext {
             cached.content_valid = true;
             if (!key.host_data) {
                 ComputeBufferCostScope cost(timing.enabled, timing.upload_watch_ms);
-                validate_cached_buffer_source(key, upload_skipped, true);
+                validate_cached_buffer_source(key, upload_skipped
+                    ? ComputeBufferSourceProof::ExactUnchanged
+                    : ComputeBufferSourceProof::Changed, true);
             }
         }
         return true;
@@ -2192,6 +2225,7 @@ struct VulkanComputeContext {
 
     bool retain_buffer(const ComputeBufferCacheKey& key, VkBuffer buffer, VkDeviceMemory memory,
                        VkDeviceSize allocation_bytes) {
+        if (buffer_cache.find(key) != buffer_cache.end()) return false;
         if (!make_buffer_cache_room(allocation_bytes)) return false;
         CachedComputeBuffer cached;
         cached.buffer = buffer;
@@ -2240,16 +2274,21 @@ struct VulkanComputeContext {
     }
 
     void validate_cached_buffer_source(const ComputeBufferCacheKey& key,
-                                       bool content_unchanged = false,
+                                       ComputeBufferSourceProof proof,
                                        bool watch_prepared_before_validation = false) {
         auto found = buffer_cache.find(key);
         if (found == buffer_cache.end() || key.host_data) return;
         CachedComputeBuffer& cached = found->second;
         cached.content_valid = true;
         cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
-        cached.write_watch_stable_validations = update_write_watch_stability(
-            cached.write_watch_stable_validations, content_unchanged,
-            compute_write_watch_promotion_validations());
+        // An unchanged publication preserves the proof already earned at acquisition. Counting
+        // it again promotes too early; treating it as changed prevents writable buffers from ever
+        // reaching the normal promotion threshold across submits.
+        if (proof != ComputeBufferSourceProof::PublishedUnchanged)
+            cached.write_watch_stable_validations = update_write_watch_stability(
+                cached.write_watch_stable_validations,
+                proof == ComputeBufferSourceProof::ExactUnchanged,
+                compute_write_watch_promotion_validations());
         if (watch_prepared_before_validation || cached.write_watches.empty()) return;
         for (ComputeBufferWriteWatchChunk& chunk : cached.write_watches) {
             if (chunk.watch && chunk.watch.rearm()) continue;
@@ -2261,7 +2300,10 @@ struct VulkanComputeContext {
 
     void invalidate_cached_buffer_source(const ComputeBufferCacheKey& key) {
         const auto found = buffer_cache.find(key);
-        if (found != buffer_cache.end()) found->second.content_valid = false;
+        if (found != buffer_cache.end()) {
+            found->second.content_valid = false;
+            found->second.write_watch_stable_validations = 0;
+        }
     }
 
     bool cached_buffer_result_buffer(const ComputeBufferCacheKey& key, VkDeviceSize bytes,
@@ -2295,7 +2337,10 @@ struct VulkanComputeContext {
         if (vkCreateBuffer(device, &bci, nullptr, &buffer) != VK_SUCCESS) return false;
         VkMemoryRequirements requirements{};
         vkGetBufferMemoryRequirements(device, buffer, &requirements);
-        if (!make_buffer_cache_room(requirements.size)) {
+        // Baselines use spare residency only. Evicting another primary (or cycling its baseline)
+        // here can turn a fitting primary working set into a miss and full-copy loop.
+        const VkDeviceSize limit = persistent_compute_buffer_limit();
+        if (requirements.size > limit || buffer_cache_bytes > limit - requirements.size) {
             timing.baseline = "budget";
             vkDestroyBuffer(device, buffer, nullptr);
             return false;
@@ -2318,8 +2363,7 @@ struct VulkanComputeContext {
         copy_compute_buffer(mapped, result, key.bytes);
         unmap_memory(memory);
 
-        // make_buffer_cache_room can evict other entries, so reacquire the pinned current entry
-        // before publishing ownership of the allocation.
+        // Publish ownership only after the optional allocation and seed copy succeeded.
         found = buffer_cache.find(key);
         if (found == buffer_cache.end() || found->second.result_buffer) {
             timing.baseline = found == buffer_cache.end() ? "missing-entry" : "already-present";
@@ -2330,6 +2374,7 @@ struct VulkanComputeContext {
         found->second.result_buffer = buffer;
         found->second.result_memory = memory;
         found->second.result_bytes = key.bytes;
+        found->second.result_allocation_bytes = requirements.size;
         found->second.allocation_bytes += requirements.size;
         buffer_cache_bytes += requirements.size;
         timing.baseline = "created";
@@ -10423,7 +10468,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 if (buffer.persistent) {
                     ComputeBufferCostScope cost(timing.enabled, timing.source_validation_ms);
-                    ctx.validate_cached_buffer_source(buffer.cache_key);
+                    ctx.validate_cached_buffer_source(
+                        buffer.cache_key, ComputeBufferSourceProof::PublishedUnchanged);
                 }
                 if (!buffer.resource->host_data && writer_provenance_enabled()) {
                     ComputeBufferCostScope cost(timing.enabled, timing.provenance_ms);
@@ -10616,7 +10662,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             if (buffer.persistent) {
                 ComputeBufferCostScope cost(timing.enabled, timing.source_validation_ms);
-                ctx.validate_cached_buffer_source(buffer.cache_key);
+                ctx.validate_cached_buffer_source(buffer.cache_key, changed
+                    ? ComputeBufferSourceProof::Changed
+                    : ComputeBufferSourceProof::PublishedUnchanged);
             }
             if (!buffer.resource->host_data && writer_provenance_enabled()) {
                 ComputeBufferCostScope cost(timing.enabled, timing.provenance_ms);
@@ -11414,6 +11462,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (buffer.alias_of != SIZE_MAX) continue;
             const auto& t = buffer.timing;
             const auto& r = buffer_resources[i];
+            const auto cached = ctx.buffer_cache.find(buffer.cache_key);
+            const VkDeviceSize result_charge = cached == ctx.buffer_cache.end()
+                ? 0 : cached->second.result_allocation_bytes;
+            const VkDeviceSize primary_charge = cached == ctx.buffer_cache.end()
+                ? 0 : cached->second.allocation_bytes - result_charge;
             size_t aliases = 0;
             std::string bindings = std::to_string(r.binding);
             for (const auto& other : buffers) {
@@ -11428,6 +11481,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 "host-key=0x%llx semantic=%u logical-bytes=%u bytes=%zu guest-bytes=%zu "
                 "writable=%u atomic=%u "
                 "persistent=%u upload-skipped=%u dirty-watch-chunks=%u total-watch-chunks=%u "
+                "cache-bytes=%llu cache-limit=%llu primary-allocation-bytes=%llu "
+                "result-allocation-bytes=%llu "
                 "cache=%s validation=%s baseline=%s gpu-compare=%s writeback=%s "
                 "compared-bytes=%llu uploaded-bytes=%llu result-compared-bytes=%llu "
                 "guest-copied-bytes=%llu setup_ms=%.6f validation_ms=%.6f "
@@ -11447,6 +11502,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 buffer.writable ? 1u : 0u, buffer.atomic_image ? 1u : 0u,
                 buffer.persistent ? 1u : 0u, buffer.upload_skipped ? 1u : 0u,
                 buffer.dirty_watch_chunks, buffer.total_watch_chunks,
+                (unsigned long long)ctx.buffer_cache_bytes,
+                (unsigned long long)persistent_compute_buffer_limit(),
+                (unsigned long long)primary_charge, (unsigned long long)result_charge,
                 t.cache, t.validation, t.baseline, t.gpu_compare, t.writeback,
                 (unsigned long long)t.compared_bytes, (unsigned long long)t.uploaded_bytes,
                 (unsigned long long)t.result_compared_bytes,

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3,6 +3,7 @@
 #include "shared/compute/compute_authority_live_census.hpp"
 #include "shared/compute/compute_image_borrow_census.hpp"
 #include "shared/compute/compute_timing_selector.hpp"
+#include "shared/compute/compute_buffer_timing.hpp"
 #include "shared/compute/compute_transfer_gate_census.hpp"
 #include "shared/compute/storage_image_alias_plan.hpp"
 #include "shared/live/decode_scratch.hpp"  // pooled full-surface intermediates (#3309's mechanism)
@@ -2075,9 +2076,15 @@ struct VulkanComputeContext {
 
     bool acquire_cached_buffer(const ComputeBufferCacheKey& key, const uint8_t* source,
                                VkBuffer& buffer, VkDeviceMemory& memory, bool& upload_skipped,
-                               uint32_t& dirty_watch_chunks, uint32_t& total_watch_chunks) {
+                               uint32_t& dirty_watch_chunks, uint32_t& total_watch_chunks,
+                               ComputeBufferTiming& timing) {
         auto found = buffer_cache.find(key);
-        if (found == buffer_cache.end()) return false;
+        if (found == buffer_cache.end()) {
+            timing.cache = "miss";
+            return false;
+        }
+        timing.cache = "hit";
+        ComputeBufferCostScope validation_cost(timing.enabled, timing.validation_ms);
         CachedComputeBuffer& cached = found->second;
         cached.last_use = ++buffer_cache_clock;
         ++cached.pins;
@@ -2102,15 +2109,26 @@ struct VulkanComputeContext {
         }
         dirty_watch_chunks = static_cast<uint32_t>(dirty_chunks.size());
         upload_skipped = submit_unchanged || (watches_complete && dirty_chunks.empty());
+        timing.validation = submit_unchanged ? "journal" : upload_skipped ? "watch"
+                            : watches_complete ? "dirty-chunks" : "full";
         if (submit_unchanged) g_write_watch_census.record_journal_skip(key.bytes);
         else if (upload_skipped) g_write_watch_census.record_watch_skip(key.bytes);
         if (!upload_skipped) {
             // Establish the mutation boundary before the authoritative guest-byte comparison.
             // Arming after memcmp would leave a compare-to-arm gap where a concurrent guest CPU
             // write could become permanently invisible to this cache entry.
-            prepare_cached_buffer_write_watches_before_exact(key);
+            {
+                ComputeBufferCostScope cost(timing.enabled, timing.upload_watch_ms);
+                prepare_cached_buffer_write_watches_before_exact(key);
+            }
             void* mapped = nullptr;
-            if (map_memory(cached.memory, 0, key.bytes, &mapped) != VK_SUCCESS) {
+            VkResult map_result;
+            {
+                ComputeBufferCostScope cost(timing.enabled, timing.upload_map_ms);
+                map_result = map_memory(cached.memory, 0, key.bytes, &mapped);
+            }
+            if (map_result != VK_SUCCESS) {
+                timing.cache = "map-failed";
                 --cached.pins;
                 buffer = VK_NULL_HANDLE;
                 memory = VK_NULL_HANDLE;
@@ -2127,24 +2145,47 @@ struct VulkanComputeContext {
                 for (size_t index : dirty_chunks) {
                     const ComputeBufferWriteWatchChunk& chunk = cached.write_watches[index];
                     compared_bytes += chunk.bytes;
-                    if (std::memcmp(destination + chunk.offset, source + chunk.offset,
-                                    chunk.bytes) == 0)
-                        continue;
-                    std::memcpy(destination + chunk.offset, source + chunk.offset, chunk.bytes);
+                    bool equal;
+                    {
+                        ComputeBufferCostScope cost(timing.enabled, timing.upload_compare_ms);
+                        equal = std::memcmp(destination + chunk.offset, source + chunk.offset,
+                                            chunk.bytes) == 0;
+                    }
+                    if (equal) continue;
+                    {
+                        ComputeBufferCostScope cost(timing.enabled, timing.upload_copy_ms);
+                        std::memcpy(destination + chunk.offset, source + chunk.offset, chunk.bytes);
+                    }
+                    timing.uploaded_bytes += chunk.bytes;
                     changed = true;
                 }
                 g_write_watch_census.record_exact_compare(compared_bytes);
+                timing.compared_bytes += compared_bytes;
                 upload_skipped = !changed;
             } else {
                 g_write_watch_census.record_exact_compare(key.bytes);
-                const bool changed = !compute_buffers_equal(mapped, source, key.bytes);
-                if (changed) copy_compute_buffer(mapped, source, key.bytes);
+                bool changed;
+                {
+                    ComputeBufferCostScope cost(timing.enabled, timing.upload_compare_ms);
+                    changed = !compute_buffers_equal(mapped, source, key.bytes);
+                }
+                timing.compared_bytes += key.bytes;
+                if (changed) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.upload_copy_ms);
+                    copy_compute_buffer(mapped, source, key.bytes);
+                    timing.uploaded_bytes += key.bytes;
+                }
                 upload_skipped = !changed;
             }
-            unmap_memory(cached.memory);
+            {
+                ComputeBufferCostScope cost(timing.enabled, timing.upload_map_ms);
+                unmap_memory(cached.memory);
+            }
             cached.content_valid = true;
-            if (!key.host_data)
+            if (!key.host_data) {
+                ComputeBufferCostScope cost(timing.enabled, timing.upload_watch_ms);
                 validate_cached_buffer_source(key, upload_skipped, true);
+            }
         }
         return true;
     }
@@ -2234,32 +2275,42 @@ struct VulkanComputeContext {
     }
 
     bool retain_cached_buffer_result(const ComputeBufferCacheKey& key,
-                                     const uint8_t* result) {
+                                     const uint8_t* result, ComputeBufferTiming& timing) {
+        ComputeBufferCostScope cost(timing.enabled, timing.baseline_ms);
+        timing.baseline = "disabled";
         if (!persistent_compute_buffer_result_enabled(key.bytes)) return false;
+        timing.baseline = "invalid";
         if (!result || !key.bytes || (key.bytes & 15u)) return false;
         auto found = buffer_cache.find(key);
-        if (found == buffer_cache.end() || found->second.result_buffer) return false;
+        timing.baseline = "missing-entry";
+        if (found == buffer_cache.end()) return false;
+        timing.baseline = "already-present";
+        if (found->second.result_buffer) return false;
 
         VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
         bci.size = key.bytes;
         bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
         VkBuffer buffer = VK_NULL_HANDLE;
+        timing.baseline = "create-failed";
         if (vkCreateBuffer(device, &bci, nullptr, &buffer) != VK_SUCCESS) return false;
         VkMemoryRequirements requirements{};
         vkGetBufferMemoryRequirements(device, buffer, &requirements);
         if (!make_buffer_cache_room(requirements.size)) {
+            timing.baseline = "budget";
             vkDestroyBuffer(device, buffer, nullptr);
             return false;
         }
         const uint32_t memory_type = host_memory_type(requirements.memoryTypeBits);
         VkDeviceMemory memory = allocate_memory(requirements.size, memory_type, true);
         if (!memory || vkBindBufferMemory(device, buffer, memory, 0) != VK_SUCCESS) {
+            timing.baseline = "memory-failed";
             if (memory) release_memory(memory);
             vkDestroyBuffer(device, buffer, nullptr);
             return false;
         }
         void* mapped = nullptr;
         if (map_memory(memory, 0, key.bytes, &mapped) != VK_SUCCESS) {
+            timing.baseline = "map-failed";
             release_memory(memory);
             vkDestroyBuffer(device, buffer, nullptr);
             return false;
@@ -2271,6 +2322,7 @@ struct VulkanComputeContext {
         // before publishing ownership of the allocation.
         found = buffer_cache.find(key);
         if (found == buffer_cache.end() || found->second.result_buffer) {
+            timing.baseline = found == buffer_cache.end() ? "missing-entry" : "already-present";
             release_memory(memory);
             vkDestroyBuffer(device, buffer, nullptr);
             return false;
@@ -2280,6 +2332,7 @@ struct VulkanComputeContext {
         found->second.result_bytes = key.bytes;
         found->second.allocation_bytes += requirements.size;
         buffer_cache_bytes += requirements.size;
+        timing.baseline = "created";
         return true;
     }
 
@@ -3260,6 +3313,7 @@ struct BoundBuffer {
     bool gpu_result_unchanged = false;
     uint32_t dirty_watch_chunks = 0;
     uint32_t total_watch_chunks = 0;
+    ComputeBufferTiming timing;
     ComputeBufferCacheKey cache_key{};
     std::vector<uint8_t> linear_seed;    // detiled upload for an atomic-image buffer
     uint64_t before_hash = 0, after_hash = 0;
@@ -5827,6 +5881,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr;
     const bool image_timing_requested =
         std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr;
+    const bool buffer_timing_requested =
+        std::getenv("PROSPER_COMPUTE_BUFFER_TIMING") != nullptr;
     const bool timing_capture_only =
         std::getenv("PROSPER_COMPUTE_TIMING_CAPTURE_ONLY") != nullptr;
     // Preserve the cheap timing address pre-filter. The transfer gate census deliberately hashes
@@ -5841,12 +5897,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     const bool authority_requested = authority_census.requested();
     const bool timing_address_matches = time_compute_address_matches(item);
     if (transfer_gate_requested || authority_requested ||
-        ((phase_timing_requested || image_timing_requested) && timing_address_matches)) {
+        ((phase_timing_requested || image_timing_requested || buffer_timing_requested) &&
+         timing_address_matches)) {
         timing_program_hash = gpu_capture_hash(
             reinterpret_cast<const uint8_t*>(spirv.data()),
             spirv.size() * sizeof(uint32_t));
     }
-    if ((phase_timing_requested || image_timing_requested) && timing_address_matches) {
+    if ((phase_timing_requested || image_timing_requested || buffer_timing_requested) &&
+        timing_address_matches) {
         timing_item_selected =
             runtime_compute_timing_selector().matches(item, timing_program_hash);
     }
@@ -5864,6 +5922,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         std::getenv("PROSPER_COMPUTE_TIMING_TRACE_ONLY") != nullptr;
     const bool phase_timing =
         phase_timing_requested && timing_item_selected &&
+        (!timing_capture_only || perf_capture_timing) &&
+        (!timing_trace_only || trace);
+    const bool buffer_timing =
+        buffer_timing_requested && timing_item_selected &&
         (!timing_capture_only || perf_capture_timing) &&
         (!timing_trace_only || trace);
     // Keep timing selection and the transfer/authority censuses above this return so investigations
@@ -5980,8 +6042,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     if (buffer_resources.size() != buffer_plan.total_descriptor_count) return decline("buffer-descriptor-count-mismatch");
 
     std::vector<BoundBuffer> buffers(buffer_plan.total_descriptor_count);
-    for (size_t i = 0; i < buffers.size(); ++i)
+    for (size_t i = 0; i < buffers.size(); ++i) {
         buffers[i].descriptor_index = buffer_descriptor_indices[i];
+        buffers[i].timing.enabled = buffer_timing;
+    }
     std::vector<BoundImage> images(image_descriptors.size());
     // #3157: this dispatch's guest seed sources and writeback targets, collected only when the
     // alias census is armed so a default run pays nothing.
@@ -6229,7 +6293,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 buffers[buffers[i].alias_of].writable |= buffers[i].writable;
                 break;
             }
+            buffers[i].timing.owner_resolved = true;
             if (buffers[i].alias_of == SIZE_MAX) {
+                auto& timing = buffers[i].timing;
+                ComputeBufferCostScope setup_cost(timing.enabled, timing.setup_ms);
                 // #3195: one call, not a ternary. `guest_bytes` already holds the extent each
                 // path needs -- the PHYSICAL padded footprint for an atomic image (assigned
                 // above), the materialization's logical size otherwise -- so both arms of the
@@ -6337,10 +6404,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     compute_buffer_materialization_discriminator(materialization)};
                 const bool cache_candidate = !buffers[i].atomic_image &&
                     persistent_compute_buffer_enabled(static_cast<uint32_t>(buffers[i].bytes));
+                timing.cache = "ineligible";
                 if (cache_candidate && ctx.acquire_cached_buffer(
                         buffers[i].cache_key, source, buffers[i].buffer, buffers[i].memory,
                         buffers[i].upload_skipped, buffers[i].dirty_watch_chunks,
-                        buffers[i].total_watch_chunks)) {
+                        buffers[i].total_watch_chunks, timing)) {
                     buffers[i].persistent = true;
                 } else {
                     VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
@@ -6372,14 +6440,31 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                "buffer-bind"))
                         break;
                     void* mapped = nullptr;
-                    if (!vk_ok(ctx.map_memory(buffers[i].memory, 0, buffers[i].bytes, &mapped),
-                               "buffer-map"))
+                    VkResult map_result;
+                    {
+                        ComputeBufferCostScope cost(timing.enabled, timing.upload_map_ms);
+                        map_result = ctx.map_memory(buffers[i].memory, 0, buffers[i].bytes, &mapped);
+                    }
+                    if (!vk_ok(map_result, "buffer-map"))
                         break;
                     // Pooled host-visible allocations retain their previous contents. Compare them
                     // with current guest memory before uploading: any mutation takes the exact copy.
-                    if (!compute_buffers_equal(mapped, source, buffers[i].bytes))
+                    bool equal;
+                    timing.validation = "pooled-full";
+                    {
+                        ComputeBufferCostScope cost(timing.enabled, timing.upload_compare_ms);
+                        equal = compute_buffers_equal(mapped, source, buffers[i].bytes);
+                    }
+                    timing.compared_bytes += buffers[i].bytes;
+                    if (!equal) {
+                        ComputeBufferCostScope cost(timing.enabled, timing.upload_copy_ms);
                         copy_compute_buffer(mapped, source, buffers[i].bytes);
-                    ctx.unmap_memory(buffers[i].memory);
+                        timing.uploaded_bytes += buffers[i].bytes;
+                    }
+                    {
+                        ComputeBufferCostScope cost(timing.enabled, timing.upload_map_ms);
+                        ctx.unmap_memory(buffers[i].memory);
+                    }
                     if (cache_candidate && ctx.retain_buffer(
                             buffers[i].cache_key, buffers[i].buffer, buffers[i].memory,
                             requirements.size))
@@ -6396,11 +6481,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
 
         }
-        for (BoundBuffer& buffer : buffers)
+        for (BoundBuffer& buffer : buffers) {
             if (buffer.alias_of == SIZE_MAX && buffer.persistent && buffer.writable &&
                 !buffer.result_baseline)
                 ctx.cached_buffer_result_buffer(
                     buffer.cache_key, buffer.resource->size, buffer.result_baseline);
+            if (buffer.result_baseline) buffer.timing.baseline = "present";
+        }
         bool buffers_ready = true;
         for (const auto& buffer : buffers) buffers_ready &= buffer.resource && buffer.memory;
         if (!buffers_ready) {
@@ -9259,12 +9346,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         };
         std::vector<CompareTarget> compare_targets;
         for (BoundBuffer& buffer : buffers) {
+            buffer.timing.gpu_compare = "ineligible";
             if (buffer.alias_of == SIZE_MAX && buffer.writable && buffer.persistent &&
                 buffer.upload_skipped && buffer.result_baseline && buffer.resource->size &&
-                !(buffer.resource->size & 15u))
+                !(buffer.resource->size & 15u)) {
+                buffer.timing.gpu_compare = "eligible";
                 compare_targets.push_back({
                     buffer.buffer, buffer.result_baseline, buffer.resource->size,
                     VK_ACCESS_SHADER_WRITE_BIT, &buffer, nullptr});
+            }
         }
         for (size_t i = 0; i < images.size(); ++i) {
             BoundImage& image = images[i];
@@ -9346,7 +9436,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
                         write.pBufferInfo = &infos[j][binding];
                     }
-                    if (target.buffer) target.buffer->compare_flag_index = j;
+                    if (target.buffer) {
+                        target.buffer->compare_flag_index = j;
+                        target.buffer->timing.gpu_compare = "prepared";
+                    }
                     if (target.image) target.image->compare_flag_index = j;
                 }
                 vkUpdateDescriptorSets(
@@ -9356,7 +9449,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         if (!compare_ready) {
             for (CompareTarget& target : compare_targets) {
-                if (target.buffer) target.buffer->compare_flag_index = SIZE_MAX;
+                if (target.buffer) {
+                    target.buffer->compare_flag_index = SIZE_MAX;
+                    target.buffer->timing.gpu_compare = "setup-failed";
+                }
                 if (target.image) target.image->compare_flag_index = SIZE_MAX;
             }
             compare_targets.clear();
@@ -9891,6 +9987,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // writes and image transfer writes become comparator reads; one atomic flag per target then
         // becomes a four-byte host read after the fence.
         if (!compare_targets.empty()) {
+            for (auto& target : compare_targets)
+                if (target.buffer) target.buffer->timing.gpu_compare = "recorded";
             vkCmdFillBuffer(command, compare_flags, 0,
                             compare_targets.size() * ctx.compare_flag_stride(), 0);
             std::vector<VkBufferMemoryBarrier> before_compare;
@@ -10227,6 +10325,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (!compare_targets.empty()) {
             void* mapped = nullptr;
             const VkDeviceSize flag_stride = ctx.compare_flag_stride();
+            for (auto& target : compare_targets)
+                if (target.buffer) target.buffer->timing.gpu_compare = "no-result";
             if (ctx.map_memory(compare_flags_memory, 0,
                                compare_targets.size() * flag_stride, &mapped) == VK_SUCCESS) {
                 // Step by the DESCRIPTOR stride, not by sizeof(uint32_t). Indexing a uint32_t* by
@@ -10237,7 +10337,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     CompareTarget& target = compare_targets[j];
                     uint32_t changed = 0;
                     std::memcpy(&changed, flag_bytes + j * flag_stride, sizeof(changed));
-                    if (target.buffer) target.buffer->gpu_result_unchanged = changed == 0;
+                    if (target.buffer) {
+                        target.buffer->gpu_result_unchanged = changed == 0;
+                        target.buffer->timing.gpu_compare = changed ? "changed" : "unchanged";
+                    }
                     if (target.image) target.image->gpu_result_unchanged = changed == 0;
                 }
                 ctx.unmap_memory(compare_flags_memory);
@@ -10292,12 +10395,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         const auto writeback_buffers_start = ComputeClock::now();
         bool readback_ok = true;
         for (auto& buffer : buffers) {
-            if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
+            if (buffer.alias_of != SIZE_MAX) continue;
+            auto& timing = buffer.timing;
+            if (!buffer.writable) {
+                timing.writeback = "readonly";
+                continue;
+            }
+            ComputeBufferCostScope writeback_cost(timing.enabled, timing.writeback_ms);
             // The exact GPU comparator saw the same bytes as the retained baseline, while source
             // validation independently proved that the guest mirror still contains that baseline.
             // Preserve architectural write notification, but avoid mapping and scanning the whole
             // host-visible buffer merely to rediscover equality.
             if (buffer.gpu_result_unchanged) {
+                timing.writeback = "gpu-unchanged";
                 g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
                 if (trace)
                     std::fprintf(stderr,
@@ -10306,20 +10416,32 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  buffer.resource->binding,
                                  (unsigned long long)buffer.resource->gpu_addr,
                                  buffer.resource->size);
-                if (buffer.resource->gpu_addr)
+                if (buffer.resource->gpu_addr) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.notify_ms);
                     notify_guest_gpu_write_preserving_bytes(
                         buffer.resource->gpu_addr, buffer.resource->size);
-                if (buffer.persistent)
+                }
+                if (buffer.persistent) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.source_validation_ms);
                     ctx.validate_cached_buffer_source(buffer.cache_key);
-                if (!buffer.resource->host_data && writer_provenance_enabled())
+                }
+                if (!buffer.resource->host_data && writer_provenance_enabled()) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.provenance_ms);
                     record_guest_write(GuestWriterKind::ComputeBuffer,
                                        buffer.resource->gpu_addr, buffer.resource->size,
                                        item.submit_no, item.dispatch_index,
                                        item.command_order, item.code_addr);
+                }
                 continue;
             }
             void* mapped = nullptr;
-            if (ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped) != VK_SUCCESS) {
+            VkResult map_result;
+            {
+                ComputeBufferCostScope cost(timing.enabled, timing.result_map_ms);
+                map_result = ctx.map_memory(buffer.memory, 0, buffer.bytes, &mapped);
+            }
+            if (map_result != VK_SUCCESS) {
+                timing.writeback = "map-failed";
                 readback_ok = false;
                 break;
             }
@@ -10328,47 +10450,64 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             uint8_t* destination = resource_bytes_for(buffer.resource, buffer.guest_bytes);
             const auto* result = static_cast<const uint8_t*>(mapped);
             if (buffer.atomic_image) {
+                timing.writeback = "atomic";
                 if (trace) {
                     buffer.after_hash = fnv1a(result, buffer.bytes);
                     for (size_t i = 0; i < buffer.bytes; ++i)
                         buffer.changed_bytes += buffer.linear_seed[i] != result[i];
                 }
-                if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                if (!buffer.resource->host_data && buffer.resource->gpu_addr) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.result_watch_ms);
                     prosper::host::guest_write_watch_notify_host_write(
                         buffer.resource->gpu_addr, buffer.guest_bytes);
+                }
                 // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
                 const size_t layer_linear_bytes =
                     static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
-                for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
-                    uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
-                    const uint8_t* src = result + layer * layer_linear_bytes;
-                    if (buffer.resource->tile_mode) {
-                        tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
-                                     buffer.resource->tile_mode, 0, sizeof(uint32_t));
-                    } else {
-                        const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
-                        const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
-                            ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
-                        for (uint32_t y = 0; y < buffer.resource->height; ++y)
-                            std::memcpy(dst + y * destination_pitch,
-                                        src + y * tight_pitch, tight_pitch);
+                {
+                    ComputeBufferCostScope cost(timing.enabled, timing.guest_layout_ms);
+                    for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
+                        uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
+                        const uint8_t* src = result + layer * layer_linear_bytes;
+                        if (buffer.resource->tile_mode) {
+                            tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
+                                         buffer.resource->tile_mode, 0, sizeof(uint32_t));
+                        } else {
+                            const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
+                            const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
+                                ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
+                            for (uint32_t y = 0; y < buffer.resource->height; ++y)
+                                std::memcpy(dst + y * destination_pitch,
+                                            src + y * tight_pitch, tight_pitch);
+                        }
                     }
                 }
-                ctx.unmap_memory(buffer.memory);
+                {
+                    ComputeBufferCostScope cost(timing.enabled, timing.result_map_ms);
+                    ctx.unmap_memory(buffer.memory);
+                }
                 if (buffer.resource->gpu_addr) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.notify_ms);
                     set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
                     notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
                     set_guest_gpu_write_origin(nullptr);
                 }
-                if (!buffer.resource->host_data && writer_provenance_enabled())
+                if (!buffer.resource->host_data && writer_provenance_enabled()) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.provenance_ms);
                     record_guest_write(GuestWriterKind::ComputeBuffer,
                                        buffer.resource->gpu_addr, buffer.guest_bytes,
                                        item.submit_no, item.dispatch_index,
                                        item.command_order, item.code_addr);
+                }
                 continue;
             }
-            const bool changed = !compute_buffers_equal(
-                destination, result, buffer.bytes);
+            bool changed;
+            {
+                ComputeBufferCostScope cost(timing.enabled, timing.result_compare_ms);
+                changed = !compute_buffers_equal(destination, result, buffer.bytes);
+            }
+            timing.result_compared_bytes = buffer.bytes;
+            timing.writeback = changed ? "changed" : "unchanged";
             if (trace) {
                 buffer.after_hash = fnv1a(result, buffer.bytes);
                 for (size_t i = 0; i < buffer.bytes; i++)
@@ -10441,21 +10580,31 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // invalidation and writer provenance remain unconditional: renderer-resident state can
             // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
             if (changed) {
-                if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                if (!buffer.resource->host_data && buffer.resource->gpu_addr) {
+                    ComputeBufferCostScope cost(timing.enabled, timing.result_watch_ms);
                     prosper::host::guest_write_watch_notify_host_write(
                         buffer.resource->gpu_addr, buffer.resource->size);
-                copy_compute_buffer(destination, result, buffer.bytes);
+                }
+                {
+                    ComputeBufferCostScope cost(timing.enabled, timing.guest_copy_ms);
+                    copy_compute_buffer(destination, result, buffer.bytes);
+                }
+                timing.guest_copied_bytes = buffer.bytes;
             }
             if (buffer.persistent && !buffer.result_baseline &&
-                ctx.retain_cached_buffer_result(buffer.cache_key, result) && trace)
+                ctx.retain_cached_buffer_result(buffer.cache_key, result, timing) && trace)
                 std::fprintf(stderr,
                              "[compute]   retained exact GPU buffer result baseline binding=%u "
                              "addr=0x%llx bytes=%u\n",
                              buffer.resource->binding,
                              (unsigned long long)buffer.resource->gpu_addr,
                              buffer.resource->size);
-            ctx.unmap_memory(buffer.memory);
+            {
+                ComputeBufferCostScope cost(timing.enabled, timing.result_map_ms);
+                ctx.unmap_memory(buffer.memory);
+            }
             if (buffer.resource->gpu_addr) {
+                ComputeBufferCostScope cost(timing.enabled, timing.notify_ms);
                 if (changed) {
                     set_guest_gpu_write_origin("compute-writeback(buffer-full)");
                     notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
@@ -10465,13 +10614,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         buffer.resource->gpu_addr, buffer.resource->size);
                 }
             }
-            if (buffer.persistent)
+            if (buffer.persistent) {
+                ComputeBufferCostScope cost(timing.enabled, timing.source_validation_ms);
                 ctx.validate_cached_buffer_source(buffer.cache_key);
-            if (!buffer.resource->host_data && writer_provenance_enabled())
+            }
+            if (!buffer.resource->host_data && writer_provenance_enabled()) {
+                ComputeBufferCostScope cost(timing.enabled, timing.provenance_ms);
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    buffer.resource->gpu_addr, buffer.resource->size,
                                    item.submit_no, item.dispatch_index,
                                    item.command_order, item.code_addr);
+            }
         }
         writeback_buffers_ms = std::chrono::duration<double, std::milli>(
             ComputeClock::now() - writeback_buffers_start).count();
@@ -11252,6 +11405,57 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      pack_ms, layout_ms, image_notify_ms, image_cache_ms,
                      phase_milliseconds(phase_writeback, phase_cleanup),
                      phase_milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
+    }
+    // Emit only after timers/cleanup. Resource descriptions belong to buffer_resources, whose
+    // lifetime covers this report even though cleanup has released the device allocations.
+    if (buffer_timing) {
+        for (size_t i = 0; i < buffers.size(); ++i) {
+            const auto& buffer = buffers[i];
+            if (buffer.alias_of != SIZE_MAX) continue;
+            const auto& t = buffer.timing;
+            const auto& r = buffer_resources[i];
+            size_t aliases = 0;
+            std::string bindings = std::to_string(r.binding);
+            for (const auto& other : buffers) {
+                if (other.alias_of != i) continue;
+                ++aliases;
+                bindings += "," + std::to_string(other.resource->binding);
+            }
+            std::fprintf(stderr,
+                "[compute-buffer-timing] submit=%llu dispatch=%llu order=%llu "
+                "code=0x%llx hash=0x%016llx ok=%u owner=%u owner-index=%zu "
+                "owner-resolved=%u aliases=%zu bindings=%s addr=0x%llx host-backed=%u "
+                "host-key=0x%llx semantic=%u logical-bytes=%u bytes=%zu guest-bytes=%zu "
+                "writable=%u atomic=%u "
+                "persistent=%u upload-skipped=%u dirty-watch-chunks=%u total-watch-chunks=%u "
+                "cache=%s validation=%s baseline=%s gpu-compare=%s writeback=%s "
+                "compared-bytes=%llu uploaded-bytes=%llu result-compared-bytes=%llu "
+                "guest-copied-bytes=%llu setup_ms=%.6f validation_ms=%.6f "
+                "upload_compare_ms=%.6f upload_copy_ms=%.6f upload_map_ms=%.6f "
+                "upload_watch_ms=%.6f writeback_ms=%.6f result_compare_ms=%.6f "
+                "guest_copy_ms=%.6f guest_layout_ms=%.6f result_map_ms=%.6f result_watch_ms=%.6f "
+                "baseline_ms=%.6f notify_ms=%.6f source_validation_ms=%.6f provenance_ms=%.6f\n",
+                (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
+                (unsigned long long)item.command_order, (unsigned long long)item.code_addr,
+                (unsigned long long)timing_program_hash, ok ? 1u : 0u, r.binding, i,
+                t.owner_resolved ? 1u : 0u, aliases, bindings.c_str(),
+                (unsigned long long)r.gpu_addr,
+                r.host_data && r.host_data_size >= buffer.guest_bytes ? 1u : 0u,
+                (unsigned long long)buffer.cache_key.host_data,
+                static_cast<unsigned>(buffer.cache_key.materialization.semantic),
+                r.size, buffer.bytes, buffer.guest_bytes,
+                buffer.writable ? 1u : 0u, buffer.atomic_image ? 1u : 0u,
+                buffer.persistent ? 1u : 0u, buffer.upload_skipped ? 1u : 0u,
+                buffer.dirty_watch_chunks, buffer.total_watch_chunks,
+                t.cache, t.validation, t.baseline, t.gpu_compare, t.writeback,
+                (unsigned long long)t.compared_bytes, (unsigned long long)t.uploaded_bytes,
+                (unsigned long long)t.result_compared_bytes,
+                (unsigned long long)t.guest_copied_bytes,
+                t.setup_ms, t.validation_ms, t.upload_compare_ms, t.upload_copy_ms,
+                t.upload_map_ms, t.upload_watch_ms, t.writeback_ms, t.result_compare_ms,
+                t.guest_copy_ms, t.guest_layout_ms, t.result_map_ms, t.result_watch_ms,
+                t.baseline_ms, t.notify_ms, t.source_validation_ms, t.provenance_ms);
+        }
     }
     return ok;
 }

--- a/prosper/tests/gpu/execute/test_compute_buffer_residency.cpp
+++ b/prosper/tests/gpu/execute/test_compute_buffer_residency.cpp
@@ -1,0 +1,188 @@
+// #3407: optional result baselines must not churn a primary buffer working set that fits.
+#include "gpu/capture/gpu_capture.hpp"
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/resources/shader_resources.hpp"
+#include "shared/live/live_compute.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+namespace {
+constexpr uint32_t bytes = 2u << 20;
+constexpr uint64_t code_address = 0x3407b00200ull;
+constexpr uint32_t initial_fill = 0xb1b1b100u;
+constexpr uint32_t changed_fill = 0xc2c2c200u;
+int failures = 0;
+void check(bool ok, const char* message) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; }
+}
+void env(const char* name, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
+std::string hex(uint64_t value) {
+    char text[32];
+    std::snprintf(text, sizeof(text), "0x%llx", static_cast<unsigned long long>(value));
+    return text;
+}
+struct GuestBuffer {
+    std::vector<uint32_t> data;
+    uint32_t expected = initial_fill;
+    explicit GuestBuffer(uint32_t tail, uint32_t length = bytes)
+        : data(length / sizeof(uint32_t), tail) {}
+    uint64_t address() const { return reinterpret_cast<uint64_t>(data.data()); }
+    uint32_t size() const { return static_cast<uint32_t>(data.size() * sizeof(uint32_t)); }
+    bool correct(uint32_t tail) const {
+        for (unsigned i = 0; i < 4; ++i)
+            if (data[i] != expected + i) return false;
+        return std::all_of(data.begin() + 4, data.end(),
+                           [&](uint32_t word) { return word == tail; });
+    }
+};
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 3 && argc != 4) {
+        std::fprintf(stderr, "usage: fixture MODE CACHE_MIB [LARGE_BYTES]\n");
+        return 2;
+    }
+    const std::string mode = argv[1];
+    const bool large = mode == "requirements-large" || mode == "partial";
+    if (mode != "requirements" && mode != "cycle" && mode != "pinned" && !large) return 2;
+    if (large != (argc == 4)) return 2;
+    char* end = nullptr;
+    const auto cap_mib = std::strtoull(argv[2], &end, 10);
+    if (!end || *end || cap_mib == 0 || cap_mib > 1024) return 2;
+    uint32_t large_bytes = bytes;
+    if (large) {
+        const auto length = std::strtoull(argv[3], &end, 10);
+        if (!end || *end || length < bytes || length > UINT32_MAX || (length & 15)) return 2;
+        large_bytes = static_cast<uint32_t>(length);
+    }
+    env("PROSPER_COMPUTELOG", nullptr);
+    env("PROSPER_COMPUTELOG_CODE", nullptr);
+    env("PROSPER_NO_PERSISTENT_COMPUTE_BUFFERS", nullptr);
+    env("PROSPER_NO_PERSISTENT_COMPUTE_BUFFER_RESULTS", nullptr);
+    env("PROSPER_COMPUTE_BUFFER_CACHE_MB", argv[2]);
+    env("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", "1");
+    env("PROSPER_COMPUTE_BUFFER_TIMING", "1");
+    env("PROSPER_COMPUTE_TIMING_CAPTURE_ONLY", nullptr);
+    env("PROSPER_NO_DISK_PIPELINE_CACHE", "1");
+    // Guest pointers into ordinary host vectors keep this test independent of watch promotion.
+    // No direct mapping is registered and no signal handler or watch policy is installed here.
+    std::array<GuestBuffer, 3> buffers = {
+        GuestBuffer(0xababababu), GuestBuffer(0xcdcdcdcdu), GuestBuffer(0xefefefefu, large_bytes)};
+    constexpr uint32_t tails[] = {0xababababu, 0xcdcdcdcdu, 0xefefefefu};
+    static constexpr uint32_t shader[] = {
+        0x7e080280u, // v4 = 0: one invocation writes the first uvec4 through each descriptor.
+        0x7e000204u, 0x7e020205u, 0x7e040206u, 0x7e060207u,
+        0xe01c2000u, 0x80000004u,
+        0x7e0a020cu, 0x7e0c020du, 0x7e0e020eu, 0x7e10020fu,
+        0xe01c2000u, 0x80020504u,
+        0x7e120214u, 0x7e140215u, 0x7e160216u, 0x7e180217u,
+        0xe01c2000u, 0x80040904u,
+        0xbf810000u,
+    };
+    ShaderResourceTable resources;
+    for (unsigned binding = 0; binding < 3; ++binding) {
+        ShaderResource resource{};
+        resource.cls = ResourceClass::ConstantBuffer;
+        resource.format = DataFormat::Uint32;
+        resource.num_components = 4;
+        resource.binding = binding;
+        resource.sgpr_base = binding * 8;
+        resource.stride = 16;
+        resource.gpu_addr = buffers[0].address();
+        resource.size = bytes;
+        resources.resources.push_back(resource);
+    }
+    ComputeShaderConfig config;
+    config.local_x = 1;
+    config.user_sgprs.resize(24);
+    for (unsigned binding = 0; binding < 3; ++binding)
+        for (unsigned lane = 0; lane < 4; ++lane)
+            config.user_sgprs[binding * 8 + 4 + lane] = initial_fill + lane;
+    ComputeItem prototype;
+    prototype.spirv = recompile_compute(shader, std::size(shader), &resources, config);
+    if (prototype.spirv.empty()) return 3;
+    prototype.user_sgprs = config.user_sgprs;
+    prototype.code_addr = code_address;
+    prototype.launch.threads_x = prototype.launch.threads_y = prototype.launch.threads_z = 1;
+    prototype.launch.local_x = prototype.launch.local_y = prototype.launch.local_z = 1;
+    prototype.launch.groups_x = prototype.launch.groups_y = prototype.launch.groups_z = 1;
+    const auto hash = gpu_capture_hash(reinterpret_cast<const uint8_t*>(prototype.spirv.data()),
+                                       prototype.spirv.size() * sizeof(uint32_t));
+    env("PROSPER_COMPUTE_TIMING_CODE", hex(code_address).c_str());
+    env("PROSPER_COMPUTE_TIMING_HASH", hex(hash).c_str());
+    std::fprintf(stderr, "[buffer-residency-fixture] mode=%s code=%s hash=%s cap-mib=%llu\n",
+                 mode.c_str(), hex(code_address).c_str(), hex(hash).c_str(), cap_mib);
+    unsigned notifications = 0;
+    set_guest_gpu_write_observer([&](uint64_t address, uint64_t length, const char*) {
+        for (const auto& buffer : buffers)
+            if (address == buffer.address() && length == buffer.size()) ++notifications;
+    });
+    auto run = [&](unsigned index, std::array<unsigned, 3> owners, uint32_t value) {
+        ComputeItem item = prototype;
+        auto bound = std::make_shared<ShaderResourceTable>(resources);
+        std::array<bool, 3> touched{};
+        for (unsigned binding = 0; binding < 3; ++binding) {
+            auto& buffer = buffers[owners[binding]];
+            bound->resources[binding].gpu_addr = buffer.address();
+            bound->resources[binding].size = buffer.size();
+            buffer.expected = value;
+            touched[owners[binding]] = true;
+            for (unsigned lane = 0; lane < 4; ++lane)
+                item.user_sgprs[binding * 8 + 4 + lane] = value + lane;
+        }
+        item.resources = bound;
+        item.submit_no = 4400 + index;
+        item.dispatch_index = index;
+        item.command_order = index * 10;
+        const unsigned before = notifications;
+        check(prosper::frontend::execute_live_compute_items({item}), "residency dispatch executes");
+        for (unsigned owner = 0; owner < 3; ++owner)
+            if (touched[owner])
+                check(buffers[owner].correct(tails[owner]),
+                      "shader output and full untouched tail survive cache pressure");
+        check(notifications - before == std::count(touched.begin(), touched.end(), true),
+              "publication is once per unique owner, including exact aliases");
+    };
+    auto single = [&](unsigned index, unsigned owner, uint32_t value = initial_fill) {
+        run(index, {owner, owner, owner}, value);
+    };
+    single(1, mode == "requirements-large" ? 2 : 0);
+    if (mode == "partial") {
+        single(2, 1);
+        // A is pinned by the first two bindings. B remains idle and reclaimable, but its
+        // entire primary+baseline is insufficient to admit C. Refusal must leave B intact.
+        run(3, {0, 0, 2}, initial_fill);
+        single(4, 1);
+    } else if (mode != "requirements" && mode != "requirements-large") {
+        single(2, 1);
+        unsigned index = 3;
+        if (mode == "pinned") run(index++, {0, 1, 2}, initial_fill);
+        single(index++, 2);
+        single(index++, 0);
+        single(index++, 1);
+        single(index++, 2);
+        single(index++, 0, changed_fill);
+        single(index++, 0, changed_fill);
+        buffers[1].data[0] ^= 0xffffffffu;
+        single(index++, 1);
+    }
+    set_guest_gpu_write_observer({});
+    if (!failures)
+        std::fprintf(stderr, "[buffer-residency-fixture] success mode=%s\n", mode.c_str());
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/execute/test_compute_buffer_timing.cpp
+++ b/prosper/tests/gpu/execute/test_compute_buffer_timing.cpp
@@ -1,0 +1,230 @@
+// #3407: exercise buffer decisions through the production backend, without COMPUTELOG's hashes.
+#include "gpu/capture/gpu_capture.hpp"
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/resources/shader_resources.hpp"
+#include "host/memory/guest_write_watch.hpp"
+#include "shared/live/live_compute.hpp"
+#include "shared/perf/performance_capture.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
+#if defined(__linux__)
+#include <csignal>
+#include <sys/mman.h>
+#include <sys/ucontext.h>
+#include <unistd.h>
+#endif
+
+using namespace prosper::gpu;
+namespace {
+constexpr uint32_t bytes = 2u << 20;
+constexpr uint64_t code_address = 0x3407b00100ull;
+constexpr uint64_t submit = 3407;
+constexpr uint32_t fill[] = {0xb1b1b1b1u, 0xb2b2b2b2u, 0xb3b3b3b3u, 0xb4b4b4b4u};
+int failures = 0;
+void check(bool ok, const char* message) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; }
+}
+void env(const char* name, const char* value) {
+#if defined(_WIN32)
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
+std::string hex(uint64_t value) {
+    char text[32];
+    std::snprintf(text, sizeof(text), "0x%llx", static_cast<unsigned long long>(value));
+    return text;
+}
+#if defined(__linux__)
+void fault(int signal, siginfo_t* info, void* context) {
+#if defined(__x86_64__)
+    const bool write_fault = context &&
+        (static_cast<ucontext_t*>(context)->uc_mcontext.gregs[REG_ERR] & 2) != 0;
+#else
+    const bool write_fault = context != nullptr;
+#endif
+    if (signal == SIGSEGV && write_fault && info && info->si_addr &&
+        prosper::host::guest_write_watch_handle_fault(
+            reinterpret_cast<uint64_t>(info->si_addr))) return;
+    static constexpr char message[] = "buffer timing fixture: unexpected SIGSEGV\n";
+    (void)!write(STDERR_FILENO, message, sizeof(message) - 1);
+    _exit(86);
+}
+bool install_fault_handler() {
+    static uint8_t stack_memory[256 * 1024];
+    stack_t stack{};
+    stack.ss_sp = stack_memory;
+    stack.ss_size = sizeof(stack_memory);
+    struct sigaction action{};
+    action.sa_sigaction = fault;
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&action.sa_mask);
+    return sigaltstack(&stack, nullptr) == 0 && sigaction(SIGSEGV, &action, nullptr) == 0;
+}
+#endif
+struct GuestBuffer {
+    uint32_t* data = nullptr;
+#if !defined(__linux__)
+    std::vector<uint32_t> storage;
+#endif
+    explicit GuestBuffer(uint64_t backing_offset) {
+#if defined(__linux__)
+        void* mapping = mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (mapping == MAP_FAILED) return;
+        data = static_cast<uint32_t*>(mapping);
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            address(), bytes, backing_offset, 0x3);
+#else
+        (void)backing_offset;
+        storage.resize(bytes / sizeof(uint32_t));
+        data = storage.data();
+#endif
+        std::fill_n(data, bytes / sizeof(uint32_t), 0xababababu);
+    }
+    ~GuestBuffer() {
+#if defined(__linux__)
+        if (data) {
+            prosper::host::guest_write_watch_notify_direct_mapping_removed(address(), bytes);
+            munmap(data, bytes);
+        }
+#endif
+    }
+    GuestBuffer(const GuestBuffer&) = delete;
+    GuestBuffer& operator=(const GuestBuffer&) = delete;
+    uint64_t address() const { return reinterpret_cast<uint64_t>(data); }
+    bool correct() const {
+        return std::equal(std::begin(fill), std::end(fill), data) &&
+            std::all_of(data + 4, data + bytes / sizeof(uint32_t),
+                        [](uint32_t word) { return word == 0xababababu; });
+    }
+};
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 3) { std::fprintf(stderr, "usage: fixture MODE CAPTURE_DIRECTORY\n"); return 2; }
+    const std::string mode = argv[1];
+    if (mode != "selected" && mode != "wrong-code" && mode != "wrong-hash" &&
+        mode != "disabled" && mode != "capture-idle" && mode != "capture-armed") return 2;
+    env("PROSPER_COMPUTELOG", nullptr);
+    env("PROSPER_COMPUTELOG_CODE", nullptr);
+    env("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", "1");
+    env("PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS", "1");
+    env("PROSPER_NO_DISK_PIPELINE_CACHE", "1");
+    env("PROSPER_COMPUTE_BUFFER_TIMING", mode == "disabled" ? nullptr : "1");
+    env("PROSPER_COMPUTE_TIMING_CAPTURE_ONLY",
+        mode == "capture-idle" || mode == "capture-armed" ? "1" : nullptr);
+#if defined(__linux__)
+    if (!install_fault_handler()) return 3;
+    prosper::host::guest_write_watch_set_fault_onstack(true);
+    constexpr bool watch = true;
+#else
+    constexpr bool watch = false;
+#endif
+    GuestBuffer first(0x10000000), second(0x10200000);
+    if (!first.data || !second.data) return 3;
+
+    // Same one-invocation stores as test_game_compute's two-target regression. Equal values
+    // make the shared-address arm independent of store ordering between aliased descriptors.
+    static constexpr uint32_t shader[] = {
+        0x7e080280u, 0x7e000204u, 0x7e020205u, 0x7e040206u, 0x7e060207u,
+        0xe01c2000u, 0x80000004u,
+        0x7e0a020cu, 0x7e0c020du, 0x7e0e020eu, 0x7e10020fu,
+        0xe01c2000u, 0x80020504u, 0xbf810000u,
+    };
+    ShaderResource a{};
+    a.cls = ResourceClass::ConstantBuffer;
+    a.format = DataFormat::Uint32;
+    a.num_components = 4;
+    a.binding = 0; a.sgpr_base = 0; a.stride = 16;
+    a.gpu_addr = first.address(); a.size = bytes;
+    ShaderResource b = a;
+    b.binding = 1; b.sgpr_base = 8;
+    auto resources = std::make_shared<ShaderResourceTable>();
+    resources->resources = {a, b};
+    ComputeShaderConfig config;
+    config.local_x = 1;
+    config.user_sgprs = {0, 0, 0, 0, fill[0], fill[1], fill[2], fill[3],
+                        0, 0, 0, 0, fill[0], fill[1], fill[2], fill[3]};
+    ComputeItem item;
+    item.spirv = recompile_compute(shader, std::size(shader), resources.get(), config);
+    if (item.spirv.empty()) return 4;
+    item.resources = resources;
+    item.user_sgprs = config.user_sgprs;
+    item.code_addr = code_address;
+    item.submit_no = submit;
+    item.launch.threads_x = item.launch.threads_y = item.launch.threads_z = 1;
+    item.launch.local_x = item.launch.local_y = item.launch.local_z = 1;
+    item.launch.groups_x = item.launch.groups_y = item.launch.groups_z = 1;
+    const auto hash = gpu_capture_hash(reinterpret_cast<const uint8_t*>(item.spirv.data()),
+                                       item.spirv.size() * sizeof(uint32_t));
+    env("PROSPER_COMPUTE_TIMING_CODE", hex(code_address + (mode == "wrong-code")).c_str());
+    env("PROSPER_COMPUTE_TIMING_HASH", hex(hash ^ (mode == "wrong-hash")).c_str());
+    std::fprintf(stderr, "[buffer-timing-fixture] mode=%s code=%s hash=%s watch=%u bytes=%u\n",
+                 mode.c_str(), hex(code_address).c_str(), hex(hash).c_str(), unsigned(watch), bytes);
+    auto& capture = prosper::perf::interactive_performance_capture();
+    if (mode == "capture-armed") {
+        const auto now = std::chrono::steady_clock::now().time_since_epoch();
+        const auto armed = capture.arm(argv[2], "TEST", "compute buffer fixture", "fixture",
+            std::chrono::duration_cast<std::chrono::nanoseconds>(now).count(),
+            std::chrono::system_clock::now());
+        if (!armed.ok || !capture.detailed_timing_active()) return 5;
+    }
+    auto dispatch = [&](unsigned index) {
+        ComputeItem next = item;
+        next.dispatch_index = index;
+        next.command_order = index * 10;
+        return next;
+    };
+    unsigned notifications = 0;
+    set_guest_gpu_write_observer([&](uint64_t address, uint64_t length, const char*) {
+        if ((address == first.address() || address == second.address()) && length == bytes)
+            ++notifications;
+    });
+    // A real submit scope supplies the journal; each callback still executes the Vulkan backend.
+    const auto ordered = execute_ordered_items(
+        {{SubmitOperationKind::Dispatch, 1, 10}, {SubmitOperationKind::Dispatch, 2, 20}},
+        {}, {dispatch(1), dispatch(2)}, {},
+        [&](const std::vector<ComputeItem>& items) {
+            const bool ok = prosper::frontend::execute_live_compute_items(items);
+            check(ok && first.correct(), "ordered dispatch publishes exact shader result");
+            return ok;
+        }, 1, 1);
+    check(ordered.compute_executed, "ordered submit executed compute");
+    check(notifications == 2, "one notification per owner, despite two alias bindings");
+    auto run = [&](unsigned index) {
+        check(prosper::frontend::execute_live_compute_items({dispatch(index)}),
+              "direct dispatch executes");
+        check(first.correct(), "direct dispatch preserves exact output and untouched tail");
+    };
+    run(3); // No submit journal: exact comparison establishes the write watches.
+    run(4); // Clean watch, followed by exact retained GPU-result comparison.
+    const auto skips = prosper::frontend::live_compute_buffer_gpu_result_skips();
+    first.data[0] ^= 0xffffffffu; // Real external guest write, without a GPU notification.
+    run(5); // Dirty first MiB must upload and repair the modified word.
+    check(prosper::frontend::live_compute_buffer_gpu_result_skips() == skips,
+          "guest mutation refuses stale retained-result skip");
+    run(6);
+    check(prosper::frontend::live_compute_buffer_gpu_result_skips() > skips,
+          "unchanged result skip recovers after guest repair");
+    auto distinct = std::make_shared<ShaderResourceTable>(*resources);
+    distinct->resources[1].gpu_addr = second.address();
+    item.resources = distinct;
+    run(7);
+    check(second.correct(), "separate second owner receives its own shader result");
+    check(notifications == 8, "six alias dispatches plus two distinct owners publish once each");
+    set_guest_gpu_write_observer({});
+    capture.cancel();
+    if (!failures) std::fprintf(stderr, "[buffer-timing-fixture] success mode=%s\n", mode.c_str());
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/execute/test_compute_buffer_timing.cpp
+++ b/prosper/tests/gpu/execute/test_compute_buffer_timing.cpp
@@ -114,12 +114,16 @@ struct GuestBuffer {
 int main(int argc, char** argv) {
     if (argc != 3) { std::fprintf(stderr, "usage: fixture MODE CAPTURE_DIRECTORY\n"); return 2; }
     const std::string mode = argv[1];
+    const bool promotion = mode == "promotion" || mode == "promotion-cpu";
+    const bool cpu_result = mode == "promotion-cpu";
     if (mode != "selected" && mode != "wrong-code" && mode != "wrong-hash" &&
-        mode != "disabled" && mode != "capture-idle" && mode != "capture-armed") return 2;
+        mode != "disabled" && mode != "capture-idle" && mode != "capture-armed" &&
+        !promotion) return 2;
     env("PROSPER_COMPUTELOG", nullptr);
     env("PROSPER_COMPUTELOG_CODE", nullptr);
-    env("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", "1");
-    env("PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS", "1");
+    env("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", cpu_result ? nullptr : "1");
+    env("PROSPER_NO_PERSISTENT_COMPUTE_BUFFER_RESULTS", cpu_result ? "1" : nullptr);
+    env("PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS", promotion ? nullptr : "1");
     env("PROSPER_NO_DISK_PIPELINE_CACHE", "1");
     env("PROSPER_COMPUTE_BUFFER_TIMING", mode == "disabled" ? nullptr : "1");
     env("PROSPER_COMPUTE_TIMING_CAPTURE_ONLY",
@@ -191,6 +195,42 @@ int main(int argc, char** argv) {
         if ((address == first.address() || address == second.address()) && length == bytes)
             ++notifications;
     });
+    if (promotion) {
+        const auto initial_skips = prosper::frontend::live_compute_buffer_gpu_result_skips();
+        for (unsigned index = 1; index <= 9; ++index) {
+            const bool mutation = index == 3 || index == 8;
+            const auto skips_before = prosper::frontend::live_compute_buffer_gpu_result_skips();
+            if (mutation) first.data[0] ^= 0xffffffffu;
+            auto next = dispatch(index);
+            next.submit_no = submit + index;
+            // Every call owns a distinct real submit journal. Reusing the item or incrementing
+            // its submit number inside ONE scope would accidentally test journal skips instead.
+            const auto result = execute_ordered_items(
+                {{SubmitOperationKind::Dispatch, index, next.command_order}}, {}, {next}, {},
+                [&](const std::vector<ComputeItem>& items) {
+                    return prosper::frontend::execute_live_compute_items(items);
+                }, 1, 1);
+            check(result.compute_executed && first.correct(),
+                  "promotion dispatch publishes exact result and preserves untouched tail");
+            check(notifications == index,
+                  "promotion dispatch publishes one owner despite aliased bindings");
+            const auto skips_after = prosper::frontend::live_compute_buffer_gpu_result_skips();
+            if (cpu_result || mutation || index == 1)
+                check(skips_after == skips_before,
+                      "cold/changed/CPU-only result cannot use GPU-identical shortcut");
+            else
+                check(skips_after == skips_before + 1,
+                      "unchanged promotion dispatch proves its retained GPU result");
+        }
+        if (cpu_result)
+            check(prosper::frontend::live_compute_buffer_gpu_result_skips() == initial_skips,
+                  "CPU promotion arm never uses retained GPU-result comparison");
+        set_guest_gpu_write_observer({});
+        capture.cancel();
+        if (!failures)
+            std::fprintf(stderr, "[buffer-timing-fixture] success mode=%s\n", mode.c_str());
+        return failures ? 1 : 0;
+    }
     // A real submit scope supplies the journal; each callback still executes the Vulkan backend.
     const auto ordered = execute_ordered_items(
         {{SubmitOperationKind::Dispatch, 1, 10}, {SubmitOperationKind::Dispatch, 2, 20}},

--- a/prosper/tools/perf/test_compute_buffer_residency_runtime.py
+++ b/prosper/tools/perf/test_compute_buffer_residency_runtime.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Exercise primary residency versus optional result allocations on the actual backend.
+
+Charges are VkMemoryRequirements sizes retained by the cache, not physical allocator pool sizes.
+A fresh probe process discovers those sizes before the two pressure processes set their cap.
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+PREFIX = "[compute-buffer-timing] "
+FIXTURE = "[buffer-residency-fixture] "
+MIB = 1 << 20
+BYTES = 2 * MIB
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def parse(line, prefix):
+    pairs = [part.split("=", 1) for part in line[len(prefix):].split()]
+    require(all(len(pair) == 2 for pair in pairs), f"malformed record: {line}")
+    result = dict(pairs)
+    require(len(result) == len(pairs), f"duplicate field: {line}")
+    return result
+
+
+def number(row, key):
+    return int(row[key], 0)
+
+
+def expect(row, **wanted):
+    for key, value in wanted.items():
+        key = key.replace("_", "-")
+        actual = number(row, key) if isinstance(value, int) else row[key]
+        require(actual == value, f"dispatch {row['dispatch']} owner {row['owner']}: "
+                f"{key}={actual!r}, expected {value!r}")
+
+
+def run(binary, mode, cap_mib, large_bytes=None):
+    environment = {key: value for key, value in os.environ.items()
+                   if not key.startswith("PROSPER_COMPUTE") and
+                   key not in {"PROSPER_NO_PERSISTENT_COMPUTE_BUFFERS",
+                               "PROSPER_NO_PERSISTENT_COMPUTE_BUFFER_RESULTS"}}
+    command = [str(binary), mode, str(cap_mib)]
+    if large_bytes is not None:
+        command.append(str(large_bytes))
+    result = subprocess.run(command, env=environment,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            text=True, timeout=120, check=False)
+    # Preserve validation-layer messages for the outer suite's scanner on success as well.
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    require(result.returncode == 0, f"{mode}: fixture exited {result.returncode}")
+    lines = result.stderr.splitlines()
+    require(FIXTURE + "success mode=" + mode in lines, f"{mode}: no successful guest-output witness")
+    witnesses = [parse(line, FIXTURE) for line in lines if line.startswith(FIXTURE + "mode=")]
+    require(len(witnesses) == 1 and witnesses[0]["mode"] == mode, "missing/invalid identity")
+    witness = witnesses[0]
+    rows = [parse(line, PREFIX) for line in lines if line.startswith(PREFIX)]
+    require(rows, f"{mode}: empty cache-decision census")
+    identities = set()
+    for row in rows:
+        dispatch = number(row, "dispatch")
+        identity = (dispatch, number(row, "owner"))
+        require(identity not in identities, f"duplicate unique owner {identity}")
+        identities.add(identity)
+        large_owner = mode == "requirements-large" or (mode == "partial" and identity == (3, 2))
+        owner_bytes = large_bytes if large_owner else BYTES
+        expect(row, submit=4400 + dispatch, order=10 * dispatch, ok=1,
+               code=number(witness, "code"), hash=number(witness, "hash"),
+               owner_resolved=1, host_backed=0, host_key=0, semantic=0,
+               bytes=owner_bytes, logical_bytes=owner_bytes, guest_bytes=owner_bytes,
+               writable=1, atomic=0, cache_limit=cap_mib * MIB)
+        charge = number(row, "primary-allocation-bytes") + number(row, "result-allocation-bytes")
+        require(0 <= charge <= number(row, "cache-bytes") <= cap_mib * MIB,
+                f"invalid cache accounting or exceeded cap: {row}")
+    return rows, witness
+
+
+def probe(binary):
+    rows, witness = run(binary, "requirements", 64)
+    require(len(rows) == 1, "requirements probe duplicated alias ownership")
+    row = rows[0]
+    expect(row, owner=0, aliases=2, bindings="0,1,2", cache="miss", persistent=1,
+           baseline="created", writeback="changed")
+    primary = number(row, "primary-allocation-bytes")
+    baseline = number(row, "result-allocation-bytes")
+    require(primary >= BYTES and baseline >= BYTES, "probe did not retain both allocation types")
+    expect(row, cache_bytes=primary + baseline)
+    # Fit all three primaries and one baseline; also fit the two primaries+baselines used by
+    # the pinned arm. Rounding is in MiB because that is the production cache-cap interface.
+    cap_mib = (max(3 * primary + baseline, 2 * (primary + baseline)) + MIB - 1) // MIB
+    require(cap_mib <= 1024 and cap_mib * MIB < 3 * primary + 2 * baseline,
+            "unsupported driver allocation shape: cannot establish bounded baseline pressure")
+    return primary, baseline, cap_mib, witness
+
+
+def pressure(binary, mode, primary, baseline, cap_mib):
+    rows, witness = run(binary, mode, cap_mib)
+    pinned = mode == "pinned"
+    require(len(rows) == (12 if pinned else 9), "wrong pressure owner census")
+    grouped = {}
+    for row in rows:
+        grouped.setdefault(number(row, "dispatch"), []).append(row)
+    last = 10 if pinned else 9
+    require(set(grouped) == set(range(1, last + 1)), "missing pressure dispatch")
+    for dispatch, owners in grouped.items():
+        if pinned and dispatch == 3:
+            continue
+        require(len(owners) == 1, "an exact alias produced multiple owners")
+        expect(owners[0], owner=0, owner_index=0, aliases=2, bindings="0,1,2",
+               persistent=1, primary_allocation_bytes=primary)
+    first = grouped[1][0]
+    second = grouped[2][0]
+    expect(first, cache="miss", result_allocation_bytes=baseline)
+    expect(second, cache="miss", result_allocation_bytes=baseline)
+    if pinned:
+        by_binding = {number(row, "owner"): row for row in grouped[3]}
+        require(set(by_binding) == {0, 1, 2}, "pinned arm lost a distinct owner")
+        for binding, row in by_binding.items():
+            expect(row, owner_index=binding, aliases=0, bindings=str(binding))
+        for binding in (0, 1):
+            expect(by_binding[binding], cache="hit", persistent=1,
+                   primary_allocation_bytes=primary, result_allocation_bytes=baseline,
+                   gpu_compare="unchanged", writeback="gpu-unchanged")
+        # The two existing result owners are pinned during C's attempted admission. Refusal
+        # keeps C transient for this dispatch; it must not destroy resources already in use.
+        expect(by_binding[2], cache="miss", persistent=0, primary_allocation_bytes=0,
+               result_allocation_bytes=0, writeback="changed")
+        require(len({number(row, "cache-bytes") for row in by_binding.values()}) == 1,
+                "end-of-dispatch owner rows disagree on total residency")
+        expect(by_binding[0], cache_bytes=2 * (primary + baseline))
+    cold_c = 4 if pinned else 3
+    warm = cold_c + 1
+    expect(grouped[cold_c][0], cache="miss")
+    addresses = [number(first, "addr"), number(second, "addr"),
+                 number(grouped[cold_c][0], "addr")]
+    require(len(set(addresses)) == 3, "working set does not contain three distinct buffers")
+    for offset in range(3):
+        row = grouped[warm + offset][0]
+        expect(row, addr=addresses[offset], cache="hit", upload_skipped=1, uploaded_bytes=0)
+        require(row["writeback"] in ("unchanged", "gpu-unchanged"),
+                "warm identical guest result was not recognized")
+    changed = warm + 3
+    expect(grouped[changed][0], addr=addresses[0], cache="hit", upload_skipped=1,
+           uploaded_bytes=0, writeback="changed", guest_copied_bytes=BYTES)
+    repeated = grouped[changed + 1][0]
+    expect(repeated, addr=addresses[0], cache="hit", upload_skipped=1, uploaded_bytes=0,
+           guest_copied_bytes=0)
+    require(repeated["writeback"] in ("unchanged", "gpu-unchanged"),
+            "changed result did not become the new unchanged result")
+    repaired = grouped[changed + 2][0]
+    expect(repaired, addr=addresses[1], cache="hit", upload_skipped=0,
+           uploaded_bytes=BYTES, writeback="changed", guest_copied_bytes=BYTES,
+           gpu_compare="ineligible")
+    return witness
+
+
+def partial_reclaim(binary, primary, baseline, cap_mib):
+    combined = primary + baseline
+    limit = cap_mib * MIB
+    large_bytes = ((limit - combined) // MIB + 1) * MIB
+    require(BYTES <= large_bytes <= limit, "unsupported partial-admission source extent")
+    # Measure C in a fresh roomy cache. Its actual primary must fit the pressure cap alone;
+    # otherwise the ordinary oversized-allocation guard could hide a broken reclaim preflight.
+    discovery, discovery_identity = run(binary, "requirements-large", max(64, cap_mib), large_bytes)
+    require(len(discovery) == 1, "large probe duplicated alias ownership")
+    measured = discovery[0]
+    expect(measured, owner=0, aliases=2, bindings="0,1,2", cache="miss", persistent=1,
+           baseline="created", writeback="changed", guest_copied_bytes=large_bytes)
+    large_primary = number(measured, "primary-allocation-bytes")
+    require(large_primary >= large_bytes and limit - combined < large_primary <= limit,
+            "unsupported allocation shape: cannot isolate insufficient partial reclaim")
+    # B's full combined charge is idle and reclaimable, but less than the required reclamation.
+    require(0 < combined < 2 * combined + large_primary - limit,
+            "partial-reclaim fixture lacks nonzero, insufficient reclaimable bytes")
+    rows, witness = run(binary, "partial", cap_mib, large_bytes)
+    require(witness["hash"] == discovery_identity["hash"], "large probe changed compiled shader")
+    require(len(rows) == 5, "wrong partial-reclaim owner census")
+    indexed = {(number(row, "dispatch"), number(row, "owner")): row for row in rows}
+    require(set(indexed) == {(1, 0), (2, 0), (3, 0), (3, 2), (4, 0)},
+            "missing/duplicate partial-reclaim dispatch owner")
+    for index in (1, 2):
+        expect(indexed[index, 0], cache="miss", persistent=1, aliases=2, bindings="0,1,2",
+               primary_allocation_bytes=primary, result_allocation_bytes=baseline)
+    for key in ((3, 0), (4, 0)):
+        expect(indexed[key], cache="hit", persistent=1, upload_skipped=1,
+               primary_allocation_bytes=primary, result_allocation_bytes=baseline,
+               cache_bytes=2 * combined, writeback="gpu-unchanged", gpu_compare="unchanged",
+               guest_copied_bytes=0)
+    expect(indexed[3, 0], owner_index=0, aliases=1, bindings="0,1",
+           addr=number(indexed[1, 0], "addr"))
+    expect(indexed[3, 2], owner_index=2, aliases=0, bindings="2", cache="miss", persistent=0,
+           primary_allocation_bytes=0, result_allocation_bytes=0, cache_bytes=2 * combined,
+           writeback="changed", guest_copied_bytes=large_bytes)
+    expect(indexed[4, 0], owner_index=0, aliases=2, bindings="0,1,2",
+           addr=number(indexed[2, 0], "addr"))
+    require(len({number(indexed[key], "addr") for key in ((1, 0), (2, 0), (3, 2))}) == 3,
+            "partial-reclaim owners are not three distinct allocations")
+    return witness
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: test_compute_buffer_residency_runtime.py FIXTURE_EXECUTABLE")
+    binary = Path(sys.argv[1]).resolve(strict=True)
+    primary, baseline, cap_mib, witness = probe(binary)
+    print(f"cache residency charges: primary={primary} baseline={baseline} cap={cap_mib} MiB")
+    errors = []
+    for mode in ("cycle", "pinned"):
+        try:
+            other = pressure(binary, mode, primary, baseline, cap_mib)
+            require(other["hash"] == witness["hash"], "pressure arm changed its compiled shader")
+        except AssertionError as error:
+            errors.append(f"{mode}: {error}")
+    try:
+        other = partial_reclaim(binary, primary, baseline, cap_mib)
+        require(other["hash"] == witness["hash"], "partial-reclaim arm changed compiled shader")
+    except AssertionError as error:
+        errors.append(f"partial: {error}")
+    require(not errors, "\n".join(errors))
+    print("compute buffer residency: primary reuse, bounded charges and failed admission passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/prosper/tools/perf/test_compute_buffer_timing_runtime.py
+++ b/prosper/tools/perf/test_compute_buffer_timing_runtime.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Check actual backend decisions and selectors, with full compute logging disabled.
+
+The executable verifies shader output, external-mutation repair and publication independently.
+This wrapper requires the corresponding per-owner evidence, so empty output cannot pass a
+positive arm. Each process starts with a fresh buffer cache and lazy diagnostic selectors.
+"""
+
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+PREFIX = "[compute-buffer-timing] "
+FIXTURE = "[buffer-timing-fixture] "
+BYTES = 2 << 20
+TIMERS = (
+    "setup_ms validation_ms upload_compare_ms upload_copy_ms upload_map_ms "
+    "upload_watch_ms writeback_ms result_compare_ms guest_copy_ms guest_layout_ms "
+    "result_map_ms result_watch_ms baseline_ms notify_ms source_validation_ms provenance_ms"
+).split()
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def fields(line, prefix):
+    pairs = [part.split("=", 1) for part in line[len(prefix):].split()]
+    require(all(len(pair) == 2 for pair in pairs), f"malformed record: {line}")
+    result = dict(pairs)
+    require(len(result) == len(pairs), f"duplicate fields: {line}")
+    return result
+
+
+def number(row, key):
+    return int(row[key], 0)
+
+
+def expect(row, **wanted):
+    for key, value in wanted.items():
+        key = key.replace("_", "-")
+        actual = number(row, key) if isinstance(value, int) else row[key]
+        require(actual == value,
+                f"dispatch {row['dispatch']} owner {row['owner']}: "
+                f"{key}={actual!r}, expected {value!r}")
+
+
+def check_selected(rows, witness):
+    require(len(rows) == 8, f"expected eight unique owner records, got {len(rows)}")
+    grouped = {}
+    identities = set()
+    for row in rows:
+        identity = (number(row, "submit"), number(row, "dispatch"), number(row, "owner"))
+        require(identity not in identities, f"duplicate owner record {identity}")
+        identities.add(identity)
+        dispatch = identity[1]
+        grouped.setdefault(dispatch, []).append(row)
+        expect(row, submit=3407, order=dispatch * 10, ok=1,
+               code=number(witness, "code"), hash=number(witness, "hash"),
+               owner_resolved=1, host_backed=0, host_key=0, semantic=0,
+               logical_bytes=BYTES, bytes=BYTES, guest_bytes=BYTES,
+               writable=1, atomic=0, persistent=1)
+        for timer in TIMERS:
+            value = float(row[timer])
+            require(math.isfinite(value) and value >= 0, f"invalid {timer}: {row[timer]}")
+    require(set(grouped) == set(range(1, 8)), f"wrong dispatch census: {sorted(grouped)}")
+    # A disabled clock can preserve every decision and byte counter. Require a positive measured
+    # interval over the whole workload, while allowing short individual leaf timers to round to 0.
+    for timer in ("setup_ms", "writeback_ms"):
+        require(sum(float(row[timer]) for row in rows) > 0,
+                f"positive arm collected no {timer}")
+    for dispatch in range(1, 7):
+        require(len(grouped[dispatch]) == 1, f"alias duplicated at dispatch {dispatch}")
+        expect(grouped[dispatch][0], owner=0, owner_index=0, aliases=1, bindings="0,1")
+    initial_address = number(grouped[1][0], "addr")
+    require(all(number(grouped[n][0], "addr") == initial_address for n in range(1, 7)),
+            "same-address cache sequence lost its identity")
+    cold = grouped[1][0]
+    expect(cold, cache="miss", validation="pooled-full", upload_skipped=0,
+           compared_bytes=BYTES, baseline="created",
+           gpu_compare="ineligible", writeback="changed",
+           result_compared_bytes=BYTES, guest_copied_bytes=BYTES)
+    # A fresh Vulkan allocation's initial contents are unspecified. The cold path always
+    # compares its full extent, but an already-equal allocation legitimately needs no copy.
+    require(number(cold, "uploaded-bytes") in (0, BYTES), "invalid cold upload byte count")
+    journal = grouped[2][0]
+    expect(journal, cache="hit", validation="journal", upload_skipped=1,
+           compared_bytes=0, uploaded_bytes=0, gpu_compare="unchanged",
+           writeback="gpu-unchanged", result_compared_bytes=0, guest_copied_bytes=0)
+    exact = grouped[3][0]
+    expect(exact, cache="hit", validation="full", upload_skipped=1,
+           compared_bytes=BYTES, uploaded_bytes=0, gpu_compare="unchanged",
+           writeback="gpu-unchanged", result_compared_bytes=0, guest_copied_bytes=0)
+    watched = number(witness, "watch") == 1
+    for dispatch in (4, 6):
+        row = grouped[dispatch][0]
+        expect(row, cache="hit", validation="watch" if watched else "full",
+               upload_skipped=1, compared_bytes=0 if watched else BYTES,
+               uploaded_bytes=0, gpu_compare="unchanged", writeback="gpu-unchanged",
+               result_compared_bytes=0, guest_copied_bytes=0)
+        if watched:
+            expect(row, dirty_watch_chunks=0, total_watch_chunks=2)
+    repaired = grouped[5][0]
+    expect(repaired, cache="hit", validation="dirty-chunks" if watched else "full",
+           upload_skipped=0, compared_bytes=(1 << 20) if watched else BYTES,
+           uploaded_bytes=(1 << 20) if watched else BYTES,
+           gpu_compare="ineligible", writeback="changed",
+           result_compared_bytes=BYTES, guest_copied_bytes=BYTES)
+    if watched:
+        expect(repaired, dirty_watch_chunks=1, total_watch_chunks=2)
+    separated = grouped[7]
+    require(len(separated) == 2, "distinct storage buffers must report two owners")
+    owners = {number(row, "owner"): row for row in separated}
+    require(set(owners) == {0, 1}, "distinct buffer bindings lost an owner")
+    for owner, row in owners.items():
+        expect(row, owner_index=owner, aliases=0, bindings=str(owner))
+    require(number(owners[0], "addr") == initial_address and
+            number(owners[1], "addr") != initial_address,
+            "distinct-address arm must retain the old identity and add a new one")
+    expect(owners[0], cache="hit", upload_skipped=1, writeback="gpu-unchanged")
+    expect(owners[1], cache="miss", validation="pooled-full", compared_bytes=BYTES,
+           baseline="created", writeback="changed", guest_copied_bytes=BYTES)
+
+
+def run_fixture(binary, mode, directory):
+    # These tests intentionally control diagnostic/cache policy. Preserve driver/validation
+    # settings so running the ctest under the validation-layer wrapper still validates Vulkan.
+    environment = {key: value for key, value in os.environ.items()
+                   if not key.startswith("PROSPER_COMPUTE") and
+                   key not in {"PROSPER_NO_PERSISTENT_COMPUTE_BUFFERS",
+                               "PROSPER_NO_PERSISTENT_COMPUTE_BUFFER_RESULTS"}}
+    result = subprocess.run([str(binary), mode, str(directory)], env=environment,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            text=True, timeout=120, check=False)
+    # Keep all layer messages visible to the outer suite's validation scanner, including success.
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    require(result.returncode == 0, f"{mode}: fixture failed with {result.returncode}")
+    lines = result.stderr.splitlines()
+    require(f"{FIXTURE}success mode={mode}" in lines, f"{mode}: no successful execution witness")
+    witnesses = [fields(line, FIXTURE) for line in lines
+                 if line.startswith(FIXTURE + "mode=")]
+    require(len(witnesses) == 1, f"{mode}: expected one fixture identity")
+    require(witnesses[0]["mode"] == mode, "fixture mode mismatch")
+    rows = [fields(line, PREFIX) for line in lines if line.startswith(PREFIX)]
+    if mode in ("selected", "capture-armed"):
+        check_selected(rows, witnesses[0])
+    else:
+        require(not rows, f"{mode}: rejected selector/capture gate emitted buffer records")
+    return witnesses[0]
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: test_compute_buffer_timing_runtime.py FIXTURE_EXECUTABLE")
+    binary = Path(sys.argv[1]).resolve(strict=True)
+    with tempfile.TemporaryDirectory(prefix="compute-buffer-timing-") as scratch:
+        witnesses = []
+        for mode in ("selected", "wrong-code", "wrong-hash", "disabled",
+                     "capture-idle", "capture-armed"):
+            directory = Path(scratch) / mode
+            directory.mkdir()
+            witnesses.append(run_fixture(binary, mode, directory))
+        require(len({row["hash"] for row in witnesses}) == 1,
+                "selector controls did not execute the same compiled guest shader")
+    print("compute buffer runtime: owner decisions and six selector/capture arms passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/prosper/tools/perf/test_compute_buffer_timing_runtime.py
+++ b/prosper/tools/perf/test_compute_buffer_timing_runtime.py
@@ -127,6 +127,56 @@ def check_selected(rows, witness):
            baseline="created", writeback="changed", guest_copied_bytes=BYTES)
 
 
+def check_promotion(rows, witness):
+    require(len(rows) == 9, f"expected nine promotion owner records, got {len(rows)}")
+    indexed = {number(row, "dispatch"): row for row in rows}
+    require(set(indexed) == set(range(1, 10)), "duplicate/missing promotion dispatch")
+    cpu_result = witness["mode"] == "promotion-cpu"
+    watched = number(witness, "watch") == 1
+    address = number(indexed[1], "addr")
+    for dispatch, row in indexed.items():
+        expect(row, submit=3407 + dispatch, order=dispatch * 10, ok=1,
+               code=number(witness, "code"), hash=number(witness, "hash"),
+               addr=address, owner=0, owner_index=0, owner_resolved=1,
+               aliases=1, bindings="0,1", host_backed=0, host_key=0, semantic=0,
+               logical_bytes=BYTES, bytes=BYTES, guest_bytes=BYTES,
+               writable=1, atomic=0, persistent=1)
+        for timer in TIMERS:
+            require(math.isfinite(float(row[timer])) and float(row[timer]) >= 0,
+                    f"invalid {timer}: {row[timer]}")
+        changed = dispatch in (1, 3, 8)
+        expect(row, cache="miss" if dispatch == 1 else "hit",
+               upload_skipped=0 if changed else 1,
+               writeback="changed" if changed else "unchanged" if cpu_result else "gpu-unchanged",
+               gpu_compare="ineligible" if changed or cpu_result else "unchanged",
+               result_compared_bytes=BYTES if changed or cpu_result else 0,
+               guest_copied_bytes=BYTES if changed else 0)
+        if cpu_result:
+            expect(row, baseline="disabled")
+        if dispatch == 1:
+            expect(row, validation="pooled-full", compared_bytes=BYTES)
+            if not cpu_result:
+                expect(row, baseline="created")
+            require(number(row, "uploaded-bytes") in (0, BYTES), "invalid cold upload bytes")
+        elif dispatch == 8 and watched:
+            expect(row, validation="dirty-chunks", dirty_watch_chunks=1, total_watch_chunks=2,
+                   compared_bytes=1 << 20, uploaded_bytes=1 << 20)
+        elif dispatch in (7, 9) and watched:
+            expect(row, validation="watch", dirty_watch_chunks=0, total_watch_chunks=2,
+                   compared_bytes=0, uploaded_bytes=0)
+        else:
+            expect(row, validation="full", compared_bytes=BYTES,
+                   uploaded_bytes=BYTES if changed else 0)
+            if watched:
+                # 2: first unchanged validation; 3: mutation resets the ladder. 4 and 5
+                # accumulate two new validations. 6 arms before its third full comparison;
+                # the setup census still saw zero preexisting watches on that acquisition.
+                expect(row, dirty_watch_chunks=0, total_watch_chunks=0)
+    for timer in ("setup_ms", "writeback_ms"):
+        require(sum(float(row[timer]) for row in rows) > 0,
+                f"promotion arm collected no {timer}")
+
+
 def run_fixture(binary, mode, directory):
     # These tests intentionally control diagnostic/cache policy. Preserve driver/validation
     # settings so running the ctest under the validation-layer wrapper still validates Vulkan.
@@ -150,6 +200,8 @@ def run_fixture(binary, mode, directory):
     rows = [fields(line, PREFIX) for line in lines if line.startswith(PREFIX)]
     if mode in ("selected", "capture-armed"):
         check_selected(rows, witnesses[0])
+    elif mode in ("promotion", "promotion-cpu"):
+        check_promotion(rows, witnesses[0])
     else:
         require(not rows, f"{mode}: rejected selector/capture gate emitted buffer records")
     return witnesses[0]
@@ -161,14 +213,20 @@ def main():
     binary = Path(sys.argv[1]).resolve(strict=True)
     with tempfile.TemporaryDirectory(prefix="compute-buffer-timing-") as scratch:
         witnesses = []
+        errors = []
         for mode in ("selected", "wrong-code", "wrong-hash", "disabled",
-                     "capture-idle", "capture-armed"):
+                     "capture-idle", "capture-armed", "promotion", "promotion-cpu"):
             directory = Path(scratch) / mode
             directory.mkdir()
-            witnesses.append(run_fixture(binary, mode, directory))
+            try:
+                witnesses.append(run_fixture(binary, mode, directory))
+            except AssertionError as error:
+                # Run both promotion implementations even when the first exposes a defect.
+                errors.append(f"{mode}: {error}")
+        require(not errors, "\n".join(errors))
         require(len({row["hash"] for row in witnesses}) == 1,
                 "selector controls did not execute the same compiled guest shader")
-    print("compute buffer runtime: owner decisions and six selector/capture arms passed")
+    print("compute buffer runtime: owner decisions, six selectors and two promotion arms passed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Optional exact-result baselines share the persistent compute-buffer budget with primary buffers. Under pressure they evict a reusable primary working set, causing repeated uploads, comparisons and baseline creation. Preserve primaries by reclaiming unpinned baselines first and admitting new baselines only from spare capacity. Preflight impossible admission before discarding anything; preserve existing owner pins and the 256 MiB requested-residency cap.

Unchanged writable publication now preserves watch-promotion progress earned by exact source validation without counting it twice. Changed content still resets it, and watches are armed before exact comparison. Capture-gated per-owner diagnostics identify aliases, actual validation/copy decisions, timing and requested allocation charges without additional content scans.

The selected Sonic buffer population changes from 152 misses to 180 hits with write-watch validation. Using identical five-owner baseline weights, setup plus writeback falls 2.92432→1.21464 ms (58.46%) in this diagnostic pair. Full result comparisons remain expensive. This is a shared cache policy with no title-specific behavior; no newly rendered FPS or full-library speedup is claimed.

Validation:

- Complete local build and **392/392 CTest tests pass** (`ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure`).
- Both production buffer fixtures pass Vulkan core and synchronization validation with **zero messages**, after layer-load and deliberate-hazard controls. Cases cover default promotion, GPU/CPU result equality, guest mutation, alias ownership, actual allocation requirements, working-set pressure, pinned owners and impossible partial reclamation.
- Original code fails the warm-residency and default-promotion guards. Removing only preflight fails the partial-reclamation guard; all mutations were restored before final validation.
- Sonic/GTA captures and native Worms compatibility checks complete. Sonic’s known title/cloud/modal defects reproduce on both versions and remain in #2206. GTA’s presentation rate is unchanged. Worms has no compute records in its sample. Blue Prince’s candidate F9 reaches the entrance hall while the reference F9 shows the opening movie; the owner watched the candidate movie and confirmed it looked perfect. That pair is explicitly excluded from performance comparisons.
- All seven required Linux/general CI checks pass. Windows MinGW retains the unrelated `session_start` failure tracked in #3426. Windows/macOS completion is outside the user’s required merge gate.

Exact source/binary identities, commands, controls, audio observations and limits are recorded in the [author verification](https://github.com/mattias800/prosper/pull/3440#issuecomment-5575361418). Audio remains independently measured per output; no audio improvement or hardware-XRUN claim is made.

Refs #3407, #3155. Both remain open for their wider scopes.
