### PR TITLE
tools(shader_inspect): add --wave-reasons, an offline fragment wave-width census (#3464)

### DIFF
--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -119,19 +119,40 @@ dropped. On *Grand Theft Auto V* that removes most of the world's lighting (#346
 
 ```sh
 shader_inspect <raw-rdna2.bin> --wave-reasons
-wave-reasons required-subgroup-size=64 reasons=0x2 names=wave-any native-wave32-admitted=1
-wave-reasons-end file=... dwords=12 recompiled=1 table_dependent=0 endpgm=1
+wave-reasons required-subgroup-size=64 reasons=0x2 names=wave-any reason-set-admissible=1 \
+    internal-gds=0 subgroup-features=0x1
+wave-reasons gate-undecided=title-allowlist,host-subgroup-size-control,host-subgroup-features ...
+wave-reasons-end file=... input=rdna2 dwords=12 recompiled=1 table_dependent=0 endpgm=1
 ```
 
-`native-wave32-admitted` mirrors the shipping gate in `tests/fixtures/render_runner.h`
-**exactly** -- equality against `kFragmentWaveReasonWaveAny` -- rather than re-deriving what
-ought to be admissible. The census reports the emulator that ships; a proposal about what
-*should* be admitted belongs in the classifier, where a test can hold it.
+### `reason-set-admissible` is NOT `admitted`, and the difference is most of the answer
 
-A module that needs no particular width reports `size=0 reasons=0x0 admitted=0`: it never
-reaches the gate, and counting it as admitted would bury the interesting population under every
-ordinary shader in a dump. A module carrying no reason marker at all reports `reasons=absent`,
-never `0x0` -- absent is not none.
+The renderer's gate is **five conjuncts** (`tests/fixtures/render_runner.h:7128-7133`). The
+reason-set equality at `:7140` -- the one this field mirrors -- is only the innermost. The
+decisive one is `bd.allow_native_fragment_vote_width`, which **defaults false** (`:565`) and is
+set in exactly one place, from `title_id == "PPSA04263"` (`live_renderer.cpp:1216`, assigned
+`:7591`). Its own comment says so: *"Tests, replay and all other titles leave this false."*
+
+**So outside GTA V, every shader requiring more than 32 lanes is dropped regardless of its
+reason set.** An earlier version of this tool called the reason-set test `native-wave32-admitted`
+and was therefore wrong in the one direction that mattered: it under-reported the loss #3464
+exists to size. Its *Blasphemous 2* validation run reported `0 dropped` where the true answer
+was `2` -- and it went unquestioned because it agreed with the expectation.
+
+The two conjuncts a module CAN decide are reported beside it (`internal-gds`,
+`subgroup-features`); the three it cannot are named on their own `gate-undecided=` line, every
+time, so no consumer can read admission into the row by omission. For a per-title verdict use
+`capture_wave_census.py --title`.
+
+A module that needs no particular width reports `size=0 reasons=absent reason-set-admissible=0`.
+`reasons=0x0` is never printed: a module either carries the marker or does not, and `absent` is
+not none. A module that fails to recompile prints **no census row at all** -- only the sentinel,
+with `recompiled=0`.
+
+A SPIR-V input reports `recompiled=n/a` (nothing was recompiled -- the module was read) plus
+`spirv-walk=ok|truncated`. That last field exists because a corrupt module reports `size=0
+reasons=absent`, byte-identical to a genuine wave-free shader, so without it an unreadable dump
+lands in the population that says #3464 does not affect it.
 
 `wave_reason_census.py` tallies the mode over a directory and prints the reason-set histogram
 plus the names of the dropped shaders. It exists because the *runtime* skip log answers this

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -158,8 +158,25 @@ its numbers. A census that silently equated "could not be analysed" with "needs 
 would have reported that GTA V has essentially no Wave64 problem, which is the opposite of the
 truth.
 
-For a census over shaders that use memory, the reasons must come from a path that HAS the real
-descriptors -- `gpu_replay <capture>.prgcap`, as with every other table-dependent verdict here.
+### The way out: read the module gpu_replay compiled
+
+`--wave-reasons` accepts **either** a raw RDNA2 stream **or** a SPIR-V module, detected by the
+SPIR-V magic rather than by a flag or a file extension -- the magic is the format's own
+self-identification, so a renamed or mislabelled file cannot be read as the wrong kind.
+
+`gpu_replay` has the real resource table, and `--dump-shader DRAW:fs PATH` already writes the
+recompiled module. So the census over memory-using shaders is a two-step pipeline with no new
+analysis in it:
+
+```sh
+gpu_replay --dump-shader 18:fs fs.spv <capture>.prgcap   # real descriptors, real compile
+shader_inspect fs.spv --wave-reasons                     # reads the module's own markers
+```
+
+The reasons then come from a real-table compile while this tool remains the single place that
+formats them. A SPIR-V input reports `input=spirv` in the sentinel and leaves `table_dependent`
+and `endpgm` at zero -- those describe an RDNA2 walk that did not happen.
+
 
 ## `--stage` cannot prove a shader is unsupported (#1571)
 

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -111,6 +111,56 @@ input or one that is not a whole number of dwords. A stream that stops short of 
 reported as `endpgm=0` rather than as a failure — a census over a truncated dump is still an exact
 census of what could be decoded.
 
+## `--wave-reasons`: which shaders need the guest Wave64, and why
+
+On any NVIDIA host the entire supported subgroup range is `32..32` -- no extension, driver or
+device yields a 64-wide subgroup -- so a fragment module that requires the guest's Wave64 is
+dropped. On *Grand Theft Auto V* that removes most of the world's lighting (#3464).
+
+```sh
+shader_inspect <raw-rdna2.bin> --wave-reasons
+wave-reasons required-subgroup-size=64 reasons=0x2 names=wave-any native-wave32-admitted=1
+wave-reasons-end file=... dwords=12 recompiled=1 table_dependent=0 endpgm=1
+```
+
+`native-wave32-admitted` mirrors the shipping gate in `tests/fixtures/render_runner.h`
+**exactly** -- equality against `kFragmentWaveReasonWaveAny` -- rather than re-deriving what
+ought to be admissible. The census reports the emulator that ships; a proposal about what
+*should* be admitted belongs in the classifier, where a test can hold it.
+
+A module that needs no particular width reports `size=0 reasons=0x0 admitted=0`: it never
+reaches the gate, and counting it as admitted would bury the interesting population under every
+ordinary shader in a dump. A module carrying no reason marker at all reports `reasons=absent`,
+never `0x0` -- absent is not none.
+
+`wave_reason_census.py` tallies the mode over a directory and prints the reason-set histogram
+plus the names of the dropped shaders. It exists because the *runtime* skip log answers this
+only for whatever a route happened to reach, once per distinct shader, at whatever scene depth
+the run stopped: two runtime counts taken that way, 43 and 86, differed by run length alone and
+read as a regression until they were matched by frame.
+
+### Measured limit: over a raw dump this mode is mostly blind, and says so
+
+Run against a 3,453-shader dump of GTA V's pixel-shader database (2026-09-08):
+
+```
+files=3453  errors=0  unrecompiled(no resource table)=3430  analysed=23
+```
+
+**99.3% contributed no reason data.** A real pixel shader samples a texture, and the section
+below explains why a table-less tool can never lower one. The 23 that were analysed are the
+shaders that happen not to touch memory, which is not a random sample of anything -- a
+texture-sampling lighting shader is exactly the kind that is missing.
+
+This is reported rather than hidden: an unrecompilable shader is counted in its own column and
+is **never** tallied as `requires nothing`, and the tally prints the caveat both above and below
+its numbers. A census that silently equated "could not be analysed" with "needs no wide wave"
+would have reported that GTA V has essentially no Wave64 problem, which is the opposite of the
+truth.
+
+For a census over shaders that use memory, the reasons must come from a path that HAS the real
+descriptors -- `gpu_replay <capture>.prgcap`, as with every other table-dependent verdict here.
+
 ## `--stage` cannot prove a shader is unsupported (#1571)
 
 **`shader_inspect` has no resource table, and a table-less stage rejection is NOT evidence of a shader

--- a/prosper/tools/shader_inspect/capture_wave_census.py
+++ b/prosper/tools/shader_inspect/capture_wave_census.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Wave-width census over a captured frame, using the REAL resource table.
+
+`wave_reason_census.py` sweeps a directory of raw RDNA2 dumps, and over GTA V's shader database
+99.3% of them could not be lowered: shader_inspect has no descriptors and a real pixel shader
+samples a texture. That census is therefore blind to precisely the lighting shaders #3464 is about.
+
+gpu_replay has the real descriptors. This script drives it:
+
+    gpu_replay --bundle F --bundle-extract-submit N cap.prgcap   # one submit, replayable
+    gpu_replay --inspect-only cap.prgcap                         # draw list, with fs= identities
+    gpu_replay --dump-shader ID:fs fs.spv cap.prgcap             # the REAL-TABLE compiled module
+    shader_inspect fs.spv --wave-reasons                         # reads that module's own markers
+
+so every reason it reports comes from a module compiled the way the renderer compiles it, and no
+analysis is reimplemented anywhere.
+
+    python capture_wave_census.py --gpu-replay G --shader-inspect S --capture cap.prgcap
+    python capture_wave_census.py --gpu-replay G --shader-inspect S --bundle f.prgbundle
+
+SCOPE, which bounds every number this prints: a capture is ONE FRAME. This answers "of the fragment
+shaders this frame ran, how many need a wide wave and what for" -- not "how many does the title
+have". That is the right question for #3464 (a frame with missing lighting is the evidence), but it
+is a different question from the database sweep, and the two must not be quoted as one number.
+"""
+import argparse
+import collections
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DRAW = re.compile(r"^draw\[(\d+)\].*?\bfs=(\d+)/([0-9a-f]+)/", re.M)
+DS_SUBMIT = re.compile(r"\bfirst=(\d+) last=(\d+)")
+ROW = re.compile(r"wave-reasons required-subgroup-size=(\d+) reasons=(\S+) names=(\S+) "
+                 r"native-wave32-admitted=(\d+)")
+END = re.compile(r"wave-reasons-end .*?recompiled=(\d+)")
+
+
+def run(cmd):
+    return subprocess.run([str(c) for c in cmd], capture_output=True, text=True)
+
+
+def discover_submit(gpu_replay, bundle):
+    """The bundle's submit index is the capture's own ordinal, not 0 or 1.
+
+    `--bundle-extract-submit` matches on `submit_index` and rejects 0, so on a single-submit bundle
+    neither of the two numbers anyone tries first works: 0 is refused by the parser and 1 reports
+    "bundle has no submit 1". `--bundle-ds-summary` prints the real ordinal as `first=`/`last=`.
+    """
+    done = run([gpu_replay, "--bundle", bundle, "--bundle-ds-summary"])
+    found = {int(m.group(1)) for m in DS_SUBMIT.finditer(done.stdout + done.stderr)}
+    if not found:
+        return None
+    return sorted(found)[-1]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gpu-replay", required=True)
+    ap.add_argument("--shader-inspect", required=True)
+    ap.add_argument("--capture", help="a .prgcap (one submit)")
+    ap.add_argument("--bundle", help="a .prgbundle; one submit is extracted from it")
+    ap.add_argument("--submit", type=int, help="submit index in the bundle (default: discovered)")
+    ap.add_argument("--work", help="directory for intermediates (default: a temporary one)")
+    args = ap.parse_args()
+    # Resolved to absolute up front. A relative tool path that a shell finds is not
+    # necessarily one CreateProcess finds on Windows, and the failure is a bare
+    # FileNotFoundError from deep inside subprocess that names neither which path nor which
+    # of the four child invocations produced it.
+    args.gpu_replay = str(Path(args.gpu_replay).resolve())
+    args.shader_inspect = str(Path(args.shader_inspect).resolve())
+    for name in ("capture", "bundle"):
+        if getattr(args, name):
+            setattr(args, name, str(Path(getattr(args, name)).resolve()))
+    if bool(args.capture) == bool(args.bundle):
+        print("give exactly one of --capture or --bundle", file=sys.stderr)
+        return 2
+
+    tmp = None
+    if args.work:
+        work = Path(args.work)
+        work.mkdir(parents=True, exist_ok=True)
+    else:
+        tmp = tempfile.TemporaryDirectory()
+        work = Path(tmp.name)
+
+    capture = args.capture
+    if args.bundle:
+        submit = args.submit or discover_submit(args.gpu_replay, args.bundle)
+        if submit is None:
+            print("could not discover a submit index; pass --submit", file=sys.stderr)
+            return 2
+        capture = work / "submit.prgcap"
+        done = run([args.gpu_replay, "--bundle", args.bundle,
+                    "--bundle-extract-submit", submit, capture])
+        if not Path(capture).exists():
+            print("extract failed:\n" + done.stdout + done.stderr, file=sys.stderr)
+            return 2
+        print("extracted submit %d" % submit)
+
+    done = run([args.gpu_replay, "--inspect-only", capture])
+    draws = DRAW.findall(done.stdout + done.stderr)
+    if not draws:
+        print("no draws found in %s" % capture, file=sys.stderr)
+        print((done.stdout + done.stderr)[-2000:], file=sys.stderr)
+        return 2
+
+    # One dump per DISTINCT fragment shader. The `fs=<dwords>/<hash>/` identity on each draw line is
+    # the renderer's own content key, so this counts shaders rather than draws -- a frame that draws
+    # one shader 400 times must not read as 400 blocked shaders.
+    first_draw = {}
+    draw_count = collections.Counter()
+    for draw_id, dwords, fs_hash in draws:
+        draw_count[fs_hash] += 1
+        first_draw.setdefault(fs_hash, (draw_id, int(dwords)))
+
+    results = {}
+    for fs_hash, (draw_id, dwords) in sorted(first_draw.items()):
+        spv = work / ("fs_%s.spv" % fs_hash)
+        run([args.gpu_replay, "--dump-shader", "%s:fs" % draw_id, spv, capture])
+        if not spv.exists():
+            results[fs_hash] = ("dump-failed", 0, "", "", 0)
+            continue
+        done = run([args.shader_inspect, spv, "--wave-reasons"])
+        out = done.stdout + done.stderr
+        if not END.search(out):
+            # The sentinel's purpose: no line at all must never be tallied as "needs nothing".
+            results[fs_hash] = ("no-sentinel", 0, "", "", 0)
+            continue
+        row = ROW.search(out)
+        if not row:
+            results[fs_hash] = ("no-census-row", 0, "", "", 0)
+            continue
+        results[fs_hash] = ("ok", int(row.group(1)), row.group(2), row.group(3),
+                            int(row.group(4)))
+
+    ok = {h: r for h, r in results.items() if r[0] == "ok"}
+    bad = {h: r for h, r in results.items() if r[0] != "ok"}
+    needs = {h: r for h, r in ok.items() if r[1] > 32}
+    dropped = {h: r for h, r in needs.items() if not r[4]}
+
+    print("draws=%d  distinct fragment shaders=%d  analysed=%d  unreadable=%d"
+          % (len(draws), len(first_draw), len(ok), len(bad)))
+    print("require>32=%d  admitted at native wave32=%d  DROPPED=%d"
+          % (len(needs), len(needs) - len(dropped), len(dropped)))
+    if needs:
+        hist = collections.Counter((r[2], r[3]) for r in needs.values())
+        print("\nreason sets among the %d requiring a wide wave:" % len(needs))
+        for (mask, names), n in hist.most_common():
+            print("  %-8s %-42s %3d shaders" % (mask, names, n))
+    if dropped:
+        print("\ndropped shaders (hash, reasons, draws using it):")
+        for h, r in sorted(dropped.items(), key=lambda kv: -draw_count[kv[0]]):
+            print("  %s  %-8s %-40s %3d draws" % (h[:16], r[2], r[3], draw_count[h]))
+    if bad:
+        print("\n%d shader(s) yielded no census row -- NOT counted as needing nothing:" % len(bad))
+        for h, r in sorted(bad.items()):
+            print("  %s  %s" % (h[:16], r[0]))
+    print("\nSCOPE: one frame. This is what this frame RAN, not what the title contains.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/shader_inspect/capture_wave_census.py
+++ b/prosper/tools/shader_inspect/capture_wave_census.py
@@ -76,7 +76,14 @@ def discover_submit(gpu_replay, bundle):
     ordinals = sorted({int(m.group(1)) for m in DS_SUBMIT.finditer(text)})
     if not ordinals:
         return None, "no submit ordinal found in --bundle-ds-summary output"
-    if count and int(count.group(1)) != 1:
+    # Fail CLOSED. If the header did not parse we do not know how many submits the bundle
+    # holds, and the whole point of this guard is to stop a fraction of a frame being
+    # reported as the frame. Skipping the check on an unrecognised header would do exactly
+    # that, silently, on the bundles most likely to be unusual.
+    if not count:
+        return None, ("could not read the bundle's submit count from --bundle-ds-summary; "
+                      "pass --submit or --ds-submits explicitly rather than assume one")
+    if int(count.group(1)) != 1:
         return None, ("bundle holds %s submits and the ds-summary ordinals (%s) do not identify "
                       "which to census; pass --submit explicitly"
                       % (count.group(1), ",".join(str(o) for o in ordinals[:8])))
@@ -87,11 +94,16 @@ def discover_submit(gpu_replay, bundle):
 
 
 def ds_submit_ordinals(gpu_replay, bundle):
-    """Every submit ordinal --bundle-ds-summary names, from both first= and last=.
+    """The submit ordinals --bundle-ds-summary names: per identity, its FIRST and its LAST.
 
-    These are the submits that ran a depth-stencil pass. That is a SUBSET of the
-    frame -- a UI or post pass with no DS never appears -- so a census over them is a
-    census of the world-rendering passes, not of the frame, and the caller must say so.
+    NOT "every depth-stencil submit", which is what this looks like and what an earlier
+    version of this docstring claimed. gpu_replay keeps `min`/`max` per identity
+    (gpu_replay.cpp:1266-1267), so an identity live across submits 3..40 contributes {3, 40}
+    and the 37 between are never named. It is a sample of the depth-stencil work, biased
+    toward the ends of each identity's life, and it is also a subset of the frame -- a UI or
+    post pass with no depth-stencil target never appears at all.
+
+    That is why every count this tool prints is labelled a lower bound rather than a total.
     """
     done = run([gpu_replay, "--bundle", bundle, "--bundle-ds-summary"])
     text = done.stdout + done.stderr
@@ -112,7 +124,7 @@ def main() -> int:
     ap.add_argument("--submit", type=int, help="submit index in the bundle (default: discovered)")
     ap.add_argument("--submits", help="comma-separated submit ordinals to census together")
     ap.add_argument("--ds-submits", action="store_true",
-                    help="census every submit named by --bundle-ds-summary (the depth-stencil\n                         passes: world geometry and lighting)")
+                    help="census the submits --bundle-ds-summary names: the FIRST and LAST\n                         submit of each depth-stencil identity. Not every DS submit -- see\n                         ds_submit_ordinals().")
     ap.add_argument("--title", default="",
                     help="title id the capture came from, e.g. PPSA04263. Decides whether the "
                          "native-wave32 allowlist applies; without it, assumed NOT on the "
@@ -162,8 +174,11 @@ def main() -> int:
             one, error = discover_submit(args.gpu_replay, args.bundle)
             if one is None:
                 print("cannot choose a submit: %s" % error, file=sys.stderr)
-                print("(--ds-submits censuses every depth-stencil submit instead)", file=sys.stderr)
+                print("(--ds-submits samples them: first+last submit per depth-stencil identity)",
+                      file=sys.stderr)
                 return 2
+            # discover_submit only returns when it read a count of exactly 1, so this is
+            # a measured 1 rather than an assumed one.
             chosen, bundle_submits = [one], 1
         print("censusing %d submit(s) of %d in the bundle" % (len(chosen), bundle_submits))
         for ordinal in chosen:
@@ -265,8 +280,10 @@ def main() -> int:
               % (len(captures), bundle_submits))
         print("listed above, so every count here is a LOWER bound on the frame.")
         if args.ds_submits:
