### PR TITLE
Print every compute timer the capture carries, with the remainder named

### DIFF
--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -694,6 +694,11 @@ def print_summary(summary):
             cpu_parts.append(f"unattributed={unattributed:.1f}ms")
         gpu_parts = []
         for field in COMPUTE_GPU_BRACKETS:
+            # One-sided deliberately, unlike the CPU loop above. These are masked differences of
+            # GPU tick counters, so an out-of-order pair does not go negative -- it WRAPS to an
+            # enormous positive, which this threshold cannot hide and abs() would not help with.
+            # The summary table's shared abs() makes such a value loud instead: an injected
+            # storage-copy of 500ms against a 65ms device prints 769.2% with a -684.6% remainder.
             if group.get(field, 0.0) >= 0.05:
                 gpu_parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
         sections = []

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -224,6 +224,52 @@ def _resource_breakdown(renderer):
     return breakdown
 
 
+# The eleven per-dispatch compute timers the capture records, split by what they bracket.
+# `dispatch_wait_ms` is CPU wall time around the submit; the GPU brackets below decompose the
+# device work inside it, so the two groups are siblings and must not be summed together.
+#
+# Every one of these is written by performance_capture.cpp. This tool used to print five of them,
+# and the ones it dropped were repeatedly the largest -- `pipeline_ms` was 66% of one window and
+# `gpu_storage_copy_ms` was 88% of device time in two others, neither visible in the output
+# (#3447). A report that silently drops a bucket steers optimisation by the part it happens to
+# show, so everything the record carries is printed, and any remainder is named rather than left
+# to be inferred by subtraction.
+COMPUTE_CPU_PHASES = (
+    "setup_ms",
+    "pipeline_ms",
+    "dispatch_wait_ms",
+    "writeback_ms",
+    "cleanup_ms",
+)
+
+COMPUTE_GPU_BRACKETS = (
+    "gpu_pre_ms",
+    "gpu_shader_ms",
+    "gpu_storage_copy_ms",
+    "gpu_compare_ms",
+    "gpu_restore_ms",
+)
+
+# Short labels for the one-line breakdowns; the long names stay in the JSON.
+PHASE_LABELS = {
+    "setup_ms": "setup",
+    "pipeline_ms": "pipeline",
+    "dispatch_wait_ms": "wait",
+    "writeback_ms": "wb",
+    "cleanup_ms": "cleanup",
+    "gpu_pre_ms": "pre",
+    "gpu_shader_ms": "shader",
+    "gpu_storage_copy_ms": "storage-copy",
+    "gpu_compare_ms": "compare",
+    "gpu_restore_ms": "restore",
+}
+
+
+def _phase_totals(records, fields):
+    """Sum `fields` over `records`, returning a plain dict so callers can add derived rows."""
+    return {field: sum(float(record.get(field, 0.0)) for record in records) for field in fields}
+
+
 def _hex64(value):
     return f"0x{value:016x}"
 
@@ -245,19 +291,20 @@ def _compute_program_groups(records, limit=10, address_limit=8):
             continue
         group = groups.setdefault(program_hash, {
             "records": 0, "dispatches": 0, "total_ms": 0.0, "max_ms": 0.0,
-            "setup_ms": 0.0, "writeback_ms": 0.0, "dispatch_wait_ms": 0.0,
-            "gpu_device_ms": 0.0, "gpu_shader_ms": 0.0,
             "addresses": set(),
+            **{field: 0.0 for field in COMPUTE_CPU_PHASES},
+            **{field: 0.0 for field in COMPUTE_GPU_BRACKETS},
+            "gpu_device_ms": 0.0,
         })
         group["records"] += 1
         group["dispatches"] += dispatches
         group["total_ms"] += total_ms
         group["max_ms"] = max(group["max_ms"], total_ms)
-        group["setup_ms"] += float(record.get("setup_ms", 0.0))
-        group["writeback_ms"] += float(record.get("writeback_ms", 0.0))
-        group["dispatch_wait_ms"] += float(record.get("dispatch_wait_ms", 0.0))
+        for field in COMPUTE_CPU_PHASES:
+            group[field] += float(record.get(field, 0.0))
+        for field in COMPUTE_GPU_BRACKETS:
+            group[field] += float(record.get(field, 0.0))
         group["gpu_device_ms"] += float(record.get("gpu_device_ms", 0.0))
-        group["gpu_shader_ms"] += float(record.get("gpu_shader_ms", 0.0))
         group["addresses"].add(address)
 
     ranked = []
@@ -515,6 +562,9 @@ def summarize(records):
         "rates": rates,
         "graphics_total_ms": graphics_total,
         "compute_total_ms": compute_total,
