### PR TITLE
perf(memory): reduce write-watch publication overhead

### DIFF
--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -753,10 +753,15 @@ bool page_requires_read_only_locked(const WatchState& w, const WatchedPage& page
            (trace_page && w.trace.status == GuestDmemWriteTraceStatus::Armed);
 }
 
+WatchedPage* page_pointer(WatchedPage* page) { return page; }
+WatchedPage* page_pointer(const RegistrationPage& page) { return page.page; }
+
+template <typename Page>
 std::vector<ProtectionRun> protection_runs(const WatchState& w,
-                                           const std::vector<WatchedPage*>& pages, bool arm) {
+                                           const std::vector<Page>& pages, bool arm) {
     std::vector<ProtectionRun> runs;
-    for (WatchedPage* page : pages) {
+    for (const auto& entry : pages) {
+        WatchedPage* page = page_pointer(entry);
         if (!page) continue;
         const bool prior_read_only = page_requires_read_only_locked(w, *page, page->armed);
         const bool wanted_read_only = page_requires_read_only_locked(w, *page, arm);
@@ -764,9 +769,19 @@ std::vector<ProtectionRun> protection_runs(const WatchState& w,
         for (const PageAlias& alias : page->aliases) {
             if (!cpu_writable(alias.prot)) continue;
             const int full = host_prot(alias.prot);
-            runs.push_back({alias.addr, kPage,
-                            prior_read_only ? (full & ~PROT_WRITE) : full,
-                            wanted_read_only ? (full & ~PROT_WRITE) : full});
+            const ProtectionRun run{alias.addr, kPage,
+                                    prior_read_only ? (full & ~PROT_WRITE) : full,
+                                    wanted_read_only ? (full & ~PROT_WRITE) : full};
+            // Ordered single-alias spans are common for image writeback. Combine them while
+            // collecting, so a contiguous texture needs one record rather than thousands of
+            // per-page records to allocate and sort. Keep the general sort/merge below for
+            // interleaved aliases, unordered physical-page walks, and protection boundaries.
+            if (!runs.empty() && runs.back().from == run.from && runs.back().to == run.to &&
+                runs.back().addr + runs.back().size == run.addr) {
+                runs.back().size += run.size;
+            } else {
+                runs.push_back(run);
+            }
         }
     }
     std::sort(runs.begin(), runs.end(), [](const ProtectionRun& a, const ProtectionRun& b) {
@@ -774,26 +789,31 @@ std::vector<ProtectionRun> protection_runs(const WatchState& w,
         if (a.to != b.to) return a.to < b.to;
         return a.addr < b.addr;
     });
-    std::vector<ProtectionRun> merged;
-    merged.reserve(runs.size());
-    for (const ProtectionRun& run : runs) {
-        if (!merged.empty() && merged.back().from == run.from && merged.back().to == run.to &&
-            merged.back().addr + merged.back().size == run.addr) {
-            merged.back().size += run.size;
+    size_t merged_count = 0;
+    // Compact the sorted records in their existing storage. Read by value: an output slot can
+    // be the current input slot, and no output ever reaches an unread record.
+    for (const ProtectionRun run : runs) {
+        if (merged_count && runs[merged_count - 1].from == run.from &&
+            runs[merged_count - 1].to == run.to &&
+            runs[merged_count - 1].addr + runs[merged_count - 1].size == run.addr) {
+            runs[merged_count - 1].size += run.size;
         } else {
-            merged.push_back(run);
+            runs[merged_count++] = run;
         }
     }
-    return merged;
+    runs.resize(merged_count);
+    return runs;
 }
 
 // mprotect every writable alias of `pages` to read-only (arm) or back to its guest prot (disarm).
 // Read-only / PROT_NONE aliases are left untouched (a CPU store can't dirty them). Returns false and
 // attempts rollback on the first mprotect failure. Failed/partial coverage remains explicit until
 // a complete pass succeeds; rollback itself can fail and is not proof that all aliases are restored.
-bool set_pages_armed(WatchState& w, const std::vector<WatchedPage*>& pages, bool arm) {
+template <typename Page>
+bool set_pages_armed(WatchState& w, const std::vector<Page>& pages, bool arm) {
     if (arm && w.trace.status == GuestDmemWriteTraceStatus::Stepping &&
-        std::any_of(pages.begin(), pages.end(), [&](const WatchedPage* page) {
+        std::any_of(pages.begin(), pages.end(), [&](const auto& entry) {
+            const WatchedPage* page = page_pointer(entry);
             return page && trace_covers_phys_locked(w, page->phys);
         }))
         return false;
@@ -802,7 +822,8 @@ bool set_pages_armed(WatchState& w, const std::vector<WatchedPage*>& pages, bool
     for (const ProtectionRun& run : runs) {
         if (watch_mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(run.addr)),
                            static_cast<size_t>(run.size), run.to) != 0) {
-            for (WatchedPage* page : pages) if (page) page->coverage_incomplete = true;
+            for (const auto& entry : pages)
+                if (WatchedPage* page = page_pointer(entry)) page->coverage_incomplete = true;
             while (changed) {
                 const ProtectionRun& prior = runs[--changed];
                 watch_mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(prior.addr)),
@@ -812,9 +833,11 @@ bool set_pages_armed(WatchState& w, const std::vector<WatchedPage*>& pages, bool
         }
         ++changed;
     }
-    for (WatchedPage* page : pages) if (page) {
-        page->armed = arm;
-        page->coverage_incomplete = false;
+    for (const auto& entry : pages) {
+        if (WatchedPage* page = page_pointer(entry)) {
+            page->armed = arm;
+            page->coverage_incomplete = false;
+        }
     }
     return true;
 }
@@ -1399,9 +1422,9 @@ bool GuestWriteWatch::rearm() {
     std::lock_guard lock(w.mutex);
     auto found = w.registrations.find(id_);
     if (found == w.registrations.end() || !found->second.mapping_valid) return false;
-    std::vector<WatchedPage*> pages;
-    for (const RegistrationPage& rp : found->second.pages) if (rp.page) pages.push_back(rp.page);
-    if (!set_pages_armed(w, pages, true)) return false;   // couldn't re-protect -> caller re-creates
+    // The registration already owns the page list under this lock. Use it directly instead of
+    // allocating and copying a second list, including when all pages are already armed.
+    if (!set_pages_armed(w, found->second.pages, true)) return false;
     for (RegistrationPage& rp : found->second.pages) if (rp.page) rp.generation = rp.page->generation;
     found->second.gpu_dirty = false;
     bump(stats().rearms);

--- a/prosper/tests/host/memory/test_guest_write_watch.cpp
+++ b/prosper/tests/host/memory/test_guest_write_watch.cpp
@@ -86,12 +86,43 @@ int main() {
 #else   // ---- Linux: exercise the real mprotect + SIGSEGV dirty-tracking (#1144) ------------------
 
 #include <cerrno>
+#include <atomic>
 #include <csignal>
 #include <cstring>
+#include <new>
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+namespace {
+// Count requested scalar C++ allocation bytes only in explicit single-threaded scopes below.
+// This observes the linked production vectors, not malloc/aligned allocations or physical memory.
+std::atomic<bool> count_allocations{false};
+std::atomic<size_t> requested_allocation_bytes{0};
+class AllocationScope {
+public:
+    AllocationScope() {
+        requested_allocation_bytes.store(0, std::memory_order_relaxed);
+        count_allocations.store(true, std::memory_order_relaxed);
+    }
+    ~AllocationScope() { count_allocations.store(false, std::memory_order_relaxed); }
+    size_t finish() {
+        count_allocations.store(false, std::memory_order_relaxed);
+        return requested_allocation_bytes.load(std::memory_order_relaxed);
+    }
+};
+} // namespace
+
+void* operator new(std::size_t bytes) {
+    void* allocation = std::malloc(bytes ? bytes : 1);
+    if (!allocation) throw std::bad_alloc();
+    if (count_allocations.load(std::memory_order_relaxed))
+        requested_allocation_bytes.fetch_add(bytes, std::memory_order_relaxed);
+    return allocation;
+}
+void operator delete(void* allocation) noexcept { std::free(allocation); }
+void operator delete(void* allocation, std::size_t) noexcept { std::free(allocation); }
 
 namespace {
 // dmem is section-backed (one memfd, MAP_SHARED at multiple VAs) — mirror that so the alias handling
@@ -218,6 +249,230 @@ int main() {
             }
             close(large_fd);
         }
+    }
+
+    // Long protection runs must stop at unwatched gaps and guest-permission boundaries, even
+    // when each physical page has multiple aliases. Probe the actual permissions independently
+    // of the fault handler, then use real parent-thread stores to observe dirty generations.
+    {
+        const size_t max_unit_pages = (1u << 20) / (6 * page);
+        const size_t unit_pages = max_unit_pages < 8 ? max_unit_pages : 8;
+        CHECK(unit_pages != 0, "long-run fixture fits the watch size policy");
+        if (!unit_pages) return 1;
+        const size_t unit = unit_pages * page;
+        const size_t run_bytes = 16 * unit;
+        int run_fd = memfd_create("prosper-ww-long-runs", 0);
+        CHECK(run_fd >= 0, "long-run memfd created");
+        if (run_fd < 0) return 1;
+        const bool sized = ftruncate(run_fd, static_cast<off_t>(run_bytes)) == 0;
+        CHECK(sized, "long-run memfd sized");
+        if (!sized) return 1;
+        auto* first = static_cast<uint8_t*>(mmap(
+            nullptr, run_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, run_fd, 0));
+        auto* second = static_cast<uint8_t*>(mmap(
+            nullptr, run_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, run_fd, 0));
+        CHECK(first != MAP_FAILED && second != MAP_FAILED, "long-run aliases mapped");
+        if (first == MAP_FAILED || second == MAP_FAILED) return 1;
+        const bool permissions = mprotect(second + 4 * unit, 2 * unit, PROT_READ) == 0 &&
+            mprotect(second + 6 * unit, 2 * unit, PROT_NONE) == 0;
+        // Replace part of B with an anonymous guard: it is a hole in physical alias coverage,
+        // kept reserved so a later host allocation cannot reuse the addresses during probes.
+        void* guard = mmap(second + 8 * unit, 4 * unit, PROT_NONE,
+                           MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+        CHECK(permissions && guard == second + 8 * unit,
+              "long-run read-only, inaccessible and non-alias guard sections installed");
+        if (!permissions || guard != second + 8 * unit) return 1;
+        constexpr uint64_t phys = 0x20000000;
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(first), run_bytes, phys, kCpuRw);
+        auto add_second = [&](size_t begin, size_t units, uint32_t prot) {
+            prosper::host::guest_write_watch_notify_direct_mapping_added(
+                reinterpret_cast<uint64_t>(second + begin * unit), units * unit,
+                phys + begin * unit, prot);
+        };
+        add_second(0, 4, kCpuRw);
+        add_second(4, 2, 0x1); // CPU_READ only
+        add_second(6, 2, 0x0); // no CPU access; outside both watched physical intervals
+        add_second(12, 4, kCpuRw);
+        auto left = GuestWriteWatch::create(reinterpret_cast<uint64_t>(first), 6 * unit);
+        auto right = GuestWriteWatch::create(
+            reinterpret_cast<uint64_t>(first + 10 * unit), 6 * unit);
+        CHECK(left && right && left.query() == GuestWriteWatchQuery::Unchanged &&
+                  right.query() == GuestWriteWatchQuery::Unchanged,
+              "disjoint long watches arm across multiple aliases and an alias gap");
+        if (!left || !right) return 1;
+        auto fixed_permissions = [&] {
+            CHECK(probe_access(second + 4 * unit + 32, false) == AccessProbe::Allowed &&
+                      probe_access(second + 4 * unit + 32, true) == AccessProbe::Faulted &&
+                      probe_access(second + 6 * unit + 32, false) == AccessProbe::Faulted &&
+                      probe_access(second + 6 * unit + 32, true) == AccessProbe::Faulted &&
+                      probe_access(second + 8 * unit + 32, true) == AccessProbe::Faulted,
+                  "protection runs preserve read-only, inaccessible and non-alias guard sections");
+        };
+        auto armed_permissions = [&] {
+            CHECK(probe_access(first + 32, true) == AccessProbe::Faulted &&
+                      probe_access(first + 6 * unit - 32, true) == AccessProbe::Faulted &&
+                      probe_access(first + 10 * unit + 32, true) == AccessProbe::Faulted &&
+                      probe_access(first + run_bytes - 32, true) == AccessProbe::Faulted &&
+                      probe_access(second + 32, true) == AccessProbe::Faulted &&
+                      probe_access(second + run_bytes - 32, true) == AccessProbe::Faulted &&
+                      probe_access(first + 8 * unit + 32, true) == AccessProbe::Allowed,
+                  "both ends of each long run arm while the unwatched primary gap stays writable");
+        };
+        armed_permissions();
+        fixed_permissions();
+        first[32] = 0x31;
+        CHECK(second[32] == 0x31 && left.query() == GuestWriteWatchQuery::Dirty &&
+                  right.query() == GuestWriteWatchQuery::Unchanged,
+              "real store dirties only its long physical interval");
+        prosper::host::guest_write_watch_notify_host_write(
+            reinterpret_cast<uint64_t>(first), run_bytes);
+        CHECK(left.query() == GuestWriteWatchQuery::Dirty &&
+                  right.query() == GuestWriteWatchQuery::Dirty &&
+                  probe_access(first + 6 * unit - 32, true) == AccessProbe::Allowed &&
+                  probe_access(first + 10 * unit + 32, true) == AccessProbe::Allowed &&
+                  probe_access(second + 32, true) == AccessProbe::Allowed &&
+                  probe_access(second + run_bytes - 32, true) == AccessProbe::Allowed,
+              "host notification across a gap disarms every writable alias and dirties both owners");
+        first[4 * unit + 32] = 0x42;
+        first[10 * unit + 32] = 0x53;
+        CHECK(second[4 * unit + 32] == 0x42,
+              "host write is visible through the permanently read-only alias");
+        prosper::host::guest_write_watch_notify_host_write_done(
+            reinterpret_cast<uint64_t>(first), run_bytes);
+        fixed_permissions();
+        CHECK(left.rearm() && right.rearm() && left.query() == GuestWriteWatchQuery::Unchanged &&
+                  right.query() == GuestWriteWatchQuery::Unchanged,
+              "long-run rearm establishes fresh generations after the host write");
+        armed_permissions();
+        second[run_bytes - 32] = 0x64;
+        CHECK(first[run_bytes - 32] == 0x64 && right.query() == GuestWriteWatchQuery::Dirty &&
+                  left.query() == GuestWriteWatchQuery::Unchanged,
+              "real store through the far sibling alias dirties only the second interval");
+        CHECK(right.rearm(), "second long interval rearms after the sibling store");
+        left.reset();
+        CHECK(probe_access(first + 32, true) == AccessProbe::Allowed &&
+                  probe_access(second + 32, true) == AccessProbe::Allowed &&
+                  probe_access(first + run_bytes - 32, true) == AccessProbe::Faulted,
+              "releasing one long interval restores its aliases without disarming another owner");
+        right.reset();
+        CHECK(probe_access(first + run_bytes - 32, true) == AccessProbe::Allowed &&
+                  probe_access(second + run_bytes - 32, true) == AccessProbe::Allowed,
+              "final long-run release restores writable tail aliases");
+        fixed_permissions();
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(first), run_bytes);
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(second), run_bytes);
+        munmap(first, run_bytes);
+        munmap(second, run_bytes);
+        close(run_fd);
+    }
+
+    // Allocation cost is the regression oracle, not elapsed time: one contiguous alias must not
+    // expand into temporary protection records per page. Keep the actual mappings and dirty-state
+    // checks so a shortcut that stops protecting pages cannot satisfy the allocation budget.
+    {
+        const size_t allowed_pages = (1u << 20) / page;
+        const size_t pages = allowed_pages < 64 ? allowed_pages : 64;
+        CHECK(pages >= 16, "allocation fixture has enough pages within the watch cap");
+        if (pages < 16) return 1;
+        const size_t bytes = pages * page;
+        int allocation_fd = memfd_create("prosper-ww-allocation", 0);
+        CHECK(allocation_fd >= 0, "allocation fixture memfd created");
+        if (allocation_fd < 0) return 1;
+        const bool sized = ftruncate(allocation_fd, static_cast<off_t>(bytes)) == 0;
+        CHECK(sized, "allocation fixture memfd sized");
+        if (!sized) return 1;
+        auto* mapped = static_cast<uint8_t*>(mmap(
+            nullptr, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, allocation_fd, 0));
+        CHECK(mapped != MAP_FAILED, "allocation fixture mapped");
+        if (mapped == MAP_FAILED) return 1;
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(mapped), bytes, 0x30000000, kCpuRw);
+        auto first = GuestWriteWatch::create(reinterpret_cast<uint64_t>(mapped), bytes);
+        auto second = GuestWriteWatch::create(reinterpret_cast<uint64_t>(mapped), bytes);
+        CHECK(first && second && first.query() == GuestWriteWatchQuery::Unchanged &&
+                  second.query() == GuestWriteWatchQuery::Unchanged,
+              "two registrations start clean over one contiguous alias");
+        if (!first || !second) return 1;
+        mapped[32] = 0x91;
+        CHECK(first.query() == GuestWriteWatchQuery::Dirty &&
+                  second.query() == GuestWriteWatchQuery::Dirty,
+              "one raw store dirties both registrations of its physical page");
+        CHECK(first.rearm() && first.query() == GuestWriteWatchQuery::Unchanged &&
+                  second.query() == GuestWriteWatchQuery::Dirty,
+              "first owner rearm does not clear the sibling's dirty generation");
+        CHECK(second.rearm() && second.query() == GuestWriteWatchQuery::Unchanged,
+              "sibling can acknowledge its dirty generation while pages are already armed");
+        prosper::host::guest_write_watch_notify_gpu_write(
+            reinterpret_cast<uint64_t>(mapped), bytes);
+        CHECK(first.query() == GuestWriteWatchQuery::Dirty &&
+                  second.query() == GuestWriteWatchQuery::Dirty &&
+                  probe_access(mapped + 32, true) == AccessProbe::Faulted,
+              "GPU notification dirties both owners without removing actual read-only protection");
+        CHECK(first.rearm() && first.query() == GuestWriteWatchQuery::Unchanged &&
+                  second.query() == GuestWriteWatchQuery::Dirty,
+              "first owner rearm clears only its own GPU-dirty state");
+        CHECK(second.rearm() && second.query() == GuestWriteWatchQuery::Unchanged,
+              "second owner separately clears its GPU-dirty state");
+
+        size_t disarm_bytes, rearm_bytes, noop_bytes, sibling_bytes;
+        bool rearmed, noop_rearmed, sibling_rearmed;
+        {
+            AllocationScope allocations;
+            prosper::host::guest_write_watch_notify_host_write(
+                reinterpret_cast<uint64_t>(mapped), bytes);
+            disarm_bytes = allocations.finish();
+        }
+        CHECK(first.query() == GuestWriteWatchQuery::Dirty &&
+                  second.query() == GuestWriteWatchQuery::Dirty &&
+                  probe_access(mapped + 32, true) == AccessProbe::Allowed &&
+                  probe_access(mapped + bytes - 32, true) == AccessProbe::Allowed,
+              "counted disarm restores both ends and invalidates both registrations");
+        mapped[bytes - 32] = 0xa2;
+        prosper::host::guest_write_watch_notify_host_write_done(
+            reinterpret_cast<uint64_t>(mapped), bytes);
+        {
+            AllocationScope allocations;
+            rearmed = first.rearm();
+            rearm_bytes = allocations.finish();
+        }
+        CHECK(rearmed && first.query() == GuestWriteWatchQuery::Unchanged &&
+                  second.query() == GuestWriteWatchQuery::Dirty &&
+                  probe_access(mapped + 32, true) == AccessProbe::Faulted &&
+                  probe_access(mapped + bytes - 32, true) == AccessProbe::Faulted,
+              "counted rearm protects both ends without cleaning the sibling");
+        {
+            AllocationScope allocations;
+            noop_rearmed = first.rearm();
+            noop_bytes = allocations.finish();
+        }
+        {
+            AllocationScope allocations;
+            sibling_rearmed = second.rearm();
+            sibling_bytes = allocations.finish();
+        }
+        CHECK(noop_rearmed && sibling_rearmed &&
+                  first.query() == GuestWriteWatchQuery::Unchanged &&
+                  second.query() == GuestWriteWatchQuery::Unchanged,
+              "no-op and sibling rearms both preserve real clean authority");
+        CHECK(disarm_bytes <= 24 * pages,
+              "contiguous disarm scratch stays within the page-pointer collection budget");
+        CHECK(rearm_bytes <= 256,
+              "contiguous rearm allocates bounded runs instead of per-page scratch");
+        CHECK(noop_bytes == 0 && sibling_bytes == 0,
+              "already-protected owner and sibling rearms allocate no temporary page vectors");
+        std::printf("watch scalar allocation requests: pages=%zu disarm=%zu rearm=%zu noop=%zu sibling=%zu\n",
+                    pages, disarm_bytes, rearm_bytes, noop_bytes, sibling_bytes);
+        first.reset();
+        second.reset();
+        CHECK(probe_access(mapped + bytes - 32, true) == AccessProbe::Allowed,
+              "allocation fixture final release restores actual write permission");
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(mapped), bytes);
+        munmap(mapped, bytes);
+        close(allocation_fd);
     }
 
     // Arm a watch over the whole range and confirm it starts Unchanged.


### PR DESCRIPTION
Linux guest writeback builds per-page protection records and a duplicate page list when rearming cached images. Coalesce ordered spans before sorting, compact the sorted records in place, and rearm directly from the registration's page list. Alias permissions, dirty generations, diagnostic stepping refusal and rollback remain governed by the same protection path.

The new allocation guard links to the real implementation: main fails three budgets; the candidate passes alongside actual page-protection and independent-owner checks. All 403 local tests and seven focused synchronization-validation tests pass after positive controls.

A matched GTA workload (33 dispatches per arm) reduces mean publication from 0.910 to 0.785 ms and enclosing phase total from 4.726 to 4.491 ms. Presentation rate stays around 6.58/s. Sonic remains around 7 presentations/s, but its seed-validation states differ even after a fresh main control, so its aggregate dispatch timings are inconclusive. Known Sonic rendering defects and audio underruns remain separate.

This advances #3407; it does not complete the issue. The separate pre-existing seed-proof identity investigation is #3467. No new Vulkan feature or experimental driver flag is involved.