-            print("--ds-submits covers the depth-stencil passes only: world geometry and lighting,")
-            print("not UI or post passes that run without a depth-stencil target.")
+            print("--ds-submits samples the depth-stencil work: the FIRST and LAST submit of each")
+            print("depth-stencil identity, NOT every submit that had one -- submits in the middle")
+            print("of an identity's life are never named. UI and post passes without a")
+            print("depth-stencil target are outside it entirely.")
     else:
         print("\nSCOPE: one capture. This is what it RAN, not what the title contains.")
     return 0

--- a/prosper/tools/shader_inspect/capture_wave_census.py
+++ b/prosper/tools/shader_inspect/capture_wave_census.py
@@ -7,21 +7,30 @@ samples a texture. That census is therefore blind to precisely the lighting shad
 
 gpu_replay has the real descriptors. This script drives it:
 
-    gpu_replay --bundle F --bundle-extract-submit N cap.prgcap   # one submit, replayable
-    gpu_replay --inspect-only cap.prgcap                         # draw list, with fs= identities
-    gpu_replay --inspect-only --dump-shader ID:fs fs.spv cap.prgcap   # REAL-TABLE module
-    shader_inspect fs.spv --wave-reasons                         # reads that module's own markers
+    gpu_replay --bundle F --bundle-extract-submit N cap.prgcap        # one submit, replayable
+    gpu_replay --inspect-only cap.prgcap                              # draws, with fs= identities
+    gpu_replay --inspect-only --dump-shader ID:fs fs.spv cap.prgcap   # the REAL-TABLE module
+    shader_inspect fs.spv --wave-reasons                              # reads that module's markers
 
-so every reason it reports comes from a module compiled the way the renderer compiles it, and no
-analysis is reimplemented anywhere.
+so every reason it reports comes from a module compiled the way the renderer compiles it, and
+nothing is reimplemented: this script only sequences those tools and tallies their output.
 
     python capture_wave_census.py --gpu-replay G --shader-inspect S --capture cap.prgcap
     python capture_wave_census.py --gpu-replay G --shader-inspect S --bundle f.prgbundle
 
-SCOPE, which bounds every number this prints: a capture is ONE FRAME. This answers "of the fragment
+WHAT "DROPPED" MEANS, spelled out because getting it wrong made the first version of this script
+report the opposite of the truth. The renderer's gate is FIVE conjuncts
+(`render_runner.h:7128-7133`); the reason-set equality at `:7140` is only the innermost. The
+decisive one is `bd.allow_native_fragment_vote_width`, which defaults false (`:565`) and is set from
+`title_id == "PPSA04263"` alone (`live_renderer.cpp:1216`, `:7591`) -- so **outside GTA V every
+shader requiring more than 32 lanes is dropped, whatever its reason set**. Pass `--title` to say
+which title the capture came from; without it this assumes NOT on the allowlist, which is true for
+every title but one.
+
+SCOPE: a capture is ONE FRAME (and, with --bundle, one SUBMIT of it). This answers "of the fragment
 shaders this frame ran, how many need a wide wave and what for" -- not "how many does the title