+        "compute_cpu_phases": _phase_totals(compute, COMPUTE_CPU_PHASES),
+        "compute_gpu_brackets": _phase_totals(compute, COMPUTE_GPU_BRACKETS),
+        "compute_gpu_device_ms": _total(compute, "gpu_device_ms"),
         "compute_programs": compute_programs,
         "gpu_timestamp_samples": gpu_timestamp_samples,
         "gpu_timestamps_available": gpu_timestamps_available,
@@ -532,6 +582,58 @@ def summarize(records):
             "compute": footer["compute_records"],
         },
     }
+
+
+def _print_phase_line(label, totals, denominator, extra=None):
+    """One `name=ms (pct)` line; percentages are of `denominator`, which is named by the caller."""
+    if denominator <= 0:
+        return
+    parts = []
+    for field, value in totals.items():
+        if value < 0.05:
+            continue
+        name = PHASE_LABELS.get(field, field)
+        parts.append(f"{name}={value:.1f}ms ({100.0 * value / denominator:.1f}%)")
+    if extra:
+        parts.extend(extra)
+    if parts:
+        print(f"  {label}: {' '.join(parts)}")
+
+
+def _print_compute_phases(summary):
+    """Print every compute timer the capture carries, with the remainder named.
+
+    Two sibling decompositions, deliberately not summed: the CPU phases partition `total_ms`,
+    while the GPU brackets partition `gpu_device_ms`, which is itself inside `dispatch_wait_ms`.
+    """
+    total = summary.get("compute_total_ms", 0.0)
+    cpu = summary.get("compute_cpu_phases") or {}
+    gpu = summary.get("compute_gpu_brackets") or {}
+    device = summary.get("compute_gpu_device_ms", 0.0)
+    if total <= 0 and device <= 0:
+        return
+    # Announce only the tables actually printed: a capture with no GPU timestamps has no bracket
+    # table, and a header promising one reads as a missing section rather than an absent capability.
+    scopes = []
+    if total > 0:
+        scopes.append("CPU phases partition total")
+    if device > 0:
+        scopes.append("GPU brackets partition device time")
+    print(f"compute decomposition ({'; '.join(scopes)}):")
+    if total > 0:
+        unattributed = total - sum(cpu.values())
+        extra = ([f"unattributed={unattributed:.1f}ms ({100.0 * unattributed / total:.1f}%)"]
+                 if abs(unattributed) >= 0.05 else None)
+        _print_phase_line(f"CPU phases of {total:.1f}ms total", cpu, total, extra)
+    if device > 0:
+        unattributed = device - sum(gpu.values())
+        extra = ([f"unattributed={unattributed:.1f}ms ({100.0 * unattributed / device:.1f}%)"]
+                 if abs(unattributed) >= 0.05 else None)
+        _print_phase_line(f"GPU brackets of {device:.1f}ms device", gpu, device, extra)
+        shader = gpu.get("gpu_shader_ms", 0.0)
+        if device > 0 and shader >= 0.0:
+            print(f"    the guest's own compute shader is {100.0 * shader / device:.1f}% of the "
+                  f"device time prosper spends running it")
 
 
 def _fmt_rate(value):
@@ -560,6 +662,7 @@ def print_summary(summary):
           f"rendered={_fmt_rate(rates['rendered_fps'])} host-presented={_fmt_rate(rates['host_fps'])}")
     print(f"measured totals: graphics={summary['graphics_total_ms']:.1f} ms "
           f"compute={summary['compute_total_ms']:.1f} ms")
+    _print_compute_phases(summary)
     programs = summary["compute_programs"]
     print(f"compute identities: groups={programs['group_count']} "
           f"unknown={programs['unknown_records']} records/{programs['unknown_total_ms']:.1f} ms")
@@ -568,16 +671,19 @@ def print_summary(summary):
         if group["address_count"] > len(group["addresses"]):
             addresses += f",+{group['address_count'] - len(group['addresses'])}"
         parts = []
-        if group.get("setup_ms", 0.0) >= 0.05:
-            parts.append(f"setup={group['setup_ms']:.1f}ms")
-        if group.get("writeback_ms", 0.0) >= 0.05:
-            parts.append(f"wb={group['writeback_ms']:.1f}ms")
-        if group.get("dispatch_wait_ms", 0.0) >= 0.05:
-            parts.append(f"wait={group['dispatch_wait_ms']:.1f}ms")
+        for field in COMPUTE_CPU_PHASES:
+            if group.get(field, 0.0) >= 0.05:
+                parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
+        # Name the remainder instead of leaving it to subtraction: an unmeasured cost hides here.
+        cpu_attributed = sum(group.get(field, 0.0) for field in COMPUTE_CPU_PHASES)
+        unattributed = group.get("total_ms", 0.0) - cpu_attributed
+        if unattributed >= 0.05:
+            parts.append(f"unattributed={unattributed:.1f}ms")
         if group.get("gpu_device_ms", 0.0) >= 0.05:
             parts.append(f"dev={group['gpu_device_ms']:.1f}ms")
