### PR TITLE
Record Grand Theft Auto V at rung 3 — the world has rendered since #2996

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ For anything title- or subsystem-specific, use the table in the next section rat
 
 ## Where the project stands (2026-08-17)
 
-`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 49 tracked titles
+`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 54 tracked titles
 at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
 whatever you are about to touch. This section is a map, not a status report. Long-lived `tracker:game`
 issues and their comments carry each active title's current development rung, route, blockers and
@@ -136,7 +136,7 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | *The House of the Dead 2: Remake* `PPSA24203` | rung 3 — a fresh-save route reaches Training 1 with real GPU draws through the normal full-cadence renderer; severe world-rendering defects remain (#1907) | `docs/HOUSE_OF_THE_DEAD_2_STATUS.md` |
 | *Sonic Frontiers* `PPSA03831` | **rung 2** — a route reaches Cyber Space gameplay in the guest but the world is black behind the HUD (#2790), which is rung 2 under the rendering bar; 4K opening sequence, auto-save notice, title screen and main menu on a default launch. The four-session black-screen wall was one unregistered NID answering `SCE_OK`: `sceSaveDataTransferringMountPs4` (#2023). The menu heading draws the wrong string (#2206) | `docs/SONIC_FRONTIERS_STATUS.md` |
 | *Sonic Racing: CrossWorlds* `PPSA08804` | rung 2 — a pulsed pad route reaches the complete 4K title screen and profile menu; the profile panel is black and the sequence later holds on white (#2013 / #2358 / #2360) | `docs/SONIC_CROSSWORLDS_STATUS.md` |
-| *Grand Theft Auto V* `PPSA04263` | **rung 2** — the guest reaches routed gameplay entry with real GPU draws, but the world does not render, and rung 3 requires the scene to render; the HUD, radar and tutorial text render over an absent 3D world. **The missing world is now one compute program**: `0x413dc6700` hangs the GPU into a RADV hard recovery, which disables live compute process-wide and drops every later indirect draw; skipping it (`PROSPER_COMPUTE_SKIP_PROGRAM`) yields 0 device losses and the first real scene content. The descriptor-array lift is complete, and the recompiler is **not** the frontier — 16 of 20 "unsupported" programs recompile cleanly | `docs/GTA5_STATUS.md` (read its `## Ruled out`, including the *void, not falsified* subsection), tracker #1873, issue #2481 |
+| *Grand Theft Auto V* `PPSA04263` | **rung 3** — the prologue bank heist renders in full colour with the HUD and radar over it, on a default launch. **The world renders only in the game's own Performance graphics mode**, chosen from the landing menu before the world loads; the default is Fidelity, where a run started straight into Story shows the HUD over a dark scene and looks exactly like a renderer regression — a route property, not a build property. Route: `scripts/gta5/reach-performance-story.pad`. **This row said "rung 2, the world does not render" for twelve days after #2996 made it render**, and on 2026-08-29 a user reporting a regression was told from a stale document that it had never worked — read `GTA5_STATUS.md`, which is authoritative for this title, before quoting this row. The frontier is now **framerate**, not the picture. The descriptor-array lift is complete, and the recompiler is **not** the frontier — 16 of 20 "unsupported" programs recompile cleanly | `docs/GTA5_STATUS.md` (read its `## Ruled out`, including the *void, not falsified* subsection), tracker #1873, issues #2542 / #2690 (#2481 is closed and superseded) |
 | *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 6 / rung 6 / rung 1 — GRIS and Cobra are guarded, not merely playable: reviewed `gris-gameplay` / `cobra-gameplay` entries in `tools/snapshot/snapshots.json` (trackers #1869 / #1870). Sonic's black startup loop is fixed (#1905: `sceSaveDataCreateTransactionResource` must return a positive resource id); it renders the 4K SEGA logo and then decoded 4K movie frames, with **no title screen observed** — the old "holds on white to the end" reading is falsified since #2571 made videodec2 decode by default. **#1871's issue *body* still says rung 0 — its 2026-08-17 comment corrects that to rung 1; read the comment thread, not the body** | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
 | Concurrent title work | the 2026-07-31 lane allocation is historical; use live issue claims for ownership and the dated checkpoint for the current cross-lane handoff | `docs/GAME_COMPAT_ORCHESTRATION.md` |
 | *Tactics Ogre: Reborn* `PPSA03839` | rung 3 — gameplay reached; HEVC movies render, sprite/HUD composition remains open | `docs/TACTICS_OGRE_STATUS.md` |
@@ -552,8 +552,8 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
      saying so: it has genuinely got further than a title stuck at a menu, and the *text* is what
      carries that, not the number. The bar is "somewhat correct rendering", deliberately loose:
      a scene a person would recognise as the game. Degraded still counts (*Syberia: Remastered*'s
-     composite, *The House of the Dead 2*'s world defects); absent does not (*Grand Theft Auto V*,
-     *Sonic Frontiers*). Rung 4 remains the stricter "a human confirms it looks right".
+     composite, *The House of the Dead 2*'s world defects); absent does not (*Sonic Frontiers*).
+     Rung 4 remains the stricter "a human confirms it looks right".
   4. **Manual visual verification** — the user plays it and confirms by eye that it looks right.
   5. **Oracle comparison** — reference screenshots from PS5 hardware, compared against routed
      captures for visual correctness.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -36,7 +36,7 @@ Last updated: 2026-08-28
 | *Sonic Racing: CrossWorlds* | `PPSA08804` | Unreal Engine 5 | 🔬 4K title screen and menus with a pad route; needs input to advance past the logos | [#1895](https://github.com/mattias800/prosper/issues/1895) |
 | *Terminator 2D: NO FATE* | `PPSA25872` | Unity / IL2CPP | ✅ Main menu and attract-mode gameplay | [#1872](https://github.com/mattias800/prosper/issues/1872) |
 | *Blue Prince* | `PPSA25009` | Unity | 🚧 Manor entrance-hall gameplay | [#1808](https://github.com/mattias800/prosper/issues/1808) |
-| *Grand Theft Auto V* | `PPSA04263` | RAGE | 🚧 Story Mode reached in the guest; HUD and radar render over an absent 3D world | [#1873](https://github.com/mattias800/prosper/issues/1873) |
+| *Grand Theft Auto V* | `PPSA04263` | RAGE | 🚧 Rung 3 — the prologue bank heist renders in full colour, on a default launch with the game's own **Performance** graphics mode chosen from the landing menu (the default is Fidelity, where the world stays dark — a route property, not a build property) | [#1873](https://github.com/mattias800/prosper/issues/1873) |
 | *Dragon Quest VII Reimagined* | `PPSA17942` | Unreal Engine 4 | 🚧 Rung 3 — **the field state in Pilchard Bay**: minimap, party block, area banner and the player character, 144 frames over 588 s. Locomotion is measured, not inferred: the minimap changes in **8 of 8** stick windows against **0 of 8** neutral. The blocker was never a control but the route's patience — the opening chapter needs ~450 confirms, and routes giving it ~40 reached the field **zero** times. **Geometry and the 2D/UI path are correct; the lit-material shading is not** — buildings, cliffs and the boat blow to white while the water crushes dark, and 25% (run 3) to 56% (run 4) of field frames render a recognisable scene (#1486 / #1588). Route: `scripts/dragon-quest-vii/reach-field-control.pad` | [#1874](https://github.com/mattias800/prosper/issues/1874) |
 | *Alex Kidd in Miracle World DX* | `PPSA02664` | Unity / IL2CPP | ✅ First-level gameplay | [#1875](https://github.com/mattias800/prosper/issues/1875) |
 | *New Joe &amp; Mac: Caveman Ninja* | `PPSA02801` | Unity / IL2CPP | ✅ Level 1 gameplay | [#1876](https://github.com/mattias800/prosper/issues/1876) |
@@ -84,7 +84,7 @@ Last updated: 2026-08-28
 
 Derived from the table above by reading each row's **milestone text** against the six-rung bring-up
 ladder in `CLAUDE.md`. It is *not* derived from the ✅/🚧/🔬 markers, which are not a rung scale:
-twelve of the twenty-five titles that reach gameplay are marked 🚧 rather than ✅, and the fifteen 🔬
+fourteen of the twenty-seven titles that reach gameplay are marked 🚧 rather than ✅, and the fifteen 🔬
 rows sit at three different rungs — four at rung 2, three at rung 1 and eight at rung 0 — with none
 unrun. Counting markers gives a different — and wrong — answer.
 
@@ -94,8 +94,8 @@ unmeasured title is never mistaken for a failing one; newly tracked titles start
 
 | Where the title stops | Titles |
 | --- | --- |
-| **Gameplay reached**, with the scene rendering (rung 3 or better) | 26 |
-| **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 17 |
+| **Gameplay reached**, with the scene rendering (rung 3 or better) | 27 |
+| **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 16 |
 | **Below a title screen** — logo or splash only (rung 1) | 3 |
 | **Boots, but no frame with content** (rung 0) | 8 |
 | **Not yet booted** — tracked, no run attempted yet | 0 |
@@ -124,22 +124,28 @@ folding it into rung 0 would have been wrong in both directions.
 **Rung 3 requires the gameplay scene to actually render, not merely to be reached.** The bar is
 deliberately loose — a scene a person would recognise as the game — so *degraded* still counts:
 *Syberia: Remastered*'s composite is degraded and *The House of the Dead 2*'s world carries severe
-defects, and both are rung 3. **Absent does not count.** *Grand Theft Auto V* and *Sonic Frontiers*
-each reach the game loop in the guest, with a correct HUD over a world that never draws; both are
-**rung 2**, and their milestone text says what they reached. They have genuinely got further than a
-title stuck at a menu — the text carries that, not the number.
+defects, and both are rung 3. **Absent does not count.** *Sonic Frontiers* reaches the game loop in
+the guest with a correct HUD over a world that never draws, so it is **rung 2**, and its milestone
+text says what it reached. It has genuinely got further than a title stuck at a menu — the text
+carries that, not the number.
+
+*Grand Theft Auto V* was the second title in this paragraph until 2026-08-26, when #2996 made its
+world render; it is now rung 3. The lag is the point. `GTA5_STATUS.md` had been correct for days
+while this file, `CLAUDE.md` and the tracker body all still said the world was absent, and on
+2026-08-29 a user who reported a regression was told from a stale document that it had never
+worked. **A rung claim outside the title's own status doc is the copy most likely to be stale.**
 
 ### Where the titles accumulate
 
-The 17 titles at rung 2 — a title screen or menu, or gameplay reached without a rendered world — by
+The 16 titles at rung 2 — a title screen or menu, or gameplay reached without a rendered world — by
 the engine recorded in the table:
 
 | Engine | Titles |
 | --- | --- |
 | Unreal Engine — 10 × UE4, 1 × UE5, 1 unversioned | 12 |
-| Hedgehog Engine, Hedgehog Engine 2, RAGE, Custom (Ancient), ASOBI — one each | 5 |
+| Hedgehog Engine, Hedgehog Engine 2, Custom (Ancient), ASOBI — one each | 4 |
 
-**Unreal dominates this group, and it no longer accounts for all of it.** Twelve of the 17 rung-2
+**Unreal dominates this group, and it no longer accounts for all of it.** Twelve of the 16 rung-2
 rows are Unreal, against 18 Unreal rows in the table overall — the other six are one at gameplay
 (*Dragon Quest VII Reimagined*, whose world renders), two at rung 1 (*Little Nightmares II* and
 *Beast of Reincarnation*) and three at rung 0 (*The Lord of the Rings: Gollum*, *The First Berserker:
@@ -148,8 +154,8 @@ is not true in either direction: one has passed it and five have not reached it.
 
 The distribution on the other side is the mirror image: the titles at gameplay are overwhelmingly
 Unity-family, and **no Unity title remains at rung 2 for want of a rendered world.** The rung-2 group
-is twelve Unreal titles plus *Sonic Origins*, *Earthion*, *Astro Bot*, and the two that reach the
-game loop without a world, *Grand Theft Auto V* and *Sonic Frontiers*.
+is twelve Unreal titles plus *Sonic Origins*, *Earthion*, *Astro Bot*, and the one that reaches the
+game loop without a world, *Sonic Frontiers*.
 
 **This is an observation about where titles accumulate, not a claim that the twelve Unreal titles
 share one root cause** — and this is no longer merely an untested hypothesis in either direction.
@@ -356,11 +362,20 @@ The manor entrance hall renders with real 3D gameplay content. See the [tracker]
 
 <p align="center"><img src="assets/screenshots/gta5-title.webp" alt="Grand Theft Auto V — title screen"></p>
 <p align="center"><img src="assets/screenshots/gta5-main-menu.webp" alt="Grand Theft Auto V — main menu"></p>
+<p align="center"><img src="assets/screenshots/gta5-prologue-bank-restored.webp" alt="Grand Theft Auto V — the prologue bank interior in full colour, the masked gunman in a red plaid shirt, water cooler, holiday cards and radar"></p>
 
-The title and STORY/ONLINE main menu render. A checked-in pad route also reaches Story Mode gameplay:
-the HUD, radar and tutorial text are visible, but the 3D world is still black. See the
-[tracker](https://github.com/mattias800/prosper/issues/1873) and the exact compute-failure census in
-[#2481](https://github.com/mattias800/prosper/issues/2481).
+The title and STORY/ONLINE main menu render, and since [#2996](https://github.com/mattias800/prosper/pull/2996)
+(2026-08-26) **so does the world**: the checked-in route reaches the prologue bank heist and it draws in
+full colour, with the HUD and radar over it.
+
+**The world renders only in the game's own Performance graphics mode**, chosen from the landing menu
+before the world loads; the default is Fidelity, where a run started straight into Story shows the HUD
+over a dark scene and looks exactly like a renderer regression. That is a route property, not a build
+property. Framerate is the open frontier, not the picture. See
+[`docs/GTA5_STATUS.md`](prosper/docs/GTA5_STATUS.md), which is authoritative for this title, and the
+[tracker](https://github.com/mattias800/prosper/issues/1873). The compute-failure census in #2481 is
+closed and superseded by [#2542](https://github.com/mattias800/prosper/issues/2542) and
+[#2690](https://github.com/mattias800/prosper/issues/2690).
 
 ## Dragon Quest VII Reimagined — `PPSA17942`
 


### PR DESCRIPTION
Refs #1873. Documentation only.

## What was stale

`prosper/docs/GTA5_STATUS.md` has said **rung 3, world renders** since [#2996](https://github.com/mattias800/prosper/pull/2996) merged on 2026-08-26. Three documents a reader reaches *first* still said the world was absent:

| Document | Said | Actually |
| --- | --- | --- |
| `prosper/docs/GTA5_STATUS.md` | rung 3, world renders | correct, unchanged by this PR |
| `CLAUDE.md` table row | "**rung 2** ... the world does not render" | stale 12 days |
| `COMPATIBILITY.md` row + 6 further places | "🚧 HUD and radar render over an absent 3D world" | stale 12 days |
| tracker #1873 body | "Rung 2 ... the world does not draw" | stale 12 days (comment posted separately) |

The lag has already cost something concrete, and `GTA5_STATUS.md` records it in its own header: on **2026-08-29 a user reported the world had regressed and was told from a stale document that it had never worked.** The project owner raised it again today, which is what prompted this.

## Counts

Moving one title between buckets changes seven derived figures. **Every bucket was re-derived by classifying each of the 54 table rows against the ladder, not by decrementing the printed figure** — that independent pass reproduced the existing **26 / 17 / 3 / 8 (= 54)** exactly, which is what makes the single move safe to apply:

- gameplay-with-scene **26 → 27**; rung 2 **17 → 16** (total 54 unchanged)
- rung-2 engine table loses its RAGE entry, **5 → 4** (12 Unreal + 4 = 16 ✓)
- "The **17** titles at rung 2" → 16; "Twelve of the **17** rung-2 rows" → "of the 16"
- the rung-2 group list loses its second game-loop-without-a-world title, leaving *Sonic Frontiers* alone
- the ladder's worked example of "absent does not count" (both files) no longer names this title

Two figures were **already wrong before this change** and are corrected in passing:

- `COMPATIBILITY.md`: *"twelve of the twenty-five titles that reach gameplay are marked 🚧"* — counting the rows gives thirteen of twenty-six today, and fourteen of twenty-seven after this move.
- `CLAUDE.md`: *"49 tracked titles"* against a table that lists **54**.

I also verified the 🔬 breakdown ("fifteen rows — four at rung 2, three at rung 1, eight at rung 0") against the rows; it is correct and unaffected.

## What is preserved

The nuance that makes this title easy to misread, in both files: **the world renders only in the game's own Performance graphics mode**, chosen from the landing menu before the world loads. The default is Fidelity, where a run started straight into Story shows the HUD over a dark scene and *looks exactly like a renderer regression*. That is a route property, not a build property — and it is almost certainly what the 2026-08-29 report was.

The `COMPATIBILITY.md` section now shows `gta5-prologue-bank-restored.webp`, already checked in and already blogged (2026-08-26), so no new image is added and no `BLOG.md` entry is due.

Both files keep a one-line note recording that the claim was stale and for how long. A rung claim outside a title's own status doc is the copy most likely to be stale, and this is the second time this title has demonstrated it.

## Verification

- `git diff --name-only origin/main...HEAD` is `.md`-only (`CLAUDE.md`, `COMPATIBILITY.md`).
- `check_numbered_table.py` over every tracked `.md`: **PASS**, all files unbroken. `GAME_COMPAT_ORCHESTRATION.md` is untouched, so no `--baseline` / merge-result concern.
- `git diff --check` clean; CRLF preserved (0 bare LF in both files).
- Frontier claim independently confirmed: `gh pr view 2996` reports `MERGED 2026-08-26`, and a run on `main` (`93a0a506`) tonight on Windows rendered 2,644 frames with the scene drawing correctly, visually confirmed by the project owner.

## Deliberately not changed

The rung stays at **3**, matching `GTA5_STATUS.md`. Tonight's visual confirmation by the owner is arguably rung 4 evidence, but promoting a rung is a judgment call for the title's owner and is left to them rather than taken here.