### PR TITLE
fix(capture): move owned bundle writing off the guest flip path

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2177,6 +2177,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_capture_bundle PRIVATE prosper_core)
   add_test(NAME gpu_capture_bundle_roundtrip COMMAND test_gpu_capture_bundle)
 
+  add_executable(test_interactive_capture_writer tests/gpu/capture/test_interactive_capture_writer.cpp)
+  target_include_directories(test_interactive_capture_writer PRIVATE tests)
+  target_link_libraries(test_interactive_capture_writer PRIVATE prosper_core)
+  add_test(NAME interactive_capture_writer COMMAND test_interactive_capture_writer)
+  add_test(NAME interactive_capture_writer_shutdown_collecting COMMAND test_interactive_capture_writer shutdown)
+  set_tests_properties(interactive_capture_writer interactive_capture_writer_shutdown_collecting
+                       PROPERTIES TIMEOUT 30)
+
   # Framerate must count DISTINCT guest frames, not publications: the renderer re-serves its retained
   # frame through the ordinary publish path, so a present-counting fps reads full speed for a frozen
   # title (#2783 / instrument trap 90). Pure -- no Vulkan, no dump.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1790,11 +1790,92 @@ int main(int argc, char** argv) {
         suffix = 0;
         return false;
     };
+    // Shared result reporting for the app loop and the explicit shutdown drain.
+    auto reportGrabOutcome = [&] {
+        prosper::gpu::InteractiveGrabOutcome grab;
+        if (prosper::gpu::take_interactive_grab_outcome(grab)) {
+            unsigned bundleSuffix = 0;
+            // Not every outcome is a frame grab's: the same channel reports the env-driven
+            // captures, whose path this frontend never created.
+            const bool reservedHere = take_bundle_reservation(grab.bundle_path, bundleSuffix);
+            if (grab.ok) {
+                // The file exists now, so this line may name it.
+                std::fprintf(stderr, "%s\n",
+                             prosper::frontend::frame_grab_write_line(
+                                 "bundle", grab.bundle_path, bundleSuffix).c_str());
+                grabNotice = "F9: captured " +
+                    std::filesystem::path(grab.bundle_path).filename().string();
+            } else {
+                // What became of the output path. Every branch reports the state it actually
+                // found, and NOTHING is deleted unless this frontend created it: a capture
+                // configured through PROSPER_CAPTURE_BUNDLE* arrives on this same channel with a
+                // path prosper never reserved, and a zero-byte file sitting at such a path
+                // belongs to whoever put it there.
+                std::string state;
+                if (grab.bundle_path.empty()) {
+                    state = "no output path was recorded for it";
+                } else if (!reservedHere) {
+                    state = "this path was configured, not reserved by a frame grab: nothing was "
+                            "written to it and nothing was removed";
+                } else {
+                    std::error_code ec;
+                    const bool present = std::filesystem::exists(grab.bundle_path, ec);
+                    if (ec) {
+                        // "I could not tell" is not "gone" — an unreadable parent directory
+                        // lands here, and naming the wrong cause is what this logging avoids.
+                        state = "its reserved file could not be checked: " + ec.message();
+                    } else if (!present) {
+                        state = "its reserved file is already gone";
+                    } else {
+                        const uintmax_t bytes = std::filesystem::file_size(grab.bundle_path, ec);
+                        if (ec) {
+                            state = "its reserved file could not be examined: " + ec.message();
+                        } else if (bytes != 0) {
+                            // Cannot happen on this path today; if it ever does, the file has real
+                            // content and is not ours to delete.
+                            state = "its reserved file holds " + std::to_string(bytes) +
+                                    " bytes and was left alone";
+                        } else {
+                            // Leaving a zero-byte .prgbundle after saying none was written would
+                            // be the same class of untrue statement this logging exists to avoid.
+                            const bool removed = std::filesystem::remove(grab.bundle_path, ec);
+                            if (removed && !ec) state = "the empty reservation has been removed";
+                            // remove() reports false with NO error when the file was already
+                            // gone — a race with an external deleter. Printing "could not be
+                            // removed: Success" there would assert a failure that did not happen.
+                            else if (!ec)       state = "the empty reservation was already gone";
+                            else                state = "the empty reservation could not be removed: " +
+                                                        ec.message();
+                        }
+                    }
+                }
+                std::fprintf(stderr,
+                    "\n=========================== F9 FRAME GRAB FAILED ===========================\n"
+                    "  %s\n"
+                    "  no bundle content was written; the output path was %s\n"
+                    "  %s\n"
+                    "  %s\n"
+                    "  budget in force: %llu MiB -- raise it with "
+                    "PROSPER_CAPTURE_BUNDLE_MAX_MB=<64..3072> and re-arm the capture\n"
+                    "============================================================================\n\n",
+                    grab.error.c_str(), grab.bundle_path.c_str(), state.c_str(),
+                    reservedHere
+                        ? "the .bmp screenshot for this press is a separate file with the same stem"
+                        : "this capture was configured, not pressed; it has no screenshot",
+                    static_cast<unsigned long long>(grab.max_unique_bytes >> 20));
+                grabNotice = "F9 GRAB FAILED - see console (raise PROSPER_CAPTURE_BUNDLE_MAX_MB)";
+            }
+            grabNoticeUntil = std::chrono::steady_clock::now() + std::chrono::seconds(grab.ok ? 4 : 12);
+            if (win) SDL_SetWindowTitle(win, (title + " - " + grabNotice).c_str());
+        }
+    };
+
     // The F9 frame grab, callable from the hotkey AND from the headless triggers below (#2233).
     // Extracted verbatim so an unattended capture takes exactly the interactive path -- the
     // supersede accounting and the reservation bookkeeping included. A second implementation for
     // automation would mean a second set of rules for who owns a reserved file, and that is the
     // one part of this that has already been hard to get right.