-        if group.get("gpu_shader_ms", 0.0) >= 0.05 and abs(group.get("gpu_shader_ms", 0.0) - group.get("gpu_device_ms", 0.0)) >= 0.05:
-            parts.append(f"shader={group['gpu_shader_ms']:.1f}ms")
+        for field in COMPUTE_GPU_BRACKETS:
+            if group.get(field, 0.0) >= 0.05:
+                parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
         breakdown_str = f" ({' '.join(parts)})" if parts else ""
         print(f"  {group['program_hash']} records={group['records']} "
               f"dispatches={group['dispatches']} total={group['total_ms']:.1f} ms "

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -631,9 +631,8 @@ def _print_compute_phases(summary):
                  if abs(unattributed) >= 0.05 else None)
         _print_phase_line(f"GPU brackets of {device:.1f}ms device", gpu, device, extra)
         shader = gpu.get("gpu_shader_ms", 0.0)
-        if device > 0 and shader >= 0.0:
-            print(f"    the guest's own compute shader is {100.0 * shader / device:.1f}% of the "
-                  f"device time prosper spends running it")
+        print(f"    the guest's own compute shader is {100.0 * shader / device:.1f}% of the "
+              f"device time prosper spends running it")
 
 
 def _fmt_rate(value):
@@ -670,21 +669,33 @@ def print_summary(summary):
         addresses = ",".join(group["addresses"])
         if group["address_count"] > len(group["addresses"]):
             addresses += f",+{group['address_count'] - len(group['addresses'])}"
-        parts = []
+        # Two scopes on one line, so they are LABELLED and the nesting is stated. Printed flat,
+        # these numbers invite being added up: the CPU phases partition total, the GPU brackets
+        # partition dev, and dev is itself inside wait -- so a flat list of eleven fields sums to
+        # well over the total on the same line and reads as an arithmetic error in the tool.
+        cpu_parts = []
         for field in COMPUTE_CPU_PHASES:
             if group.get(field, 0.0) >= 0.05:
-                parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
+                cpu_parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
         # Name the remainder instead of leaving it to subtraction: an unmeasured cost hides here.
+        # Signed, and printed on either side of zero, matching the convention this file uses for
+        # every other remainder -- a negative one is a real producer state, not a rounding artifact.
         cpu_attributed = sum(group.get(field, 0.0) for field in COMPUTE_CPU_PHASES)
         unattributed = group.get("total_ms", 0.0) - cpu_attributed
-        if unattributed >= 0.05:
-            parts.append(f"unattributed={unattributed:.1f}ms")
-        if group.get("gpu_device_ms", 0.0) >= 0.05:
-            parts.append(f"dev={group['gpu_device_ms']:.1f}ms")
+        if abs(unattributed) >= 0.05:
+            cpu_parts.append(f"unattributed={unattributed:.1f}ms")
+        gpu_parts = []
         for field in COMPUTE_GPU_BRACKETS:
             if group.get(field, 0.0) >= 0.05:
-                parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
-        breakdown_str = f" ({' '.join(parts)})" if parts else ""
+                gpu_parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
+        sections = []
+        if cpu_parts:
+            sections.append("cpu " + " ".join(cpu_parts))
+        device_ms = group.get("gpu_device_ms", 0.0)
+        if device_ms >= 0.05:
+            inside = f" of which {' '.join(gpu_parts)}" if gpu_parts else ""
+            sections.append(f"gpu dev={device_ms:.1f}ms (inside wait){inside}")
+        breakdown_str = f" [{' | '.join(sections)}]" if sections else ""
         print(f"  {group['program_hash']} records={group['records']} "
               f"dispatches={group['dispatches']} total={group['total_ms']:.1f} ms "
               f"mean={group['mean_ms']:.2f} ms max={group['max_ms']:.2f} ms{breakdown_str} "

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -590,7 +590,12 @@ def _print_phase_line(label, totals, denominator, extra=None):
         return
     parts = []
     for field, value in totals.items():
-        if value < 0.05:
+        # abs(): a negative is a VALUE, not an absence. Suppressing it hid the compensating
+        # term of a signed pair, so the visible parts summed to 183% of their own total while
+        # the remainder -- computed from the full set, hidden term included -- came to exactly
+        # zero and printed no warning. The one mechanism that would flag the inconsistency was
+        # silenced by the value it should have been reporting.
+        if abs(value) < 0.05:
             continue
         name = PHASE_LABELS.get(field, field)
         parts.append(f"{name}={value:.1f}ms ({100.0 * value / denominator:.1f}%)")
@@ -675,11 +680,14 @@ def print_summary(summary):
         # well over the total on the same line and reads as an arithmetic error in the tool.
         cpu_parts = []
         for field in COMPUTE_CPU_PHASES:
-            if group.get(field, 0.0) >= 0.05:
+            # abs() for the same reason as the summary table: see _print_phase_line.
+            if abs(group.get(field, 0.0)) >= 0.05:
                 cpu_parts.append(f"{PHASE_LABELS[field]}={group[field]:.1f}ms")
         # Name the remainder instead of leaving it to subtraction: an unmeasured cost hides here.
-        # Signed, and printed on either side of zero, matching the convention this file uses for
-        # every other remainder -- a negative one is a real producer state, not a rounding artifact.
+        # Signed on either side of zero, matching this file's convention for every remainder.
+        # No current producer path yields a negative remainder -- the five phases telescope to
+        # cleanup-start, so a skipped marker moves cost between phases without changing their
+        # sum (#3461) -- but the threshold must not be the thing that decides.
         cpu_attributed = sum(group.get(field, 0.0) for field in COMPUTE_CPU_PHASES)
         unattributed = group.get("total_ms", 0.0) - cpu_attributed
         if abs(unattributed) >= 0.05:

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -410,6 +410,7 @@ BROKEN_DISPATCH_COMPUTE = [{
     "gpu_device_ms": 0.0, "gpu_timestamp_samples": 0,
 }]
 
+
 class ComputeDecompositionTests(unittest.TestCase):
     def _render(self, compute):
         summary = summarize(capture(SAMPLES, compute=compute))
@@ -545,10 +546,18 @@ class ComputeDecompositionTests(unittest.TestCase):
                        if line.strip().startswith("CPU phases of"))
         self.assertIn("pipeline=-10.0ms", summary)
         self.assertIn("pipeline=-10.0ms", self._group_line(text))