-have". That is the right question for #3464 (a frame with missing lighting is the evidence), but it
-is a different question from the database sweep, and the two must not be quoted as one number.
+have". That is the right question for #3464, but it is a different question from the database
+sweep, and the two must not be quoted as one number.
 """
 import argparse
 import collections
@@ -31,11 +40,17 @@ import sys
 import tempfile
 from pathlib import Path
 
+# The title whose reviewed route may run the narrow WaveAny class at native wave32. One string, in
+# one place, mirroring live_renderer.cpp:1216.
+NATIVE_VOTE_ALLOWLIST = ("PPSA04263",)
+
 DRAW = re.compile(r"^draw\[(\d+)\].*?\bfs=(\d+)/([0-9a-f]+)/", re.M)
 DS_SUBMIT = re.compile(r"\bfirst=(\d+) last=(\d+)")
+BUNDLE_SUBMITS = re.compile(r"\bbundle v\d+ submits=(\d+)")
 ROW = re.compile(r"wave-reasons required-subgroup-size=(\d+) reasons=(\S+) names=(\S+) "
-                 r"native-wave32-admitted=(\d+)")
-END = re.compile(r"wave-reasons-end .*?recompiled=(\d+)")
+                 r"reason-set-admissible=(\d+)")
+END = re.compile(r"wave-reasons-end\b")
+WALK = re.compile(r"\bspirv-walk=(\w+)")
 
 
 def run(cmd):
@@ -43,17 +58,32 @@ def run(cmd):
 
 
 def discover_submit(gpu_replay, bundle):
-    """The bundle's submit index is the capture's own ordinal, not 0 or 1.
+    """The bundle's submit index is the CAPTURE's ordinal, not 0 or 1.
 
     `--bundle-extract-submit` matches on `submit_index` and rejects 0, so on a single-submit bundle
-    neither of the two numbers anyone tries first works: 0 is refused by the parser and 1 reports
-    "bundle has no submit 1". `--bundle-ds-summary` prints the real ordinal as `first=`/`last=`.
+    neither number anyone tries first works: 0 is refused by the parser and 1 reports "bundle has no
+    submit 1". `--bundle-ds-summary` prints the real ordinal as `first=`/`last=`.
+
+    Returns (submit, error). It REFUSES to guess when the bundle holds more than one submit: the
+    `first=` fields are per depth-stencil identity and record where each identity was FIRST seen, so
+    the maximum of them is not the largest, busiest or last submit -- it is an arbitrary one. A
+    census of an arbitrary fraction of a frame that then prints "SCOPE: one frame" is worse than a
+    refusal, so the caller is asked for --submit instead.
     """
     done = run([gpu_replay, "--bundle", bundle, "--bundle-ds-summary"])
-    found = {int(m.group(1)) for m in DS_SUBMIT.finditer(done.stdout + done.stderr)}
-    if not found:
-        return None
-    return sorted(found)[-1]
+    text = done.stdout + done.stderr
+    count = BUNDLE_SUBMITS.search(text)
+    ordinals = sorted({int(m.group(1)) for m in DS_SUBMIT.finditer(text)})
+    if not ordinals:
+        return None, "no submit ordinal found in --bundle-ds-summary output"
+    if count and int(count.group(1)) != 1:
+        return None, ("bundle holds %s submits and the ds-summary ordinals (%s) do not identify "
+                      "which to census; pass --submit explicitly"
+                      % (count.group(1), ",".join(str(o) for o in ordinals[:8])))
+    if len(ordinals) > 1:
+        return None, ("ambiguous submit ordinals %s; pass --submit explicitly"
+                      % ",".join(str(o) for o in ordinals[:8]))
+    return ordinals[0], None
 
 
 def main() -> int:
@@ -63,12 +93,15 @@ def main() -> int:
     ap.add_argument("--capture", help="a .prgcap (one submit)")
     ap.add_argument("--bundle", help="a .prgbundle; one submit is extracted from it")
     ap.add_argument("--submit", type=int, help="submit index in the bundle (default: discovered)")
+    ap.add_argument("--title", default="",
+                    help="title id the capture came from, e.g. PPSA04263. Decides whether the "
+                         "native-wave32 allowlist applies; without it, assumed NOT on the "
+                         "allowlist, which is true for every title but one.")
     ap.add_argument("--work", help="directory for intermediates (default: a temporary one)")
     args = ap.parse_args()
-    # Resolved to absolute up front. A relative tool path that a shell finds is not
-    # necessarily one CreateProcess finds on Windows, and the failure is a bare
-    # FileNotFoundError from deep inside subprocess that names neither which path nor which
-    # of the four child invocations produced it.
+    # Resolved to absolute up front. A relative tool path that a shell finds is not necessarily one
+    # CreateProcess finds on Windows, and the failure is a bare FileNotFoundError from deep inside
+    # subprocess that names neither which path nor which of the child invocations produced it.
     args.gpu_replay = str(Path(args.gpu_replay).resolve())
     args.shader_inspect = str(Path(args.shader_inspect).resolve())
     for name in ("capture", "bundle"):
@@ -77,6 +110,8 @@ def main() -> int:
     if bool(args.capture) == bool(args.bundle):
         print("give exactly one of --capture or --bundle", file=sys.stderr)
         return 2
+
+    allowlisted = args.title in NATIVE_VOTE_ALLOWLIST
 
     tmp = None
     if args.work:
@@ -88,10 +123,12 @@ def main() -> int:
 
     capture = args.capture
     if args.bundle:
-        submit = args.submit or discover_submit(args.gpu_replay, args.bundle)
+        submit = args.submit
         if submit is None:
-            print("could not discover a submit index; pass --submit", file=sys.stderr)
-            return 2
+            submit, error = discover_submit(args.gpu_replay, args.bundle)
+            if submit is None:
+                print("cannot choose a submit: %s" % error, file=sys.stderr)
+                return 2
         capture = work / "submit.prgcap"
         done = run([args.gpu_replay, "--bundle", args.bundle,
                     "--bundle-extract-submit", submit, capture])
@@ -119,11 +156,11 @@ def main() -> int:
     results = {}
     for fs_hash, (draw_id, dwords) in sorted(first_draw.items()):
         spv = work / ("fs_%s.spv" % fs_hash)
-        # --inspect-only alongside --dump-shader: the module is written from the same
-        # realization either way (byte-identical output, verified), but the frame is not
-        # REPLAYED. That matters beyond speed on the title this exists for -- GTA V has two
-        # compute programs that hang the GPU into a driver recovery (#2542, #2690), and a
-        # census over N distinct shaders would otherwise trigger them N times.
+        # --inspect-only alongside --dump-shader: the module is written from the same realization
+        # either way (byte-identical output, verified), but the frame is not REPLAYED. That matters
+        # beyond speed on the title this exists for -- GTA V has two compute programs that hang the
+        # GPU into a driver recovery (#2542, #2690), and a census over N distinct shaders would
+        # otherwise trigger them N times.
         run([args.gpu_replay, "--inspect-only", "--dump-shader", "%s:fs" % draw_id,
              spv, capture])
         if not spv.exists():
@@ -135,6 +172,13 @@ def main() -> int:
             # The sentinel's purpose: no line at all must never be tallied as "needs nothing".
             results[fs_hash] = ("no-sentinel", 0, "", "", 0)
             continue
+        walk = WALK.search(out)
+        if walk and walk.group(1) != "ok":
+            # A truncated module reports size=0/reasons=absent, byte-identical to a genuine
+            # wave-free shader. Counting it as analysed would put a module we could not read into
+            # the population that says #3464 does not affect it.
+            results[fs_hash] = ("spirv-" + walk.group(1), 0, "", "", 0)
+            continue
         row = ROW.search(out)
         if not row:
             results[fs_hash] = ("no-census-row", 0, "", "", 0)
@@ -145,12 +189,19 @@ def main() -> int:
     ok = {h: r for h, r in results.items() if r[0] == "ok"}
     bad = {h: r for h, r in results.items() if r[0] != "ok"}
     needs = {h: r for h, r in ok.items() if r[1] > 32}
-    dropped = {h: r for h, r in needs.items() if not r[4]}
+    # Admitted only if the title is on the allowlist AND the reason set passes. Two more conjuncts
+    # (host subgroup-size control, host subgroup features) are properties of the RUN and cannot be
+    # decided here, so even a 1 is an upper bound on admission, never a guarantee.
+    admitted = {h: r for h, r in needs.items() if allowlisted and r[4]}
+    dropped = {h: r for h, r in needs.items() if h not in admitted}
 
     print("draws=%d  distinct fragment shaders=%d  analysed=%d  unreadable=%d"
           % (len(draws), len(first_draw), len(ok), len(bad)))
-    print("require>32=%d  admitted at native wave32=%d  DROPPED=%d"
-          % (len(needs), len(needs) - len(dropped), len(dropped)))
+    print("title=%s  native-wave32 allowlist: %s"
+          % (args.title or "(unspecified)",
+             "YES" if allowlisted else "no -- every wide-wave shader below is dropped"))
+    print("require>32=%d  possibly admitted=%d  DROPPED=%d"
+          % (len(needs), len(admitted), len(dropped)))
     if needs:
         hist = collections.Counter((r[2], r[3]) for r in needs.values())
         print("\nreason sets among the %d requiring a wide wave:" % len(needs))
@@ -161,10 +212,15 @@ def main() -> int:
         for h, r in sorted(dropped.items(), key=lambda kv: -draw_count[kv[0]]):
             print("  %s  %-8s %-40s %3d draws" % (h[:16], r[2], r[3], draw_count[h]))
     if bad:
-        print("\n%d shader(s) yielded no census row -- NOT counted as needing nothing:" % len(bad))
+        print("\n%d shader(s) yielded no usable census row -- NOT counted as needing nothing:"
+              % len(bad))
         for h, r in sorted(bad.items()):
             print("  %s  %s" % (h[:16], r[0]))
-    print("\nSCOPE: one frame. This is what this frame RAN, not what the title contains.")
+    if admitted:
+        print("\nNOTE: 'possibly admitted' is an UPPER bound. Admission also needs the host to "
+              "support\nthe width and the module's subgroup features, which this tool cannot see.")
+    print("\nSCOPE: one frame%s. This is what it RAN, not what the title contains."
+          % (" (one submit of it)" if args.bundle else ""))
     return 0
 
 

--- a/prosper/tools/shader_inspect/capture_wave_census.py
+++ b/prosper/tools/shader_inspect/capture_wave_census.py
@@ -86,6 +86,23 @@ def discover_submit(gpu_replay, bundle):
     return ordinals[0], None
 
 
+def ds_submit_ordinals(gpu_replay, bundle):
+    """Every submit ordinal --bundle-ds-summary names, from both first= and last=.
+
+    These are the submits that ran a depth-stencil pass. That is a SUBSET of the
+    frame -- a UI or post pass with no DS never appears -- so a census over them is a
+    census of the world-rendering passes, not of the frame, and the caller must say so.
+    """
+    done = run([gpu_replay, "--bundle", bundle, "--bundle-ds-summary"])
+    text = done.stdout + done.stderr
+    found = set()
+    for m in DS_SUBMIT.finditer(text):
+        found.add(int(m.group(1)))
+        found.add(int(m.group(2)))
+    count = BUNDLE_SUBMITS.search(text)
+    return sorted(found), (int(count.group(1)) if count else 0)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--gpu-replay", required=True)
@@ -93,6 +110,9 @@ def main() -> int:
     ap.add_argument("--capture", help="a .prgcap (one submit)")
     ap.add_argument("--bundle", help="a .prgbundle; one submit is extracted from it")
     ap.add_argument("--submit", type=int, help="submit index in the bundle (default: discovered)")
