### PR TITLE
fix(gpu): preserve guest authority across retained storage writes

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3084,6 +3084,27 @@ if(TARGET prosper_core)
       target_link_libraries(test_renderer_uint_copy PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
       add_test(NAME renderer_uint_copy COMMAND test_renderer_uint_copy)
 
+      add_executable(test_near_full_storage_authority
+                     tests/gpu/execute/test_near_full_storage_authority.cpp)
+      target_include_directories(test_near_full_storage_authority PRIVATE tests frontends)
+      target_link_libraries(test_near_full_storage_authority PRIVATE
+                           prosper_live_renderer prosper_core Vulkan::Vulkan)
+      add_test(NAME near_full_storage_authority COMMAND ${CMAKE_COMMAND} -E env
+               --unset=PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK
+               $<TARGET_FILE:test_near_full_storage_authority>)
+      add_test(NAME near_full_storage_authority_export COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1
+               $<TARGET_FILE:test_near_full_storage_authority>)
+      add_test(NAME near_full_storage_full_transition_default COMMAND ${CMAKE_COMMAND} -E env
+               --unset=PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK
+               $<TARGET_FILE:test_near_full_storage_authority> full-transition)
+      add_test(NAME near_full_storage_full_transition COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1
+               $<TARGET_FILE:test_near_full_storage_authority> full-transition)
+      set_tests_properties(near_full_storage_authority near_full_storage_authority_export
+                           near_full_storage_full_transition
+                           near_full_storage_full_transition_default PROPERTIES TIMEOUT 60)
+
       if(Python3_Interpreter_FOUND)
         add_executable(test_compute_buffer_timing tests/gpu/execute/test_compute_buffer_timing.cpp)
         target_include_directories(test_compute_buffer_timing PRIVATE tests frontends)

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3542,8 +3542,6 @@ struct BoundImage {
     bool compute_transfer_seed_borrowed = false;
     std::vector<uint8_t> cache_source_snapshot; // first-use source captured before the transfer
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
-    bool near_full_coverage = false;    // >= 99.8% written post-processing target (cutouts like minimap)
-    bool near_full_retained_export = false; // near-full target bypassing seed upload when retained
     uint64_t written_layers_mask = ~0ULL; // bitmask of touched array layers (depth <= 64)
     bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
     bool write_skip = false;            // untouched storage image: unwritten and unread; skip staging, readback, and writeback
@@ -7295,7 +7293,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         proven_full = it->second.cov == SeedCoverage::Full;
                         proven_none = it->second.cov == SeedCoverage::None;
                         bi.written_layers_mask = it->second.written_layers;
-                        bi.near_full_coverage = it->second.near_full;
                         // #1127: periodically re-prove a Full, None, or layer-masked/near-full Partial verdict
                         // so a data-dependent store that later changes coverage is caught (#3328 B1/N2). The helper
                         // resets the counter, so concurrent dispatches on this key don't all re-prove at once.
@@ -8378,14 +8375,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         bi.dcc_metadata && bi.dcc_metadata_bytes,
                         bi.alias_of == SIZE_MAX,
                     });