-        # And with it visible, the printed shares add up to the whole rather than to 183%.
-        shares = [float(part.rsplit("(", 1)[1].removesuffix("%)"))
-                  for part in summary.split() if part.endswith("%)")]
-        self.assertAlmostEqual(sum(shares), 100.0, places=1)
+        # And with it visible, the printed parts account for the whole rather than 183% of it.
+        #
+        # Summed in MILLISECONDS, not in the rendered percentages. Percentages are each rounded
+        # to one decimal before being printed, so their sum lands on 100.0 only when the errors
+        # happen to cancel: this fixture does (its suppressed phases are exactly 0.0 and its
+        # +/-0.033 errors are equal and opposite), while HIDDEN_COST_COMPUTE sums to 99.9 with
+        # nothing suppressed at all. A tolerance wide enough for both would no longer detect the
+        # 183% this arm exists to catch, so the check is done on the underlying values, as
+        # test_group_line_cpu_fields_account_for_its_own_total already does.
+        values = [float(part.split("=")[1].split("ms")[0])
+                  for part in summary.split() if "=" in part and "ms" in part]
+        self.assertAlmostEqual(sum(values), 12.0, places=3)
 
     def test_absent_gpu_timestamps_do_not_invent_a_bracket_table(self):
         from performance_capture_report import COMPUTE_GPU_BRACKETS

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -419,8 +419,11 @@ class ComputeDecompositionTests(unittest.TestCase):
         return lines[0]
 
     def test_every_captured_timer_is_reported(self):
-        # Fails on the old report, which printed setup/writeback/wait/dev/shader and dropped the
-        # rest -- including the two that hold 92% of this dispatch.
+        # COVERAGE arm, deliberately whole-text: it asserts the summary carries every field and
+        # that each name reaches the output SOMEWHERE. It does not distinguish the summary from
+        # the group line -- either satisfies it -- so it survives a mutation of either surface.
+        # The surface-specific pinning is done by the summary arms and the _group_line arms;
+        # this one exists so a newly added timer that reaches neither surface still fails.
         from performance_capture_report import COMPUTE_CPU_PHASES, COMPUTE_GPU_BRACKETS
         summary, text = self._render(HIDDEN_COST_COMPUTE)
         for field in COMPUTE_CPU_PHASES:
@@ -489,6 +492,23 @@ class ComputeDecompositionTests(unittest.TestCase):
         values = [float(part.split("=")[1].removesuffix("ms"))
                   for part in cpu_section.split() if "=" in part]
         self.assertAlmostEqual(sum(values), 300.0, places=1)