+    ap.add_argument("--submits", help="comma-separated submit ordinals to census together")
+    ap.add_argument("--ds-submits", action="store_true",
+                    help="census every submit named by --bundle-ds-summary (the depth-stencil\n                         passes: world geometry and lighting)")
     ap.add_argument("--title", default="",
                     help="title id the capture came from, e.g. PPSA04263. Decides whether the "
                          "native-wave32 allowlist applies; without it, assumed NOT on the "
@@ -121,27 +141,48 @@ def main() -> int:
         tmp = tempfile.TemporaryDirectory()
         work = Path(tmp.name)
 
-    capture = args.capture
-    if args.bundle:
-        submit = args.submit
-        if submit is None:
-            submit, error = discover_submit(args.gpu_replay, args.bundle)
-            if submit is None:
-                print("cannot choose a submit: %s" % error, file=sys.stderr)
+    # Each entry is (capture path, label). One for a .prgcap; one per selected submit otherwise.
+    captures = []
+    bundle_submits = 0
+    if args.capture:
+        captures.append((args.capture, "capture"))
+    else:
+        if args.submits:
+            chosen = [int(s) for s in args.submits.split(",") if s.strip()]
+            _, bundle_submits = ds_submit_ordinals(args.gpu_replay, args.bundle)
+        elif args.ds_submits:
+            chosen, bundle_submits = ds_submit_ordinals(args.gpu_replay, args.bundle)
+            if not chosen:
+                print("--bundle-ds-summary named no submits", file=sys.stderr)
                 return 2
-        capture = work / "submit.prgcap"
-        done = run([args.gpu_replay, "--bundle", args.bundle,
-                    "--bundle-extract-submit", submit, capture])
-        if not Path(capture).exists():
-            print("extract failed:\n" + done.stdout + done.stderr, file=sys.stderr)
-            return 2
-        print("extracted submit %d" % submit)
+        elif args.submit is not None:
+            chosen = [args.submit]
+            _, bundle_submits = ds_submit_ordinals(args.gpu_replay, args.bundle)
+        else:
+            one, error = discover_submit(args.gpu_replay, args.bundle)
+            if one is None:
+                print("cannot choose a submit: %s" % error, file=sys.stderr)
+                print("(--ds-submits censuses every depth-stencil submit instead)", file=sys.stderr)
+                return 2
+            chosen, bundle_submits = [one], 1
+        print("censusing %d submit(s) of %d in the bundle" % (len(chosen), bundle_submits))
+        for ordinal in chosen:
+            out_path = work / ("submit_%d.prgcap" % ordinal)
+            if not out_path.exists():
+                run([args.gpu_replay, "--bundle", args.bundle,
+                     "--bundle-extract-submit", ordinal, out_path])
+            if out_path.exists():
+                captures.append((str(out_path), "submit %d" % ordinal))
+            else:
+                print("  submit %d: extract failed, SKIPPED (not counted either way)" % ordinal)
 
-    done = run([args.gpu_replay, "--inspect-only", capture])
-    draws = DRAW.findall(done.stdout + done.stderr)
+    draws = []
+    for capture, label in captures:
+        done = run([args.gpu_replay, "--inspect-only", capture])
+        found = DRAW.findall(done.stdout + done.stderr)
+        draws.extend((capture, d[0], d[1], d[2]) for d in found)
     if not draws:
-        print("no draws found in %s" % capture, file=sys.stderr)
-        print((done.stdout + done.stderr)[-2000:], file=sys.stderr)
+        print("no draws found in %d capture(s)" % len(captures), file=sys.stderr)
         return 2
 
     # One dump per DISTINCT fragment shader. The `fs=<dwords>/<hash>/` identity on each draw line is
@@ -149,12 +190,12 @@ def main() -> int:
     # one shader 400 times must not read as 400 blocked shaders.
     first_draw = {}
     draw_count = collections.Counter()
-    for draw_id, dwords, fs_hash in draws:
+    for capture, draw_id, dwords, fs_hash in draws:
         draw_count[fs_hash] += 1
-        first_draw.setdefault(fs_hash, (draw_id, int(dwords)))
+        first_draw.setdefault(fs_hash, (capture, draw_id, int(dwords)))
 
     results = {}
-    for fs_hash, (draw_id, dwords) in sorted(first_draw.items()):
+    for fs_hash, (capture, draw_id, dwords) in sorted(first_draw.items()):
         spv = work / ("fs_%s.spv" % fs_hash)
         # --inspect-only alongside --dump-shader: the module is written from the same realization
         # either way (byte-identical output, verified), but the frame is not REPLAYED. That matters
@@ -219,8 +260,15 @@ def main() -> int:
     if admitted:
         print("\nNOTE: 'possibly admitted' is an UPPER bound. Admission also needs the host to "
               "support\nthe width and the module's subgroup features, which this tool cannot see.")
-    print("\nSCOPE: one frame%s. This is what it RAN, not what the title contains."
-          % (" (one submit of it)" if args.bundle else ""))
+    if args.bundle:
+        print("\nSCOPE: %d of the bundle's %d submits. Submits not censused may run shaders not"
+              % (len(captures), bundle_submits))
+        print("listed above, so every count here is a LOWER bound on the frame.")
+        if args.ds_submits:
+            print("--ds-submits covers the depth-stencil passes only: world geometry and lighting,")
+            print("not UI or post passes that run without a depth-stencil target.")
+    else:
+        print("\nSCOPE: one capture. This is what it RAN, not what the title contains.")
     return 0
 
 

--- a/prosper/tools/shader_inspect/capture_wave_census.py
+++ b/prosper/tools/shader_inspect/capture_wave_census.py
@@ -9,7 +9,7 @@ gpu_replay has the real descriptors. This script drives it:
 
     gpu_replay --bundle F --bundle-extract-submit N cap.prgcap   # one submit, replayable
     gpu_replay --inspect-only cap.prgcap                         # draw list, with fs= identities
-    gpu_replay --dump-shader ID:fs fs.spv cap.prgcap             # the REAL-TABLE compiled module
+    gpu_replay --inspect-only --dump-shader ID:fs fs.spv cap.prgcap   # REAL-TABLE module
     shader_inspect fs.spv --wave-reasons                         # reads that module's own markers
 
 so every reason it reports comes from a module compiled the way the renderer compiles it, and no
@@ -119,7 +119,13 @@ def main() -> int:
     results = {}
     for fs_hash, (draw_id, dwords) in sorted(first_draw.items()):
         spv = work / ("fs_%s.spv" % fs_hash)
-        run([args.gpu_replay, "--dump-shader", "%s:fs" % draw_id, spv, capture])
+        # --inspect-only alongside --dump-shader: the module is written from the same
+        # realization either way (byte-identical output, verified), but the frame is not
+        # REPLAYED. That matters beyond speed on the title this exists for -- GTA V has two
+        # compute programs that hang the GPU into a driver recovery (#2542, #2690), and a
+        # census over N distinct shaders would otherwise trigger them N times.
+        run([args.gpu_replay, "--inspect-only", "--dump-shader", "%s:fs" % draw_id,
+             spv, capture])
         if not spv.exists():
             results[fs_hash] = ("dump-failed", 0, "", "", 0)
             continue

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -157,6 +157,10 @@ int main(int argc, char** argv) {
             "--wave-reasons prints ONLY a machine-readable fragment wave-width census: the guest\n"
             "wave width the recompiled module requires, why, and whether render_runner.h would\n"
             "admit it at a host native wave32 today. Same sentinel discipline as --mimg-sites.\n"
+            "It accepts EITHER a raw RDNA2 stream or a SPIR-V module (detected by the magic). A\n"
+            "raw dump has no descriptors, so a texture-sampling shader cannot be lowered here and\n"
+            "yields no reason data; pass the module from `gpu_replay --dump-shader DRAW:fs`, which\n"
+            "was compiled with the real resource table.\n"
             "\n"
             "IMPORTANT: shader_inspect has NO resource table (a raw dump carries no descriptors), so\n"
             "the recompiler cannot lower MIMG/MUBUF/MTBUF -- nor SMEM in the vertex/fragment stages.\n"
@@ -252,11 +256,28 @@ int main(int argc, char** argv) {
     // no descriptors and most real fragment shaders sample a texture: that is the tool's
     // limitation and must never be tallied as `requires nothing`.
     if (wave_reasons) {
-        const std::vector<uint32_t> spirv = recompile_fragment(words.data(), words.size());
+        // A SPIR-V input is READ, never recompiled. This is what makes the census usable at
+        // all: shader_inspect has no resource table, so a shader that samples a texture cannot
+        // be lowered here -- measured at 99.3% of GTA V's 3,453-shader pixel-shader database,
+        // i.e. the census over a raw dump is blind to precisely the lighting shaders #3464 is
+        // about. gpu_replay HAS the real descriptors and `--dump-shader DRAW:fs` already writes
+        // the recompiled module, so the reasons can come from a real-table compile while this
+        // tool stays the single place that formats them.
+        //
+        // Detected by the SPIR-V magic rather than by a flag or a file extension: the magic is
+        // the file format's own self-identification, so a mislabelled or renamed file cannot be
+        // read as the wrong kind. A raw RDNA2 stream cannot begin with it -- 0x07230203 decodes
+        // as neither a valid instruction nor a plausible first word.
+        const bool is_spirv = !words.empty() && words[0] == 0x07230203u;
+        const std::vector<uint32_t> spirv =
+            is_spirv ? words : recompile_fragment(words.data(), words.size());
         const bool recompiled = !spirv.empty();
         uint32_t table_dependent = 0;
-        for (const Rdna2Inst& in : instructions)
-            if (needs_resource_table(in.fmt, "fragment")) ++table_dependent;
+        // Meaningless for a SPIR-V input -- those fields describe an RDNA2 walk that did not
+        // happen -- so they are left at zero and the sentinel names the input kind.
+        if (!is_spirv)
+            for (const Rdna2Inst& in : instructions)
+                if (needs_resource_table(in.fmt, "fragment")) ++table_dependent;
         if (recompiled) {
             const uint32_t size = fragment_spirv_required_subgroup_size(spirv);
             const uint32_t reasons = fragment_spirv_required_subgroup_reasons(spirv);
@@ -270,10 +291,11 @@ int main(int argc, char** argv) {
             print_wave_reason_names(marked ? reasons : 0u);
             std::printf(" native-wave32-admitted=%d\n", admitted ? 1 : 0);
         }
-        std::printf("wave-reasons-end file=%s dwords=%zu recompiled=%d "
+        std::printf("wave-reasons-end file=%s input=%s dwords=%zu recompiled=%d "
                     "table_dependent=%u endpgm=%d\n",
-                    input_path.c_str(), words.size(), recompiled ? 1 : 0, table_dependent,
-                    (!instructions.empty() && instructions.back().is_end) ? 1 : 0);
+                    input_path.c_str(), is_spirv ? "spirv" : "rdna2", words.size(),
+                    recompiled ? 1 : 0, table_dependent,
+                    (!is_spirv && !instructions.empty() && instructions.back().is_end) ? 1 : 0);
         return 0;
     }
 

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -34,6 +34,45 @@ const char* operand_kind_name(OperandKind kind) {
     return index < std::size(names) ? names[index] : "invalid";
 }
 
+// The fragment wave-reason bits, named. Kept adjacent to the constants they mirror so a bit
+// added to rdna2_to_spirv.hpp without a name here shows up as an `unknown-bitN` token rather
+// than silently vanishing from the census.
+struct WaveReasonName {
+    uint32_t bit;
+    const char* name;
+};
+
+constexpr WaveReasonName kWaveReasonNames[] = {
+    {kFragmentWaveReasonLaneId,       "lane-id"},
+    {kFragmentWaveReasonWaveAny,      "wave-any"},
+    {kFragmentWaveReasonDppRow16,     "dpp-row16"},
+    {kFragmentWaveReasonPermLane32,   "permlane32"},
+    {kFragmentWaveReasonReadLane64,   "readlane64"},
+    {kFragmentWaveReasonShuffle,      "shuffle"},
+    {kFragmentWaveReasonWaveBallot,   "wave-ballot"},
+    {kFragmentWaveReasonScalarReduce, "scalar-reduce"},
+};
+
+// Prints the set bits by name, then any bit this table does not know about. The unknown pass
+// is the point: it makes a header change visible in the census output instead of dropping it.
+void print_wave_reason_names(uint32_t reasons) {
+    uint32_t named = 0;
+    bool first = true;
+    for (const WaveReasonName& entry : kWaveReasonNames) {
+        named |= entry.bit;
+        if (!(reasons & entry.bit)) continue;
+        std::printf("%s%s", first ? "" : ",", entry.name);
+        first = false;
+    }
+    for (uint32_t bit = 0; bit < 32; ++bit) {
+        const uint32_t mask = 1u << bit;
+        if (!(reasons & mask) || (named & mask)) continue;
+        std::printf("%sunknown-bit%u", first ? "" : ",", bit);
+        first = false;
+    }
+    if (first) std::printf("none");
+}
+
 bool is_branch(const Rdna2Inst& in) {
     return in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 && in.opcode <= 0x09 &&
            in.opcode != 0x03;
@@ -84,6 +123,7 @@ int main(int argc, char** argv) {
     std::string stage;
     std::string input_path;
     bool mimg_sites = false;
+    bool wave_reasons = false;
     bool bad_usage = false;
     for (int i = 1; i < argc && !bad_usage; ++i) {
         const std::string arg = argv[i];
@@ -92,6 +132,8 @@ int main(int argc, char** argv) {
             else stage = argv[++i];
         } else if (arg == "--mimg-sites") {
             mimg_sites = true;
+        } else if (arg == "--wave-reasons") {
+            wave_reasons = true;
         } else if (!arg.empty() && arg[0] == '-') {
             bad_usage = true;
         } else if (input_path.empty()) {
@@ -101,15 +143,20 @@ int main(int argc, char** argv) {
         }
     }
     if (input_path.empty() || bad_usage || (mimg_sites && !stage.empty()) ||
+        (wave_reasons && !stage.empty()) || (wave_reasons && mimg_sites) ||
         (!stage.empty() && stage != "vertex" && stage != "fragment" && stage != "compute")) {
         std::fprintf(stderr, "usage: %s <raw-rdna2.bin> [--stage vertex|fragment|compute]\n", argv[0]);
         std::fprintf(stderr, "       %s <raw-rdna2.bin> --mimg-sites\n", argv[0]);
+    std::fprintf(stderr, "       %s <raw-rdna2.bin> --wave-reasons\n", argv[0]);
         std::fprintf(stderr,
             "\n"
             "Decodes a raw RDNA2 shader dump. With --stage it also attempts a stage recompile.\n"
             "--mimg-sites prints ONLY a machine-readable MIMG census (pc, opcode, dim) from the same\n"
             "rdna2_walk, terminated by a `mimg-sites-end` line so a consumer can tell a real empty\n"
             "census from a run that died before printing one.\n"
+            "--wave-reasons prints ONLY a machine-readable fragment wave-width census: the guest\n"
+            "wave width the recompiled module requires, why, and whether render_runner.h would\n"
+            "admit it at a host native wave32 today. Same sentinel discipline as --mimg-sites.\n"
             "\n"
             "IMPORTANT: shader_inspect has NO resource table (a raw dump carries no descriptors), so\n"
             "the recompiler cannot lower MIMG/MUBUF/MTBUF -- nor SMEM in the vertex/fragment stages.\n"
@@ -178,6 +225,55 @@ int main(int argc, char** argv) {
         }
         std::printf("mimg-sites-end dwords=%zu consumed=%zu instructions=%zu sites=%zu endpgm=%d\n",
                     words.size(), consumed, instructions.size(), sites, walk_ended ? 1 : 0);
+        return 0;
+    }
+
+    // --wave-reasons: the fragment wave-width census, and nothing else.
+    //
+    // Motivation (#3464): on any NVIDIA host the entire supported subgroup range is 32..32, so a
+    // fragment module that requires the guest's Wave64 is DROPPED -- on GTA V that removes most
+    // of the world's lighting. Deciding what to do about it needs to start from what the title's
+    // shaders actually require, and a runtime skip log answers that only for whatever the route
+    // happened to reach, once per distinct shader, at whatever scene depth the run stopped.
+    // (Two counts taken that way, 43 and 86, differed by run length alone and read as a
+    // regression.) Over a dump of the title's shader database this is instead a total.
+    //
+    // `native-wave32-admitted` mirrors render_runner.h's gate EXACTLY -- equality against
+    // kFragmentWaveReasonWaveAny -- rather than re-deriving what ought to be admissible. The
+    // census reports the emulator that ships; proposals about what SHOULD be admitted belong in
+    // the classifier, where a test can hold them.
+    //
+    // A module needing no particular width reports size=0, reasons=0x0 and admitted=0: it never
+    // reaches the gate, and counting it as admitted would bury the interesting population under
+    // every ordinary shader in the dump.
+    //
+    // `wave-reasons-end` is a completion sentinel, not decoration -- see --mimg-sites above.
+    // A recompile that fails prints reasons=absent rather than 0x0, because a raw dump carries
+    // no descriptors and most real fragment shaders sample a texture: that is the tool's
+    // limitation and must never be tallied as `requires nothing`.
+    if (wave_reasons) {
+        const std::vector<uint32_t> spirv = recompile_fragment(words.data(), words.size());
+        const bool recompiled = !spirv.empty();
+        uint32_t table_dependent = 0;
+        for (const Rdna2Inst& in : instructions)
+            if (needs_resource_table(in.fmt, "fragment")) ++table_dependent;
+        if (recompiled) {
+            const uint32_t size = fragment_spirv_required_subgroup_size(spirv);
+            const uint32_t reasons = fragment_spirv_required_subgroup_reasons(spirv);
+            // UINT32_MAX means the module carries no reason marker at all. Absent is not none,
+            // so it is reported as `absent` and never printed as a mask a consumer would sum.
+            const bool marked = reasons != UINT32_MAX;
+            const bool admitted = marked && reasons == kFragmentWaveReasonWaveAny;
+            std::printf("wave-reasons required-subgroup-size=%u reasons=", size);
+            if (marked) std::printf("0x%x names=", reasons);
+            else std::printf("absent names=");
+            print_wave_reason_names(marked ? reasons : 0u);
+            std::printf(" native-wave32-admitted=%d\n", admitted ? 1 : 0);
+        }
+        std::printf("wave-reasons-end file=%s dwords=%zu recompiled=%d "
+                    "table_dependent=%u endpgm=%d\n",
+                    input_path.c_str(), words.size(), recompiled ? 1 : 0, table_dependent,
+                    (!instructions.empty() && instructions.back().is_end) ? 1 : 0);
         return 0;
     }
 

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -73,6 +73,35 @@ void print_wave_reason_names(uint32_t reasons) {
     if (first) std::printf("none");
 }
 
+// Whether a SPIR-V module's instruction stream walks cleanly from the 5-word header to the
+// exact end of the buffer.
+//
+// This exists because `required-subgroup-size=0 reasons=absent` is what a genuine wave-free
+// shader reports AND what a truncated one reports. Without a way to tell them apart, a corrupt
+// dump lands in the population that says #3464 does not affect it -- the same failure as
+// tallying an unlowerable shader as `requires nothing`, which is the thing this whole mode
+// exists to avoid.
+//
+// Deliberately structural, not semantic: it validates word counts and nothing else, mirroring
+// exactly the traversal fragment_spirv_required_subgroup_reasons() performs to find its
+// markers. So `ok` means precisely 'the marker search saw the whole module', which is the only
+// claim a census needs. It is not a substitute for spirv-val.
+bool spirv_stream_walks_cleanly(const std::vector<uint32_t>& words) {
+    if (words.size() < 5) return false;
+    size_t offset = 5;
+    while (offset < words.size()) {
+        const uint32_t count = words[offset] >> 16;
+        // A zero count would not advance -- an unguarded walk hangs here rather than failing,
+        // so this is a termination guard as much as a validity test.
+        if (!count || count > words.size() - offset) return false;
+        offset += count;
+    }
+    // Landing exactly on the end, not past it. A header with no instructions walks cleanly:
+    // zero instructions is a complete stream, and calling it corrupt would relabel every
+    // wave-free module as unreadable.
+    return offset == words.size();
+}
+
 bool is_branch(const Rdna2Inst& in) {
     return in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 && in.opcode <= 0x09 &&
            in.opcode != 0x03;
@@ -156,7 +185,10 @@ int main(int argc, char** argv) {
             "census from a run that died before printing one.\n"
             "--wave-reasons prints ONLY a machine-readable fragment wave-width census: the guest\n"
             "wave width the recompiled module requires, why, and whether render_runner.h would\n"
-            "admit it at a host native wave32 today. Same sentinel discipline as --mimg-sites.\n"
+            "would ADMIT at a host native wave32. `reason-set-admissible` is the module half of\n"
+            "that gate only -- admission also needs a title allowlist and host support, which an\n"
+            "offline tool cannot see, and every line says so. Same sentinel discipline as\n"
+            "--mimg-sites.\n"
             "It accepts EITHER a raw RDNA2 stream or a SPIR-V module (detected by the magic). A\n"
             "raw dump has no descriptors, so a texture-sampling shader cannot be lowered here and\n"
             "yields no reason data; pass the module from `gpu_replay --dump-shader DRAW:fs`, which\n"
@@ -242,19 +274,22 @@ int main(int argc, char** argv) {
     // (Two counts taken that way, 43 and 86, differed by run length alone and read as a
     // regression.) Over a dump of the title's shader database this is instead a total.
     //
-    // `native-wave32-admitted` mirrors render_runner.h's gate EXACTLY -- equality against
-    // kFragmentWaveReasonWaveAny -- rather than re-deriving what ought to be admissible. The
-    // census reports the emulator that ships; proposals about what SHOULD be admitted belong in
-    // the classifier, where a test can hold them.
+    // `reason-set-admissible` is the MODULE half of the renderer's gate and nothing more. That
+    // gate is five conjuncts (render_runner.h:7128-7133) and this equality (:7140) is the
+    // innermost; the decisive one, allow_native_fragment_vote_width, defaults false (:565) and
+    // comes from `title_id == "PPSA04263"` alone (live_renderer.cpp:1216, :7591). An earlier
+    // version of this mode called the equality `native-wave32-admitted` and was wrong in the
+    // only direction that mattered -- it under-reported the loss #3464 exists to size, for
+    // every title but one. The undecidable conjuncts are now named on their own output line.
     //
-    // A module needing no particular width reports size=0, reasons=0x0 and admitted=0: it never
-    // reaches the gate, and counting it as admitted would bury the interesting population under
-    // every ordinary shader in the dump.
+    // A module needing no particular width reports size=0 reasons=absent
+    // reason-set-admissible=0. `reasons=0x0` is NEVER printed: a module either carries the
+    // marker or it does not, and absent is not none.
     //
     // `wave-reasons-end` is a completion sentinel, not decoration -- see --mimg-sites above.
-    // A recompile that fails prints reasons=absent rather than 0x0, because a raw dump carries
-    // no descriptors and most real fragment shaders sample a texture: that is the tool's
-    // limitation and must never be tallied as `requires nothing`.
+    // A recompile that FAILS prints no census row at all, only the sentinel with recompiled=0:
+    // a raw dump carries no descriptors and most real fragment shaders sample a texture, so
+    // that outcome is the tool's limitation and must never be tallied as `requires nothing`.
     if (wave_reasons) {
         // A SPIR-V input is READ, never recompiled. This is what makes the census usable at
         // all: shader_inspect has no resource table, so a shader that samples a texture cannot
@@ -266,8 +301,13 @@ int main(int argc, char** argv) {
         //
         // Detected by the SPIR-V magic rather than by a flag or a file extension: the magic is
         // the file format's own self-identification, so a mislabelled or renamed file cannot be
-        // read as the wrong kind. A raw RDNA2 stream cannot begin with it -- 0x07230203 decodes
-        // as neither a valid instruction nor a plausible first word.
+        // read as the wrong kind.
+        //
+        // This does NOT rest on 0x07230203 being undecodable as RDNA2 -- it decodes as VOP2
+        // op=0x003 in this tool's own decoder. It rests on no real shader dump beginning with
+        // that exact word: a fragment program's first instruction is a prologue, not a lone
+        // VOP2 with those operands. A dump that did begin with it would be misread, which is
+        // why `input=` is on every sentinel line for a consumer to check.
         const bool is_spirv = !words.empty() && words[0] == 0x07230203u;
         const std::vector<uint32_t> spirv =
             is_spirv ? words : recompile_fragment(words.data(), words.size());
@@ -284,17 +324,43 @@ int main(int argc, char** argv) {
             // UINT32_MAX means the module carries no reason marker at all. Absent is not none,
             // so it is reported as `absent` and never printed as a mask a consumer would sum.
             const bool marked = reasons != UINT32_MAX;
-            const bool admitted = marked && reasons == kFragmentWaveReasonWaveAny;
+            // NOT an admission verdict, and the name says so. render_invoke's gate is FIVE
+            // conjuncts (render_runner.h:7128-7133) and only this equality (:7140) is a
+            // property of the module. Reporting it as `admitted` was wrong in the one
+            // direction that matters: `allow_native_fragment_vote_width` defaults false
+            // (:565) and is set from `title_id == "PPSA04263"` alone (live_renderer.cpp:1216,
+            // :7591), so for every other title the renderer DROPS these shaders while the
+            // census called them admitted -- an undercount of the loss #3464 is about, in a
+            // field whose whole purpose is to size that loss.
+            const bool reason_set_admissible =
+                marked && reasons == kFragmentWaveReasonWaveAny;
+            // The two conjuncts a module CAN decide, reported rather than assumed to pass.
+            const uint32_t features = fragment_spirv_required_subgroup_features(spirv);
+            const bool internal_gds = fragment_spirv_uses_internal_gds(spirv);
             std::printf("wave-reasons required-subgroup-size=%u reasons=", size);
             if (marked) std::printf("0x%x names=", reasons);
             else std::printf("absent names=");
             print_wave_reason_names(marked ? reasons : 0u);
-            std::printf(" native-wave32-admitted=%d\n", admitted ? 1 : 0);
+            std::printf(" reason-set-admissible=%d internal-gds=%d subgroup-features=0x%x\n",
+                        reason_set_admissible ? 1 : 0, internal_gds ? 1 : 0, features);
+            // Named explicitly, every time, so no consumer can read the line above as an
+            // admission verdict by omission. These are the conjuncts an OFFLINE tool cannot
+            // evaluate at all -- they are properties of the run, not of the module.
+            std::printf("wave-reasons gate-undecided=title-allowlist,host-subgroup-size-control,"
+                        "host-subgroup-features NOTE: admission additionally requires the title to be"
+                        " on the allowlist (currently PPSA04263 only) and the host to support the"
+                        " width and features; this tool knows none of those.\n");
         }
-        std::printf("wave-reasons-end file=%s input=%s dwords=%zu recompiled=%d "
-                    "table_dependent=%u endpgm=%d\n",
-                    input_path.c_str(), is_spirv ? "spirv" : "rdna2", words.size(),
-                    recompiled ? 1 : 0, table_dependent,
+        // `recompiled` is honest only for a raw stream -- a SPIR-V input is READ, not
+        // recompiled -- so it is reported as n/a there rather than as a 1 that would inflate
+        // any tally of how many modules this tool actually compiled.
+        std::printf("wave-reasons-end file=%s input=%s dwords=%zu ",
+                    input_path.c_str(), is_spirv ? "spirv" : "rdna2", words.size());
+        if (is_spirv)
+            std::printf("recompiled=n/a spirv-walk=%s ",
+                        spirv_stream_walks_cleanly(words) ? "ok" : "truncated");
+        else std::printf("recompiled=%d ", recompiled ? 1 : 0);
+        std::printf("table_dependent=%u endpgm=%d\n", table_dependent,
                     (!is_spirv && !instructions.empty() && instructions.back().is_end) ? 1 : 0);
         return 0;
     }

--- a/prosper/tools/shader_inspect/test_shader_inspect.py
+++ b/prosper/tools/shader_inspect/test_shader_inspect.py
@@ -169,6 +169,51 @@ def main() -> int:
     check("a wave-free shader is not counted as gate-admitted",
           "native-wave32-admitted=0" in out, "\n" + out)
 
+    # ---- #3464: the census must read a SPIR-V module too ------------------------------------
+    #
+    # A raw dump carries no descriptors, so a texture-sampling shader cannot be lowered and
+    # contributes no reason data -- 99.3% of GTA V's pixel-shader database. gpu_replay has the
+    # real table and `--dump-shader DRAW:fs` writes the recompiled SPIR-V, so reading a .spv is
+    # what makes this census reach the shaders the issue is actually about.
+    #
+    # Built by hand from the header plus two OpModuleProcessed strings, NOT by recompiling: a
+    # fixture from the recompiler would share its assumptions with the reader under test.
+    def module_processed(text):
+        raw = text.encode("utf-8") + b"\x00"
+        raw += b"\x00" * (-len(raw) % 4)
+        payload = list(struct.unpack("<%dI" % (len(raw) // 4), raw))
+        return [((1 + len(payload)) << 16) | 330] + payload   # Op_ModuleProcessed = 330
+
+    def spirv_module(size, reasons):
+        words = [0x07230203, 0x00010300, 0, 1, 0]   # magic, version, generator, bound, schema
+        words += module_processed("Prosper.FragmentSubgroupSize=%d" % size)
+        words += module_processed("Prosper.FragmentSubgroupWhy=%d" % reasons)
+        return words
+
+    # lane-id + wave-ballot: the reason set that blocks every one of GTA V's skipped shaders.
+    code, out = run(binary, spirv_module(64, 0x41), extra=["--wave-reasons"])
+    check("a SPIR-V module is accepted by the census",
+          "wave-reasons-end" in out and "input=spirv" in out, "\n" + out)
+    check("a SPIR-V module reports its recorded width",
+          "required-subgroup-size=64" in out, "\n" + out)
+    check("a SPIR-V module reports its recorded reasons",
+          "reasons=0x41" in out and "lane-id" in out and "wave-ballot" in out, "\n" + out)
+    # 0x41 is not equal to kFragmentWaveReasonWaveAny, so the shipping gate drops it.
+    check("a SPIR-V module blocked by lane-id is not gate-admitted",
+          "native-wave32-admitted=0" in out, "\n" + out)
+
+    # WaveAny alone IS admitted, so the column cannot be reading a constant.
+    code, out = run(binary, spirv_module(64, 0x2), extra=["--wave-reasons"])
+    check("a wave-any-only SPIR-V module is gate-admitted",
+          "native-wave32-admitted=1" in out, "\n" + out)
+
+    # No marker at all: absent is not none, and must never be printed as a mask.
+    code, out = run(binary, [0x07230203, 0x00010300, 0, 1, 0], extra=["--wave-reasons"])
+    check("an unmarked SPIR-V module reports absent, not 0x0",
+          "reasons=absent" in out and "reasons=0x0" not in out, "\n" + out)
+    check("an unmarked SPIR-V module is not gate-admitted",
+          "native-wave32-admitted=0" in out, "\n" + out)
+
     print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
     return 1 if failures else 0
 

--- a/prosper/tools/shader_inspect/test_shader_inspect.py
+++ b/prosper/tools/shader_inspect/test_shader_inspect.py
@@ -33,11 +33,13 @@ def s_load_dwordx4(sdata: int, sbase_pair: int, offset: int) -> tuple:
     return word0, word1
 
 
-def run(binary: str, words, stage=None):
+def run(binary: str, words, stage=None, extra=None):
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "shader.bin"
         path.write_bytes(struct.pack("<%dI" % len(words), *words))
         cmd = [binary, str(path)]
+        if extra:
+            cmd += list(extra)
         if stage:
             cmd += ["--stage", stage]
         done = subprocess.run(cmd, capture_output=True, text=True)
@@ -116,6 +118,56 @@ def main() -> int:
           "got exit %d" % done.returncode)
     check("usage text warns about the missing resource table",
           "resource table" in done.stderr, "\n" + done.stderr)
+
+    # ---- #3464: offline wave-reason census -----------------------------------------------
+    #
+    # A fragment shader that votes (compare, then branch on the result) requires the guest wave
+    # width for a reason that is RECOVERABLE at 32 lanes -- two half-waves union to the same
+    # answer -- and prosper already admits exactly this class. The census must say so in a form
+    # a script can filter, so a dump of a title's shaders becomes a table rather than 86 manual
+    # inspections.
+    vote_words = (
+        0x7E040280,              # v_mov_b32 v2,0
+        0x7E060280,              # v_mov_b32 v3,0
+        0x7C020300,              # v_cmp_lt_f32 vcc,v0,v1
+        0xBF13806A,              # s_cmp_lg_u64 vcc,0
+        0xBF840001,              # s_cbranch_scc0 -> +1
+        0x7E040281,              # v_mov_b32 v2,1
+        0x7E080280,              # v_mov_b32 v4,0
+        0x7E0A0280,              # v_mov_b32 v5,0
+        0xF800180F, 0x05040302,  # exp mrt0 v2,v3,v4,v5 done vm
+        S_ENDPGM,
+    )
+    code, out = run(binary, vote_words, extra=["--wave-reasons"])
+    check("wave-reasons census emits its sentinel",
+          "wave-reasons-end" in out, "\n" + out)
+    check("wave-reasons census reports the required width",
+          "required-subgroup-size=64" in out, "\n" + out)
+    check("wave-reasons census names the reason bits",
+          "reasons=0x2" in out and "wave-any" in out, "\n" + out)
+    # The actionable column, and it is deliberately a fact about SHIPPING code rather than a
+    # judgement: render_runner.h admits a fragment shader at the host's native wave32 only when
+    # its reason set equals kFragmentWaveReasonWaveAny exactly. A reason set of precisely WaveAny
+    # is therefore admitted today, and the census must say so in the same terms, so a count taken
+    # over a title's shaders describes the emulator someone actually runs.
+    check("wave-reasons census reports native-wave32 admission",
+          "native-wave32-admitted=1" in out, "\n" + out)
+
+    # A shader with no wave op at all must report a real, empty census -- not silence, which a
+    # consumer cannot distinguish from a crash.
+    plain_words = (
+        0x7E040280, 0x7E060280, 0x7E080280, 0x7E0A0280,
+        0xF800180F, 0x05040302,
+        S_ENDPGM,
+    )
+    code, out = run(binary, plain_words, extra=["--wave-reasons"])
+    check("a wave-free shader still emits a census",
+          "wave-reasons-end" in out and "required-subgroup-size=0" in out, "\n" + out)
+    # A shader that requires no width at all never reaches the gate, so it is not "admitted" by
+    # it. Conflating "needs nothing" with "needs something prosper can supply" would inflate every
+    # admission count by the entire population of ordinary shaders.
+    check("a wave-free shader is not counted as gate-admitted",
+          "native-wave32-admitted=0" in out, "\n" + out)
 
     print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
     return 1 if failures else 0

--- a/prosper/tools/shader_inspect/test_shader_inspect.py
+++ b/prosper/tools/shader_inspect/test_shader_inspect.py
@@ -271,6 +271,28 @@ def main() -> int:
     code, out = run(binary, [0x07230203, 0x00010300, 0, 1, 0], extra=["--wave-reasons"])
     check("a header-only module is a clean walk, not a truncated one",
           "spirv-walk=ok" in out, "\n" + out)
+    # ---- #3464 re-review: pin the FAILED-recompile honesty contract ------------------------
+    #
+    # A shader needing a resource table cannot be lowered here, and the census must then print
+    # the sentinel with recompiled=0 and NO census row. The row is what a consumer tallies, so
+    # emitting one for a shader that was never read would put it in the population that says
+    # #3464 does not affect it -- the same failure as the unrecompiled column, one layer down.
+    # This was reported as covered in an earlier round and was not; nothing would have reddened.
+    code, out = run(binary, cbuf_load, extra=["--wave-reasons"])
+    check("a table-dependent shader still emits the sentinel",
+          "wave-reasons-end" in out, "\n" + out)
+    check("a failed recompile reports recompiled=0",
+          "recompiled=0" in out, "\n" + out)
+    check("a failed recompile emits NO census row",
+          "required-subgroup-size=" not in out, "\n" + out)
+    check("a failed recompile is not reported as reason-set admissible",
+          "reason-set-admissible=1" not in out, "\n" + out)
+
+    # And the SPIR-V sentinel must say recompiled=n/a -- nothing was recompiled, it was read.
+    # Load-bearing: wave_reason_census.py distinguishes the two on this field.
+    code, out = run(binary, spirv_module(64, 0x2), extra=["--wave-reasons"])
+    check("a SPIR-V input reports recompiled=n/a, never a count",
+          "recompiled=n/a" in out and "recompiled=1" not in out, "\n" + out)
     print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
     return 1 if failures else 0
 

--- a/prosper/tools/shader_inspect/test_shader_inspect.py
+++ b/prosper/tools/shader_inspect/test_shader_inspect.py
@@ -285,8 +285,13 @@ def main() -> int:
           "recompiled=0" in out, "\n" + out)
     check("a failed recompile emits NO census row",
           "required-subgroup-size=" not in out, "\n" + out)
-    check("a failed recompile is not reported as reason-set admissible",
-          "reason-set-admissible=1" not in out, "\n" + out)
+    # NOT `reason-set-admissible=1 not in out`, which was the first draft: that is implied by
+    # the row-absence arm above, and in the one world where THAT breaks the printed value is 0
+    # anyway -- an arm satisfied for a reason other than the one it names. The gate-undecided
+    # line is a SEPARATE printf and can be moved out of the recompiled guard on its own, so
+    # asserting on its absence covers a failure the row-absence arm cannot see.
+    check("a failed recompile emits no gate-undecided line either",
+          "gate-undecided=" not in out, "\n" + out)
 
     # And the SPIR-V sentinel must say recompiled=n/a -- nothing was recompiled, it was read.
     # Load-bearing: wave_reason_census.py distinguishes the two on this field.

--- a/prosper/tools/shader_inspect/test_shader_inspect.py
+++ b/prosper/tools/shader_inspect/test_shader_inspect.py
@@ -150,8 +150,8 @@ def main() -> int:
     # its reason set equals kFragmentWaveReasonWaveAny exactly. A reason set of precisely WaveAny
     # is therefore admitted today, and the census must say so in the same terms, so a count taken
     # over a title's shaders describes the emulator someone actually runs.
-    check("wave-reasons census reports native-wave32 admission",
-          "native-wave32-admitted=1" in out, "\n" + out)
+    check("wave-reasons census reports reason-set admissibility",
+          "reason-set-admissible=1" in out, "\n" + out)
 
     # A shader with no wave op at all must report a real, empty census -- not silence, which a
     # consumer cannot distinguish from a crash.
@@ -166,8 +166,8 @@ def main() -> int:
     # A shader that requires no width at all never reaches the gate, so it is not "admitted" by
     # it. Conflating "needs nothing" with "needs something prosper can supply" would inflate every
     # admission count by the entire population of ordinary shaders.
-    check("a wave-free shader is not counted as gate-admitted",
-          "native-wave32-admitted=0" in out, "\n" + out)
+    check("a wave-free shader is not reason-set admissible",
+          "reason-set-admissible=0" in out, "\n" + out)
 
     # ---- #3464: the census must read a SPIR-V module too ------------------------------------
     #
@@ -199,21 +199,78 @@ def main() -> int:
     check("a SPIR-V module reports its recorded reasons",
           "reasons=0x41" in out and "lane-id" in out and "wave-ballot" in out, "\n" + out)
     # 0x41 is not equal to kFragmentWaveReasonWaveAny, so the shipping gate drops it.
-    check("a SPIR-V module blocked by lane-id is not gate-admitted",
-          "native-wave32-admitted=0" in out, "\n" + out)
+    check("a SPIR-V module blocked by lane-id is not reason-set admissible",
+          "reason-set-admissible=0" in out, "\n" + out)
 
     # WaveAny alone IS admitted, so the column cannot be reading a constant.
     code, out = run(binary, spirv_module(64, 0x2), extra=["--wave-reasons"])
-    check("a wave-any-only SPIR-V module is gate-admitted",
-          "native-wave32-admitted=1" in out, "\n" + out)
+    check("a wave-any-only SPIR-V module is reason-set admissible",
+          "reason-set-admissible=1" in out, "\n" + out)
 
     # No marker at all: absent is not none, and must never be printed as a mask.
     code, out = run(binary, [0x07230203, 0x00010300, 0, 1, 0], extra=["--wave-reasons"])
     check("an unmarked SPIR-V module reports absent, not 0x0",
           "reasons=absent" in out and "reasons=0x0" not in out, "\n" + out)
-    check("an unmarked SPIR-V module is not gate-admitted",
-          "native-wave32-admitted=0" in out, "\n" + out)
+    check("an unmarked SPIR-V module is not reason-set admissible",
+          "reason-set-admissible=0" in out, "\n" + out)
 
+    # ---- #3464 review: the census must not claim ADMISSION it cannot determine -------------
+    #
+    # render_runner.h:7128-7133 is a five-conjunct condition and only the innermost equality
+    # (:7140) is a module property. `bd.allow_native_fragment_vote_width` defaults false
+    # (:565) and is set from `title_id == "PPSA04263"` alone (live_renderer.cpp:1216, :7591),
+    # and two more conjuncts depend on the HOST's subgroup limits. An offline tool knows none
+    # of those, so it must report the reason-set test under its own name and say plainly that
+    # admission needs more -- otherwise every non-GTA-V count reads as admitted when the
+    # renderer in fact drops the shader.
+    code, out = run(binary, spirv_module(64, 0x2), extra=["--wave-reasons"])
+    check("the census states that admission is not decided by the module alone",
+          "gate-undecided=" in out, "\n" + out)
+    check("the census names the title allowlist as an undecided conjunct",
+          "title-allowlist" in out, "\n" + out)
+    check("the census names the host subgroup limits as an undecided conjunct",
+          "host-subgroup" in out, "\n" + out)
+    # The two conjuncts a module CAN decide are reported rather than silently assumed to pass.
+    check("the census reports the internal-GDS conjunct",
+          "internal-gds=" in out, "\n" + out)
+    check("the census reports the required subgroup features",
+          "subgroup-features=0x" in out, "\n" + out)
+
+    # And the old name must be gone: a consumer keying on it would otherwise keep reading an
+    # admission claim that is no longer made.
+    check("the overclaiming field name is gone",
+          "native-wave32-admitted" not in out, "\n" + out)
+    # ---- #3464 review: a corrupt module must not be counted as "needs nothing" --------------
+    #
+    # `required-subgroup-size=0 reasons=absent` is what a genuine wave-free shader reports AND
+    # what a truncated one reports, so a corrupt dump lands in the population that says #3464
+    # does not affect it. The marker search already walks word/opcode pairs, so whether that
+    # walk lands exactly on the end is free to report -- and it is the difference between a
+    # module that says nothing and a module that could not be read.
+    code, out = run(binary, spirv_module(64, 0x2), extra=["--wave-reasons"])
+    check("a well-formed module reports a clean walk",
+          "spirv-walk=ok" in out, "\n" + out)
+
+    # An instruction claiming more words than remain: the walk cannot complete.
+    truncated = [0x07230203, 0x00010300, 0, 1, 0, (999 << 16) | 330]
+    code, out = run(binary, truncated, extra=["--wave-reasons"])
+    check("an overrunning instruction is reported as a bad walk",
+          "spirv-walk=truncated" in out, "\n" + out)
+    check("a bad walk still emits the sentinel",
+          "wave-reasons-end" in out, "\n" + out)
+
+    # A zero word count would loop forever if the walk were unguarded; it must terminate AND
+    # be reported as unreadable rather than as a shader with no requirement.
+    zero_len = [0x07230203, 0x00010300, 0, 1, 0, 0]
+    code, out = run(binary, zero_len, extra=["--wave-reasons"])
+    check("a zero-length instruction is reported as a bad walk",
+          "spirv-walk=truncated" in out, "\n" + out)
+
+    # And the header alone IS a clean walk -- zero instructions is a complete stream, not a
+    # corrupt one. Without this the fix would just relabel every wave-free module as corrupt.
+    code, out = run(binary, [0x07230203, 0x00010300, 0, 1, 0], extra=["--wave-reasons"])
+    check("a header-only module is a clean walk, not a truncated one",
+          "spirv-walk=ok" in out, "\n" + out)
     print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
     return 1 if failures else 0
 

--- a/prosper/tools/shader_inspect/wave_reason_census.py
+++ b/prosper/tools/shader_inspect/wave_reason_census.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Tally `shader_inspect --wave-reasons` over a directory of raw RDNA2 shader dumps.
+
+Answers, for a whole title rather than for whatever a route happened to reach: how many fragment
+shaders require the guest Wave64, what they require it for, and how many of those prosper admits
+today at a host native wave32. On any NVIDIA host the entire supported subgroup range is 32..32, so
+every shader this reports as requiring 64 and not admitted is a shader that is DROPPED -- on GTA V
+that is most of the world's lighting (#3464).
+
+Why a whole-database sweep rather than the runtime skip log: the runtime logs once per distinct
+shader, so its count is a function of how far the route got. Two runtime counts taken this way, 43
+and 86, differed by run length alone and read as a regression until they were matched by frame.
+
+    python wave_reason_census.py <shader_inspect> <dir> [--stage-token PS] [--csv out.csv]
+
+IMPORTANT -- read `unrecompiled` before quoting any total. shader_inspect has no resource table, so
+a shader that samples a texture cannot be lowered and contributes NO reason data. Those are counted
+and reported separately, never as "requires nothing". A census whose unrecompiled count is large is
+a census of the shaders that happen not to touch memory, which is not a random sample of anything.
+"""
+import argparse
+import collections
+import concurrent.futures
+import csv
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+END = re.compile(r"wave-reasons-end .*?recompiled=(\d+) table_dependent=(\d+) endpgm=(\d+)")
+ROW = re.compile(r"wave-reasons required-subgroup-size=(\d+) reasons=(\S+) names=(\S+) "
+                 r"native-wave32-admitted=(\d+)")
+
+
+class Result:
+    __slots__ = ("path", "recompiled", "table_dependent", "endpgm",
+                 "size", "reasons", "names", "admitted", "error")
+
+    def __init__(self, path):
+        self.path = path
+        self.recompiled = self.table_dependent = self.endpgm = 0
+        self.size = 0
+        self.reasons = self.names = ""
+        self.admitted = 0
+        self.error = ""
+
+
+def inspect(binary: str, path: Path) -> Result:
+    r = Result(path)
+    try:
+        done = subprocess.run([binary, str(path), "--wave-reasons"],
+                              capture_output=True, text=True, timeout=120)
+    except (OSError, subprocess.SubprocessError) as exc:
+        r.error = str(exc)
+        return r
+    end = END.search(done.stdout)
+    if not end:
+        # The sentinel's whole purpose. Without it a dead process and a shader with no wave
+        # requirement look identical, and the second is the answer that would be tallied.
+        r.error = "no sentinel (exit %d)" % done.returncode
+        return r
+    r.recompiled, r.table_dependent, r.endpgm = (int(g) for g in end.groups())
+    row = ROW.search(done.stdout)
+    if row:
+        r.size = int(row.group(1))
+        r.reasons, r.names = row.group(2), row.group(3)
+        r.admitted = int(row.group(4))
+    return r
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("binary")
+    ap.add_argument("directory")
+    ap.add_argument("--stage-token", default="PS",
+                    help="only files whose name contains _<TOKEN>_ (default PS)")
+    ap.add_argument("--csv")
+    ap.add_argument("--jobs", type=int, default=16)
+    args = ap.parse_args()
+
+    root = Path(args.directory)
+    token = "_%s_" % args.stage_token
+    files = sorted(p for p in root.rglob("*.bin") if token in p.name)
+    if not files:
+        print("no files matching %s under %s" % (token, root), file=sys.stderr)
+        return 2
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        results = list(pool.map(lambda p: inspect(args.binary, p), files))
+
+    errors = [r for r in results if r.error]
+    unrecompiled = [r for r in results if not r.error and not r.recompiled]
+    ok = [r for r in results if not r.error and r.recompiled]
+    needs = [r for r in ok if r.size > 32]
+    admitted = [r for r in needs if r.admitted]
+    dropped = [r for r in needs if not r.admitted]
+
+    print("files=%d  errors=%d  unrecompiled(no resource table)=%d  analysed=%d"
+          % (len(files), len(errors), len(unrecompiled), len(ok)))
+    if not ok:
+        print("\nNOTHING was analysed -- every shader needed a resource table this tool cannot")
+        print("supply. No statement about wave width can be made from this run.")
+    else:
+        print("of the analysed: require>32=%d  of those admitted at native wave32=%d  DROPPED=%d"
+              % (len(needs), len(admitted), len(dropped)))
+        by_reason = collections.Counter((r.reasons, r.names) for r in needs)
+        if by_reason:
+            print("\nreason sets among the %d that require a wide wave:" % len(needs))
+            for (mask, names), n in by_reason.most_common():
+                print("  %-8s %-40s %4d" % (mask, names, n))
+        if dropped:
+            print("\nfirst dropped shaders by name:")
+            for r in sorted(dropped, key=lambda r: r.path.name)[:20]:
+                print("  %s  %s" % (r.reasons, r.path.name))
+    # The caveat repeated at the END too: a reader who scrolls to the bottom for the numbers must
+    # meet it there as well as at the top.
+    if unrecompiled:
+        print("\nCAVEAT: %d of %d shaders (%.1f%%) could not be lowered without a resource table"
+              % (len(unrecompiled), len(files), 100.0 * len(unrecompiled) / len(files)))
+        print("and contribute no reason data. The analysed set is the shaders that happen not to")
+        print("need one, which is NOT a random sample -- a texture-sampling lighting shader is")
+        print("exactly the kind that is missing. Treat every count above as a lower bound.")
+    for r in errors[:10]:
+        print("  error: %s: %s" % (r.path.name, r.error))
+
+    if args.csv:
+        with open(args.csv, "w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh)
+            w.writerow(["name", "recompiled", "table_dependent", "endpgm",
+                        "required_subgroup_size", "reasons", "names",
+                        "native_wave32_admitted", "error"])
+            for r in results:
+                w.writerow([r.path.name, r.recompiled, r.table_dependent, r.endpgm,
+                            r.size, r.reasons, r.names, r.admitted, r.error])
+        print("\nwrote %s" % args.csv)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/shader_inspect/wave_reason_census.py
+++ b/prosper/tools/shader_inspect/wave_reason_census.py
@@ -4,7 +4,7 @@
 Answers, for a whole title rather than for whatever a route happened to reach: how many fragment
 shaders require the guest Wave64, what they require it for, and how many of those prosper admits
 today at a host native wave32. On any NVIDIA host the entire supported subgroup range is 32..32, so
-every shader this reports as requiring 64 and not admitted is a shader that is DROPPED -- on GTA V
+a shader requiring 64 that the renderer does not admit is DROPPED entirely -- on GTA V
 that is most of the world's lighting (#3464).
 
 Why a whole-database sweep rather than the runtime skip log: the runtime logs once per distinct
@@ -29,19 +29,19 @@ from pathlib import Path
 
 END = re.compile(r"wave-reasons-end .*?recompiled=(\d+) table_dependent=(\d+) endpgm=(\d+)")
 ROW = re.compile(r"wave-reasons required-subgroup-size=(\d+) reasons=(\S+) names=(\S+) "
-                 r"native-wave32-admitted=(\d+)")
+                 r"reason-set-admissible=(\d+)")
 
 
 class Result:
     __slots__ = ("path", "recompiled", "table_dependent", "endpgm",
-                 "size", "reasons", "names", "admitted", "error")
+                 "size", "reasons", "names", "admissible", "error")
 
     def __init__(self, path):
         self.path = path
         self.recompiled = self.table_dependent = self.endpgm = 0
         self.size = 0
         self.reasons = self.names = ""
-        self.admitted = 0
+        self.admissible = 0
         self.error = ""
 
 
@@ -64,7 +64,7 @@ def inspect(binary: str, path: Path) -> Result:
     if row:
         r.size = int(row.group(1))
         r.reasons, r.names = row.group(2), row.group(3)
-        r.admitted = int(row.group(4))
+        r.admissible = int(row.group(4))
     return r
 
 
@@ -77,6 +77,10 @@ def main() -> int:
     ap.add_argument("--csv")
     ap.add_argument("--jobs", type=int, default=16)
     args = ap.parse_args()
+    # Absolute up front: a relative tool path a shell resolves is not necessarily one
+    # CreateProcess resolves on Windows. Caught here by the sentinel check rather than
+    # producing a wrong number, but it still made the documented invocation fail.
+    args.binary = str(Path(args.binary).resolve())
 
     root = Path(args.directory)
     token = "_%s_" % args.stage_token
@@ -92,8 +96,14 @@ def main() -> int:
     unrecompiled = [r for r in results if not r.error and not r.recompiled]
     ok = [r for r in results if not r.error and r.recompiled]
     needs = [r for r in ok if r.size > 32]
-    admitted = [r for r in needs if r.admitted]
-    dropped = [r for r in needs if not r.admitted]
+    # The reason-set test is only the INNERMOST of the renderer's five conjuncts
+    # (render_runner.h:7128-7133). The decisive one, `allow_native_fragment_vote_width`,
+    # defaults false (:565) and comes from `title_id == "PPSA04263"` alone
+    # (live_renderer.cpp:1216), and two more are properties of the HOST. A raw-dump sweep has
+    # neither a title nor a host, so it reports the module property under its own name and
+    # never calls anything admitted -- an earlier version did, and undercounted the loss
+    # #3464 is about for every title but one.
+    admissible = [r for r in needs if r.admissible]
 
     print("files=%d  errors=%d  unrecompiled(no resource table)=%d  analysed=%d"
           % (len(files), len(errors), len(unrecompiled), len(ok)))
@@ -101,17 +111,21 @@ def main() -> int:
         print("\nNOTHING was analysed -- every shader needed a resource table this tool cannot")
         print("supply. No statement about wave width can be made from this run.")
     else:
-        print("of the analysed: require>32=%d  of those admitted at native wave32=%d  DROPPED=%d"
-              % (len(needs), len(admitted), len(dropped)))
+        print("of the analysed: require>32=%d  of those reason-set admissible=%d"
+              % (len(needs), len(admissible)))
+        print("NOTE: admissible is NOT admitted. The renderer also requires the title to be on")
+        print("the native-wave32 allowlist (currently PPSA04263 only) and the host to support")
+        print("the width and features. For a per-title verdict use capture_wave_census.py.")
         by_reason = collections.Counter((r.reasons, r.names) for r in needs)
         if by_reason:
             print("\nreason sets among the %d that require a wide wave:" % len(needs))
             for (mask, names), n in by_reason.most_common():
                 print("  %-8s %-40s %4d" % (mask, names, n))
-        if dropped:
-            print("\nfirst dropped shaders by name:")
-            for r in sorted(dropped, key=lambda r: r.path.name)[:20]:
-                print("  %s  %s" % (r.reasons, r.path.name))
+        if needs:
+            print("\nfirst wide-wave shaders by name:")
+            for r in sorted(needs, key=lambda r: r.path.name)[:20]:
+                print("  %-8s admissible=%d  %s"
+                      % (r.reasons, r.admissible, r.path.name))
     # The caveat repeated at the END too: a reader who scrolls to the bottom for the numbers must
     # meet it there as well as at the top.
     if unrecompiled:
@@ -128,10 +142,10 @@ def main() -> int:
             w = csv.writer(fh)
             w.writerow(["name", "recompiled", "table_dependent", "endpgm",
                         "required_subgroup_size", "reasons", "names",
-                        "native_wave32_admitted", "error"])
+                        "reason_set_admissible", "error"])
             for r in results:
                 w.writerow([r.path.name, r.recompiled, r.table_dependent, r.endpgm,
-                            r.size, r.reasons, r.names, r.admitted, r.error])
+                            r.size, r.reasons, r.names, r.admissible, r.error])
         print("\nwrote %s" % args.csv)
     return 0
 


### PR DESCRIPTION
Refs #3464. On any NVIDIA host the entire supported subgroup range is `32..32` — no extension,
driver or device yields a 64-wide subgroup — so a fragment module that requires the guest's Wave64
is dropped. On *Grand Theft Auto V* that removes most of the world's lighting.

Acting on that has to start from **what a title's shaders actually require**, and the only
instrument was the runtime skip log — which reports whatever a route reached, once per distinct
shader, at whatever scene depth the run stopped. Two counts taken that way, 43 and 86, differed by
run length alone and read as a regression until they were matched by frame.

This PR builds that instrument. It is read-only diagnostics: no recompiler, emitter or renderer
behaviour changes, and nothing changes what prosper admits or drops.

## What it adds

**`shader_inspect --wave-reasons`** — the required guest wave width, the reason bits by name, and
the module-level half of the renderer's admission gate:

```
wave-reasons required-subgroup-size=64 reasons=0x2 names=wave-any reason-set-admissible=1 \
    internal-gds=0 subgroup-features=0x1
wave-reasons gate-undecided=title-allowlist,host-subgroup-size-control,host-subgroup-features ...
wave-reasons-end file=... input=rdna2 dwords=12 recompiled=1 table_dependent=0 endpgm=1
```

It accepts **either** a raw RDNA2 stream **or** a SPIR-V module, detected by the SPIR-V magic.

**`wave_reason_census.py`** sweeps a directory of raw dumps. **`capture_wave_census.py`** censuses a
captured frame using the REAL resource table, by sequencing four existing tools:

```
gpu_replay --bundle F --bundle-extract-submit N cap.prgcap
gpu_replay --inspect-only cap.prgcap                              # draws, with fs= identities
gpu_replay --inspect-only --dump-shader ID:fs fs.spv cap.prgcap   # real-table module
shader_inspect fs.spv --wave-reasons
```

No analysis is reimplemented anywhere; the scripts only sequence and tally.

## Why the SPIR-V path is the substance, not a convenience

Over a 3,453-shader dump of GTA V's pixel-shader database:

```
files=3453  errors=0  unrecompiled(no resource table)=3430  analysed=23
```

**99.3% contributed no reason data** — `shader_inspect` has no descriptors and a real pixel shader
samples a texture. Those are counted in their own column, **never** as "requires nothing", and the
caveat prints above and below the numbers. A census that equated "could not be analysed" with "needs
no wide wave" would have reported that GTA V has essentially no Wave64 problem, the opposite of the
truth. `gpu_replay` has the real table, so the fix is to read a module rather than synthesise one.

## Review found a blocking defect; it is fixed, and it is worth reading

**`native-wave32-admitted` claimed to mirror the renderer's gate and mirrored one-fifth of it.** That
gate is five conjuncts (`render_runner.h:7128-7133`); I reproduced the innermost equality (`:7140`)
alone. The decisive conjunct is `allow_native_fragment_vote_width`, which defaults false (`:565`) and
is set from `title_id == "PPSA04263"` alone (`live_renderer.cpp:1216`, `:7591`). **So for every title
but GTA V the renderer drops these shaders while the census called them admitted** — an undercount of
exactly the loss #3464 exists to size.

It also invalidated this PR's own positive control, which is the part worth dwelling on. I had
reported the *Blasphemous 2* frame as "2 requiring a wide wave, **0 dropped**" and presented it as
evidence the instrument worked. The true answer is **2 dropped**. The control passed because it
agreed with what I expected of a title that renders correctly.

Fixed by reporting what the module decides and refusing to claim the rest: `reason-set-admissible`
for the equality, `internal-gds=` / `subgroup-features=` for the two conjuncts a module *can* decide,
and a `gate-undecided=` line naming the three it cannot, printed on every census so admission cannot
be read in by omission. `capture_wave_census.py` takes `--title`; without it the title is assumed
**not** allowlisted, true for every title but one.

Second blocking finding, also fixed: `discover_submit` took `sorted(first=)[-1]` over
`--bundle-ds-summary`, which is the max over each depth-stencil identity's *first appearance* — an
arbitrary submit. It now reads the bundle's `submits=N` and refuses when N != 1.

Six non-blocking findings taken, including a truncated `.spv` being tallied as "requires nothing"
(now `spirv-walk=ok|truncated`), `recompiled=n/a` for a SPIR-V input, and two false statements in the
tool's own comments.

## Verification

- **Every commit is TDD**: 6/6, 7/7, 11/11 and 4/4 arms red before their implementations. **51 checks
  pass.**
- The SPIR-V fixture is built **by hand** from the header plus two `OpModuleProcessed` strings, not by
  recompiling — a fixture from the recompiler would share its assumptions with the reader under test.
- Both admission directions exercised on one capture: `--title PPSA13579` → DROPPED=2,
  `--title PPSA04263` → DROPPED=0, no `--title` → DROPPED=2. The field cannot be a constant.
- **The corrected control was then confirmed at runtime**, not left derived: a 100-second Blasphemous
  2 boot emits 8 `[render] skip … requires subgroup size 64 … why=0x2 wave-any` lines.
- Malformed SPIR-V fed by hand (overrunning word count, zero-length instruction, unterminated string,
  unknown reason bit): all terminate, and the unknown bit prints `names=unknown-bit20`, so the
  drift guard fires on an instance built outside the generator.
- Registered ctest case `shader_inspect_resource_table_honesty`; registration unchanged.
- Docs gate clean; `diff --check` clean.

## Result it produced

A GTA V world frame (16 of 114 submits, depth-stencil passes, phase confirmed by screenshot):
1923 draws, 93 distinct fragment shaders, 41 requiring >32 lanes — **20 admitted by the existing
allowance, 21 dropped**, all `lane-id + wave-ballot`, top two covering 254 draws. That is W3 on
#3464, and it reordered the plan there.

## CI

`Windows MinGW` is red and it is **not this PR**: `capture_tunables` times out identically on `main`,
bisected to a single commit (#3460) and filed as #3470. This diff is five files under
`tools/shader_inspect/` and cannot reach `gpu_timeline`. Every other check is green.

## Risk

Low — opt-in, exclusive mode in an offline diagnostic; the shared code path it touches is argument
parsing. The judgement worth a reviewer's attention is now the `gate-undecided=` framing: whether
reporting the module half plus a named list of undecidable conjuncts is genuinely honest, or still
lets a consumer infer admission.

