### PR TITLE
Derive the session-start worktree root relatively instead of from git path output

### DIFF
--- a/prosper/tools/session_start.py
+++ b/prosper/tools/session_start.py
@@ -35,8 +35,13 @@ def git(repo: Path, *args: str, allow_missing: bool = False, deadline: float) ->
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise Unverified("Git unavailable or timed out while checking " + args[0]) from exc
     if result.returncode and not allow_missing:
-        # Do not echo a remote URL, credential-helper output, or local instruction contents.
-        raise Unverified("Git could not verify " + args[0])
+        # Name the whole subcommand and its exit status, never git's stderr: the arguments are
+        # this file's own literals, while stderr can carry a remote URL, credential-helper
+        # output, or instruction contents. Reporting only args[0] was not enough to act on --
+        # three distinct calls here are "rev-parse", and #3443 cost an investigation to tell
+        # which one had failed.
+        raise Unverified("Git could not verify " + " ".join(args)
+                         + " (exit " + str(result.returncode) + ")")
     return result.stdout if result.returncode == 0 else b""
 
 
@@ -46,7 +51,16 @@ def inspect(repo: Path, offline: bool = False) -> tuple[int, str]:
     def checked(*args, **kwargs):
         return git(*args, deadline=deadline, **kwargs)
     try:
-        root = Path(os.fsdecode(checked(repo, "rev-parse", "--show-toplevel").strip()))
+        # Ask for the root RELATIVELY. Git answers path queries in its own build's path
+        # flavour, and an absolute answer does not survive the trip back: the MSYS2 git the
+        # Windows CI job installs replies to --show-toplevel in POSIX form (/c/Users/...),
+        # which native Python reads as the drive-relative \c\Users\... -- a path neither
+        # Python nor that same git can then resolve, so every later -C missed the repository
+        # and the check reported UNVERIFIED on every platform pairing but its own (#3443).
+        # --show-cdup is relative ("../.." or empty), so the absolute path stays the
+        # caller's and never changes flavour.
+        cdup = os.fsdecode(checked(repo, "rev-parse", "--show-cdup").strip())
+        root = Path(repo, cdup).resolve()
         head = checked(root, "rev-parse", "HEAD").decode().strip()
         branch = checked(root, "symbolic-ref", "--quiet", "--short", "HEAD",
                      allow_missing=True).decode().strip() or "(detached)"

--- a/prosper/tools/test_session_start.py
+++ b/prosper/tools/test_session_start.py
@@ -155,5 +155,37 @@ class StartupTest(unittest.TestCase):
             run.assert_not_called()
 
 