+
+    def test_negative_remainder_is_shown_signed_on_both_surfaces(self):
+        # A record whose named phases exceed its own total. Reachable from the producer: a
+        # dispatch that breaks out before phase_pipeline leaves that interval unrecorded while
+        # total_ms still spans the batch, so the remainder goes negative.
+        #
+        # It must be PRINTED, not hidden by a one-sided threshold: a negative remainder means
+        # the phases do not partition the total, which is a producer defect worth seeing. This
+        # is the file's convention for every other remainder, and it was the one line in the
+        # change that no arm pinned.
+        over = [dict(HIDDEN_COST_COMPUTE[0])]
+        over[0]["total_ms"] = 290.0          # named CPU phases sum to 296.0
+        _, text = self._render(over)
+        self.assertIn("unattributed=-6.0ms", self._group_line(text))
+        cpu_summary = next(line for line in text.splitlines()
+                           if line.strip().startswith("CPU phases of"))
+        self.assertIn("unattributed=-6.0ms", cpu_summary)
 
     def test_absent_gpu_timestamps_do_not_invent_a_bracket_table(self):
         from performance_capture_report import COMPUTE_GPU_BRACKETS

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -494,14 +494,24 @@ class ComputeDecompositionTests(unittest.TestCase):
         self.assertAlmostEqual(sum(values), 300.0, places=1)
 
     def test_negative_remainder_is_shown_signed_on_both_surfaces(self):
-        # A record whose named phases exceed its own total. Reachable from the producer: a
-        # dispatch that breaks out before phase_pipeline leaves that interval unrecorded while
-        # total_ms still spans the batch, so the remainder goes negative.
+        # A record whose named phases exceed its own total. NO CURRENT PRODUCER PATH BUILDS ONE,
+        # and the reason is worth stating so nobody re-derives it: the five CPU phases are
+        # consecutive differences over start->setup->pipeline->dispatch->writeback->cleanup
+        # (live_compute.cpp:11639-11643), and phase_milliseconds (:11635) is a plain signed
+        # difference with no clamping, so they telescope to cleanup-start for ANY ordering of the
+        # markers -- degenerate ones included. A break leaves a marker behind and yields a
+        # negative PHASE offset by a compensating positive one; the SUM is unchanged. Since
+        # total_ms spans at least that window, the remainder cannot go negative today.
         #
-        # It must be PRINTED, not hidden by a one-sided threshold: a negative remainder means
-        # the phases do not partition the total, which is a producer defect worth seeing. This
-        # is the file's convention for every other remainder, and it was the one line in the
-        # change that no arm pinned.
+        # An earlier version of this comment claimed a break before phase_pipeline produced one.
+        # It does not, and the claim reached here from a review citation that skipped the
+        # telescoping step -- which is why it is corrected rather than quietly dropped.
+        #
+        # The arm stays because the THRESHOLD is what is under test, not that mechanism: a
+        # one-sided threshold would silently hide a negative remainder if the telescoping ever
+        # broke (a clamp, or a phase measured outside the start..cleanup window), and a
+        # remainder that does not partition its total is precisely what this report exists to
+        # surface. It also matches the signed convention used for every other remainder here.
         over = [dict(HIDDEN_COST_COMPUTE[0])]
         over[0]["total_ms"] = 290.0          # named CPU phases sum to 296.0
         _, text = self._render(over)

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -2,8 +2,11 @@
 
 import unittest
 
+import contextlib
+import io
+
 from performance_capture_report import (CaptureError, CLASSIFICATION_EVIDENCE_SHARE,
-                                        READBACK_NOTE_MIN_SHARE, summarize,
+                                        READBACK_NOTE_MIN_SHARE, print_summary, summarize,
                                         validate_capture)
 
 
@@ -378,6 +381,79 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         records.pop()
         with self.assertRaisesRegex(CaptureError, "incomplete"):
             validate_capture(records)