+
     auto arm_frame_grab = [&](bool automatic, const char* why) {
         // Every line this path emits is read by an agent, not an operator. `source` names what armed
         // the capture, so a SCHEDULED grab reports its trigger rather than a keypress nobody made --
@@ -1821,22 +1902,31 @@ int main(int argc, char** argv) {
                 // apart from a result, and this fleet's agents read these logs to find artifacts.
                 // The real paths are logged by the writes, once the files exist. Do not "helpfully"
                 // restore a filename here.
-                std::fprintf(stderr, "%s\n",
-                             prosper::frontend::frame_grab_arm_line(
-                                 grab.index, grabNamer.title_label(), source).c_str());
                 // Honour PROSPER_CAPTURE_BUNDLE_MAX_MB here too (#1587). It was consulted only on
                 // the headless/scheduled paths, so the hotkey was pinned to the 2 GiB default with
                 // no way to raise it without editing code — and one 3840x2160 frame of a deferred
                 // renderer exceeds that, which made F9 unusable on 4K UE titles.
-                // Supersede and EXPLAIN, rather than refuse. A press that lands before the
-                // previous arm was promoted replaces it, and a replaced arm never runs and never
-                // reports — so this frontend is the only thing that can account for the names it
-                // reserved. Refusing the press instead was considered and rejected: the flag that
-                // says "a grab is in flight" is cleared only by a guest PRESENT, so a hung title
-                // would leave F9 dead for the rest of the session — and a hung title is exactly
-                // when someone reaches for F9.
-                const std::string replaced =
+                const auto request =
                     prosper::gpu::request_interactive_capture_bundle(grab.bundle, grabBundleMaxMb);
+                if (!request.accepted) {
+                    // These are this request's exclusive reservations, never the previous grab's.
+                    for (const auto& path : {grab.bundle, grab.screenshot}) {
+                        std::error_code ec;
+                        if (std::filesystem::is_regular_file(path, ec) && !ec &&
+                            std::filesystem::file_size(path, ec) == 0 && !ec)
+                            std::filesystem::remove(path, ec);
+                    }
+                    std::fprintf(stderr, "[grab] %s request rejected: %s\n", source,
+                                 request.error.c_str());
+                    grabNotice = "Capture busy: " + request.error;
+                    grabNoticeUntil = std::chrono::steady_clock::now() + std::chrono::seconds(4);
+                    if (win) SDL_SetWindowTitle(win, (title + " - " + grabNotice).c_str());
+                    return;
+                }
+                const auto& replaced = request.replaced_path;
+                std::fprintf(stderr, "%s\n",
+                             prosper::frontend::frame_grab_arm_line(
+                                 grab.index, grabNamer.title_label(), source).c_str());
                 if (!grab.warning.empty())
                     std::fprintf(stderr, "[grab] %s\n", grab.warning.c_str());
                 if (!replaced.empty()) {
@@ -2810,82 +2900,7 @@ int main(int argc, char** argv) {
         // is deliberately non-modal: F9 can be pressed during a routed run, and a message box would
         // block the render loop mid-capture.
         {
-            prosper::gpu::InteractiveGrabOutcome grab;
-            if (prosper::gpu::take_interactive_grab_outcome(grab)) {
-                unsigned bundleSuffix = 0;
-                // Not every outcome is a frame grab's: the same channel reports the env-driven
-                // captures, whose path this frontend never created.
-                const bool reservedHere = take_bundle_reservation(grab.bundle_path, bundleSuffix);
-                if (grab.ok) {
-                    // The file exists now, so this line may name it.
-                    std::fprintf(stderr, "%s\n",
-                                 prosper::frontend::frame_grab_write_line(
-                                     "bundle", grab.bundle_path, bundleSuffix).c_str());
-                    grabNotice = "F9: captured " +
-                        std::filesystem::path(grab.bundle_path).filename().string();
-                } else {
-                    // What became of the output path. Every branch reports the state it actually
-                    // found, and NOTHING is deleted unless this frontend created it: a capture
-                    // configured through PROSPER_CAPTURE_BUNDLE* arrives on this same channel with a
-                    // path prosper never reserved, and a zero-byte file sitting at such a path
-                    // belongs to whoever put it there.
-                    std::string state;
-                    if (grab.bundle_path.empty()) {
-                        state = "no output path was recorded for it";
-                    } else if (!reservedHere) {
-                        state = "this path was configured, not reserved by a frame grab: nothing was "
-                                "written to it and nothing was removed";
-                    } else {
-                        std::error_code ec;
-                        const bool present = std::filesystem::exists(grab.bundle_path, ec);
-                        if (ec) {
-                            // "I could not tell" is not "gone" — an unreadable parent directory
-                            // lands here, and naming the wrong cause is what this logging avoids.
-                            state = "its reserved file could not be checked: " + ec.message();
-                        } else if (!present) {
-                            state = "its reserved file is already gone";
-                        } else {
-                            const uintmax_t bytes = std::filesystem::file_size(grab.bundle_path, ec);
-                            if (ec) {
-                                state = "its reserved file could not be examined: " + ec.message();
-                            } else if (bytes != 0) {
-                                // Cannot happen on this path today; if it ever does, the file has real
-                                // content and is not ours to delete.
-                                state = "its reserved file holds " + std::to_string(bytes) +
-                                        " bytes and was left alone";
-                            } else {
-                                // Leaving a zero-byte .prgbundle after saying none was written would
-                                // be the same class of untrue statement this logging exists to avoid.
-                                const bool removed = std::filesystem::remove(grab.bundle_path, ec);
-                                if (removed && !ec) state = "the empty reservation has been removed";
-                                // remove() reports false with NO error when the file was already
-                                // gone — a race with an external deleter. Printing "could not be
-                                // removed: Success" there would assert a failure that did not happen.
-                                else if (!ec)       state = "the empty reservation was already gone";
-                                else                state = "the empty reservation could not be removed: " +
-                                                            ec.message();
-                            }
-                        }
-                    }
-                    std::fprintf(stderr,
-                        "\n=========================== F9 FRAME GRAB FAILED ===========================\n"
-                        "  %s\n"
-                        "  no bundle content was written; the output path was %s\n"
-                        "  %s\n"
-                        "  %s\n"
-                        "  budget in force: %llu MiB -- raise it with "
-                        "PROSPER_CAPTURE_BUNDLE_MAX_MB=<64..3072> and re-arm the capture\n"
-                        "============================================================================\n\n",
-                        grab.error.c_str(), grab.bundle_path.c_str(), state.c_str(),
-                        reservedHere
-                            ? "the .bmp screenshot for this press is a separate file with the same stem"
-                            : "this capture was configured, not pressed; it has no screenshot",
-                        static_cast<unsigned long long>(grab.max_unique_bytes >> 20));
-                    grabNotice = "F9 GRAB FAILED - see console (raise PROSPER_CAPTURE_BUNDLE_MAX_MB)";
-                }
-                grabNoticeUntil = std::chrono::steady_clock::now() + std::chrono::seconds(grab.ok ? 4 : 12);
-                if (win) SDL_SetWindowTitle(win, (title + " - " + grabNotice).c_str());
-            }
+            reportGrabOutcome();
             if (!grabNotice.empty() && std::chrono::steady_clock::now() >= grabNoticeUntil) {
                 grabNotice.clear();
                 if (win) SDL_SetWindowTitle(win, title.c_str());
@@ -3139,6 +3154,11 @@ int main(int argc, char** argv) {
     // deliberate _Exit, so a registered flush list is the natural home; that is a cross-layer seam
     // which does not exist yet and is deliberately not invented here.
     //
+    // Completed F9 jobs own all their bytes. Drain them before _Exit skips destructors; an
+    // unfinished guest capture is cancelled explicitly rather than written as a complete frame.
+    prosper::gpu::shutdown_interactive_capture_bundle();
+    reportGrabOutcome();
+
     // Unlike its F8 sibling below, this CLOSES rather than cancels. RenderDoc decides for itself
     // whether the span held anything: a span containing real work is written and worth having even
     // though it ended at shutdown rather than on a guest present, and one containing nothing returns

--- a/prosper/src/gpu/timeline/gpu_timeline.cpp
+++ b/prosper/src/gpu/timeline/gpu_timeline.cpp
@@ -16,6 +16,7 @@
 #include <cctype>
 #include <cerrno>
 #include <chrono>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -25,6 +26,8 @@
 #include <iterator>
 #include <limits>
 #include <mutex>
+#include <optional>
+#include <thread>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -2111,12 +2114,28 @@ uint64_t capture_max_submits() {
 // Capture ONE complete displayed frame — every submit between two presents — on demand, so the produced
 // .prgbundle replays faithfully (the producer submits re-run and regenerate renderer-owned RTTs a single
 // .prgcap leaves black). State machine: F9 arms `armed_path`; the NEXT present promotes it to a fresh
-// capturing frame; each submit appends; the following present writes the bundle and disarms. The hot
+// capturing frame; each submit appends; the following present queues owned writing and disarms. The hot
 // per-submit/per-present hooks are guarded by g_interactive_frame_active (one atomic load) so normal
 // play pays nothing until F9 is pressed.
 namespace {
+std::atomic<bool> g_interactive_frame_active{false}; // armed OR collecting guest state
 struct InteractiveFrameBundle {
+    struct WriteJob {
+        GpuCaptureBundle bundle;
+        InteractiveGrabOutcome outcome;
+        std::function<void()> hook;
+    };
     std::mutex mx;
+    std::mutex shutdown_mx;
+    std::condition_variable wake;
+    std::thread writer;
+    std::optional<WriteJob> job;
+    std::function<void()> writer_hook;
+    bool writing = false;
+    bool stopping = false;
+    ~InteractiveFrameBundle() { shutdown(); }
+    void run_writer();
+    void shutdown();
     std::string armed_path;      // set by F9; the next present begins the window
     uint32_t arm_delay_presents = 0; // optional complete presents to skip before that boundary
     std::string current_path;    // path for the window currently being captured
@@ -2129,9 +2148,7 @@ struct InteractiveFrameBundle {
     std::string pending_failure_error;
     // Outcome of the last completed grab, awaiting collection by the frontend (#1587).
     bool outcome_pending = false;
-    bool outcome_ok = false;
-    std::string outcome_path;
-    std::string outcome_error;
+    InteractiveGrabOutcome outcome;
     uint32_t frames_wanted = 1;  // one frame suffices: the capture seeds the sampled renderer-owned RTTs
                                  // with their live pixels (#1291), so a deferred/temporal-AA frame replays
                                  // faithfully from a single submit — no need to re-run producers across a
@@ -2142,7 +2159,6 @@ struct InteractiveFrameBundle {
     GpuCaptureBundle bundle;
 };
 InteractiveFrameBundle& interactive_frame_bundle() { static InteractiveFrameBundle b; return b; }
-std::atomic<bool> g_interactive_frame_active{false};   // armed OR capturing
 // Latched, never cleared. `g_interactive_frame_active` goes back to false when a window closes, so
 // it cannot answer "did anything ever arm?" — which is exactly the question the exit report needs in
 // order to say that PROSPER_CAPTURE_BUNDLE was set and nothing ever used it (#2565).
@@ -2167,32 +2183,105 @@ bool append_capture_to_frame_bundle(GpuCaptureBundle& bundle, const GpuCaptureFi
 }
 }  // namespace
 
-std::string request_interactive_capture_bundle(const std::string& path, uint32_t max_mb,
-                                               uint32_t delay_presents) {
+InteractiveGrabRequest request_interactive_capture_bundle(const std::string& path, uint32_t max_mb,
+                                                          uint32_t delay_presents) {
     InteractiveFrameBundle& b = interactive_frame_bundle();
     std::lock_guard<std::mutex> lk(b.mx);
-    // An arm that has not been promoted yet is REPLACED here, and a replaced capture never runs and
-    // never reports an outcome. Report it to the caller under this lock — asking beforehand would
-    // race the render thread promoting it, and the answer would be wrong exactly when it mattered.
-    //
-    // `path` must not alias b.armed_path, or it would be read after being moved from — the classic
-    // way this pattern breaks. It cannot: InteractiveFrameBundle is file-static with no accessor, so
-    // every caller passes its own storage.
+    if (b.stopping) return {false, {}, "capture writer is shutting down"};
+    if (b.capturing || b.writing || b.outcome_pending)
+        return {false, {}, "previous capture is collecting, writing, or awaiting its result"};
+    if (path.empty()) return {false, {}, "capture path is empty"};
+    // Start before admitting any guest collection. Failure leaves the previous unstarted arm intact.
+    if (!b.writer.joinable()) {
+        try { b.writer = std::thread([&b] { b.run_writer(); }); }
+        catch (const std::exception& error) { return {false, {}, error.what()}; }
+    }
     std::string replaced = std::move(b.armed_path);
     b.armed_path = path;
     b.arm_delay_presents = delay_presents;
     if (max_mb)
         b.max_unique_bytes = static_cast<uint64_t>(std::clamp<uint32_t>(
-                                 max_mb, kInteractiveBundleMinMb, kInteractiveBundleMaxMb))
-                             << 20;
-    // Strict, and it says what it did (#2565). An unparseable value used to become 0 and then be
-    // clamped straight back to the 1-present default, which is precisely the width the empty-window
-    // message tells the operator to widen — so a mistyped remedy reproduced the original failure and
-    // read as the remedy not working. The value in force is unchanged; the silence is not.
+                                 max_mb, kInteractiveBundleMinMb, kInteractiveBundleMaxMb)) << 20;
     if (std::getenv("PROSPER_CAPTURE_FRAMES")) b.frames_wanted = resolve_capture_frames();
     g_interactive_frame_active.store(true, std::memory_order_release);
     g_interactive_capture_ever_armed.store(true, std::memory_order_release);
-    return replaced;
+    return {true, std::move(replaced), {}};
+}
+
+void InteractiveFrameBundle::run_writer() {
+    for (;;) {
+        WriteJob work;
+        {
+            std::unique_lock lock(mx);
+            wake.wait(lock, [&] { return job.has_value() || stopping; });
+            if (!job) return;
+            work = std::move(*job);
+            job.reset();
+        }
+        const auto start = std::chrono::steady_clock::now();
+        const size_t submits = work.bundle.submits.size();
+        try {
+            if (work.hook) work.hook();
+            if (work.outcome.error.empty())
+                work.outcome.ok = write_gpu_capture_bundle(
+                    work.outcome.bundle_path, work.bundle, work.outcome.error);
+        } catch (const std::exception& error) {
+            work.outcome.ok = false;
+            work.outcome.error = error.what();
+        } catch (...) {
+            work.outcome.ok = false;
+            work.outcome.error = "unexpected capture writer exception";
+        }
+        // Free the potentially gigabyte-sized payload here, before opening admission again.
+        work.bundle = {};
+        if (work.outcome.ok)
+            std::fprintf(stderr, "[grab] frame-bundle written (%zu submits) -> %s\n",
+                         submits, work.outcome.bundle_path.c_str());
+        else
+            std::fprintf(stderr, "[grab] frame-bundle write failed: %s\n",
+                         work.outcome.error.c_str());
+        std::fprintf(stderr, "[grab] frame-bundle owned writer finished in %.3f ms\n",
+                     std::chrono::duration<double, std::milli>(
+                         std::chrono::steady_clock::now() - start).count());
+        {
+            std::lock_guard lock(mx);
+            outcome = std::move(work.outcome);
+            outcome_pending = true;
+            writing = false;
+        }
+    }
+}
+
+void InteractiveFrameBundle::shutdown() {
+    // Serializes joiners without holding the state mutex while the writer publishes its result.
+    std::lock_guard shutdown_lock(shutdown_mx);
+    {
+        std::lock_guard lock(mx);
+        stopping = true;
+        if (capturing || !armed_path.empty()) {
+            WriteJob cancelled;
+            cancelled.bundle = std::move(bundle);
+            cancelled.outcome.bundle_path = capturing ? current_path : armed_path;
+            cancelled.outcome.max_unique_bytes = max_unique_bytes;
+            cancelled.outcome.error = "capture window cancelled at shutdown";
+            job = std::move(cancelled);
+            writing = true;
+            capturing = false;
+            armed_path.clear(); current_path.clear();
+        }
+        g_interactive_frame_active.store(false, std::memory_order_release);
+        wake.notify_one();
+    }
+    if (writer.joinable()) writer.join();
+}
+
+void shutdown_interactive_capture_bundle() { interactive_frame_bundle().shutdown(); }
+bool set_interactive_bundle_writer_hook_for_test(std::function<void()> hook) {
+    auto& b = interactive_frame_bundle();
+    std::lock_guard lock(b.mx);
+    if (b.capturing || b.writing || !b.armed_path.empty() || b.stopping) return false;
+    b.writer_hook = std::move(hook);
+    return true;
 }
 bool interactive_capture_bundle_active() {
     return g_interactive_frame_active.load(std::memory_order_acquire);
@@ -2383,7 +2472,12 @@ void observe_guest_log_for_capture(const char* bytes, size_t size,
     // The marker is a phase gate, not a frame oracle. Skip exactly one completed present so the
     // transition boundary cannot be mistaken for the scene it announced, then use the established
     // F9 whole-frame path to retain every submit and persistent RTT/DS boundary seed.
-    const std::string replaced = request_interactive_capture_bundle(state.path, state.max_mb, 1);
+    const auto request = request_interactive_capture_bundle(state.path, state.max_mb, 1);
+    if (!request.accepted) {
+        std::fprintf(stderr, "[grab] guest-log capture rejected: %s\n", request.error.c_str());
+        return;
+    }
+    const auto& replaced = request.replaced_path;
     std::string source_names;
     constexpr const char* names[] = {
         "unknown", "printf", "puts", "putchar", "fputs", "fwrite", "write",
@@ -2764,8 +2858,12 @@ void capture_bundle_trigger_file_on_present(uint64_t present_count) {
     if (state.fired.exchange(true, std::memory_order_acq_rel)) return;
     g_automatic_capture_gate_fired[kGateTriggerFile].store(true, std::memory_order_release);
 
-    const std::string replaced =
-        request_interactive_capture_bundle(state.bundle_path, state.max_mb);
+    const auto request = request_interactive_capture_bundle(state.bundle_path, state.max_mb);
+    if (!request.accepted) {
+        std::fprintf(stderr, "[grab] trigger-file capture rejected: %s\n", request.error.c_str());
+        return;
+    }
+    const auto& replaced = request.replaced_path;
     std::fprintf(stderr,
                  "[grab] trigger file observed at present %llu; whole-frame capture armed; "
                  "trigger path %s; target path %s\n",
@@ -2953,12 +3051,10 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     b.submits = append.submits_appended;
 }
 
-// Called per present (flip): starts the frame on the first present after F9, writes it on the next.
+// Called per present: opens the window, then transfers its owned payload to the writer at closure.
 void interactive_frame_bundle_on_present() {
     if (!g_interactive_frame_active.load(std::memory_order_acquire)) return;
     InteractiveFrameBundle& b = interactive_frame_bundle();
-    std::string write_path;
-    GpuCaptureBundle write_bundle;
     {
         std::lock_guard<std::mutex> lk(b.mx);
         if (b.capturing) {
@@ -2995,13 +3091,15 @@ void interactive_frame_bundle_on_present() {
                 (!wait_for_submits || b.submits > 0 ||
                  b.frames_seen >= kNoSubmitPresentCeiling);
             if (b.failed || window_complete) {   // window complete (or aborted)
-                if (!b.failed && b.submits > 0) { write_path = b.current_path; write_bundle = std::move(b.bundle); }
-                else if (b.failed) {
+                InteractiveFrameBundle::WriteJob work;
+                work.outcome.bundle_path = b.current_path;
+                work.outcome.max_unique_bytes = b.max_unique_bytes;
+                work.hook = b.writer_hook;
+                if (b.failed) {
                     std::fprintf(stderr, "[grab] frame-bundle aborted (see error above); not written\n");
-                    b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
-                    b.outcome_error = b.pending_failure_error.empty() ? std::string("grab aborted")
+                    work.outcome.error = b.pending_failure_error.empty() ? std::string("grab aborted")
                                                                      : b.pending_failure_error;
-                } else {
+                } else if (!b.submits) {
                     // Names no key: this path is reached by the scheduled triggers too (#2233), where there is
                     // no operator. It also points at the actual fix rather than at a repeat -- a
                     // single-present window on a title that presents faster than it submits catches
@@ -3021,10 +3119,13 @@ void interactive_frame_bundle_on_present() {
                                      std::chrono::steady_clock::now().time_since_epoch()).count() -
                                      g_grab_window_open_ms),
                                  b.frames_seen);
-                    b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
-                    b.outcome_error = "the capture window contained no GPU submits";
+                    work.outcome.error = "the capture window contained no GPU submits";
                 }
-                b.capturing = false; b.current_path.clear(); b.bundle = GpuCaptureBundle{};
+                work.bundle = std::move(b.bundle);
+                b.job = std::move(work);
+                b.writing = true;
+                b.wake.notify_one();
+                b.capturing = false; b.current_path.clear();
                 b.submits = 0; b.frames_seen = 0; b.failed = false;
                 b.pending_failure_error.clear();
                 if (b.armed_path.empty()) g_interactive_frame_active.store(false, std::memory_order_release);
@@ -3046,33 +3147,14 @@ void interactive_frame_bundle_on_present() {
                          b.frames_wanted, b.current_path.c_str());
         }
     }
-    if (!write_path.empty()) {
-        std::string error;
-        const size_t n = write_bundle.submits.size();
-        const bool written = write_gpu_capture_bundle(write_path, write_bundle, error);
-        if (written)
-            // Path LAST. This line reports a file that now exists, so it may carry an arrow — but
-            // anything after the path turns the documented read into a path that does not exist.
-            std::fprintf(stderr, "[grab] frame-bundle written (%zu submits) -> %s\n", n, write_path.c_str());
-        else
-            std::fprintf(stderr, "[grab] frame-bundle write failed: %s\n", error.c_str());
-        InteractiveFrameBundle& b = interactive_frame_bundle();
-        std::lock_guard<std::mutex> lk(b.mx);
-        b.outcome_pending = true; b.outcome_ok = written; b.outcome_path = write_path;
-        b.outcome_error = written ? std::string() : error;
-    }
 }
 
 bool take_interactive_grab_outcome(InteractiveGrabOutcome& out) {
     InteractiveFrameBundle& b = interactive_frame_bundle();
     std::lock_guard<std::mutex> lk(b.mx);
     if (!b.outcome_pending) return false;
-    out.ok = b.outcome_ok;
-    out.bundle_path = b.outcome_path;
-    out.error = b.outcome_error;
-    out.max_unique_bytes = b.max_unique_bytes;
-    b.outcome_pending = false; b.outcome_ok = false;
-    b.outcome_path.clear(); b.outcome_error.clear();
+    out = std::move(b.outcome);
+    b.outcome_pending = false;
     return true;
 }
 
@@ -3719,15 +3801,19 @@ void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64
     if (scheduled.valid && present_count >= scheduled.present &&
         !scheduled_fired.exchange(true, std::memory_order_acq_rel)) {
         g_automatic_capture_gate_fired[kGateAtPresent].store(true, std::memory_order_release);
-        const std::string replaced =
-            request_interactive_capture_bundle(scheduled.path, scheduled.max_mb);
-        std::fprintf(stderr,
-                     "[grab] scheduled whole-frame capture armed at present %llu; target path %s\n",
-                     static_cast<unsigned long long>(present_count), scheduled.path.c_str());
-        if (!replaced.empty())
+        const auto request = request_interactive_capture_bundle(scheduled.path, scheduled.max_mb);
+        if (!request.accepted)
+            std::fprintf(stderr, "[grab] scheduled capture rejected: %s\n", request.error.c_str());
+        else {
+            const auto& replaced = request.replaced_path;
             std::fprintf(stderr,
-                         "[grab] this arm replaced an armed capture that had not started; it will "
-                         "never report: %s\n", replaced.c_str());
+                         "[grab] scheduled whole-frame capture armed at present %llu; target path %s\n",
+                         static_cast<unsigned long long>(present_count), scheduled.path.c_str());
+            if (!replaced.empty())
+                std::fprintf(stderr,
+                             "[grab] this arm replaced an armed capture that had not started; it will "
+                             "never report: %s\n", replaced.c_str());
+        }
     }
     interactive_frame_bundle_on_present();
     static const bool requested = [] {

--- a/prosper/src/gpu/timeline/gpu_timeline.hpp
+++ b/prosper/src/gpu/timeline/gpu_timeline.hpp
@@ -286,15 +286,24 @@ void close_gpu_timeline();
 // thread; the frame is captured on the render thread between the next two presents. On-demand: near-zero
 // cost (one atomic load per submit) until armed.
 //
-// Returns the path of an arm this call REPLACED, or "" when there was none. A replaced arm had not
-// started capturing yet, so it never runs and never reports an outcome — the caller is the only one
-// who can explain, or clean up, whatever it had already created under that name.
-[[nodiscard]] std::string request_interactive_capture_bundle(const std::string& path,
+// An unstarted arm may be replaced. Collecting/writing a bundle, or an unread outcome, rejects a
+// new request before it can collect another large payload. Rejection leaves the existing job intact.
+struct InteractiveGrabRequest {
+    bool accepted = false;
+    std::string replaced_path;
+    std::string error;
+};
+[[nodiscard]] InteractiveGrabRequest request_interactive_capture_bundle(const std::string& path,
                                                              uint32_t max_mb = 0,
                                                              uint32_t delay_presents = 0);
 bool interactive_capture_bundle_active();
+// Stop admission, cancel an incomplete window, and drain completed owned work. No guest/Vulkan
+// access is performed by the writer. Call before deliberate _Exit; ordinary teardown also drains.
+void shutdown_interactive_capture_bundle();
+// Test latch at the real writer boundary; install only while idle. The hook does not replace I/O.
+bool set_interactive_bundle_writer_hook_for_test(std::function<void()> hook);
 
-// The outcome of the most recently COMPLETED interactive grab, so a frontend can tell the user what
+// The retained outcome of a COMPLETED interactive grab, so a frontend can tell the user what
 // happened instead of leaving the answer in stderr among tens of thousands of lines (#1587). The user
 // pressed a key; a keystroke that silently produces nothing is indistinguishable from one that never
 // registered, and several agents on a 4K title concluded exactly that.

--- a/prosper/tests/fixtures/interactive_capture_wait.h
+++ b/prosper/tests/fixtures/interactive_capture_wait.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "gpu/timeline/gpu_timeline.hpp"
+#include <chrono>
+#include <thread>
+
+// Bound a test's wait for the production background writer; never infer completion from a file
+// merely appearing, since installation and result publication are separate operations.
+inline bool wait_for_interactive_grab(prosper::gpu::InteractiveGrabOutcome& outcome) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    do {
+        if (prosper::gpu::take_interactive_grab_outcome(outcome)) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return false;
+}

--- a/prosper/tests/gpu/capture/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/gpu/capture/test_gpu_capture_bundle.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <iterator>
 #include "fixtures/test_scratch.h"
+#include "fixtures/interactive_capture_wait.h"
 
 using namespace prosper::gpu;
 
@@ -261,6 +262,10 @@ int main() {
     record_gpu_timeline_present(3, 0, 0, 1920, 1080);   // end the frame (no submits captured here)
     CHECK(!interactive_capture_bundle_active(),
           "the following present ends the frame and disarms (no re-arm)");
+    InteractiveGrabOutcome first_empty;
+    CHECK(wait_for_interactive_grab(first_empty) && !first_empty.ok &&
+          first_empty.bundle_path.find("prosper_frame_grab_unit.prgbundle") != std::string::npos,
+          "the first empty window reports its own failure before rearming");
     (void)request_interactive_capture_bundle(prosper_test::test_scratch_file("prosper_frame_grab_unit2.prgbundle"));
     CHECK(interactive_capture_bundle_active(), "the grab can be re-armed for another press");
     record_gpu_timeline_present(4, 0, 0, 1920, 1080);
@@ -275,7 +280,7 @@ int main() {
         InteractiveGrabOutcome outcome;
         // Both grabs above ended with an empty window (no submits recorded between the presents).
         // That is a failure the user needs told, not silence.
-        CHECK(take_interactive_grab_outcome(outcome),
+        CHECK(wait_for_interactive_grab(outcome),
               "#1587: a completed grab leaves an outcome for the frontend to report");
         CHECK(!outcome.ok && !outcome.error.empty(),
               "#1587: an empty-window grab reports failure with a reason, not silence");
@@ -298,7 +303,7 @@ int main() {
         record_gpu_timeline_present(6, 0, 0, 3840, 2160);
         record_gpu_timeline_present(7, 0, 0, 3840, 2160);
         InteractiveGrabOutcome budget;
-        CHECK(take_interactive_grab_outcome(budget) && budget.max_unique_bytes == (3072ull << 20),
+        CHECK(wait_for_interactive_grab(budget) && budget.max_unique_bytes == (3072ull << 20),
               "#1587: a requested budget of 3072 MiB is the budget actually in force");
         // And the clamp still holds at the top end.
         (void)request_interactive_capture_bundle(
@@ -306,7 +311,7 @@ int main() {
         record_gpu_timeline_present(8, 0, 0, 3840, 2160);
         record_gpu_timeline_present(9, 0, 0, 3840, 2160);
         InteractiveGrabOutcome clamped;
-        CHECK(take_interactive_grab_outcome(clamped) && clamped.max_unique_bytes == (3072ull << 20),
+        CHECK(wait_for_interactive_grab(clamped) && clamped.max_unique_bytes == (3072ull << 20),
               "#1587: an over-large request clamps to the 3072 MiB ceiling rather than overflowing");
         // Restore the default budget: this state is global, and leaving it at 3072 would silently
         // change the ceiling every later grab in this binary runs under.
@@ -315,7 +320,7 @@ int main() {
         record_gpu_timeline_present(10, 0, 0, 1920, 1080);
         record_gpu_timeline_present(11, 0, 0, 1920, 1080);
         InteractiveGrabOutcome restored;
-        CHECK(take_interactive_grab_outcome(restored) && restored.max_unique_bytes == (2048ull << 20),
+        CHECK(wait_for_interactive_grab(restored) && restored.max_unique_bytes == (2048ull << 20),
               "#1587: the budget is restored to the default for later grabs");
     }
 
@@ -335,6 +340,8 @@ int main() {
     record_gpu_timeline_submit(empty_submit, 77);
     record_gpu_timeline_submit(empty_submit, 78);
     record_gpu_timeline_present(7, 0, 0, 1920, 1080);
+    InteractiveGrabOutcome ok_outcome;
+    CHECK(wait_for_interactive_grab(ok_outcome), "owned DS bundle writer completes");
     GpuCaptureBundle ds_bundle;
     GpuCaptureFile ds_first, ds_second;
     CHECK(ds_snapshots == 1 && read_gpu_capture_bundle(ds_bundle_path.string(), ds_bundle, error) &&
@@ -350,8 +357,7 @@ int main() {
     // would pass the suite. It also restores the consume-once invariant: leaving this grab's outcome
     // uncollected would hand it to whichever later test polls next.
     {
-        InteractiveGrabOutcome ok_outcome;
-        CHECK(take_interactive_grab_outcome(ok_outcome) && ok_outcome.ok &&
+        CHECK(ok_outcome.ok &&
               ok_outcome.error.empty() &&
               ok_outcome.bundle_path == ds_bundle_path.string(),
               "#1587: a grab that writes its bundle publishes ok with no error and the exact path");

--- a/prosper/tests/gpu/capture/test_interactive_capture_writer.cpp
+++ b/prosper/tests/gpu/capture/test_interactive_capture_writer.cpp
@@ -1,0 +1,151 @@
+#include "fixtures/interactive_capture_wait.h"
+#include "fixtures/test_scratch.h"
+#include "gpu/capture/gpu_capture_bundle.hpp"
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <stdexcept>
+
+using namespace prosper::gpu;
+using namespace std::chrono_literals;
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("[FAIL] %s\n", m); ++fails; } } while (0)
+
+int main(int argc, char**) {
+    const auto directory = prosper_test::test_scratch_dir();
+    const auto path = (directory / "owned.prgbundle").string();
+    GpuCaptureDsSeed seed;
+    seed.depth_read_base = seed.depth_write_base = 0x310000;
+    seed.width = seed.height = 64;
+    seed.depth_valid = true;
+    seed.depth.resize(64 * 64 * 4);
+    for (size_t i = 0; i < seed.depth.size(); ++i) seed.depth[i] = uint8_t(i * 37 + i / 251);
+    const auto expected = seed.depth;
+    set_gpu_capture_ds_seed_snapshot_reader(
+        [&](std::vector<GpuCaptureDsSeed>& seeds, std::string&) { seeds = {seed}; return true; });
+    GpuState state;
+    auto collect = [&](const std::string& target) {
+        CHECK(request_interactive_capture_bundle(target, 64).accepted, "capture admitted");
+        record_gpu_timeline_present(1, 0, 0, 64, 64);
+        record_gpu_timeline_submit(state, 77);
+    };
+
+    if (argc > 1) {
+        collect(path);
+        shutdown_interactive_capture_bundle();
+        InteractiveGrabOutcome cancelled;
+        CHECK(take_interactive_grab_outcome(cancelled) && !cancelled.ok &&
+              cancelled.bundle_path == path && cancelled.max_unique_bytes == (64ull << 20) &&
+              cancelled.error.find("cancelled at shutdown") != std::string::npos,
+              "shutdown reports the incomplete window with its own identity and budget");
+        CHECK(!std::filesystem::exists(path), "incomplete window is never installed as complete");
+        CHECK(!interactive_capture_bundle_active(), "shutdown disables guest capture hooks");
+        CHECK(!request_interactive_capture_bundle(path).accepted, "shutdown stops admission");
+        set_gpu_capture_ds_seed_snapshot_reader({});
+        return fails ? 1 : 0;
+    }
+
+    std::promise<void> entered, release;
+    auto entered_future = entered.get_future();
+    auto released = release.get_future().share();
+    CHECK(set_interactive_bundle_writer_hook_for_test([&] {
+        entered.set_value(); released.wait();
+    }), "install latch on the actual writer");
+    const auto replaced = request_interactive_capture_bundle("unused.prgbundle", 128);
+    CHECK(replaced.accepted, "unstarted arm admitted");
+    const auto replacement = request_interactive_capture_bundle(path, 64);
+    CHECK(replacement.accepted && replacement.replaced_path == "unused.prgbundle",
+          "unstarted arm replacement remains explicit");
+    record_gpu_timeline_present(1, 0, 0, 64, 64);
+    CHECK(!request_interactive_capture_bundle("busy-collecting", 3072).accepted,
+          "collection rejects a second job before it can change the current budget");
+    record_gpu_timeline_submit(state, 77);
+    auto closing = std::async(std::launch::async, [&] {
+        record_gpu_timeline_present(2, 0, 0, 64, 64);
+    });
+    CHECK(entered_future.wait_for(5s) == std::future_status::ready, "writer reaches blocked boundary");
+    const bool returned = closing.wait_for(1s) == std::future_status::ready;
+    CHECK(returned, "closing present returns while writer is still blocked");
+    if (returned) {
+        CHECK(!interactive_capture_bundle_active(), "writing does not enable guest capture hooks");
+        InteractiveGrabOutcome premature;
+        CHECK(!take_interactive_grab_outcome(premature), "no success before installation");
+        CHECK(!request_interactive_capture_bundle("busy-writing", 3072).accepted,
+              "blocked writer rejects another large capture without replacing its result");
+        CHECK(!std::filesystem::exists(path), "blocked writer has installed no file");
+        seed.depth.assign(seed.depth.size(), 0xee); // producer storage no longer has captured bytes
+    }
+    // Always release, including the synchronous-writer negative control. Never leave a failed
+    // assertion holding a thread or static teardown forever.
+    release.set_value();
+    closing.get();
+    if (!returned) { shutdown_interactive_capture_bundle(); return 1; }
+
+    // Clearing the hook succeeds only after the actual writer releases its job. Leave the result
+    // unread to test admission separately from the writer-busy case above.
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    bool idle = false;
+    do {
+        idle = set_interactive_bundle_writer_hook_for_test({});
+        if (!idle) std::this_thread::sleep_for(1ms);
+    } while (!idle && std::chrono::steady_clock::now() < deadline);
+    CHECK(idle, "writer releases its owned work");
+    CHECK(!request_interactive_capture_bundle("unread-result", 3072).accepted,
+          "unread outcome cannot be overwritten by another request");
+    InteractiveGrabOutcome outcome;
+    CHECK(wait_for_interactive_grab(outcome) && outcome.ok && outcome.bundle_path == path &&
+          outcome.max_unique_bytes == (64ull << 20), "original identity and budget survive busy requests");
+    GpuCaptureBundle bundle;
+    GpuCaptureFile capture;
+    std::string error;
+    CHECK(read_gpu_capture_bundle(path, bundle, error) && bundle.submits.size() == 1 &&
+          materialize_gpu_capture_bundle_submit(bundle, 0, capture, error) &&
+          capture.ds_seeds.size() == 1 && capture.ds_seeds[0].depth == expected,
+          "real installed bundle retains original owned bytes after producer storage changes");
+    CHECK(!take_interactive_grab_outcome(outcome), "completion is reported exactly once");
+
+    const auto bad_path = directory / "directory-not-a-file";
+    std::filesystem::create_directory(bad_path);
+    { std::ofstream sentinel(bad_path / "keep"); sentinel << "existing content"; }
+    collect(bad_path.string());
+    record_gpu_timeline_present(2, 0, 0, 64, 64);
+    CHECK(wait_for_interactive_grab(outcome) && !outcome.ok && !outcome.error.empty() &&
+          outcome.bundle_path == bad_path.string(), "real installation failure reports its own outcome");
+    CHECK(std::filesystem::is_regular_file(bad_path / "keep"), "failed install preserves existing content");
+    CHECK(set_interactive_bundle_writer_hook_for_test([] { throw std::runtime_error("writer failure"); }),
+          "install worker exception control");
+    collect((directory / "exception.prgbundle").string());
+    record_gpu_timeline_present(2, 0, 0, 64, 64);
+    CHECK(wait_for_interactive_grab(outcome) && !outcome.ok && outcome.error == "writer failure",
+          "worker exception becomes a failure and leaves the worker usable");
+
+    std::promise<void> shutdown_entered, shutdown_release;
+    auto shutdown_started = shutdown_entered.get_future();
+    auto shutdown_released = shutdown_release.get_future().share();
+    CHECK(set_interactive_bundle_writer_hook_for_test([&] {
+        shutdown_entered.set_value(); shutdown_released.wait();
+    }), "install shutdown writer latch");
+    const auto final_path = (directory / "shutdown.prgbundle").string();
+    collect(final_path);
+    record_gpu_timeline_present(2, 0, 0, 64, 64);
+    CHECK(shutdown_started.wait_for(5s) == std::future_status::ready, "final writer is blocked");
+    auto shutdown = std::async(std::launch::async, shutdown_interactive_capture_bundle);
+    const auto stop_deadline = std::chrono::steady_clock::now() + 5s;
+    bool stopped = false;
+    do {
+        stopped = request_interactive_capture_bundle("after-shutdown").error ==
+                  "capture writer is shutting down";
+        if (!stopped) std::this_thread::sleep_for(1ms);
+    } while (!stopped && std::chrono::steady_clock::now() < stop_deadline);
+    CHECK(stopped, "shutdown has actually stopped admission before the drain assertion");
+    CHECK(shutdown.wait_for(0ms) == std::future_status::timeout, "shutdown drains pending owned writing");
+    shutdown_release.set_value();
+    shutdown.get();
+    CHECK(take_interactive_grab_outcome(outcome) && outcome.ok && outcome.bundle_path == final_path,
+          "shutdown preserves the completed result for frontend reporting");
+    CHECK(!request_interactive_capture_bundle(path).accepted, "drained writer cannot admit new work");
+    shutdown_interactive_capture_bundle(); // ordinary teardown can safely repeat this
+    set_gpu_capture_ds_seed_snapshot_reader({});
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/gpu/test_capture_trigger_file.cpp
+++ b/prosper/tests/gpu/test_capture_trigger_file.cpp
@@ -1,3 +1,4 @@
+#include "fixtures/interactive_capture_wait.h"
 // Externally triggered headless whole-frame capture. Pure/offline: no guest or Vulkan device.
 #include "gpu/capture/gpu_capture_bundle.hpp"
 #include "gpu/timeline/gpu_timeline.hpp"
@@ -133,6 +134,9 @@ int main(int argc, char** argv) {
     record_gpu_timeline_submit(state, 91);
     record_gpu_timeline_present(4, 0, 0, 4, 4);
 
+    InteractiveGrabOutcome completed;
+    CHECK(wait_for_interactive_grab(completed) && completed.ok,
+          "background bundle installation completes before reading its bytes");
     GpuCaptureBundle bundle;
     std::string error;
     CHECK(read_gpu_capture_bundle(bundle_path.string(), bundle, error),

--- a/prosper/tests/gpu/test_guest_log_capture.cpp
+++ b/prosper/tests/gpu/test_guest_log_capture.cpp
@@ -1,3 +1,4 @@
+#include "fixtures/interactive_capture_wait.h"
 // Exact guest-log phase gate for whole-frame captures. Pure/offline: no guest or Vulkan device.
 #include "gpu/capture/gpu_capture_bundle.hpp"
 #include "gpu/timeline/gpu_timeline.hpp"
@@ -146,6 +147,9 @@ int main() {
           "capture starts only after the one-present delay and remains open until the next present");
     record_gpu_timeline_present(3, 0, 0, 4, 4);
 
+    InteractiveGrabOutcome completed;
+    CHECK(wait_for_interactive_grab(completed) && completed.ok,
+          "background bundle installation completes before reading its bytes");
     GpuCaptureBundle bundle;
     std::string error;
     CHECK(read_gpu_capture_bundle(bundle_path.string(), bundle, error),


### PR DESCRIPTION
F9 serialized and destroyed large completed bundles inside the guest's closing flip call while guest flip/submission locks were held. Move that owned work to one lazy background writer, allowing closing present to return before serialization finishes.

Keep guest/Vulkan capture reads synchronized. Reject overlapping collection/writing and unread-result replacement; retain each job's path and budget. Drain owned work and report its actual installation outcome before frontend teardown or deliberate `_Exit`. Guest-initiated exits bypassing frontend cleanup remain separate.

Validation: full Release app build, 394/394 tests, five focused Vulkan core/synchronization validation tests with zero findings after positive controls. A blocked-writer test installs and reads a real bundle, verifies owned bytes after producer mutation, and covers admission, failure and shutdown. Restoring inline writing makes exactly the closing-present-return assertion fail without hanging.

Paired Sonic/GTA captures preserve their existing scene correctness; Sonic's known black world remains. Audio results are mixed: post-frame covering shortfalls fell 20→7 in Sonic but rose 0→6 in GTA, with one additional GTA callback in a post-completion boundary bucket. No general audio or FPS improvement is claimed. Collection costs and background CPU/memory/filesystem contention remain; #3435 stays open for repeated F9/no-F9 controls and remaining shortages. Exact revisions, manifests, phase denominators, images and analysis recipes are recorded in the author verification comment.

Refs #3435, #3407.