+    def test_git_path_output_is_never_used_as_a_filesystem_path(self):
+        # An MSYS2/Cygwin git answers path queries in POSIX form (/c/Users/...), which native
+        # Windows Python reads back as the drive-relative \c\Users\... and which that same git
+        # then rejects. A check that round-trips its own root through git's path flavour loses
+        # the repository on exactly the pairing the Windows CI job runs (#3443).
+        #
+        # The poisoned answer is built BY HAND rather than taken from the git on this host,
+        # whose flavour happens to survive the trip: a control drawn from the same source as
+        # the null it validates cannot express the case being tested for.
+        real = PROBE.subprocess.run
+        consulted = []
+
+        def poisoned(argv, **kwargs):
+            if "--show-toplevel" in argv:
+                consulted.append(argv)
+                return subprocess.CompletedProcess(argv, 0, b"/c/nonexistent/checkout\n", b"")
+            return real(argv, **kwargs)
+
+        with patch.object(PROBE.subprocess, "run", side_effect=poisoned):
+            status, report = PROBE.inspect(self.repo)
+        # The damage first, then the contract that prevents it: a check that consults the
+        # poisoned answer reports UNVERIFIED on a checkout that is perfectly current.
+        self.assertEqual(status, 0, report)
+        self.assertIn("OK:", report)
+        self.assertEqual(consulted, [], "the worktree root must not come from git path output")
+
+    def test_root_is_found_from_a_subdirectory(self):
+        # The relative derivation that replaced --show-toplevel still has to climb: this is the
+        # only arm where the cdup is non-empty, so it is what proves the join is right.
+        self.assertIn("OK:", self.check(0, repo=self.repo / "prosper/tools"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #3443. Every `main` CI run since 883dbc8b (#3421) has been red on **Windows MinGW**, test 31 `session_start`, 8 of 12 subtests. It has never been green on Windows.

## Failure scenario

`session_start.py` round-tripped its own worktree root through git:

```python
root = Path(os.fsdecode(checked(repo, "rev-parse", "--show-toplevel").strip()))
```

Git answers path queries in its own build's path flavour, and an absolute answer does not survive the trip back on the pairing this job runs. The Windows MinGW job installs the **msys-flavour** `git` package (`git-2.55.0-1`) while CMake finds a **native Windows** Python. Measured on a Windows host with an msys2 binary:

```
msys pwd from a Windows cwd -> /c/Users/.../ps5ys/prosper
Path(that)                  -> cUsers...ps5ysprosper   # drive-relative
exists?                     -> False

cUsersmattirepos  -> rc 2  /usr/bin/ls: cannot access ...: No such file or directory
/c/Users/matti/repos      -> rc 0
C:Usersmattirepos   -> rc 0
```

So `root` became a path neither Python nor that same git could resolve, and the very next call (`rev-parse HEAD`) returned non-zero — before any line was appended to the report. That is why the CI log carried only `UNVERIFIED:` and no `Checkout:` line.

Linux is POSIX python + POSIX git (consistent) and a local Windows checkout uses Git-for-Windows (mingw-flavour, answers `C:/Users/...`, which round-trips). Only the msys-git + native-python pair breaks, which is exactly the CI job.

## Approach and invariant

`--show-cdup` answers **relatively** (`"../.."` or empty), so the absolute path stays the caller's and never changes flavour:

```python
cdup = os.fsdecode(checked(repo, "rev-parse", "--show-cdup").strip())
root = Path(repo, cdup).resolve()
```

The invariant: **no absolute path crosses the process boundary from git back into Python.**

Also makes the diagnostic actionable — it now names the whole subcommand and its exit status. Three distinct calls here are `rev-parse`, and reporting only `args[0]` is what made the CI log unreadable; diagnosing this needed a bisect of CI history rather than a glance. Git's **stderr is still never echoed**: the arguments are this file's own literals, while stderr can carry a remote URL, credential-helper output, or instruction contents.

## Tests

Two arms added.

`test_git_path_output_is_never_used_as_a_filesystem_path` poisons exactly the `--show-toplevel` answer with a Cygwin-style absolute path and asserts the check still reports `OK:`. The poison is **built by hand**, not taken from the git on the host — a control drawn from the same source as the null cannot express the case being tested, since this host's git answers in a flavour that happens to survive the trip.

Verified it fails without the fix, reproducing the CI symptom on a non-MSYS host:

```
$ python prosper/tools/test_session_start.py StartupTest.test_git_path_output_is_never_used_as_a_filesystem_path
AssertionError: 2 != 0 : UNVERIFIED: Git could not verify rev-parse
FAILED (failures=1)
```

and passes with it.

`test_root_is_found_from_a_subdirectory` is the only arm where the cdup is non-empty, so it is what proves the join is right.

Note the four subtests that were *passing* on Windows were passing **vacuously**: they assert exit 2, which the broken tool returned for the wrong reason.

## Results

`python prosper/tools/test_session_start.py` on Windows: **14 tests, 6 failures**, identical to the 6 on unmodified `main` on this host. All six are `hook()` arms, and the cause is local and pre-existing: the shipped hook command is `python3`, which on a bare Windows host resolves to the Microsoft Store stub (`9009 != 0 : Python was not found`). CI has `python3` on PATH. Both new arms pass.

`git diff --check` clean; CRLF preserved (17/3 and 32/0 numstat, no whole-file EOL churn).

## Unaffected

Behaviour on Linux and macOS is unchanged — `--show-cdup` and `--show-toplevel` agree there. No other caller reads git path output; no docs referenced `--show-toplevel`.

## Risk

Low, and confined to one tool that is read-only by construction. The one behaviour change beyond the fix is a longer failure string, which no test matches on beyond the `UNVERIFIED:` prefix.