+
+
+# The record shape that made #3447 invisible: almost all of the cost is in `pipeline_ms` and
+# `gpu_storage_copy_ms`, both of which the report captured and never printed. The five timers it
+# did print account for 6 ms of a 300 ms dispatch.
+HIDDEN_COST_COMPUTE = [{
+    "program_addr": 0x1000, "program_hash": 0xABCD, "dispatches": 1,
+    "total_ms": 300.0,
+    "setup_ms": 2.0, "pipeline_ms": 220.0, "dispatch_wait_ms": 70.0,
+    "writeback_ms": 3.0, "cleanup_ms": 1.0,
+    "gpu_device_ms": 65.0, "gpu_pre_ms": 1.0, "gpu_shader_ms": 4.0,
+    "gpu_storage_copy_ms": 55.0, "gpu_compare_ms": 5.0, "gpu_restore_ms": 0.0,
+    "gpu_timestamp_samples": 1,
+}]
+
+
+class ComputeDecompositionTests(unittest.TestCase):
+    def _render(self, compute):
+        summary = summarize(capture(SAMPLES, compute=compute))
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            print_summary(summary)
+        return summary, buffer.getvalue()
+
+    def test_every_captured_timer_is_reported(self):
+        # Fails on the old report, which printed setup/writeback/wait/dev/shader and dropped the
+        # rest -- including the two that hold 92% of this dispatch.
+        from performance_capture_report import COMPUTE_CPU_PHASES, COMPUTE_GPU_BRACKETS
+        summary, text = self._render(HIDDEN_COST_COMPUTE)
+        for field in COMPUTE_CPU_PHASES:
+            self.assertIn(field, summary["compute_cpu_phases"], field)
+        for field in COMPUTE_GPU_BRACKETS:
+            self.assertIn(field, summary["compute_gpu_brackets"], field)
+        self.assertEqual(summary["compute_cpu_phases"]["pipeline_ms"], 220.0)
+        self.assertEqual(summary["compute_gpu_brackets"]["gpu_storage_copy_ms"], 55.0)
+        self.assertIn("pipeline=220.0ms", text)
+        self.assertIn("storage-copy=55.0ms", text)
+
+    def test_dominant_timer_reaches_the_printed_output(self):
+        # The point of the fix: the largest cost must be visible without parsing the file by hand.
+        _, text = self._render(HIDDEN_COST_COMPUTE)
+        self.assertIn("(73.3%)", text)   # pipeline_ms, 220 of 300
+        self.assertIn("(84.6%)", text)   # gpu_storage_copy_ms, 55 of 65 device
+
+    def test_remainder_is_named_rather_than_left_to_subtraction(self):
+        # 300 total against 296 of named CPU phases: the 4 ms must be stated, not inferred.
+        _, text = self._render(HIDDEN_COST_COMPUTE)
+        self.assertIn("unattributed=4.0ms", text)
+
+    def test_gpu_brackets_are_scaled_against_device_time_not_total(self):
+        # The brackets sit inside dispatch_wait, so they partition gpu_device_ms. Scaling them
+        # against total_ms would understate the storage copy by 4.6x here and invite summing two
+        # sibling decompositions into one bogus 100%.
+        _, text = self._render(HIDDEN_COST_COMPUTE)
+        self.assertIn("GPU brackets of 65.0ms device", text)
+        self.assertNotIn("storage-copy=55.0ms (18.3%)", text)
+
+    def test_shader_share_of_device_time_is_stated(self):
+        # The headline this whole change exists to surface.
+        _, text = self._render(HIDDEN_COST_COMPUTE)
+        self.assertIn("compute shader is 6.2% of the device time", text)
+
+    def test_absent_gpu_timestamps_do_not_invent_a_bracket_table(self):
+        from performance_capture_report import COMPUTE_GPU_BRACKETS
+        no_gpu = [dict(HIDDEN_COST_COMPUTE[0])]
+        for field in ("gpu_device_ms", *COMPUTE_GPU_BRACKETS):
+            no_gpu[0][field] = 0.0
+        no_gpu[0]["gpu_timestamp_samples"] = 0
+        _, text = self._render(no_gpu)
+        self.assertIn("CPU phases of 300.0ms total", text)
+        self.assertNotIn("GPU brackets of", text)
+        # ...and the header must not advertise a section this capture cannot supply.
+        self.assertNotIn("GPU brackets partition", text)
 
 
 if __name__ == "__main__":

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -405,6 +405,19 @@ class ComputeDecompositionTests(unittest.TestCase):
             print_summary(summary)
         return summary, buffer.getvalue()
 
+    def _group_line(self, text):
+        """The per-program line alone.
+
+        Every assertion about the group breakdown must run against THIS, not against the whole
+        report: the summary table prints the same field names, so a substring match on the full
+        text is satisfied by the summary and never reaches the group line. That is why reverting
+        the entire group-line change once left this suite green.
+        """
+        lines = [line for line in text.splitlines() if line.strip().startswith("0x")
+                 and "records=" in line]
+        self.assertEqual(len(lines), 1, f"expected exactly one group line in:\n{text}")
+        return lines[0]
+
     def test_every_captured_timer_is_reported(self):
         # Fails on the old report, which printed setup/writeback/wait/dev/shader and dropped the
         # rest -- including the two that hold 92% of this dispatch.
@@ -442,6 +455,40 @@ class ComputeDecompositionTests(unittest.TestCase):
         # The headline this whole change exists to surface.
         _, text = self._render(HIDDEN_COST_COMPUTE)
         self.assertIn("compute shader is 6.2% of the device time", text)