-                static const bool skip_export_writeback_enabled =
-                    std::getenv("PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK") != nullptr;
-                const bool near_full_export_eligible = bi.near_full_coverage &&
-                    skip_export_writeback_enabled && bi.graphics_sampled_usage && !bi.poison_verify &&
-                    !bi.mirror_result_to_imported;
                 if (bi.cache_candidate) {
                     const auto cache_lookup_start = ComputeClock::now();
-                    const bool source_snapshot_req = (!bi.seed_skip && !near_full_export_eligible) ||
+                    const bool source_snapshot_req = !bi.seed_skip ||
                         !adaptive_storage_result_validation_enabled();
                     bi.persistent = ctx.acquire_cached_image(
                         bi.cache_key, resource_bytes_for(r, guest_bytes), image_validation_epoch,
@@ -8403,7 +8395,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     cache_lookup_ms = std::chrono::duration<double, std::milli>(
                         ComputeClock::now() - cache_lookup_start).count();
                 }
-                bi.near_full_retained_export = bi.persistent && near_full_export_eligible;
                 transfer_gate_census.record_storage_cache(
                     transfer_gate_observation.role, *r, bi.binding,
                     storage_cache_gates,
@@ -8426,8 +8417,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     cache_lookup_ms += std::chrono::duration<double, std::milli>(
                         ComputeClock::now() - cache_lookup_start).count();
                 }
-                if (!(bi.persistent && (bi.upload_skipped || bi.near_full_retained_export))) {
-                const size_t linear_size = (bi.seed_skip || bi.near_full_retained_export || bi.seed_from_imported != SIZE_MAX)
+                if (!(bi.persistent && bi.upload_skipped)) {
+                const size_t linear_size = (bi.seed_skip || bi.seed_from_imported != SIZE_MAX)
                     ? size_t{0} : static_cast<size_t>(linear_guest_bytes);
                 // Pooled, not freshly allocated: a 4K RGBA16F seed is 63.3 MiB, which is past
                 // glibc's 32 MiB mmap threshold, so a per-dispatch allocation is an mmap, a page
@@ -8453,9 +8444,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      r->tile_mode, static_cast<uint32_t>(guest_texel)));
                 }
                 const uint8_t* unpack_source = nullptr;
-                if (bi.seed_skip || bi.near_full_retained_export) {
-                    // #1122: write-only full-coverage target or near-full retained export --
-                    // the retained GPU image is already valid or will be overwritten.
+                if (bi.seed_skip) {
+                    // #1122: a proven full writer overwrites every texel. Partial writers
+                    // require current source contents even when an allocation is retained.
                     // No seed upload needed.
                 } else if (bi.seed_from_imported != SIZE_MAX) {
                     // The command buffer copies the renderer's exact native image into this target.
@@ -9930,7 +9921,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      nullptr, 2, ready);
                 continue;
             }
-            if (bi.persistent && (bi.upload_skipped || bi.seed_skip || bi.near_full_retained_export)) {
+            if (bi.persistent && (bi.upload_skipped || bi.seed_skip)) {
                 // The previous synchronous dispatch left this read-only sampled image in GENERAL,
                 // and either the guest source is unchanged or the proven-full shader cannot observe
                 // that source. No transfer or layout transition is needed.
@@ -10146,13 +10137,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.write_skip) continue;
-            static const bool skip_export_writeback_enabled =
-                std::getenv("PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK") != nullptr;
-            const bool skip_exported_writeback = skip_export_writeback_enabled &&
-                bi.graphics_sampled_usage && bi.cache_candidate && bi.persistent &&
-                (bi.seed_skip || bi.near_full_coverage) &&
-                !bi.poison_verify && !bi.mirror_result_to_imported;
-            if (skip_exported_writeback) continue;
+            // Coverage only proves this writer can discard its seed. A future partial
+            // writer or guest reader still needs the completed architectural bytes (#3455).
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -10890,27 +10876,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, (unsigned long long)bi.resource->gpu_addr);
                 continue;
             }
-            static const bool skip_export_writeback_enabled =
-                std::getenv("PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK") != nullptr;
-            const bool skip_exported_writeback = skip_export_writeback_enabled &&
-                bi.graphics_sampled_usage && bi.cache_candidate && bi.persistent &&
-                (bi.seed_skip || bi.near_full_coverage) &&
-                !bi.poison_verify && !bi.mirror_result_to_imported;
-            if (skip_exported_writeback) {
-                if (trace) {
-                    std::fprintf(stderr,
-                        "[compute]   skipped exported storage writeback binding=%u addr=0x%llx\n",
-                        bi.binding, (unsigned long long)bi.resource->gpu_addr);
-                }
-                // Announce write range invalidation without modifying host bytes. Safe because graphics
-                // borrows the device image directly via compute export, and no CPU reader observes these
-                // intermediate post-processing surface bytes.
-                if (bi.resource && bi.resource->gpu_addr) {
-                    notify_guest_gpu_write_preserving_bytes(bi.resource->gpu_addr, bi.guest_bytes);
-                }
-                ctx.validate_cached_image_source_from_compute_transfer(bi.cache_key);
-                continue;
-            }
             const auto image_writeback_start = ComputeClock::now();
             const bool image_cache_hit = bi.persistent;
             const ShaderResource* r = bi.resource;
