### PR TITLE
perf(gpu): retile standard 3D storage images on the device

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3321,7 +3321,16 @@ if(TARGET prosper_live_renderer AND TARGET Vulkan::Vulkan)
   add_test(NAME gpu_retile_mapping_loss COMMAND test_gpu_retile --map-loss)
   add_test(NAME gpu_retile_allocation_fallback COMMAND test_gpu_retile --alloc-oom)
   add_test(NAME gpu_retile_mapping_fallback COMMAND test_gpu_retile --map-oom)
-  set_tests_properties(gpu_retile_cpu PROPERTIES ENVIRONMENT "PROSPER_NO_GPU_RETILE=1")
+  add_test(NAME gpu_retile_mixed COMMAND test_gpu_retile --mixed)
+  add_test(NAME gpu_retile_volume COMMAND test_gpu_retile --volume)
+  add_test(NAME gpu_retile_volume_cpu COMMAND test_gpu_retile --volume-cpu)
+  add_test(NAME gpu_retile_volume_allocation_fallback COMMAND test_gpu_retile --volume-alloc-oom)
+  add_test(NAME gpu_retile_volume_mapping_loss COMMAND test_gpu_retile --volume-map-loss)
+  set_tests_properties(gpu_retile_mixed gpu_retile_volume gpu_retile_volume_cpu
+                       gpu_retile_volume_allocation_fallback gpu_retile_volume_mapping_loss
+                       PROPERTIES TIMEOUT 120)
+  set_tests_properties(gpu_retile_cpu gpu_retile_volume_cpu
+                       PROPERTIES ENVIRONMENT "PROSPER_NO_GPU_RETILE=1")
   add_executable(test_gpu_detile_render tests/gpu/execute/test_gpu_detile_render.cpp)
   target_include_directories(test_gpu_detile_render PRIVATE tests frontends)
   target_link_libraries(test_gpu_detile_render PRIVATE prosper_live_renderer Vulkan::Vulkan)

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -2067,3 +2067,14 @@ temporal window around the Plucky title/gameplay transition. It must include the
 48x48 volumes and close with zero unresolved leaves, providing a native pixel oracle as well as exact compute
 pipeline contracts. Keep the exact-byte and disable-switch A/B discipline used here, and preserve
 screenshot/capture correctness while reducing the synchronous boundaries.
+
+
+### Ruled out: reusable CPU comparison workers (2026-09-08)
+
+A bounded reusable-worker candidate for `parallel_compute_texels` was implemented and rejected
+under #3407. The production-backend fixture's 63.75 MiB equal-result comparisons became slower
+with both four and eight reused workers across three fresh-process repetitions; smaller comparisons
+were mixed and did not establish an enclosing `execute_item` gain. The candidate was discarded.
+This rejects that implementation on the measured workload, not all worker-pool designs or the
+possibility that thread creation costs matter. Retained commands, source identities and measurements
+are in #3407; no game speedup is claimed from this experiment.

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -14,8 +14,9 @@ found Vulkan.
   pipeline cache, descriptor pools, memory pool and command buffers, and does not include
   `render_runner.h` at all. Reflected storage buffers and storage images are materialized from guest
   memory, dispatched, and written back into guest memory synchronously.
-- `gpu_retile.hpp` — exact 2D storage-image writeback layout conversion in the guest compute
-  submission. Keeps linear comparison baselines separate from the tiled host-read buffer.
+- `gpu_retile.hpp` — exact 2D and standard 3D storage-image writeback layout conversion in the
+  guest compute submission. 3D SW_4KB_S/SW_64KB_S uses a separate pipeline variant and checks
+  padded XYZ dispatch limits; unsupported layouts or sub-word texels retain CPU conversion. Keeps linear comparison baselines separate from the tiled host-read buffer.
 - `packed_rtt_conversion.hpp` — device-owned RGBA8→packed-10-bit sampled conversion.
   Records transfers and conversion into the guest compute submission; setup failures retain their
   `VkResult` so optional fallback cannot hide device loss.