+
+    def test_group_line_carries_the_dropped_timers(self):
+        # Asserted on the group line ALONE. The old report printed five fields here and the
+        # two holding 92% of this dispatch were absent; a whole-text match cannot see that,
+        # because the summary table above prints the same names.
+        _, text = self._render(HIDDEN_COST_COMPUTE)
+        line = self._group_line(text)
+        self.assertIn("pipeline=220.0ms", line)
+        self.assertIn("storage-copy=55.0ms", line)
+        self.assertIn("cleanup=1.0ms", line)
+        self.assertIn("unattributed=4.0ms", line)
+
+    def test_group_line_separates_the_two_scopes(self):
+        # Printed flat, the eleven fields sum to 430ms against the 300ms total on the same line,
+        # because the GPU brackets are inside dev which is inside wait. The line must say so
+        # rather than leaving a reader to add them up and conclude the tool cannot count.
+        _, text = self._render(HIDDEN_COST_COMPUTE)
+        line = self._group_line(text)
+        self.assertIn("cpu ", line)
+        self.assertIn("gpu dev=65.0ms (inside wait)", line)
+        self.assertIn("of which", line)
+        cpu_section = line.split("[", 1)[1].split(" | ", 1)[0]
+        self.assertNotIn("storage-copy", cpu_section)
+        self.assertNotIn("dev=", cpu_section)
+
+    def test_group_line_cpu_fields_account_for_its_own_total(self):
+        # The invariant the labelling exists to protect: the cpu section, remainder included,
+        # sums to the total printed on the same line.
+        _, text = self._render(HIDDEN_COST_COMPUTE)
+        line = self._group_line(text)
+        cpu_section = line.split("[", 1)[1].split(" | ", 1)[0]
+        values = [float(part.split("=")[1].removesuffix("ms"))
+                  for part in cpu_section.split() if "=" in part]
+        self.assertAlmostEqual(sum(values), 300.0, places=1)
 
     def test_absent_gpu_timestamps_do_not_invent_a_bracket_table(self):
         from performance_capture_report import COMPUTE_GPU_BRACKETS

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -397,6 +397,19 @@ HIDDEN_COST_COMPUTE = [{
 }]
 
 
+
+# A dispatch that broke during setup, in the shape #3461 describes: `phase_writeback` never
+# advanced, so `cleanup_ms` books the whole item and `pipeline_ms` books the compensating
+# negative. The stored values are self-consistent -- they telescope to the item duration --
+# so the capture is right and only the RENDERING can go wrong.
+BROKEN_DISPATCH_COMPUTE = [{
+    "program_addr": 0x2000, "program_hash": 0xBEEF, "dispatches": 1,
+    "total_ms": 12.0,
+    "setup_ms": 10.0, "pipeline_ms": -10.0, "dispatch_wait_ms": 0.0,
+    "writeback_ms": 0.0, "cleanup_ms": 12.0,
+    "gpu_device_ms": 0.0, "gpu_timestamp_samples": 0,
+}]
+
 class ComputeDecompositionTests(unittest.TestCase):
     def _render(self, compute):
         summary = summarize(capture(SAMPLES, compute=compute))
@@ -519,6 +532,23 @@ class ComputeDecompositionTests(unittest.TestCase):
         cpu_summary = next(line for line in text.splitlines()
                            if line.strip().startswith("CPU phases of"))
         self.assertIn("unattributed=-6.0ms", cpu_summary)
+
+    def test_negative_phase_values_are_printed_not_suppressed(self):
+        # A `value < 0.05` threshold treats a negative as an absence. That hid the compensating
+        # term of a signed pair, so the visible parts summed to 183% of their own total, while
+        # the `unattributed` row -- computed from the full set, hidden term included -- came to
+        # exactly zero and printed nothing. The one mechanism that would have flagged the
+        # inconsistency was silenced by the very value it should have reported, which is the
+        # same shape as the defect this whole change exists to fix.
+        _, text = self._render(BROKEN_DISPATCH_COMPUTE)
+        summary = next(line for line in text.splitlines()
+                       if line.strip().startswith("CPU phases of"))
+        self.assertIn("pipeline=-10.0ms", summary)
+        self.assertIn("pipeline=-10.0ms", self._group_line(text))
+        # And with it visible, the printed shares add up to the whole rather than to 183%.
+        shares = [float(part.rsplit("(", 1)[1].removesuffix("%)"))
+                  for part in summary.split() if part.endswith("%)")]
+        self.assertAlmostEqual(sum(shares), 100.0, places=1)
 
     def test_absent_gpu_timestamps_do_not_invent_a_bracket_table(self):
         from performance_capture_report import COMPUTE_GPU_BRACKETS


### PR DESCRIPTION
Fixes #3447. Refs #3450 (task T1).

## Failure scenario

`performance_capture_report.py` aggregates **eleven** per-dispatch compute timers and prints **five**. The dropped ones are repeatedly the largest, so the report `CLAUDE.md` tells agents to read before optimising anything has been steering by a minority of its own signal.

Concretely, as the tool printed it before this change:

```
0x2b1c4d31... records=1 dispatches=1 total=277.2 ms (setup=6.3ms wb=17.8ms wait=16.1ms dev=15.7ms shader=0.4ms)
```

`6.3 + 17.8 + 16.1 = 40.2 ms` of a `277.2 ms` dispatch. Over the printed groups, **75% of the time was unaccounted in the output** while sitting in the file all along.

Measured on GTA V (`PPSA04263`), Windows/NVIDIA: the dropped CPU timer `pipeline_ms` held **66%** of one window, and the dropped GPU bracket `gpu_storage_copy_ms` held **88%** of device time in two others.

