### PR TITLE
perf(renderer): avoid per-upload CPU topology probes

### DIFF
--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -2643,13 +2643,17 @@ inline void parallel_render_memcpy(void* dst, const void* src, size_t bytes) {
     // Below this the copy is not worth splitting; above it the win is real and bandwidth-bound,
     // which is why the worker count is capped rather than scaled to the core count.
     constexpr size_t kMinParallelBytes = 2u << 20;
-    const unsigned hardware = std::thread::hardware_concurrency();
-    const unsigned wanted = configured ? configured
-                                       : std::min(hardware ? hardware : 4u, 8u);
-    if (bytes < kMinParallelBytes || wanted <= 1) {
+    if (bytes < kMinParallelBytes || configured == 1) {
         std::memcpy(dst, src, bytes);
         return;
     }
+    // hardware_concurrency is only a scheduling hint, and some standard libraries probe sysfs
+    // on every call. Discover it once, only when an automatic parallel copy actually needs it.
+    static const unsigned wanted = [] {
+        if (configured) return configured;
+        const unsigned hardware = std::thread::hardware_concurrency();
+        return std::min(hardware ? hardware : 4u, 8u);
+    }();
     const unsigned threads = static_cast<unsigned>(
         std::min<size_t>(wanted, bytes / (1u << 20)));
     if (threads <= 1) { std::memcpy(dst, src, bytes); return; }


### PR DESCRIPTION
Renderer uploads queried `std::thread::hardware_concurrency()` on every copy, including tiny buffers and explicitly scalar copies. On the tested Linux runtime each query opens, reads and closes the CPU-topology sysfs file.

Return before topology discovery for copies below 2 MiB and scalar configuration. Cache the automatic worker hint once and skip discovery for explicit worker counts. Copy partitioning, worker limits, synchronous completion and worker-creation fallback are unchanged; this uses portable C++ without new Vulkan requirements.

In one comparable pair per title, renderer buffer-copy totals fall from 553 to 165 ms for GTA and 343 to 211 ms for Sonic, despite more renderer records in the fixed captures. Overall presentation rates move only slightly; this does not establish a general FPS gain. GTA's bank visuals are preserved; Sonic retains its known black-world/HUD defect. The same-binary scalar-copy control did not remove the cost, so worker scheduling remains unchanged.

Validation: full Release app build, 392/392 tests, five focused renderer cases with Vulkan synchronization validation and positive controls, 88 actual-helper byte/guard checks, and syscall negative controls. [Exact-head author verification, commands, manifests and evidence](https://github.com/mattias800/prosper/pull/3459#issuecomment-5581433468).

Fixes #3458. Refs #3407, #3414; their broader remaining scope stays open.