--- a/prosper/frontends/shared/live/gpu_retile.hpp
+++ b/prosper/frontends/shared/live/gpu_retile.hpp
@@ -21,9 +21,10 @@ inline std::atomic<bool>& gpu_retile_poison_output_for_test() {
 }
 
 struct GpuRetileParameters {
-    std::array<uint32_t, 22> words{};
+    std::array<uint32_t, 26> words{};
     uint64_t linear_bytes = 0, tiled_bytes = 0;
-    uint32_t groups_x = 0, groups_y = 0;
+    uint32_t groups_x = 0, groups_y = 0, groups_z = 1;
+    bool volume = false;
 
     bool initialize(uint32_t width, uint32_t height, uint32_t bpe, uint32_t mode,
                     const VkPhysicalDeviceLimits& limits) {
@@ -60,6 +61,43 @@ struct GpuRetileParameters {
         groups_y = uint32_t(padded_height);
         return true;
     }
+    bool initialize_volume(uint32_t width, uint32_t height, uint32_t depth,
+                           uint32_t bpe, uint32_t mode, const VkPhysicalDeviceLimits& limits) {
+        *this = {};
+        std::array<uint32_t, 16> equation{};
+        uint32_t bw = 0, bh = 0, bd = 0, bits = 0;
+        if (!width || !height || !depth ||
+            !prosper::gpu::tile_volume_word_equation(mode, bpe, equation, bw, bh, bd, bits))
+            return false;
+        if (!std::has_single_bit(bw) || !std::has_single_bit(bh) || !std::has_single_bit(bd))
+            return false;
+        const uint64_t row_words = uint64_t(width) * (bpe / 4);
+        const uint64_t bx = (uint64_t(width) + bw - 1) / bw;
+        const uint64_t by = (uint64_t(height) + bh - 1) / bh;
+        const uint64_t bz = (uint64_t(depth) + bd - 1) / bd;
+        const uint64_t block_bytes = uint64_t{1} << bits;
+        if (row_words > UINT32_MAX / uint64_t(height) ||
+            row_words * height > UINT32_MAX / uint64_t(depth) ||
+            bx > UINT32_MAX / block_bytes / by ||
+            bx * by > UINT32_MAX / block_bytes / bz) return false;
+        linear_bytes = row_words * height * depth * 4;
+        tiled_bytes = bx * by * bz * block_bytes;
+        const uint64_t gx = (bx * bw * (bpe / 4) + 127) / 128;
+        const uint64_t gy = by * bh, gz = bz * bd;
+        if (linear_bytes > limits.maxStorageBufferRange || tiled_bytes > limits.maxStorageBufferRange ||
+            limits.maxComputeWorkGroupSize[0] < 128 || limits.maxComputeWorkGroupInvocations < 128 ||
+            limits.maxPushConstantsSize < sizeof(words) || gx > limits.maxComputeWorkGroupCount[0] ||
+            gy > limits.maxComputeWorkGroupCount[1] || gz > limits.maxComputeWorkGroupCount[2])
+            return false;
+        words[0] = width; words[1] = height; words[2] = std::countr_zero(bpe / 4);
+        words[3] = std::countr_zero(bw); words[4] = std::countr_zero(bh); words[5] = uint32_t(bx);
+        std::copy(equation.begin(), equation.end(), words.begin() + 6);
+        words[22] = depth; words[23] = std::countr_zero(bd); words[24] = uint32_t(by);
+        words[25] = bits - 2; // Word offset of a whole block.
+        groups_x = uint32_t(gx); groups_y = uint32_t(gy); groups_z = uint32_t(gz);
+        volume = true;
+        return true;
+    }
 };
 
 // Context-owned pipeline. Per-dispatch buffers and descriptors remain owned by
@@ -77,7 +115,7 @@ struct GpuRetilePipeline {
         if (descriptors) vkDestroyDescriptorSetLayout(device, descriptors, nullptr);
         pipeline = VK_NULL_HANDLE; layout = VK_NULL_HANDLE; descriptors = VK_NULL_HANDLE;
     }
-    VkResult initialize(VkDevice dev, VkPipelineCache cache) {
+    VkResult initialize(VkDevice dev, VkPipelineCache cache, bool volume = false) {
         if (attempted) return setup_result;
         attempted = true; device = dev;
         const VkDescriptorSetLayoutBinding bindings[]{
@@ -87,13 +125,13 @@ struct GpuRetilePipeline {
         dci.bindingCount = 2; dci.pBindings = bindings;
         setup_result = vkCreateDescriptorSetLayout(device, &dci, nullptr, &descriptors);
         if (setup_result != VK_SUCCESS) return setup_result;
-        const VkPushConstantRange push{VK_SHADER_STAGE_COMPUTE_BIT, 0, 22 * sizeof(uint32_t)};
+        const VkPushConstantRange push{VK_SHADER_STAGE_COMPUTE_BIT, 0, 26 * sizeof(uint32_t)};
         VkPipelineLayoutCreateInfo lci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
         lci.setLayoutCount = 1; lci.pSetLayouts = &descriptors;
         lci.pushConstantRangeCount = 1; lci.pPushConstantRanges = &push;
         setup_result = vkCreatePipelineLayout(device, &lci, nullptr, &layout);
         if (setup_result != VK_SUCCESS) { destroy(); return setup_result; }
-        const auto words = prosper::gpu::build_compute_retile_words();
+        const auto words = prosper::gpu::build_compute_retile_words(volume);
         VkShaderModuleCreateInfo sci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
         sci.codeSize = words.size() * sizeof(uint32_t); sci.pCode = words.data();
         VkShaderModule shader = VK_NULL_HANDLE;
@@ -157,7 +195,7 @@ struct GpuRetilePipeline {
         vkCmdBindPipeline(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
         vkCmdBindDescriptorSets(command, VK_PIPELINE_BIND_POINT_COMPUTE, layout, 0, 1, &set, 0, nullptr);
         vkCmdPushConstants(command, layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(p.words), p.words.data());
-        vkCmdDispatch(command, p.groups_x, p.groups_y, 1);
+        vkCmdDispatch(command, p.groups_x, p.groups_y, p.groups_z);
         gpu_retile_recordings().fetch_add(1, std::memory_order_relaxed);
         // The host reads the entire shader-written allocation, even if exact-result
         // comparison later skips this mapping.

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1447,7 +1447,7 @@ struct VulkanComputeContext {
     VkPipelineLayout compare_pipeline_layout = VK_NULL_HANDLE;
     VkPipeline compare_pipeline = VK_NULL_HANDLE;
     PackedRttConversion packed_rtt_conversion;
-    GpuRetilePipeline retile_pipeline;
+    GpuRetilePipeline retile_pipeline, volume_retile_pipeline;
     // Storage-image support (#590): the recompiler's storage path declares the
     // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
     // tests/fixtures/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
@@ -1632,6 +1632,7 @@ struct VulkanComputeContext {
         if (compare_pool) vkDestroyDescriptorPool(device, compare_pool, nullptr);
         packed_rtt_conversion.destroy();
         retile_pipeline.destroy();
+        volume_retile_pipeline.destroy();
         if (compare_pipeline) vkDestroyPipeline(device, compare_pipeline, nullptr);
         if (compare_pipeline_layout)
             vkDestroyPipelineLayout(device, compare_pipeline_layout, nullptr);
@@ -9265,7 +9266,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         if (!images_ready) break;
 
-        // Exact 2D tiling runs after image transfer in this same submission. Keep
+        // Exact 2D and standard 3D tiling runs after image transfer in this same submission. Keep
         // the original linear result for cache comparison and publication; the
         // tiled result has its own allocation owned through completion.
         static const bool gpu_retile_disabled = std::getenv("PROSPER_NO_GPU_RETILE") != nullptr;
@@ -9277,20 +9278,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const auto* r = bi.resource;
                 if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.write_skip ||
                     bi.poison_verify || !bi.exact_storage_bytes() || !r ||
-                    r->depth != 1 || (r->img_dim != 1 && r->img_dim != 5) ||
-                    bi.array_layers != 1 || bi.texel_depth != 1 || r->in_mip_tail ||
+                    bi.array_layers != 1 || r->in_mip_tail ||
                     r->layer_mip_offset_bytes || !staging[i]) continue;
+                const bool volume = r->img_dim == 2 && r->depth > 1 && bi.texel_depth == r->depth;
+                if (!volume && (r->depth != 1 || (r->img_dim != 1 && r->img_dim != 5) ||
+                                bi.texel_depth != 1)) continue;
                 // One-layer array descriptors use the same physical 2D tiling,
                 // with either an ordinary or a reflected one-layer array view.
                 const uint32_t bpe = r->format == DataFormat::Float10_11_11 ||
                     r->format == DataFormat::Unorm2_10_10_10 ? 4u :
                     data_format_bytes(r->format) * (r->num_components ? r->num_components : 1u);
-                if (!bi.retile_parameters.initialize(r->width, r->height, bpe,
-                        r->tile_mode, properties.limits) ||
+                const bool layout_ok = volume
+                    ? bi.retile_parameters.initialize_volume(r->width, r->height, r->depth,
+                        bpe, r->tile_mode, properties.limits)
+                    : bi.retile_parameters.initialize(r->width, r->height, bpe,
+                        r->tile_mode, properties.limits);
+                if (!layout_ok ||
                     bi.retile_parameters.tiled_bytes != bi.guest_bytes ||
                     bi.retile_parameters.linear_bytes != staging_bytes[i]) continue;
+                auto& retile = volume ? ctx.volume_retile_pipeline : ctx.retile_pipeline;
                 auto prepare = [&] {
-                    if (!vk_soft_ok(ctx.retile_pipeline.initialize(ctx.device, ctx.pipeline_cache),
+                    if (!vk_soft_ok(retile.initialize(ctx.device, ctx.pipeline_cache, volume),
                                     "retile-pipeline")) return false;
                     VkBufferCreateInfo ci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                     ci.size = bi.retile_parameters.tiled_bytes;
@@ -9306,7 +9314,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         !vk_soft_handle_ok(bi.retile_memory, "retile-memory-handle") ||
                         !vk_soft_ok(vkBindBufferMemory(ctx.device, bi.retile_buffer,
                             bi.retile_memory, 0), "retile-bind")) return false;
-                    return vk_soft_ok(ctx.retile_pipeline.bind(staging[i], bi.retile_buffer,
+                    return vk_soft_ok(retile.bind(staging[i], bi.retile_buffer,
                         bi.retile_parameters, bi.retile_pool, bi.retile_set), "retile-descriptors");
                 };
                 if (!prepare()) {
@@ -10163,8 +10171,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // buffer, and the source scope has to name the write that actually produced the bytes.
             prosper::gpu::record_host_read_barrier(command, staging[i]);
             if (bi.retile_buffer)
-                ctx.retile_pipeline.record(command, staging[i], bi.retile_buffer,
-                                            bi.retile_set, bi.retile_parameters);
+                (bi.retile_parameters.volume ? ctx.volume_retile_pipeline : ctx.retile_pipeline)
+                    .record(command, staging[i], bi.retile_buffer,
+                            bi.retile_set, bi.retile_parameters);
             if (bi.mirror_result_to_imported) {
                 const BoundImage& mirror = images[bi.seed_from_imported];
                 VkImageMemoryBarrier mirror_to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};

--- a/prosper/src/gpu/recompiler/spirv_builder.cpp
+++ b/prosper/src/gpu/recompiler/spirv_builder.cpp
@@ -433,7 +433,7 @@ std::vector<uint32_t> build_compute_detile_rgba16f() {
   return e.assemble();
 }
 
-std::vector<uint32_t> build_compute_retile_words() {
+std::vector<uint32_t> build_compute_retile_words(bool volume) {
     Emitter e;
     const auto void_t = e.id(), fn_t = e.id(), bool_t = e.id(), uint_t = e.id();
     const auto v3_t = e.id(), input_ptr = e.id(), gid = e.id();
@@ -478,7 +478,7 @@ std::vector<uint32_t> build_compute_retile_words() {
         const auto id = e.id(); constants.emplace_back(value, id);
         Emitter::put(e.types, Op_Constant, {uint_t, id, value}); return id;
     };
-    Emitter::put(e.types, Op_TypeArray, {push_array, uint_t, constant(22)});
+    Emitter::put(e.types, Op_TypeArray, {push_array, uint_t, constant(26)});
     Emitter::put(e.types, Op_TypeStruct, {push_t, push_array});
     Emitter::put(e.types, Op_TypePointer, {push_ptr, SC_PushConstant, push_t});
     Emitter::put(e.types, Op_TypePointer, {push_word, SC_PushConstant, uint_t});
@@ -496,10 +496,22 @@ std::vector<uint32_t> build_compute_retile_words() {
     Emitter::put(e.code, Op_Label, {entry});
     uint32_t params[6]{};
     for (uint32_t i = 0; i < 6; ++i) params[i] = load(push, push_word, constant(i));
+    uint32_t depth = 0, block_depth = 0, blocks_y = 0, block_shift = constant(14);
+    if (volume) {
+        depth = load(push, push_word, constant(22));
+        block_depth = load(push, push_word, constant(23));
+        blocks_y = load(push, push_word, constant(24));
+        block_shift = load(push, push_word, constant(25));
+    }
     const auto id3 = e.id(), word_x = e.id(), y = e.id();
+    uint32_t z = 0;
     Emitter::put(e.code, Op_Load, {v3_t, id3, gid});
     Emitter::put(e.code, Op_CompositeExtract, {uint_t, word_x, id3, 0});
     Emitter::put(e.code, Op_CompositeExtract, {uint_t, y, id3, 1});
+    if (volume) {
+        z = e.id();
+        Emitter::put(e.code, Op_CompositeExtract, {uint_t, z, id3, 2});
+    }
     const auto row_words = binary(Op_ShiftLeftLogical, params[0], params[2]);
     const auto padded_row_words = binary(Op_ShiftLeftLogical, params[5],
         binary(Op_IAdd, params[3], params[2]));
@@ -518,32 +530,53 @@ std::vector<uint32_t> build_compute_retile_words() {
     const auto component_mask = binary(Op_ISub,
         binary(Op_ShiftLeftLogical, constant(1), params[2]), constant(1));
     const auto component = binary(Op_BitwiseAnd, word_x, component_mask);
-    const auto block = binary(Op_IAdd,
-        binary(Op_IMul, binary(Op_ShiftRightLogical, y, params[4]), params[5]),
+    auto block_row = binary(Op_ShiftRightLogical, y, params[4]);
+    if (volume)
+        block_row = binary(Op_IAdd, block_row,
+            binary(Op_IMul, binary(Op_ShiftRightLogical, z, block_depth), blocks_y));
+    const auto block = binary(Op_IAdd, binary(Op_IMul, block_row, params[5]),
         binary(Op_ShiftRightLogical, x, params[3]));
     uint32_t byte_offset = binary(Op_ShiftLeftLogical, component, constant(2));
     for (uint32_t bit = 2; bit < 16; ++bit) {
         const auto equation = load(push, push_word, constant(bit + 6));
-        const auto coordinate = binary(Op_BitwiseXor,
-            binary(Op_BitwiseAnd, x, binary(Op_BitwiseAnd, equation, constant(65535))),
-            binary(Op_BitwiseAnd, y, binary(Op_ShiftRightLogical, equation, constant(16))));
+        uint32_t coordinate;
+        if (volume) {
+            const auto xy = binary(Op_BitwiseXor,
+                binary(Op_BitwiseAnd, x, binary(Op_BitwiseAnd, equation, constant(255))),
+                binary(Op_BitwiseAnd, y, binary(Op_BitwiseAnd,
+                    binary(Op_ShiftRightLogical, equation, constant(8)), constant(255))));
+            coordinate = binary(Op_BitwiseXor, xy,
+                binary(Op_BitwiseAnd, z, binary(Op_ShiftRightLogical, equation, constant(16))));
+        } else {
+            coordinate = binary(Op_BitwiseXor,
+                binary(Op_BitwiseAnd, x, binary(Op_BitwiseAnd, equation, constant(65535))),
+                binary(Op_BitwiseAnd, y, binary(Op_ShiftRightLogical, equation, constant(16))));
+        }
         const auto population = e.id();
         Emitter::put(e.code, Op_BitCount, {uint_t, population, coordinate});
         byte_offset = binary(Op_BitwiseOr, byte_offset,
             binary(Op_ShiftLeftLogical, binary(Op_BitwiseAnd, population, constant(1)), constant(bit)));
     }
-    const auto address = binary(Op_IAdd, binary(Op_ShiftLeftLogical, block, constant(14)),
+    const auto address = binary(Op_IAdd, binary(Op_ShiftLeftLogical, block, block_shift),
         binary(Op_ShiftRightLogical, byte_offset, constant(2)));
     // Padding has no source texel. Branch before the load; selecting zero AFTER
     // an out-of-range read would still violate the source descriptor's bounds.
-    const auto pixel_x = e.id(), pixel_y = e.id(), pixel_valid = e.id();
+    const auto pixel_x = e.id(), pixel_y = e.id();
+    auto pixel_valid = e.id();
     Emitter::put(e.code, Op_ULessThan, {bool_t, pixel_x, word_x, row_words});
     Emitter::put(e.code, Op_ULessThan, {bool_t, pixel_y, y, params[1]});
     Emitter::put(e.code, Op_LogicalAnd, {bool_t, pixel_valid, pixel_x, pixel_y});
+    if (volume) {
+        const auto pixel_z = e.id(), all = e.id();
+        Emitter::put(e.code, Op_ULessThan, {bool_t, pixel_z, z, depth});
+        Emitter::put(e.code, Op_LogicalAnd, {bool_t, all, pixel_valid, pixel_z});
+        pixel_valid = all;
+    }
     Emitter::put(e.code, Op_SelectionMerge, {pixel_done, 0});
     Emitter::put(e.code, Op_BranchConditional, {pixel_valid, read_pixel, pixel_done});
     Emitter::put(e.code, Op_Label, {read_pixel});
-    const auto linear = binary(Op_IAdd, binary(Op_IMul, y, row_words), word_x);
+    const auto row = volume ? binary(Op_IAdd, binary(Op_IMul, z, params[1]), y) : y;
+    const auto linear = binary(Op_IAdd, binary(Op_IMul, row, row_words), word_x);
     const auto loaded = load(source, word_ptr, linear);
     Emitter::put(e.code, Op_Branch, {pixel_done});
     Emitter::put(e.code, Op_Label, {pixel_done});

--- a/prosper/src/gpu/recompiler/spirv_builder.hpp
+++ b/prosper/src/gpu/recompiler/spirv_builder.hpp
@@ -37,10 +37,11 @@ std::vector<uint32_t> build_compute_detile_rgba16f();
 // Binding 0: storage buffer of uint32 texels; push constant: texel count.
 std::vector<uint32_t> build_compute_rgba8_to_packed10();
 
-// Exact row-major words (binding 0) -> 2D 64 KiB guest tiles (binding 1).
+// Exact row-major words (binding 0) -> 2D 64 KiB or standard 3D guest tiles (binding 1).
 // Push words: width, height, log2(words/texel), log2(block width), log2(block height),
-// blocks/row, followed by 16 packed x/y equation masks. Dispatch the full padded
-// rectangle; out-of-image texels write zero without reading the linear source.
-std::vector<uint32_t> build_compute_retile_words();
+// blocks/row, then 16 packed x/y (or x/y/z) equation masks. Volume words 22..25:
+// depth, log2(block depth), block rows/plane, log2(words/block). Dispatch the full
+// padded rectangle/volume; out-of-image texels write zero without reading the source.
+std::vector<uint32_t> build_compute_retile_words(bool volume = false);
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -1263,6 +1263,24 @@ bool tile64_word_equation(uint32_t mode, uint32_t bpe,
     return true;
 }
 
+bool tile_volume_word_equation(uint32_t mode, uint32_t bpe,
+                               std::array<uint32_t, 16>& equation,
+                               uint32_t& bw, uint32_t& bh, uint32_t& bd, uint32_t& bits) {
+    equation = {};
+    if ((mode != uint32_t(TileMode::Sw4KbS) && mode != uint32_t(TileMode::Sw64KbS)) ||
+        (bpe != 4 && bpe != 8 && bpe != 16)) return false;
+    const auto el = sw64kb_elem_log2(bpe);
+    const bool small = mode == uint32_t(TileMode::Sw4KbS);
+    const auto* dims = small ? kSw4kbS3Dims[el] : kSw64kbS3Dims[el];
+    bw = dims[0]; bh = dims[1]; bd = dims[2]; bits = small ? 12u : 16u;
+    for (uint32_t bit = el; bit < bits; ++bit) {
+        const auto& p = kSw64kbS3[el][bit];
+        if ((uint32_t(p.x) | uint32_t(p.y) | uint32_t(p.z)) & ~255u) return false;
+        equation[bit] = uint32_t(p.x) | (uint32_t(p.y) << 8) | (uint32_t(p.z) << 16);
+    }
+    return true;
+}
+
 size_t tiled_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode, uint32_t pitch,
                            uint32_t bytes_per_texel) {
     if (!tile_mode_is_tiled(tile_mode)) return (size_t)width * height * bytes_per_texel;

--- a/prosper/src/gpu/texture/tile.hpp
+++ b/prosper/src/gpu/texture/tile.hpp
@@ -50,6 +50,13 @@ bool tile64_word_equation(uint32_t tile_mode, uint32_t bytes_per_texel,
                           std::array<uint32_t, 16>& equation,
                           uint32_t& block_width, uint32_t& block_height);
 
+// Standard 3D word tiling: each equation packs x/y/z masks in successive bytes.
+// Only 4/8/16-byte texels have independently writable 32-bit output words.
+bool tile_volume_word_equation(uint32_t tile_mode, uint32_t bytes_per_texel,
+                               std::array<uint32_t, 16>& equation,
+                               uint32_t& block_width, uint32_t& block_height,
+                               uint32_t& block_depth, uint32_t& block_bits);
+
 // libSceVideoOut's own two-value tiling enum, as passed to sceVideoOutSetBufferAttribute(2) and
 // recorded with each registered display buffer. It is NOT a GFX10 swizzle index: it only says
 // whether the scanout surface is stored in the hardware's render-target layout or row-major.

--- a/prosper/tests/gpu/execute/test_gpu_retile.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_retile.cpp
@@ -39,18 +39,42 @@ static bool equation_covers_block(uint32_t mode, uint32_t bpe, uint32_t bx,
     }
     return written == seen.size();
 }
-int main(int argc, char** argv) {
-    const bool cpu = argc == 2 && std::strcmp(argv[1], "--cpu") == 0;
+static bool volume_equation_covers_block(uint32_t mode, uint32_t bpe, bool collapse = false) {
+    std::array<uint32_t, 16> equation{};
+    uint32_t bw = 0, bh = 0, bd = 0, bits = 0;
+    if (!tile_volume_word_equation(mode, bpe, equation, bw, bh, bd, bits)) return false;
+    if (collapse) equation[bits - 1] = 0;
+    std::vector<bool> seen(size_t{1} << (bits - 2));
+    size_t written = 0;
+    for (uint32_t z = 0; z < bd; ++z) for (uint32_t y = 0; y < bh; ++y)
+    for (uint32_t x = 0; x < bw; ++x) for (uint32_t component = 0; component < bpe / 4; ++component) {
+        uint32_t offset = component * 4;
+        for (uint32_t bit = 2; bit < bits; ++bit) {
+            const auto e = equation[bit];
+            offset |= uint32_t(std::popcount((x & (e & 255)) ^
+                (y & ((e >> 8) & 255)) ^ (z & (e >> 16))) & 1) << bit;
+        }
+        if ((offset & 3) || offset / 4 >= seen.size() || seen[offset / 4]) return false;
+        seen[offset / 4] = true; ++written;
+    }
+    return written == seen.size();
+}
+
+int run_case(int argc, char** argv) {
+    const bool mixed = argc == 2 && std::strstr(argv[1], "mixed");
+    const bool volume = argc == 2 && std::strstr(argv[1], "volume");
+    const bool cpu = argc == 2 && std::strstr(argv[1], "cpu");
     const bool clean = argc == 2 && std::strcmp(argv[1], "--clean") == 0;
-    const bool mapping = argc == 2 && std::strncmp(argv[1], "--map-", 6) == 0;
-    const bool allocation = argc == 2 && std::strncmp(argv[1], "--alloc-", 8) == 0;
+    const bool mapping = argc == 2 && std::strstr(argv[1], "map-");
+    const bool allocation = argc == 2 && std::strstr(argv[1], "alloc-");
     const bool fault_mode = mapping || allocation;
     const bool loss = fault_mode && std::strstr(argv[1], "loss");
     gpu_retile_poison_output_for_test().store(!cpu && !clean);
     VkPhysicalDeviceLimits limits{};
     limits.maxStorageBufferRange = UINT32_MAX;
     limits.maxComputeWorkGroupSize[0] = limits.maxComputeWorkGroupInvocations = 128;
-    limits.maxComputeWorkGroupCount[0] = limits.maxComputeWorkGroupCount[1] = 65535;
+    limits.maxComputeWorkGroupCount[0] = limits.maxComputeWorkGroupCount[1] =
+        limits.maxComputeWorkGroupCount[2] = 65535;
     limits.maxPushConstantsSize = 128;
     GpuRetileParameters params;
     check(params.initialize(3840, 2160, 4, 27, limits) &&
@@ -85,19 +109,54 @@ int main(int argc, char** argv) {
               "full block equation writes every output word exactly once, including nonzero block coordinates");
     check(!equation_covers_block(27, 4, 0, 0, true),
           "equation coverage guard rejects a manually collapsed address bit");
+    for (uint32_t mode : {5u, 9u}) for (uint32_t bpe : {4u, 8u, 16u})
+        check(volume_equation_covers_block(mode, bpe),
+              "3D equation writes every physical word exactly once");
+    check(!volume_equation_covers_block(9, 8, true),
+          "3D coverage guard rejects a collapsed coordinate bit");
     struct Format { DataFormat format; uint32_t components, bpe; };
     constexpr Format formats[]{ {DataFormat::Uint32, 1, 4}, {DataFormat::Uint8, 4, 4},
         {DataFormat::Unorm8, 4, 4}, {DataFormat::Float16, 4, 8}, {DataFormat::Float32, 4, 16} };
+    check(params.initialize_volume(64, 64, 128, 8, 9, limits) &&
+              params.linear_bytes == 4194304 && params.tiled_bytes == 4194304 &&
+              params.groups_z == 128, "representative 4 MiB standard 3D RGBA16F volume is admitted");
+    check(!params.initialize_volume(UINT32_MAX, UINT32_MAX, UINT32_MAX, 16, 9, limits) &&
+          !params.initialize_volume(64, 64, 128, 2, 9, limits) &&
+          !params.initialize_volume(64, 64, 128, 8, 27, limits),
+          "overflow, sub-word texels and unsupported 3D layouts decline");
+    auto depth_limits = limits; depth_limits.maxComputeWorkGroupCount[2] = 21;
+    check(!params.initialize_volume(67, 19, 21, 8, 9, depth_limits),
+          "3D workgroup limit applies to padded depth");
+    const std::vector<uint32_t> modes = mixed ? std::vector<uint32_t>{9} : volume ? std::vector<uint32_t>{5, 9}
+                                              : std::vector<uint32_t>{9, 24, 27};
+    const std::vector<std::pair<uint32_t, uint32_t>> extents = mixed
+        ? std::vector<std::pair<uint32_t, uint32_t>>{{67, 19}} : volume
+        ? std::vector<std::pair<uint32_t, uint32_t>>{{67, 19}, {128, 64}}
+        : std::vector<std::pair<uint32_t, uint32_t>>{{257, 131}, {384, 256}};
     uint64_t code = 0x34070000;
-    for (uint32_t mode : {9u, 24u, 27u}) for (auto format : formats)
-    for (auto [width, height] : {std::pair{257u, 131u}, std::pair{384u, 256u}})
-    for (uint32_t view : {0u, 1u, 2u}) {
+    for (uint32_t mode : modes) for (auto format : formats)
+    for (auto [width, height] : extents)
+    for (uint32_t view = 0; view < ((volume || mixed) ? 1u : 3u); ++view) {
+        if (mixed && format.format != DataFormat::Float16) continue;
+        // Integer 3D images still use the existing raw interchange path. Its packing fallback
+        // remains covered; this retile change does not broaden native storage declarations.
+        const bool native_volume = native_storage_3d_format_support_bit(
+            format.format, format.components) != 0;
+        const bool gpu = !cpu && (!volume || native_volume);
+        if (fault_mode && volume && !native_volume) continue;
         // A one-layer array descriptor may be consumed through either a plain
         // 2D instruction or an array instruction retaining its layer coordinate.
-        const uint32_t resource_dim = view ? 5u : 1u;
-        const uint32_t instruction_dim = view == 2 ? 5u : 1u;
-        const size_t linear_bytes = size_t(width) * height * format.bpe;
-        const size_t tiled_bytes = tiled_surface_bytes(width, height, mode, 0, format.bpe);
+        const uint32_t resource_dim = volume ? 2u : view ? 5u : 1u;
+        const uint32_t instruction_dim = volume ? 2u : view == 2 ? 5u : 1u;
+        const uint32_t depth = volume ? (width == 67 ? 21u : 32u) : 1u;
+        const size_t linear_bytes = size_t(width) * height * depth * format.bpe;
+        const size_t tiled_bytes = volume ? tiled_volume_bytes(width, height, depth, mode, format.bpe)
+                                           : tiled_surface_bytes(width, height, mode, 0, format.bpe);
+        auto tile = [&](uint8_t* dst, const uint8_t* src) {
+            if (volume) check(tile_volume(dst, tiled_bytes, src, width, height, depth, mode, format.bpe),
+                              "CPU volume layout supports the test resource");
+            else tile_surface(dst, src, width, height, mode, 0, format.bpe);
+        };
         std::vector<uint8_t> source_linear(linear_bytes), expected_linear(linear_bytes);
         std::vector<uint8_t> source(tiled_bytes), destination(tiled_bytes + 64, 0xcc);
         auto fill = [&](std::vector<uint8_t>& bytes, uint32_t salt) {
@@ -123,7 +182,7 @@ int main(int argc, char** argv) {
             }
         };
         fill(expected_linear, 173);
-        tile_surface(destination.data(), expected_linear.data(), width, height, mode, 0, format.bpe);
+        tile(destination.data(), expected_linear.data());
         std::vector<uint32_t> coordinates(64), dummy(4);
         for (uint32_t lane = 0; lane < 64; ++lane) coordinates[lane] = lane;
         ShaderResourceTable resources;
@@ -136,7 +195,7 @@ int main(int argc, char** argv) {
         for (uint32_t binding : {4u, 5u}) {
             ShaderResource r{}; r.cls = ResourceClass::StorageImage; r.binding = binding;
             r.sgpr_base = binding == 4 ? 0 : 8; r.img_dim = resource_dim;
-            r.width = width; r.height = height; r.depth = 1;
+            r.width = width; r.height = height; r.depth = depth;
             r.format = format.format; r.num_components = format.components; r.tile_mode = mode;
             r.size = uint32_t(tiled_bytes);
             r.gpu_addr = reinterpret_cast<uint64_t>(binding == 4 ? source.data() : destination.data());
@@ -145,21 +204,23 @@ int main(int argc, char** argv) {
         const auto before = gpu_retile_recordings().load();
         for (uint32_t round = 0; round < 3; ++round) {
             fill(source_linear, 7 + round * 31);
-            tile_surface(source.data(), source_linear.data(), width, height, mode, 0, format.bpe);
+            tile(source.data(), source_linear.data());
             const uint32_t row = round == 0 ? 0 : round == 1 ? height / 2 : height - 1;
             const uint32_t first_x = round == 2 ? width - 64 : 0;
+            const uint32_t slice = round == 0 ? 0 : round == 1 ? depth / 2 : depth - 1;
             const uint32_t shader[]{
                 0x4A0800FFu, first_x, // v_add_nc_u32 v4, first_x, v0
                 0x7E0A02FFu, row, // v5=selected y
-                0x7E0C0280u, // v6=layer zero for the array instruction
+                0x7E0C02FFu, slice, // v6=selected depth slice or array layer zero
                 0xF0000F00u | (instruction_dim << 3), 0x00000004u, 0xBF8C3F70u,
                 0xF0200F00u | (instruction_dim << 3), 0x00020004u, 0xBF810000u};
             ComputeItem item;
             ComputeShaderConfig config;
             config.user_sgprs.resize(16); config.local_x = 64;
             config.local_y = config.local_z = 1; config.tidig_comp_cnt = 0;
-            config.native_storage_format_support = native_storage_format_support_bit(
-                format.format, format.components);
+            config.native_storage_format_support = volume
+                ? native_storage_3d_format_support_bit(format.format, format.components)
+                : native_storage_format_support_bit(format.format, format.components);
             item.spirv = recompile_compute(shader, std::size(shader), &resources, config);
             item.resources = std::make_shared<ShaderResourceTable>(resources);
             item.user_sgprs = config.user_sgprs;
@@ -169,7 +230,7 @@ int main(int argc, char** argv) {
             for (const auto& descriptor : reflection.descriptors)
                 if (descriptor.kind == SpirvDescriptorKind::StorageImage &&
                     (descriptor.binding == 4 || descriptor.binding == 5) &&
-                    descriptor.image_dim == 1 && descriptor.image_arrayed == (view == 2))
+                    descriptor.image_dim == (volume ? 2u : 1u) && descriptor.image_arrayed == (view == 2))
                     ++matching_views;
             check(reflection.ok() && matching_views == 2,
                   "both storage views reflect the intended ordinary or array shader type");
@@ -196,18 +257,18 @@ int main(int argc, char** argv) {
                 return failures ? 1 : 0;
             }
             check(executed, "partial guest image copy executes through live Vulkan");
-            check(gpu_retile_recordings().load() - retile_before == (cpu ? 0 : inject ? 1 : 2),
+            check(gpu_retile_recordings().load() - retile_before == (!gpu ? 0 : inject ? 1 : 2),
                   "both storage images take the selected GPU/CPU path, including the destination");
             if (code == 0x34070000 && round == 0 && !inject)
-                check(backend_host_read_barrier_count().load() - barriers_before == (cpu ? 2 : 4),
+                check(backend_host_read_barrier_count().load() - barriers_before == (gpu ? 4 : 2),
                       "first dispatch records host availability for both linear and both tiled results");
             for (uint32_t lane : coordinates) {
                 const uint32_t x = lane + first_x;
-                std::copy_n(source_linear.data() + (size_t(row) * width + x) * format.bpe,
-                            format.bpe, expected_linear.data() + (size_t(row) * width + x) * format.bpe);
+                std::copy_n(source_linear.data() + ((size_t(slice) * height + row) * width + x) * format.bpe,
+                            format.bpe, expected_linear.data() + ((size_t(slice) * height + row) * width + x) * format.bpe);
             }
             std::vector<uint8_t> expected(tiled_bytes);
-            tile_surface(expected.data(), expected_linear.data(), width, height, mode, 0, format.bpe);
+            tile(expected.data(), expected_linear.data());
             check(std::equal(expected.begin(), expected.end(), destination.begin()),
                   "every guest byte matches CPU tiling, including untouched texels and padding");
             check(std::all_of(destination.begin() + tiled_bytes, destination.end(),
@@ -216,10 +277,22 @@ int main(int argc, char** argv) {
         std::printf("mode=%u bpe=%u format=%u extent=%ux%u resource-dim=%u instruction-dim=%u GPU retile dispatches=%llu\n",
             mode, format.bpe, unsigned(format.format), width, height, resource_dim, instruction_dim,
             static_cast<unsigned long long>(gpu_retile_recordings().load() - before));
-        check(cpu ? gpu_retile_recordings().load() == before : gpu_retile_recordings().load() == before + (fault_mode ? 5 : 6),
-              cpu ? "CPU fallback used" : "GPU tiler actually recorded; CPU equivalence alone is insufficient");
+        check(!gpu ? gpu_retile_recordings().load() == before : gpu_retile_recordings().load() == before + (fault_mode ? 5 : 6),
+              !gpu ? "CPU fallback used" : "GPU tiler actually recorded; CPU equivalence alone is insufficient");
         if (fault_mode) return failures ? 1 : 0;
         code += 16;
     }
     return failures ? 1 : 0;
+}
+
+int main(int argc, char** argv) {
+    if (argc == 2 && std::strcmp(argv[1], "--mixed") == 0) {
+        // All three use the same retained live context and its immutable retile pipelines.
+        for (const char* option : {"--mixed-2d", "--mixed-volume", "--mixed-2d"}) {
+            char* args[]{argv[0], const_cast<char*>(option)};
+            if (run_case(2, args)) return 1;
+        }
+        return 0;
+    }
+    return run_case(argc, argv);
 }

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -762,6 +762,8 @@ int main(int argc, char** argv) {
          "build_compute_detile_rgba16f");
     dump(dir, "builder_retile_words", build_compute_retile_words(),
          "build_compute_retile_words");
+    dump(dir, "builder_retile_volume_words", build_compute_retile_words(true),
+         "build_compute_retile_words");
     dump(dir, "builder_rgba8_to_packed10", build_compute_rgba8_to_packed10(),
          "build_compute_rgba8_to_packed10");
 


### PR DESCRIPTION
Standard 3D storage-image results still pass through CPU tiling before guest writeback, even when their Vulkan texels already have the exact guest format. This extends the existing GPU writeback conversion to SW_4KB_S and SW_64KB_S volumes with 4-, 8- or 16-byte texels. Refs #3407 and #3441; both retain further scope.

The volume variant uses the shared CPU layout equations and records in the existing compute submission after image transfer. It preserves linear comparison baselines, separate tiled-buffer ownership through completion, partial writes and zero padding. Device limits and exact format/layout sizes gate admission; unsupported layouts and formats retain CPU conversion. It requires no new Vulkan extension or experimental driver setting.

Validation:
- Full Release build and 403/403 local tests. Final comment-only revision: 13/13 focused retile/SPIR-V tests pass.
- 17 focused tests under core and synchronization validation, with confirmed layer loading and a detected deliberate synchronization hazard as positive controls; no real-case validation findings.
- GPU execution covers both tilings, three texel widths, non-block-aligned extents, partial writes across depth, untouched bytes/padding/guards, allocation fallback, device loss, and 2D→3D→2D reuse of the same context. Full 3D word coverage includes a deliberately collapsed equation control.
- `PROSPER_NO_GPU_RETILE=1 <BUILD>/test_gpu_retile --volume` exits 1 on 48 GPU-path assertions while all byte checks pass, proving CPU fallback cannot falsely satisfy the GPU-use guard. This is a fallback control, not a rebuilt old-commit binary.

In the paired Sonic capture, the strongest target's mean enclosing dispatch time falls **2.790→1.409 ms** (35→36 records), including the added GPU conversion work; its guest shader time is essentially unchanged. CPU layout/copy falls **1.648→0.177 ms**. A second volume also improves, but changed guest-shader GPU timing prevents assigning its entire gain to this change. GTA's presentation rate stays about **6.58/s**. No general FPS gain is established, and newly rendered FPS is unavailable.

Comparable native-resolution `prosper-app` Sonic and GTA Performance Story captures and exact evidence identities are recorded in the author verification comment. Sonic's existing title artwork/cloud and black-world defects remain open; this PR makes no visual progression or audio-fix claim.