## What it prints now

```
compute decomposition (CPU phases partition total; GPU brackets partition device time):
  CPU phases of 1472.0ms total: setup=207.6ms (14.1%) pipeline=8.9ms (0.6%) wait=927.5ms (63.0%)
    wb=312.4ms (21.2%) cleanup=3.8ms (0.3%) unattributed=11.8ms (0.8%)
  GPU brackets of 821.8ms device: pre=15.6ms (1.9%) shader=51.6ms (6.3%) storage-copy=723.1ms (88.0%)
    compare=31.6ms (3.8%)
    the guest's own compute shader is 6.3% of the device time prosper spends running it
```

## Invariants

- **The two decompositions are siblings and are never summed.** CPU phases partition `total_ms`; GPU brackets partition `gpu_device_ms`, which is itself *inside* `dispatch_wait_ms`. Scaling the brackets against `total_ms` would understate the storage copy several-fold and invite adding two overlapping decompositions into one bogus 100%. A test pins this, including a negative assertion on the wrong denominator.
- **Any remainder is named, not left to subtraction** — the rule `compute_phase_report.py` already states in its own header for `[compute-phase]` lines: *"this is where an unmeasured cost hides, so it is printed rather than silently dropped."* Applied both to the whole-capture table and to each program group.
- **The header announces only the tables a capture can supply.** A run without GPU timestamps prints no bracket table and no longer advertises one, so absence of a capability does not read as a missing section.

## Not a format change

Every field printed was already written by `performance_capture.cpp` (`:464`, `:467`) and declared in `performance_capture.hpp` (`:165`, `:168`). **Existing `.prperf` files gain the new output with no re-capture** — which is how the GTA V figures above were obtained, from captures taken days earlier.

## Tests

Six arms added in `ComputeDecompositionTests`, on a record whose cost sits entirely in previously-dropped timers (`pipeline_ms=220`, `gpu_storage_copy_ms=55` of a 300 ms dispatch):

| arm | what it pins |
| --- | --- |
| `test_every_captured_timer_is_reported` | all eleven reach the summary and the text |
| `test_dominant_timer_reaches_the_printed_output` | the largest cost is visible without parsing the file |
| `test_remainder_is_named_rather_than_left_to_subtraction` | the 4 ms remainder is stated |
| `test_gpu_brackets_are_scaled_against_device_time_not_total` | the sibling relationship |
| `test_shader_share_of_device_time_is_stated` | the headline line |
| `test_absent_gpu_timestamps_do_not_invent_a_bracket_table` | no table, and no header promising one |

**Verified they fail without the fix — on assertions, not on import.** The new constants are imported *inside* the two tests that need them, precisely so the other four fail on behaviour against the pre-change tool rather than on a missing symbol:

```
$ git show origin/main:...performance_capture_report.py > ...
$ python test_performance_capture_report.py ComputeDecompositionTests
FAIL: test_dominant_timer_reaches_the_printed_output          not found: (73.3%)
FAIL: test_gpu_brackets_are_scaled_against_device_time_...    not found: GPU brackets of 65.0ms device
FAIL: test_remainder_is_named_rather_than_left_to_subtr...    not found: unattributed=4.0ms
FAIL: test_shader_share_of_device_time_is_stated              not found: compute shader is 6.2% of the device time
Ran 6 tests -- FAILED (failures=4, errors=2)
```

The pre-fix output quoted in those failures is itself the evidence: `(setup=2.0ms wb=3.0ms wait=70.0ms dev=65.0ms shader=4.0ms)` for a 300 ms dispatch whose `pipeline_ms=220` is nowhere.

## Results

- `python prosper/tools/perf/test_performance_capture_report.py`: **32 tests, OK** (26 pre-existing, unchanged).
- Registered in ctest at `CMakeLists.txt:1232`, so CI covers it.
- Run against **8 real `.prperf` captures** spanning 3 revisions and 6 days: all exit 0. `--json` still parses and carries `compute_cpu_phases`, `compute_gpu_brackets`, `compute_gpu_device_ms`.
- `git diff --check` clean; CRLF preserved (0 bare LF in both files).

## What it immediately surfaced

Applied to captures already on disk, the storage-copy share is 42-88% on recent revisions — and on two captures from `0d6e3b2d` (2026-09-02) it is `gpu_compare_ms` at **78.7%** and **82.0%** instead, the cost `PROSPER_MAX_GPU_COMPARE_IMAGE_MB` was later added to bound. Across all eight captures, **the guest's own compute shader is 3.0%-24.9% of device time.** None of that was visible before.

## Risk

Low, and confined to one offline reporting tool. No emulator code, no capture-format change, nothing that runs during a game. The worst case is a wider report; the JSON gains keys and loses none.
