### PR TITLE
fix(gpu): isolate storage seed proofs by executable and launch

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3101,9 +3101,45 @@ if(TARGET prosper_core)
       add_test(NAME near_full_storage_full_transition COMMAND ${CMAKE_COMMAND} -E env
                PROSPER_SKIP_EXPORTED_STORAGE_WRITEBACK=1
                $<TARGET_FILE:test_near_full_storage_authority> full-transition)
+      add_test(NAME storage_seed_program_replacement COMMAND ${CMAKE_COMMAND} -E env
+               --unset=PROSPER_NO_SKIP_SEED --unset=PROSPER_VERIFY_SEED_SKIP
+               PROSPER_SEED_REPROVE=256
+               $<TARGET_FILE:test_near_full_storage_authority> program-replacement)
+      add_test(NAME storage_seed_program_replacement_seeded COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_NO_SKIP_SEED=1
+               $<TARGET_FILE:test_near_full_storage_authority> program-replacement)
+      add_executable(test_seed_coverage_dynamic tests/gpu/execute/test_seed_coverage_dynamic.cpp)
+      target_include_directories(test_seed_coverage_dynamic PRIVATE tests frontends)
+      target_link_libraries(test_seed_coverage_dynamic PRIVATE
+                           prosper_live_renderer prosper_core Vulkan::Vulkan)
+      add_test(NAME storage_seed_launch COMMAND ${CMAKE_COMMAND} -E env
+               --unset=PROSPER_NO_SKIP_SEED --unset=PROSPER_VERIFY_SEED_SKIP
+               PROSPER_SEED_REPROVE=256 $<TARGET_FILE:test_seed_coverage_dynamic> launch)
+      add_test(NAME storage_seed_launch_seeded COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_NO_SKIP_SEED=1 $<TARGET_FILE:test_seed_coverage_dynamic> launch)
+      # The default unchanged-program mask reproducer remains unresolved in #3467.
+      # Register its correct explicit-seed control; never accept corruption as a passing test.
+      add_test(NAME storage_seed_mask_seeded COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_NO_SKIP_SEED=1 $<TARGET_FILE:test_seed_coverage_dynamic> mask)
+      set_tests_properties(storage_seed_launch storage_seed_launch_seeded
+                           storage_seed_mask_seeded PROPERTIES TIMEOUT 60)
+      if(Python3_Interpreter_FOUND)
+        add_test(NAME storage_seed_program_reuse
+                 COMMAND "${Python3_EXECUTABLE}"
+                         "${CMAKE_SOURCE_DIR}/tests/gpu/execute/test_storage_seed_proof_reuse.py"
+                         $<TARGET_FILE:test_near_full_storage_authority> program-replacement)
+        add_test(NAME storage_seed_launch_reuse
+                 COMMAND "${Python3_EXECUTABLE}"
+                         "${CMAKE_SOURCE_DIR}/tests/gpu/execute/test_storage_seed_proof_reuse.py"
+                         $<TARGET_FILE:test_seed_coverage_dynamic> launch)
+        set_tests_properties(storage_seed_program_reuse storage_seed_launch_reuse
+                             PROPERTIES TIMEOUT 60)
+      endif()
       set_tests_properties(near_full_storage_authority near_full_storage_authority_export
                            near_full_storage_full_transition
-                           near_full_storage_full_transition_default PROPERTIES TIMEOUT 60)
+                           near_full_storage_full_transition_default
+                           storage_seed_program_replacement storage_seed_program_replacement_seeded
+                           PROPERTIES TIMEOUT 60)
 
       if(Python3_Interpreter_FOUND)
         add_executable(test_compute_buffer_timing tests/gpu/execute/test_compute_buffer_timing.cpp)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3127,12 +3127,17 @@ if(TARGET prosper_core)
         add_test(NAME storage_seed_program_reuse
                  COMMAND "${Python3_EXECUTABLE}"
                          "${CMAKE_SOURCE_DIR}/tests/gpu/execute/test_storage_seed_proof_reuse.py"
-                         $<TARGET_FILE:test_near_full_storage_authority> program-replacement)
+                         2 2 $<TARGET_FILE:test_near_full_storage_authority> program-replacement)
+        add_test(NAME storage_seed_variant_eviction
+                 COMMAND "${Python3_EXECUTABLE}"
+                         "${CMAKE_SOURCE_DIR}/tests/gpu/execute/test_storage_seed_proof_reuse.py"
+                         6 4 $<TARGET_FILE:test_near_full_storage_authority> variant-eviction)
         add_test(NAME storage_seed_launch_reuse
                  COMMAND "${Python3_EXECUTABLE}"
                          "${CMAKE_SOURCE_DIR}/tests/gpu/execute/test_storage_seed_proof_reuse.py"
-                         $<TARGET_FILE:test_seed_coverage_dynamic> launch)
+                         2 1 $<TARGET_FILE:test_seed_coverage_dynamic> launch)
         set_tests_properties(storage_seed_program_reuse storage_seed_launch_reuse
+                             storage_seed_variant_eviction
                              PROPERTIES TIMEOUT 60)
       endif()
       set_tests_properties(near_full_storage_authority near_full_storage_authority_export

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5960,6 +5960,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         uint32_t skips = 0;
         uint64_t written_layers = ~0ULL;
         bool near_full = false;
+        uint64_t last_used = 0;
         // The guest code address can be reused or recompiled with different lowering.
         // Own the effective module: item storage and pipeline-cache entries can expire.
         // Exact bytes, rather than a hash alone, authorize reuse of every verdict kind.
@@ -5973,7 +5974,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     using SeedCoverageKey = std::tuple<uint64_t, uint32_t, uint32_t, uint32_t, uint32_t,
                                        std::vector<uint32_t>>;
     static std::mutex seed_coverage_mu;
-    static std::map<SeedCoverageKey, SeedVerdict> seed_coverage_proof;
+    // A guest address can alternate between compiled representations every frame.
+    // Retain a bounded set so those variants do not force each other to re-prove.
+    constexpr size_t kSeedVariantsPerKey = 4;
+    static std::map<SeedCoverageKey, std::vector<SeedVerdict>> seed_coverage_proof;
+    static uint64_t seed_coverage_clock = 0;
+    const auto matches_seed_program = [&](const SeedVerdict& verdict) {
+        return verdict.program == spirv && verdict.subgroup_size == effective_subgroup &&
+               verdict.required_subgroup_size == item.required_subgroup_size &&
+               verdict.groups == std::array<uint32_t, 3>{
+                   dispatch_groups[0], dispatch_groups[1], dispatch_groups[2]};
+    };
     // PROSPER_SEED_REPROVE=N: re-prove every N fast-skips (default 256; explicit 0 disables = old
     // prove-once). Parsed fail-safe -- garbage/overflow keeps the 256 default rather than silently
     // disabling the safety (see seed_reprove_interval_from_env).
@@ -7296,22 +7307,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 {
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     auto it = seed_coverage_proof.find(proof_key);
-                    if (it != seed_coverage_proof.end() &&
-                        it->second.program == spirv &&
-                        it->second.subgroup_size == effective_subgroup &&
-                        it->second.required_subgroup_size == item.required_subgroup_size &&
-                        it->second.groups == std::array<uint32_t, 3>{
-                            dispatch_groups[0], dispatch_groups[1], dispatch_groups[2]}) {
-                        known = true;
-                        proven_full = it->second.cov == SeedCoverage::Full;
-                        proven_none = it->second.cov == SeedCoverage::None;
-                        bi.written_layers_mask = it->second.written_layers;
-                        // #1127: periodically re-prove a Full, None, or layer-masked/near-full Partial verdict
-                        // so a data-dependent store that later changes coverage is caught (#3328 B1/N2). The helper
-                        // resets the counter, so concurrent dispatches on this key don't all re-prove at once.
-                        if (seed_verdict_reprove_eligible(it->second.cov, it->second.written_layers, it->second.near_full) &&
-                            seed_reprove_due(it->second.skips, kSeedReproveInterval))
-                            reprove_due = true;
+                    if (it != seed_coverage_proof.end()) {
+                        auto verdict = std::find_if(it->second.begin(), it->second.end(),
+                                                    matches_seed_program);
+                        if (verdict != it->second.end()) {
+                            verdict->last_used = ++seed_coverage_clock;
+                            known = true;
+                            proven_full = verdict->cov == SeedCoverage::Full;
+                            proven_none = verdict->cov == SeedCoverage::None;
+                            bi.written_layers_mask = verdict->written_layers;
+                            // Reproof counters belong to this exact executable/launch variant.
+                            if (seed_verdict_reprove_eligible(
+                                    verdict->cov, verdict->written_layers, verdict->near_full) &&
+                                seed_reprove_due(verdict->skips, kSeedReproveInterval))
+                                reprove_due = true;
+                        }
                     }
                 }
                 if (force_verify || reprove_due) {
@@ -11040,14 +11050,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 {
                     const SeedCoverageKey proof_key = image_seed_coverage_key(i, *r);
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
-                    // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                    // Replace this logical key's old executable, rather than accumulating an
-                    // entry for every module ever compiled at the same guest address. Launch
-                    // geometry matters even when the total invocation count is unchanged.
-                    seed_coverage_proof[proof_key] = SeedVerdict{
-                        cov, 0, written_layers, near_full, spirv, effective_subgroup,
-                        item.required_subgroup_size,
+                    auto& variants = seed_coverage_proof[proof_key];
+                    auto verdict = std::find_if(variants.begin(), variants.end(), matches_seed_program);
+                    if (verdict == variants.end() && variants.size() == kSeedVariantsPerKey)
+                        verdict = std::min_element(variants.begin(), variants.end(),
+                            [](const SeedVerdict& a, const SeedVerdict& b) {
+                                return a.last_used < b.last_used;
+                            });
+                    // Reproof resets this variant's counter. At capacity only the least-recently
+                    // used variant loses its proof; eviction always returns it to Unknown.
+                    SeedVerdict fresh{
+                        cov, 0, written_layers, near_full, ++seed_coverage_clock, spirv,
+                        effective_subgroup, item.required_subgroup_size,
                         {dispatch_groups[0], dispatch_groups[1], dispatch_groups[2]}};
+                    if (verdict == variants.end()) variants.push_back(std::move(fresh));
+                    else *verdict = std::move(fresh);
                 }
                 if (survived == 0) {
                     std::fprintf(stderr,

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -5942,8 +5942,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // re-proves (a hard-coded store bound cannot silently under-cover a bigger extent). What this key
     // does NOT catch is a store whose predicate depends on per-frame INPUT (`if (buffer[gid] > k)
     // store`) that is full on the proving frame but partial later; that residual soundness gap is
-    // tracked in #1127 -- no exercised title shader triggers it, and a shader first seen partial is
-    // cached Partial and always seeds (safe).
+    // tracked in #3467. Program and launch identity below prevent replacement from inheriting a
+    // verdict, but do not prove input independence. A shader first seen partial seeds normally.
     using prosper::frontend::SeedCoverage;
     using prosper::frontend::classify_seed_coverage;
     using prosper::frontend::classify_near_full_coverage;
@@ -5960,6 +5960,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         uint32_t skips = 0;
         uint64_t written_layers = ~0ULL;
         bool near_full = false;
+        // The guest code address can be reused or recompiled with different lowering.
+        // Own the effective module: item storage and pipeline-cache entries can expire.
+        // Exact bytes, rather than a hash alone, authorize reuse of every verdict kind.
+        std::vector<uint32_t> program;
+        uint32_t subgroup_size = 0;
+        uint32_t required_subgroup_size = 0;
+        std::array<uint32_t, 3> groups{};
     };
     // Coverage was observed over the shared image, so its writer membership is part of the proof.
     // Splitting a previously full-coverage alias group can leave the owner only partially written.
@@ -7289,7 +7296,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 {
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     auto it = seed_coverage_proof.find(proof_key);
-                    if (it != seed_coverage_proof.end()) {
+                    if (it != seed_coverage_proof.end() &&
+                        it->second.program == spirv &&
+                        it->second.subgroup_size == effective_subgroup &&
+                        it->second.required_subgroup_size == item.required_subgroup_size &&
+                        it->second.groups == std::array<uint32_t, 3>{
+                            dispatch_groups[0], dispatch_groups[1], dispatch_groups[2]}) {
                         known = true;
                         proven_full = it->second.cov == SeedCoverage::Full;
                         proven_none = it->second.cov == SeedCoverage::None;
@@ -11029,7 +11041,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     const SeedCoverageKey proof_key = image_seed_coverage_key(i, *r);
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
-                    seed_coverage_proof[proof_key] = SeedVerdict{ cov, 0, written_layers, near_full };
+                    // Replace this logical key's old executable, rather than accumulating an
+                    // entry for every module ever compiled at the same guest address. Launch
+                    // geometry matters even when the total invocation count is unchanged.
+                    seed_coverage_proof[proof_key] = SeedVerdict{
+                        cov, 0, written_layers, near_full, spirv, effective_subgroup,
+                        item.required_subgroup_size,
+                        {dispatch_groups[0], dispatch_groups[1], dispatch_groups[2]}};
                 }
                 if (survived == 0) {
                     std::fprintf(stderr,

--- a/prosper/tests/gpu/execute/test_near_full_storage_authority.cpp
+++ b/prosper/tests/gpu/execute/test_near_full_storage_authority.cpp
@@ -44,7 +44,9 @@ ComputeItem item(const std::vector<uint32_t>& code, const ShaderResourceTable& r
 
 int main(int argc, char** argv) {
     const bool full_transition = argc == 2 && std::strcmp(argv[1], "full-transition") == 0;
-    const bool replacement = argc == 2 && std::strcmp(argv[1], "program-replacement") == 0;
+    const bool eviction = argc == 2 && std::strcmp(argv[1], "variant-eviction") == 0;
+    const bool replacement = eviction ||
+        (argc == 2 && std::strcmp(argv[1], "program-replacement") == 0);
     if (argc != 1 && !full_transition && !replacement) return 2;
     std::vector<uint32_t> guest(texels), observed(texels, 0xccccccccu);
     for (uint32_t i = 0; i < texels; ++i) guest[i] = 0xabc00000u + i;
@@ -145,6 +147,7 @@ int main(int argc, char** argv) {
         full_code.erase(std::find(full_code.begin(), full_code.end(), 0x7daa0880u));
         full_code[2] = full_value;
         producer = item(full_code, producer_resources, partial.code_addr, 1);
+        const auto full = producer;
         check(producer.spirv != partial.spirv, "replacement changes the executable module");
         check(prosper::frontend::execute_live_compute_items({producer}),
               "full writer proves coverage before any partial writer uses its key");
@@ -163,6 +166,47 @@ int main(int argc, char** argv) {
         check(guest[0] == changed_cutout, "replacement preserves the architectural guest cutout");
         consume();
         pixels(changed_cutout, "identical partial program remains correct on a warm proof");
+        auto full_pixels = [&](uint32_t expected) {
+            check(std::all_of(observed.begin(), observed.end(),
+                              [&](uint32_t value) { return value == expected; }) &&
+                  std::all_of(guest.begin(), guest.end(),
+                              [&](uint32_t value) { return value == expected; }),
+                  "returning full variant writes every GPU and guest texel");
+        };
+        producer = full;
+        consume();
+        full_pixels(full_value);
+        guest[0] = changed_cutout;
+        producer = partial;
+        consume();
+        pixels(changed_cutout, "returning partial variant preserves the changed cutout");
+        check(guest[0] == changed_cutout, "returning partial variant preserves the guest cutout");
+        if (eviction) {
+            // Fill the four-variant budget, touch A, then insert E. B must be evicted,
+            // whereas recently used A remains warm. Log assertions distinguish a
+            // bounded LRU from both an unbounded map and a one-verdict cache.
+            for (uint32_t value : {0x33333333u, 0x44444444u}) {
+                full_code[2] = value;
+                producer = item(full_code, producer_resources, partial.code_addr, 1);
+                consume(false); // A newly proved variant need not retain its image yet.
+                full_pixels(value);
+            }
+            producer = full;
+            consume();
+            full_pixels(full_value);
+            full_code[2] = 0x55555555u;
+            producer = item(full_code, producer_resources, partial.code_addr, 1);
+            consume(false);
+            full_pixels(0x55555555u);
+            producer = full;
+            consume();
+            full_pixels(full_value);
+            guest[0] = changed_cutout;
+            producer = partial;
+            consume(false); // B must safely re-prove after losing its cached identity.
+            pixels(changed_cutout, "evicted partial variant re-proves and repairs the cutout");
+            check(guest[0] == changed_cutout, "eviction preserves the guest cutout");
+        }
         return failures ? 1 : 0;
     }
     // Proving can restore untouched guest texels after a poison run. Warm outside

--- a/prosper/tests/gpu/execute/test_near_full_storage_authority.cpp
+++ b/prosper/tests/gpu/execute/test_near_full_storage_authority.cpp
@@ -44,7 +44,8 @@ ComputeItem item(const std::vector<uint32_t>& code, const ShaderResourceTable& r
 
 int main(int argc, char** argv) {
     const bool full_transition = argc == 2 && std::strcmp(argv[1], "full-transition") == 0;
-    if (argc != 1 && !full_transition) return 2;
+    const bool replacement = argc == 2 && std::strcmp(argv[1], "program-replacement") == 0;
+    if (argc != 1 && !full_transition && !replacement) return 2;
     std::vector<uint32_t> guest(texels), observed(texels, 0xccccccccu);
     for (uint32_t i = 0; i < texels; ++i) guest[i] = 0xabc00000u + i;
     ShaderResource image{};
@@ -110,7 +111,7 @@ int main(int argc, char** argv) {
     check(!producer.spirv.empty() && !consumer.spirv.empty(), "both actual shaders recompile");
     if (producer.spirv.empty() || consumer.spirv.empty()) return 1;
 
-    auto consume = [&] {
+    auto consume = [&](bool require_retained = true) {
         std::fill(observed.begin(), observed.end(), 0xccccccccu);
         unsigned calls = 0;
         bool all_ok = true;
@@ -127,8 +128,9 @@ int main(int argc, char** argv) {
             }, 1, 1);
         check(result.compute_executed && calls == 2 && all_ok,
               "producer and real sampled-to-SSBO consumer execute in order");
-        check(prosper::frontend::live_compute_storage_transfer_seeds() > before,
-              "consumer seeds from the retained GPU image rather than the guest fallback");
+        if (require_retained)
+            check(prosper::frontend::live_compute_storage_transfer_seeds() > before,
+                  "consumer seeds from the retained GPU image rather than the guest fallback");
     };
     auto pixels = [&](uint32_t cutout, const char* message) {
         check(observed[0] == cutout, message);
@@ -136,6 +138,33 @@ int main(int argc, char** argv) {
                           [](uint32_t value) { return value == stored; }),
               "all 1023 written texels reach the independent SSBO consumer");
     };
+    if (replacement) {
+        constexpr uint32_t full_value = 0x31415926u, changed_cutout = 0x2468ace0u;
+        const auto partial = producer;
+        auto full_code = writer;
+        full_code.erase(std::find(full_code.begin(), full_code.end(), 0x7daa0880u));
+        full_code[2] = full_value;
+        producer = item(full_code, producer_resources, partial.code_addr, 1);
+        check(producer.spirv != partial.spirv, "replacement changes the executable module");
+        check(prosper::frontend::execute_live_compute_items({producer}),
+              "full writer proves coverage before any partial writer uses its key");
+        consume();
+        check(std::all_of(observed.begin(), observed.end(),
+                          [](uint32_t value) { return value == full_value; }),
+              "identical full program remains correct on a warm proof");
+        guest[0] = changed_cutout;
+        producer = partial; // Same code address, binding, extent and alias membership.
+        // A fresh partial proof repairs guest bytes and invalidates the poisoned GPU
+        // image. The real GPU reader must see the repair, including via a fresh upload.
+        consume(false);
+        std::printf("program replacement witness: guest=%08x GPU=%08x expected=%08x\n",
+                    guest[0], observed[0], changed_cutout);
+        pixels(changed_cutout, "replacement preserves the newly changed input cutout");
+        check(guest[0] == changed_cutout, "replacement preserves the architectural guest cutout");
+        consume();
+        pixels(changed_cutout, "identical partial program remains correct on a warm proof");
+        return failures ? 1 : 0;
+    }
     // Proving can restore untouched guest texels after a poison run. Warm outside
     // the consumer scope first, then require real GPU transfer on every check.
     for (unsigned warm = 0; warm < 3; ++warm)

--- a/prosper/tests/gpu/execute/test_seed_coverage_dynamic.cpp
+++ b/prosper/tests/gpu/execute/test_seed_coverage_dynamic.cpp
@@ -1,0 +1,210 @@
+// #3467: observed full coverage need not survive a launch or input change.
+// Run each mode in a fresh process. PROSPER_NO_SKIP_SEED=1 is an external control;
+// neither mode treats corrupted output as an expected or passing result.
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/resources/shader_resources.hpp"
+#include "shared/live/live_compute.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+using namespace prosper::gpu;
+namespace {
+constexpr uint32_t width = 128, height = 8, texels = width * height;
+constexpr uint32_t stored = 0x13579bdfu;
+int failures = 0;
+void check(bool ok, const char* message) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; }
+}
+ComputeItem item(const std::vector<uint32_t>& code, const ShaderResourceTable& resources,
+                 uint64_t address, uint32_t index) {
+    ComputeShaderConfig config;
+    config.user_sgprs.resize(16);
+    config.local_x = 64;
+    config.local_y = config.local_z = 1;
+    config.tidig_comp_cnt = 0;
+    config.tgid_x_en = config.tgid_y_en = true;
+    config.tgid_z_en = false;
+    config.native_storage_format_support =
+        native_storage_format_support_bit(DataFormat::Uint32, 1);
+    ComputeItem result;
+    result.spirv = recompile_compute(code.data(), code.size(), &resources, config);
+    result.user_sgprs = config.user_sgprs;
+    result.resources = std::make_shared<ShaderResourceTable>(resources);
+    result.code_addr = address;
+    result.dispatch_index = index;
+    result.command_order = index * 10;
+    result.launch.local_x = 64;
+    result.launch.local_y = result.launch.local_z = 1;
+    result.launch.groups_x = 2;
+    result.launch.groups_y = result.launch.groups_z = 1;
+    result.launch.threads_x = width;
+    result.launch.threads_y = result.launch.threads_z = 1;
+    return result;
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    const bool launch = argc == 2 && std::strcmp(argv[1], "launch") == 0;
+    const bool mask_mode = argc == 2 && std::strcmp(argv[1], "mask") == 0;
+    if (!launch && !mask_mode) {
+        std::fprintf(stderr, "usage: test_seed_coverage_dynamic launch|mask\n");
+        return 2;
+    }
+    std::vector<uint32_t> guest(texels), observed(texels, 0xccccccccu);
+    std::vector<uint32_t> mask(width, 1), expected(texels, stored);
+    for (uint32_t i = 0; i < texels; ++i) guest[i] = 0xabc00000u + i;
+    ShaderResource image{};
+    image.cls = ResourceClass::StorageImage;
+    image.binding = 5;
+    image.sgpr_base = 8;
+    image.img_dim = 1;
+    image.format = DataFormat::Uint32;
+    image.num_components = 1;
+    image.width = width;
+    image.height = height;
+    image.depth = 1;
+    image.gpu_addr = reinterpret_cast<uint64_t>(guest.data());
+    image.size = texels * sizeof(uint32_t);
+    ShaderResourceTable producer_resources;
+    producer_resources.resources.push_back(image);
+    if (mask_mode) {
+        ShaderResource input{};
+        input.cls = ResourceClass::ConstantBuffer;
+        input.binding = 2;
+        input.sgpr_base = 0;
+        input.format = DataFormat::Uint32;
+        input.num_components = 1;
+        input.stride = sizeof(uint32_t);
+        input.gpu_addr = reinterpret_cast<uint64_t>(mask.data());
+        input.size = width * sizeof(uint32_t);
+        producer_resources.resources.push_back(input);
+    }
+
+    // Workgroup IDs follow the 16 user SGPRs: s16 = X, s17 = Y. Reject Y != 0
+    // uniformly so groups (1,2,1) leave half the image unwritten without races.
+    std::vector<uint32_t> writer{
+        0xbf068011u,             // s_cmp_eq_u32 s17, 0
+        0xbf840000u,             // s_cbranch_scc0 end (patched below)
+        0xd7460004u, 0x04010c10u, // v4 = (s16 << 6) + v0: global X
+    };
+    if (mask_mode) {
+        writer.insert(writer.end(), {
+            0xe0302000u, 0x80000804u, // buffer_load_dword v8, v4, s[0:3], 0 idxen
+            0xbf8c3f70u,
+            0x7daa1080u,             // v_cmpx_ne_u32 0, v8
+        });
+    }
+    writer.insert(writer.end(), {0x7e0002ffu, stored}); // v0 = stored integer
+    for (uint32_t y = 0; y < height; ++y) {
+        writer.insert(writer.end(), {
+            0x7e0a0280u + y,         // v5 = row
+            0xf0200108u, 0x00020004u, // IMAGE_STORE x, coords v4/v5, s[8:15]
+        });
+    }
+    writer[1] |= static_cast<uint32_t>(writer.size() - 2);
+    writer.push_back(0xbf810000u);
+    const uint64_t address = launch ? 0x34671001u : 0x34672001u;
+    ComputeItem producer = item(writer, producer_resources, address, 1);
+    const auto original_spirv = producer.spirv;
+    const auto original_sgprs = producer.user_sgprs;
+
+    ShaderResource sampled = image;
+    sampled.cls = ResourceClass::Texture;
+    for (unsigned c = 0; c < 4; ++c) sampled.swizzle[c] = 4 + c;
+    ShaderResource output{};
+    output.cls = ResourceClass::ConstantBuffer;
+    output.binding = 2;
+    output.sgpr_base = 0;
+    output.format = DataFormat::Uint32;
+    output.num_components = 1;
+    output.stride = sizeof(uint32_t);
+    output.gpu_addr = reinterpret_cast<uint64_t>(observed.data());
+    output.size = texels * sizeof(uint32_t);
+    ShaderResourceTable consumer_resources;
+    consumer_resources.resources = {output, sampled};
+    std::vector<uint32_t> reader{0xd7460004u, 0x04010c10u}; // v4 = global X
+    for (uint32_t y = 0; y < height; ++y) {
+        reader.insert(reader.end(), {
+            0x7e0a0280u + y,
+            0xf0000108u, 0x00020804u, // IMAGE_LOAD x -> v8, coords v4/v5
+            0xbf8c3f70u,
+            0xe0702000u | (y * width * 4u), 0x80000804u,
+        });
+    }
+    reader.push_back(0xbf810000u);
+    const ComputeItem consumer = item(reader, consumer_resources, address + 1, 2);
+    check(!producer.spirv.empty() && !consumer.spirv.empty(), "both actual shaders recompile");
+    if (failures) return 1;
+
+    auto consume = [&](bool require_retained) {
+        std::fill(observed.begin(), observed.end(), 0xccccccccu);
+        unsigned calls = 0;
+        bool all_ok = true;
+        const auto before = prosper::frontend::live_compute_storage_transfer_seeds();
+        const auto result = execute_ordered_items(
+            {{SubmitOperationKind::Dispatch, 1, 10}, {SubmitOperationKind::Dispatch, 2, 20}},
+            {}, {producer, consumer},
+            [](const std::vector<DrawItem>&, uint32_t, uint32_t) { return RenderedFrame{}; },
+            [&](const std::vector<ComputeItem>& items) {
+                ++calls;
+                const bool ok = prosper::frontend::execute_live_compute_items(items);
+                all_ok &= ok;
+                return ok;
+            }, 1, 1);
+        check(result.compute_executed && calls == 2 && all_ok,
+              "producer and sampled-to-SSBO consumer execute in order");
+        if (require_retained)
+            check(prosper::frontend::live_compute_storage_transfer_seeds() > before,
+                  "consumer uses a retained GPU image transfer");
+    };
+    auto pixels = [&](const char* phase) {
+        for (uint32_t i = 0; i < texels; ++i) {
+            if (guest[i] != expected[i] || observed[i] != expected[i]) {
+                std::fprintf(stderr, "%s %s witness (%u,%u): guest=%08x GPU=%08x expected=%08x\n",
+                             argv[1], phase, i % width, i / width,
+                             guest[i], observed[i], expected[i]);
+                break;
+            }
+        }
+        check(observed == expected, "all GPU-consumed texels match the independent expected image");
+        check(guest == expected, "all architectural guest texels match the independent expected image");
+    };
+    check(prosper::frontend::execute_live_compute_items({producer}),
+          "initial full writer establishes its coverage proof");
+    consume(true);
+    pixels("full");
+    if (failures) return 1;
+
+    if (launch) {
+        producer.launch.groups_x = 1;
+        producer.launch.groups_y = 2;
+        producer.launch.threads_x = 64;
+        producer.launch.threads_y = 2;
+        check(producer.launch.groups_x * producer.launch.groups_y * producer.launch.local_x == width,
+              "changed launch preserves the total invocation count");
+    } else {
+        mask[0] = 0;
+        check(producer.launch.groups_x == 2 && producer.launch.groups_y == 1 &&
+              producer.launch.groups_z == 1 && producer.launch.local_x == 64,
+              "runtime input change preserves the launch");
+    }
+    check(producer.spirv == original_spirv && producer.user_sgprs == original_sgprs,
+          "coverage change preserves exact executable bytes and user SGPRs");
+    for (uint32_t i = 0; i < texels; ++i) {
+        if (launch ? i % width >= 64 : i % width == 0)
+            guest[i] = expected[i] = 0x24680000u + i;
+    }
+    // Reproving partial coverage can repair poison into guest bytes and invalidate
+    // the retained image. The first consumer must also accept that correct upload.
+    consume(false);
+    pixels("changed");
+    if (failures) return 1;
+    consume(true);
+    pixels("stable partial repeat");
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/execute/test_storage_seed_proof_reuse.py
+++ b/prosper/tests/gpu/execute/test_storage_seed_proof_reuse.py
@@ -6,7 +6,8 @@ import sys
 
 env = {key: value for key, value in os.environ.items() if not key.startswith("PROSPER_")}
 env.update(PROSPER_COMPUTELOG="1", PROSPER_SEED_REPROVE="256")
-result = subprocess.run(sys.argv[1:], env=env, text=True, stdout=subprocess.PIPE,
+expected_proofs, expected_skips = map(int, sys.argv[1:3])
+result = subprocess.run(sys.argv[3:], env=env, text=True, stdout=subprocess.PIPE,
                         stderr=subprocess.STDOUT, timeout=50)
 print(result.stdout, end="")
 if result.returncode:
@@ -17,7 +18,7 @@ skips = [line for line in lines if "seed-skip write-only storage " in line]
 # Full cold proof, identical Full warm skip, changed program/launch partial proof,
 # then identical Partial warm seed. Reject an implementation that simply re-proves
 # every dispatch: it can preserve all pixels while silently removing the optimization.
-assert len(proofs) == 2, f"expected two coverage proofs, got {len(proofs)}"
+assert len(proofs) == expected_proofs, f"expected {expected_proofs} proofs, got {len(proofs)}"
 assert "poison_survived=0 " in proofs[0], "the initial writer must prove Full"
 assert "PARTIAL-COVERAGE" in proofs[1], "the changed writer must prove Partial"
-assert len(skips) == 1, f"expected one warm Full seed skip, got {len(skips)}"
+assert len(skips) == expected_skips, f"expected {expected_skips} Full skips, got {len(skips)}"

--- a/prosper/tests/gpu/execute/test_storage_seed_proof_reuse.py
+++ b/prosper/tests/gpu/execute/test_storage_seed_proof_reuse.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Require real warm seed skipping as well as the fixture's independent pixel oracle."""
+import os
+import subprocess
+import sys
+
+env = {key: value for key, value in os.environ.items() if not key.startswith("PROSPER_")}
+env.update(PROSPER_COMPUTELOG="1", PROSPER_SEED_REPROVE="256")
+result = subprocess.run(sys.argv[1:], env=env, text=True, stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT, timeout=50)
+print(result.stdout, end="")
+if result.returncode:
+    raise SystemExit(result.returncode)
+lines = result.stdout.splitlines()
+proofs = [line for line in lines if line.startswith("[seed-skip-verify] ")]
+skips = [line for line in lines if "seed-skip write-only storage " in line]
+# Full cold proof, identical Full warm skip, changed program/launch partial proof,
+# then identical Partial warm seed. Reject an implementation that simply re-proves
+# every dispatch: it can preserve all pixels while silently removing the optimization.
+assert len(proofs) == 2, f"expected two coverage proofs, got {len(proofs)}"
+assert "poison_survived=0 " in proofs[0], "the initial writer must prove Full"
+assert "PARTIAL-COVERAGE" in proofs[1], "the changed writer must prove Partial"
+assert len(skips) == 1, f"expected one warm Full seed skip, got {len(skips)}"


### PR DESCRIPTION
A partial storage-image writer could inherit a different program's Full coverage verdict when guest code reused an address, discarding newer input pixels. An unchanged program could also reuse a verdict after its dispatch geometry changed despite preserving the invocation count. Both failures are reproduced through the production backend with independent sampled-image-to-SSBO and guest-memory pixel checks.

Bind every verdict to owned exact effective SPIR-V, the subgroup contract and dispatch XYZ. Retain up to four variants per existing address/binding/extent/alias-member key, evicting the least recently used variant. This preserves warm alternating programs while retaining existing alias-access guards and separate periodic-reproof counters.

Refs #3467 and #3407. **#3467 remains open:** unchanged-program input-dependent coverage still reproduces corruption. The checked-in mask fixture documents that remaining case; its explicit-seed control is registered, and corrupted output is never accepted as a passing CTest. This PR does not establish coverage soundness for all runtime inputs.

Validation on Linux/RADV:

- 411/411 local tests; 16/16 focused core/synchronization-validation tests after independent layer-load and deliberate-hazard controls.
- The same final fixture object linked against main fails the pixel oracles. Linked against the initial single-verdict candidate, it fails alternating-variant reuse. The final bounded cache passes both reuse and five-variant eviction checks.
- Explicit-seed controls pass for code replacement, launch changes and runtime mask changes. The mask still fails with normal caching and is tracked above.

Matched-route windowed captures reach Sonic's existing black-world gameplay HUD and GTA's bank scene. Sonic proof events return to baseline scale (192 versus 178/194 retained baselines); GTA geometry, lighting and HUD remain visually consistent. Sonic presentations are 6.77/s versus roughly 6.96–6.98/s before; GTA is 6.38/s versus 6.58/s. Each final five-second capture has one fewer presentation than its retained baseline; no overall FPS improvement is claimed. Exact commands, capture identities and limits are recorded in author verification. No newly rendered FPS or audio improvement is claimed. The cache owns module bytes per retained variant and compares exact bytes on eligible dispatches; distinct logical keys retain the existing map lifetime.