@@ -11051,7 +11016,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 const bool near_full = classify_near_full_coverage(survived, texels);
                 bi.written_layers_mask = written_layers;
-                bi.near_full_coverage = near_full;
                 {
                     const SeedCoverageKey proof_key = image_seed_coverage_key(i, *r);
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);

--- a/prosper/tests/gpu/execute/test_near_full_storage_authority.cpp
+++ b/prosper/tests/gpu/execute/test_near_full_storage_authority.cpp
@@ -1,0 +1,210 @@
+// #3455: retained allocation identity cannot authorize an unwritten storage-image cutout.
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/resources/shader_resources.hpp"
+#include "shared/live/live_compute.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+using namespace prosper::gpu;
+namespace {
+constexpr uint32_t width = 64, height = 16, texels = width * height;
+constexpr uint32_t stored = 0x13579bdfu;
+int failures = 0;
+void check(bool ok, const char* message) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; }
+}
+ComputeItem item(const std::vector<uint32_t>& code, const ShaderResourceTable& resources,
+                 uint64_t address, uint32_t index) {
+    ComputeShaderConfig config;
+    config.user_sgprs.resize(16);
+    config.local_x = width;
+    config.local_y = config.local_z = 1;
+    config.tidig_comp_cnt = 0;
+    config.native_storage_format_support =
+        native_storage_format_support_bit(DataFormat::Uint32, 1);
+    ComputeItem result;
+    result.spirv = recompile_compute(code.data(), code.size(), &resources, config);
+    result.user_sgprs = config.user_sgprs;
+    result.resources = std::make_shared<ShaderResourceTable>(resources);
+    result.code_addr = address;
+    result.dispatch_index = index;
+    result.command_order = index * 10;
+    result.launch.threads_x = result.launch.local_x = width;
+    result.launch.threads_y = result.launch.threads_z = 1;
+    result.launch.local_y = result.launch.local_z = 1;
+    result.launch.groups_x = result.launch.groups_y = result.launch.groups_z = 1;
+    return result;
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    const bool full_transition = argc == 2 && std::strcmp(argv[1], "full-transition") == 0;
+    if (argc != 1 && !full_transition) return 2;
+    std::vector<uint32_t> guest(texels), observed(texels, 0xccccccccu);
+    for (uint32_t i = 0; i < texels; ++i) guest[i] = 0xabc00000u + i;
+    ShaderResource image{};
+    image.cls = ResourceClass::StorageImage;
+    image.binding = 5;
+    image.sgpr_base = 8;
+    image.img_dim = 1;
+    image.format = DataFormat::Uint32;
+    image.num_components = 1;
+    image.width = width;
+    image.height = height;
+    image.depth = 1;
+    image.gpu_addr = reinterpret_cast<uint64_t>(guest.data());
+    image.size = texels * sizeof(uint32_t);
+    ShaderResourceTable producer_resources;
+    producer_resources.resources.push_back(image);
+
+    // Each of 64 invocations writes its column's 16 rows, except (0,0). This is
+    // 1023/1024 texels, inside the near-full threshold, with no invocation races.
+    std::vector<uint32_t> writer{
+        0x7e080300u,             // v4 = local x
+        0x7e0002ffu, stored,     // v0 = stored integer
+    };
+    for (uint32_t y = 1; y < height; ++y) {
+        writer.insert(writer.end(), {
+            0x7e0a0280u + y,     // v5 = row
+            0xf0200108u, 0x00020004u, // IMAGE_STORE x, s[8:15]
+        });
+    }
+    writer.insert(writer.end(), {
+        0x7daa0880u,             // v_cmpx_ne_u32 0, v4: preserve (0,0)
+        0x7e0a0280u,             // v5 = 0
+        0xf0200108u, 0x00020004u,
+        0xbf810000u,
+    });
+    ComputeItem producer = item(writer, producer_resources, 0x34550001u, 1);
+
+    ShaderResource sampled = image;
+    sampled.cls = ResourceClass::Texture;
+    for (unsigned c = 0; c < 4; ++c) sampled.swizzle[c] = 4 + c;
+    ShaderResource output{};
+    output.cls = ResourceClass::ConstantBuffer;
+    output.binding = 2;
+    output.sgpr_base = 0;
+    output.format = DataFormat::Uint32;
+    output.num_components = 1;
+    output.stride = sizeof(uint32_t);
+    output.gpu_addr = reinterpret_cast<uint64_t>(observed.data());
+    output.size = texels * sizeof(uint32_t);
+    ShaderResourceTable consumer_resources;
+    consumer_resources.resources = {output, sampled};
+    std::vector<uint32_t> reader{0x7e080300u}; // v4 = local x
+    for (uint32_t y = 0; y < height; ++y) {
+        reader.insert(reader.end(), {
+            0x7e0a0280u + y,
+            0xf0000108u, 0x00020804u, // IMAGE_LOAD x -> v8, s[8:15]
+            0xbf8c3f70u,
+            0xe0702000u | (y * width * 4u), 0x80000804u,
+        });
+    }
+    reader.push_back(0xbf810000u);
+    ComputeItem consumer = item(reader, consumer_resources, 0x34550002u, 2);
+    check(!producer.spirv.empty() && !consumer.spirv.empty(), "both actual shaders recompile");
+    if (producer.spirv.empty() || consumer.spirv.empty()) return 1;
+
+    auto consume = [&] {
+        std::fill(observed.begin(), observed.end(), 0xccccccccu);
+        unsigned calls = 0;
+        bool all_ok = true;
+        const auto before = prosper::frontend::live_compute_storage_transfer_seeds();
+        const auto result = execute_ordered_items(
+            {{SubmitOperationKind::Dispatch, 1, 10}, {SubmitOperationKind::Dispatch, 2, 20}},
+            {}, {producer, consumer},
+            [](const std::vector<DrawItem>&, uint32_t, uint32_t) { return RenderedFrame{}; },
+            [&](const std::vector<ComputeItem>& items) {
+                ++calls;
+                const bool ok = prosper::frontend::execute_live_compute_items(items);
+                all_ok &= ok;
+                return ok;
+            }, 1, 1);
+        check(result.compute_executed && calls == 2 && all_ok,
+              "producer and real sampled-to-SSBO consumer execute in order");
+        check(prosper::frontend::live_compute_storage_transfer_seeds() > before,
+              "consumer seeds from the retained GPU image rather than the guest fallback");
+    };
+    auto pixels = [&](uint32_t cutout, const char* message) {
+        check(observed[0] == cutout, message);
+        check(std::all_of(observed.begin() + 1, observed.end(),
+                          [](uint32_t value) { return value == stored; }),
+              "all 1023 written texels reach the independent SSBO consumer");
+    };
+    // Proving can restore untouched guest texels after a poison run. Warm outside
+    // the consumer scope first, then require real GPU transfer on every check.
+    for (unsigned warm = 0; warm < 3; ++warm)
+        check(prosper::frontend::execute_live_compute_items({producer}),
+              "near-full producer proves coverage and retains its allocation");
+    consume();
+    pixels(0xabc00000u, "warm retained cutout preserves its original input");
+    if (full_transition) {
+        constexpr uint32_t full_value = 0x31415926u;
+        auto full_code = writer;
+        full_code.erase(std::find(full_code.begin(), full_code.end(), 0x7daa0880u));
+        full_code[2] = full_value;
+        // Coverage proofs do not key on the allocation. Prove on independent bytes
+        // so the target's guest mirror cannot accidentally supply the next oracle.
+        std::vector<uint32_t> proof_guest(texels, 0xeeeeeeeeu);
+        auto proof_resources = producer_resources;
+        proof_resources.resources[0].gpu_addr = reinterpret_cast<uint64_t>(proof_guest.data());
+        auto full = item(full_code, proof_resources, 0x34550003u, 1);
+        check(!full.spirv.empty() && prosper::frontend::execute_live_compute_items({full}),
+              "independent full writer proves coverage");
+        if (failures) return 1;
+        full.resources = std::make_shared<ShaderResourceTable>(producer_resources);
+        const auto partial = producer;
+        producer = full;
+        consume();
+        check(std::all_of(observed.begin(), observed.end(),
+                          [](uint32_t value) { return value == full_value; }),
+              "real consumer observes every texel of the proven full writer");
+        std::printf("full transition witness: guest=%08x GPU=%08x\n", guest[0], observed[0]);
+        check(std::all_of(guest.begin(), guest.end(),
+                          [](uint32_t value) { return value == full_value; }),
+              "completed full writer publishes the architectural guest mirror");
+        producer = partial;
+        consume();
+        pixels(full_value, "partial writer preserves the preceding full GPU result in its cutout");
+        return failures ? 1 : 0;
+    }
+    guest[0] = 0x2468ace0u;
+    guest[1] = 0xfedcba98u;
+    consume();
+    pixels(0x2468ace0u, "guest cutout mutation invalidates retained image contents");
+    consume();
+    pixels(0x2468ace0u, "stable warm repeat preserves the repaired cutout");
+    if (failures) return 1; // Do not leave the one-shot failure hook armed after an earlier failure.
+    guest[0] = 0x98765432u;
+    guest[1] = 0x55555555u;
+    const auto before_failure = guest;
+    prosper::frontend::live_compute_fail_next_storage_readback_for_test();
+    bool failed = false, exported_after_failure = false;
+    unsigned failure_calls = 0;
+    execute_ordered_items(
+        {{SubmitOperationKind::Dispatch, 1, 10}}, {}, {producer},
+        [](const std::vector<DrawItem>&, uint32_t, uint32_t) { return RenderedFrame{}; },
+        [&](const std::vector<ComputeItem>& items) {
+            ++failure_calls;
+            const bool ok = prosper::frontend::execute_live_compute_items(items);
+            failed = !ok;
+            prosper::frontend::LiveComputeImageImport imported;
+            exported_after_failure = prosper::frontend::import_live_compute_storage_image(
+                sampled, image.size, imported);
+            return ok;
+        }, 1, 1);
+    check(failure_calls == 1 && failed, "post-submit readback failure is reported");
+    check(!exported_after_failure, "failed result has no submit-local image export authority");
+    check(guest == before_failure, "failed readback preserves authoritative guest bytes");
+    consume();
+    pixels(0x98765432u, "failure retry reseeds the changed authoritative cutout");
+    consume();
+    pixels(0x98765432u, "recovered warm result retains the repaired cutout");
+    std::printf("near-full storage authority: %d failures\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
A retained near-full storage image could preserve stale cutout pixels with `PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK` set. Merely restoring partial seed uploads also loses correct GPU pixels after a full writer has left the guest mirror stale.

Remove the unsafe opt-in writeback suppression and near-full seed bypass. The legacy variable no longer changes behavior. Proven full writers can still skip their seeds; valid image caching, native GPU exports, retile and exact unchanged-result writeback remain available. This restores guest visibility rather than adding another retained-content assumption.

The production Vulkan fixture writes 1,023 of 1,024 texels and observes the result through a sampled-image consumer writing a separate SSBO. It checks guest mutation, stable reuse, failed readback/retry, and a proven-full-to-partial transition. The original backend fails the cutout and full guest-mirror assertions; retaining only full-writer suppression fails the transition. All four focused default/legacy-variable cases pass with the complete fix.

Validation on `f7e460cf47fc78b13e8c690856682964707a005e`: full Release app build, 398/398 tests, and eight Vulkan core/synchronization cases pass. The new cases have zero findings; the older fixtures retain 60 documented #1710 messages, with no new IDs or synchronization hazards. Paired Sonic/GTA captures on the current main retain their known scene correctness; Sonic’s black world remains. No speedup, audio improvement or game-specific rendering repair is claimed. Exact controls, manifests and measurements are in the author verification comment.

Fixes #3455. Refs #3407.
