### PR TITLE
tools(shader_inspect): baseline guard for refused fragment shaders (#3464 W6)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2118,6 +2118,16 @@ if(TARGET prosper_core)
                      "${CMAKE_CURRENT_SOURCE_DIR}/tools/shader_inspect/test_skip_survey.py")
   endif()
 
+  # The baseline comparison's non-obvious verdicts: a run that cannot be judged must FAIL, and a
+  # different GPU must refuse to compare at all. Both are ways the guard could go green while
+  # measuring nothing -- an AMD host refuses no shaders, so an NVIDIA baseline compared there
+  # would report every shader fixed. Pure logic over fixtures: no dump, no GPU, no boot.
+  if(Python3_Interpreter_FOUND)
+    add_test(NAME skip_baseline_refuses_what_it_cannot_compare
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_CURRENT_SOURCE_DIR}/tools/shader_inspect/test_skip_baseline.py")
+  endif()
+
   # spv_validate: emit a module from EVERY SPIR-V-producing entry point and run spirv-val on each —
   # a strict-validation gate (the render tests only prove llvmpipe accepts them; llvmpipe is
   # lenient). No Vulkan needed, but spirv-val (spirv-tools) IS required: it used to report PASS when

--- a/prosper/tools/shader_inspect/skip_baseline.json
+++ b/prosper/tools/shader_inspect/skip_baseline.json
@@ -1,0 +1,8 @@
+{
+  "device": "NVIDIA GeForce RTX 4090 (discrete GPU)",
+  "titles": {
+    "PPSA02664": 4,
+    "PPSA13579": 8,
+    "PPSA24651": 0
+  }
+}

--- a/prosper/tools/shader_inspect/skip_survey.py
+++ b/prosper/tools/shader_inspect/skip_survey.py
@@ -150,6 +150,23 @@ def survey(app, dump, seconds, out_dir):
     }
 
 
+def unjudgeable(row):
+    """Why this row cannot support a verdict, or "" if it can.
+
+    ONE definition, used by both the record and compare sides. It was written twice and drifted
+    within a single commit: the record side omitted the unrecorded-device case, so a run mixing a
+    device-less row with a good one recorded that row as 0 and then refused to compare against the
+    file it had just written. A predicate that decides what counts as evidence belongs in one place.
+    """
+    if row["exited_early"]:
+        return "exited early after %.0fs (rc=%s)" % (row["elapsed"], row["returncode"])
+    if not row["frames"]:
+        return "presented no frames"
+    if not row["device"]:
+        return "the renderer announced no Vulkan device, so its counts cannot be attributed to one"
+    return ""
+
+
 def baseline_from(rows):
     """The baseline a run would record, or (None, why) if the run cannot support one.
 
@@ -158,12 +175,13 @@ def baseline_from(rows):
     run is measured against -- which would then redden honestly on the next good run and be read as a
     regression. The failure direction is benign; the confusion is not.
     """
-    devices = {r["device"] for r in rows if r["device"]}
-    unjudged = sorted(r["title"] for r in rows if r["exited_early"] or not r["frames"])
+    unjudged = ["%s %s" % (r["title"], why)
+                for r in rows for why in [unjudgeable(r)] if why]
     if unjudged:
-        return None, ("cannot record a baseline: %s could not be judged (no frames, or exited "
-                      "early). Recording 0 for a title that never ran would bake a false clean "
-                      "state into the file." % ", ".join(unjudged))
+        return None, ("cannot record a baseline: %s. Recording 0 for a title that could not be "
+                      "judged would bake a false clean state into the file every later run is "
+                      "measured against." % "; ".join(sorted(unjudged)))
+    devices = {r["device"] for r in rows}
     if len(devices) != 1:
         return None, ("cannot record a baseline: this run reports %d distinct Vulkan devices, so "
                       "nothing later compared against it could be trusted." % len(devices))
@@ -229,14 +247,9 @@ def compare_to_baseline(rows, baseline):
                        "that did not run is not a title with no dropped shaders."
                        % (len(missing), ", ".join(missing)))
 
-    uncomparable = []
-    for title in sorted(expected):
-        r = by_title[title]
-        if r["exited_early"]:
-            uncomparable.append("%s exited early after %.0fs (rc=%s)"
-                                % (title, r["elapsed"], r["returncode"]))
-        elif not r["frames"]:
-            uncomparable.append("%s presented no frames" % title)
+    uncomparable = ["%s %s" % (title, why)
+                    for title in sorted(expected)
+                    for why in [unjudgeable(by_title[title])] if why]
     if uncomparable:
         return False, ("could not be judged: %s. A run that never got going has established "
                        "nothing, so this is a FAILURE and not an improvement."

--- a/prosper/tools/shader_inspect/skip_survey.py
+++ b/prosper/tools/shader_inspect/skip_survey.py
@@ -157,6 +157,15 @@ def unjudgeable(row):
     within a single commit: the record side omitted the unrecorded-device case, so a run mixing a
     device-less row with a good one recorded that row as 0 and then refused to compare against the
     file it had just written. A predicate that decides what counts as evidence belongs in one place.
+
+    ADMISSION RULE, because this body answers two different questions and they only happen to agree.
+    The record side asks "can this row DEFINE truth?"; the compare side asks "can it be MEASURED
+    AGAINST truth?". All three conditions below make a row unusable for BOTH, which is what makes one
+    predicate correct today. A condition that disqualifies a row for only one of them does NOT belong
+    here -- it belongs at that caller, or the two sides silently inherit each other's standards.
+
+    Two contract facts both callers rely on: the returned reason is never falsy when there is one
+    (they test `if why`), and it reads as a fragment following a title id (they format `"%s %s"`).
     """
     if row["exited_early"]:
         return "exited early after %.0fs (rc=%s)" % (row["elapsed"], row["returncode"])

--- a/prosper/tools/shader_inspect/skip_survey.py
+++ b/prosper/tools/shader_inspect/skip_survey.py
@@ -83,6 +83,10 @@ SKIP = re.compile(r"\[render\] skip draw=\d+ fs=([0-9a-f]+): fragment shader req
 ADMIT = re.compile(r"\[render\] GTA V native-width fragment vote: subgroup (\d+) -> (\d+) "
                    r"\(why=(\S+)\)")
 FPS = re.compile(r"\[app\] [\d.]+ fps \((\d+) frames")
+# The counts are host-dependent in the extreme: on an AMD host wave64 is native, nothing is refused,
+# and every count is legitimately 0. A baseline recorded on one GPU and compared against another
+# would report every shader as fixed and go green, so the device is recorded and checked.
+DEVICE = re.compile(r"\[render\] Vulkan device: (.+)")
 
 
 def survey(app, dump, seconds, out_dir):
@@ -130,8 +134,10 @@ def survey(app, dump, seconds, out_dir):
     # drawing, and skip lines are emitted from the submit path independently of presentation. It is
     # reported for context and never used to suppress a count.
     frames = max([int(m) for m in FPS.findall(text)] or [0])
+    device = DEVICE.search(text)
     return {
         "title": title,
+        "device": device.group(1).strip() if device else "",
         "frames": frames,
         "elapsed": round(elapsed, 1),
         "exited_early": exited_early,
@@ -144,6 +150,84 @@ def survey(app, dump, seconds, out_dir):
     }
 
 
+def write_baseline(rows, path):
+    """Record each title's refused count, plus the device that produced them."""
+    devices = {r["device"] for r in rows if r["device"]}
+    data = {
+        "device": sorted(devices)[0] if len(devices) == 1 else "",
+        "titles": {r["title"]: r["refused_shaders"] for r in rows},
+    }
+    Path(path).write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return data
+
+
+def compare_to_baseline(rows, baseline):
+    """(ok, message). A guard that cannot compare returns False.
+
+    That stance is the opposite of the survey's own reporting, and deliberately. A survey may say "I
+    could not tell"; a GUARD that cannot tell has not established the thing it exists to establish,
+    so passing would let a title that stopped booting read as a title with no dropped shaders. Every
+    non-comparable case below therefore FAILS:
+
+      - the run presented no frames, or the process exited before its window closed
+      - a title in the baseline was not surveyed at all
+      - the GPU differs from the one the baseline was recorded on, or is unknown
+
+    Only two outcomes pass: every title matched its recorded count, or some went DOWN. A decrease
+    passes and says so, because the repair is to re-record the baseline rather than to loosen it.
+    """
+    expected = baseline.get("titles", {})
+    want_device = baseline.get("device", "")
+    lines = []
+
+    seen_devices = {r["device"] for r in rows}
+    if not want_device:
+        return False, ("the baseline records no device, so nothing can be compared against it -- "
+                       "re-record it with --write-baseline")
+    if seen_devices != {want_device}:
+        got = ", ".join(sorted(d or "(unrecorded)" for d in seen_devices))
+        return False, ("REFUSING to compare: baseline recorded on %r, this run reports %s. These "
+                       "counts are host-dependent -- on a host with native wave64 nothing is "
+                       "refused and every count is legitimately 0, which would read as every "
+                       "shader being fixed." % (want_device, got))
+
+    by_title = {r["title"]: r for r in rows}
+    missing = sorted(set(expected) - set(by_title))
+    if missing:
+        return False, ("could not be judged: %d baseline title(s) were not surveyed (%s). A title "
+                       "that did not run is not a title with no dropped shaders."
+                       % (len(missing), ", ".join(missing)))
+
+    uncomparable = []
+    for title in sorted(expected):
+        r = by_title[title]
+        if r["exited_early"]:
+            uncomparable.append("%s exited early after %.0fs (rc=%s)"
+                                % (title, r["elapsed"], r["returncode"]))
+        elif not r["frames"]:
+            uncomparable.append("%s presented no frames" % title)
+    if uncomparable:
+        return False, ("could not be judged: %s. A run that never got going has established "
+                       "nothing, so this is a FAILURE and not an improvement."
+                       % "; ".join(uncomparable))
+
+    worse, better = [], []
+    for title in sorted(expected):
+        got, want = by_title[title]["refused_shaders"], expected[title]
+        if got > want:
+            worse.append("%s refuses %d, baseline %d" % (title, got, want))
+        elif got < want:
+            better.append("%s refuses %d, baseline %d" % (title, got, want))
+
+    if worse:
+        return False, ("REGRESSION: %s.%s" % ("; ".join(worse),
+                       " (also improved: %s)" % "; ".join(better) if better else ""))
+    if better:
+        return True, ("improved: %s -- re-record with --write-baseline so the gain is locked in"
+                      % "; ".join(better))
+    return True, "unchanged: %d title(s) match the baseline exactly" % len(expected)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--app", required=True)
@@ -152,6 +236,10 @@ def main() -> int:
     ap.add_argument("--out", default=".", help="where per-title logs are written")
     ap.add_argument("--only", help="comma-separated title ids to survey")
     ap.add_argument("--json", help="also write the results here")
+    ap.add_argument("--baseline",
+                    help="compare against this baseline; exit 1 on a regression, on a run "
+                         "that cannot be judged, or on a different GPU")
+    ap.add_argument("--write-baseline", help="record this run as the baseline")
     args = ap.parse_args()
 
     app = str(Path(args.app).resolve())
@@ -218,6 +306,21 @@ def main() -> int:
             [{k: (dict(v) if isinstance(v, collections.Counter) else v)
               for k, v in r.items()} for r in results], indent=2), encoding="utf-8")
         print("\nwrote %s" % args.json)
+    if args.write_baseline:
+        data = write_baseline(results, args.write_baseline)
+        if not data["device"]:
+            print("REFUSING to write a baseline: this run reports no single Vulkan device, "
+                  "so nothing later compared against it could be trusted.", file=sys.stderr)
+            return 2
+        print("wrote baseline %s (device %s, %d titles)"
+              % (args.write_baseline, data["device"], len(data["titles"])))
+
+    if args.baseline:
+        baseline = json.loads(Path(args.baseline).read_text(encoding="utf-8"))
+        ok, why = compare_to_baseline(results, baseline)
+        print("BASELINE %s: %s" % ("OK" if ok else "FAILED", why))
+        if not ok:
+            return 1
     return 0
 
 

--- a/prosper/tools/shader_inspect/skip_survey.py
+++ b/prosper/tools/shader_inspect/skip_survey.py
@@ -150,15 +150,40 @@ def survey(app, dump, seconds, out_dir):
     }
 
 
-def write_baseline(rows, path):
-    """Record each title's refused count, plus the device that produced them."""
+def baseline_from(rows):
+    """The baseline a run would record, or (None, why) if the run cannot support one.
+
+    Applies the same cannot-be-judged rule the comparison does. Without it a title that presented no
+    frames was recorded as `0`, quietly baking "this title refuses nothing" into the file every later
+    run is measured against -- which would then redden honestly on the next good run and be read as a
+    regression. The failure direction is benign; the confusion is not.
+    """
     devices = {r["device"] for r in rows if r["device"]}
-    data = {
-        "device": sorted(devices)[0] if len(devices) == 1 else "",
+    unjudged = sorted(r["title"] for r in rows if r["exited_early"] or not r["frames"])
+    if unjudged:
+        return None, ("cannot record a baseline: %s could not be judged (no frames, or exited "
+                      "early). Recording 0 for a title that never ran would bake a false clean "
+                      "state into the file." % ", ".join(unjudged))
+    if len(devices) != 1:
+        return None, ("cannot record a baseline: this run reports %d distinct Vulkan devices, so "
+                      "nothing later compared against it could be trusted." % len(devices))
+    return {
+        "device": sorted(devices)[0],
         "titles": {r["title"]: r["refused_shaders"] for r in rows},
-    }
+    }, ""
+
+
+def write_baseline(rows, path):
+    """Validate FIRST, then write. Returns (data, why).
+
+    The previous version wrote the file and then reported that it had refused, so a bad run
+    clobbered the committed baseline while printing "REFUSING to write".
+    """
+    data, why = baseline_from(rows)
+    if data is None:
+        return None, why
     Path(path).write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    return data
+    return data, ""
 
 
 def compare_to_baseline(rows, baseline):
@@ -178,7 +203,13 @@ def compare_to_baseline(rows, baseline):
     """
     expected = baseline.get("titles", {})
     want_device = baseline.get("device", "")
-    lines = []
+
+    # A baseline with no titles compared clean against every possible run, reporting
+    # "unchanged: 0 title(s)". Vacuous truth is the purest form of this guard's only real failure --
+    # passing while establishing nothing -- so an empty baseline is unusable, not satisfied.
+    if not expected:
+        return False, ("the baseline lists no titles, so it cannot establish anything -- every run "
+                       "would match it. Re-record it with --write-baseline.")
 
     seen_devices = {r["device"] for r in rows}
     if not want_device:
@@ -219,13 +250,24 @@ def compare_to_baseline(rows, baseline):
         elif got < want:
             better.append("%s refuses %d, baseline %d" % (title, got, want))
 
+    # A surveyed title the baseline has never heard of is not a regression -- there is nothing to
+    # regress from -- but dropping it silently let a title refusing 99 shaders read as
+    # "unchanged: 3 title(s)". It is reported on every verdict, with its count, so the summary can
+    # never be more reassuring than the run.
+    unknown = sorted(set(by_title) - set(expected))
+    extra = ""
+    if unknown:
+        extra = (" NOT IN BASELINE (no verdict possible, add with --write-baseline): %s."
+                 % "; ".join("%s refuses %d" % (u, by_title[u]["refused_shaders"])
+                             for u in unknown))
+
     if worse:
-        return False, ("REGRESSION: %s.%s" % ("; ".join(worse),
-                       " (also improved: %s)" % "; ".join(better) if better else ""))
+        return False, ("REGRESSION: %s.%s%s" % ("; ".join(worse),
+                       " (also improved: %s)" % "; ".join(better) if better else "", extra))
     if better:
-        return True, ("improved: %s -- re-record with --write-baseline so the gain is locked in"
-                      % "; ".join(better))
-    return True, "unchanged: %d title(s) match the baseline exactly" % len(expected)
+        return True, ("improved: %s -- re-record with --write-baseline so the gain is locked in.%s"
+                      % ("; ".join(better), extra))
+    return True, ("unchanged: %d title(s) match the baseline exactly.%s" % (len(expected), extra))
 
 
 def main() -> int:
@@ -307,10 +349,9 @@ def main() -> int:
               for k, v in r.items()} for r in results], indent=2), encoding="utf-8")
         print("\nwrote %s" % args.json)
     if args.write_baseline:
-        data = write_baseline(results, args.write_baseline)
-        if not data["device"]:
-            print("REFUSING to write a baseline: this run reports no single Vulkan device, "
-                  "so nothing later compared against it could be trusted.", file=sys.stderr)
+        data, why = write_baseline(results, args.write_baseline)
+        if data is None:
+            print("REFUSING to write a baseline: %s" % why, file=sys.stderr)
             return 2
         print("wrote baseline %s (device %s, %d titles)"
               % (args.write_baseline, data["device"], len(data["titles"])))

--- a/prosper/tools/shader_inspect/test_skip_baseline.py
+++ b/prosper/tools/shader_inspect/test_skip_baseline.py
@@ -106,11 +106,42 @@ def main() -> int:
          row("PPSA24651", 0, device="")], base)
     check("an unrecorded device refuses to compare", not ok, why)
 
+    # ---- review findings: passes that establish nothing -----------------------------------------
+    #
+    # A guard's only interesting failure is passing while measuring nothing, and each of these did.
+
+    # F1. An empty baseline matched everything it knew about, which was nothing.
+    ok, why = skip_survey.compare_to_baseline([row("PPSA13579", 99)], {"device": NVIDIA,
+                                                                       "titles": {}})
+    check("an empty baseline FAILS instead of vacuously passing", not ok, why)
+    ok, why = skip_survey.compare_to_baseline([row("PPSA13579", 99)], {"device": NVIDIA})
+    check("a baseline with no titles key FAILS", not ok, why)
+
+    # F2. The "baseline records no device" branch had NO coverage: the arm that appeared to test it
+    # landed on the GPU-mismatch branch instead, and deleting the branch left a SILENT PASS, since
+    # {""} != {""} is False. Both sides unrecorded is the case that reaches it.
+    ok, why = skip_survey.compare_to_baseline(
+        [row("PPSA13579", 8, device="")], {"device": "", "titles": {"PPSA13579": 8}})
+    check("a baseline with no recorded device FAILS even when the run also has none", not ok, why)
+    check("...and says the BASELINE is the unusable side",
+          "baseline" in why.lower(), why)
+
+    # F5. A surveyed title absent from the baseline was dropped silently, so a title refusing 99
+    # could read as "unchanged".
+    ok, why = skip_survey.compare_to_baseline(
+        [row("PPSA13579", 8), row("PPSA99999", 99)], {"device": NVIDIA,
+                                                      "titles": {"PPSA13579": 8}})
+    check("a surveyed title missing from the baseline is REPORTED, not dropped",
+          "PPSA99999" in why, why)
+    check("...and its refusal count is named so 99 cannot hide behind 'unchanged'",
+          "99" in why, why)
+
     # ---- round-trip ------------------------------------------------------------------------------
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "baseline.json"
         rows = [row("PPSA13579", 8), row("PPSA02664", 4)]
-        skip_survey.write_baseline(rows, path)
+        data, why = skip_survey.write_baseline(rows, path)
+        check("a good run writes a baseline", data is not None, why)
         loaded = json.loads(path.read_text())
         check("a written baseline records the device", loaded.get("device") == NVIDIA, str(loaded))
         check("a written baseline records each title's count",

--- a/prosper/tools/shader_inspect/test_skip_baseline.py
+++ b/prosper/tools/shader_inspect/test_skip_baseline.py
@@ -162,6 +162,22 @@ def main() -> int:
     data, why = skip_survey.baseline_from([row("PPSA13579", 8), row("PPSA02664", 4, device=AMD)])
     check("a baseline REFUSES a run spanning two GPUs", data is None, why)
 
+    # ---- F3: an ORDERING, which a condition-mutation sweep cannot express -------------------------
+    #
+    # Every guard in this file is pinned by neutralising its condition. F3 is not a condition: it is
+    # that the write happens AFTER the refusal check. Hoisting `write_text` above the guard leaves
+    # every condition untouched and the suite green, while restoring the bug where a refused write
+    # clobbers the committed baseline and prints "REFUSING to write". This arm asserts the effect on
+    # disk rather than the control flow, which is the only way to see it.
+    with tempfile.TemporaryDirectory() as tmp:
+        existing = Path(tmp) / "committed.json"
+        existing.write_text('{"device": "PRECIOUS", "titles": {"KEEP": 1}}')
+        before = existing.read_bytes()
+        data, why = skip_survey.write_baseline([row("PPSA13579", 0, frames=0)], existing)
+        check("a refused write returns no data", data is None, why)
+        check("a refused write leaves an existing baseline BYTE-IDENTICAL",
+              existing.read_bytes() == before, existing.read_text())
+
     # ---- round-trip ------------------------------------------------------------------------------
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "baseline.json"

--- a/prosper/tools/shader_inspect/test_skip_baseline.py
+++ b/prosper/tools/shader_inspect/test_skip_baseline.py
@@ -123,8 +123,10 @@ def main() -> int:
     ok, why = skip_survey.compare_to_baseline(
         [row("PPSA13579", 8, device="")], {"device": "", "titles": {"PPSA13579": 8}})
     check("a baseline with no recorded device FAILS even when the run also has none", not ok, why)
+    # Not `"baseline" in why` -- that is true of 7 of the 8 verdict messages, so the arm
+    # would survive nearly any mutation. Assert on the phrase only this branch produces.
     check("...and says the BASELINE is the unusable side",
-          "baseline" in why.lower(), why)
+          "lists no titles" in why or "records no device" in why, why)
 
     # F5. A surveyed title absent from the baseline was dropped silently, so a title refusing 99
     # could read as "unchanged".
@@ -135,6 +137,30 @@ def main() -> int:
           "PPSA99999" in why, why)
     check("...and its refusal count is named so 99 cannot hide behind 'unchanged'",
           "99" in why, why)
+
+    # ---- the RECORD side, which the first mutation sweep never reached ---------------------------
+    #
+    # The sweep covered compare_to_baseline and stopped at the function boundary, leaving F3 and F4 --
+    # the previous round's own fixes -- uncovered. Truth is defined on this side: a wrong baseline
+    # makes every later comparison wrong, however well guarded the comparison is.
+
+    # F4's rule, on the record side.
+    data, why = skip_survey.baseline_from([row("PPSA13579", 0, frames=0)])
+    check("a baseline REFUSES a run that presented no frames", data is None, why)
+    check("...and names the title and the reason",
+          "PPSA13579" in why and "no frames" in why, why)
+
+    # The drift: this row is judgeable by frames but has no device, and was recorded as 0 while the
+    # comparison refused it -- so --write-baseline X --baseline X wrote a file then rejected it.
+    mixed = [row("PPSA13579", 8), row("PPSA02664", 0, device="")]
+    data, why = skip_survey.baseline_from(mixed)
+    check("a baseline REFUSES a row whose renderer announced no device", data is None, why)
+    check("...so it can never write a file it would then refuse to compare against",
+          "PPSA02664" in why, why)
+
+    # Two devices in one run cannot produce one attributable baseline.
+    data, why = skip_survey.baseline_from([row("PPSA13579", 8), row("PPSA02664", 4, device=AMD)])
+    check("a baseline REFUSES a run spanning two GPUs", data is None, why)
 
     # ---- round-trip ------------------------------------------------------------------------------
     with tempfile.TemporaryDirectory() as tmp:

--- a/prosper/tools/shader_inspect/test_skip_baseline.py
+++ b/prosper/tools/shader_inspect/test_skip_baseline.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""The baseline comparison must FAIL when it cannot compare, not pass.
+
+#3464 W6. `skip_survey.py --baseline` locks in today's refused-shader counts per title and reddens
+when one goes up. The subtlety is entirely in the non-obvious verdicts, and both directions of getting
+them wrong are silent:
+
+**A run that could not be judged must FAIL, not pass.** This is the opposite stance from the survey's
+own reporting, and deliberately so. A survey reports "I could not tell"; a GUARD that cannot tell has
+not established the thing it exists to establish, and passing would mean a title that stopped booting
+reads as a title with no dropped shaders. Trap 273 is this family exactly.
+
+**A different GPU must refuse to compare at all.** The counts are host-dependent in the extreme: on an
+AMD host wave64 is native, nothing is refused, and every count is legitimately 0. Comparing a
+Windows/NVIDIA baseline against a Linux/AMD run would report "31 shaders fixed" and go green -- the
+most encouraging possible output for a comparison that measured nothing.
+
+Run: python test_skip_baseline.py
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve()
+sys.path.insert(0, str(HERE.parent))
+
+import skip_survey  # noqa: E402
+
+failures = []
+
+
+def check(name, ok, detail=""):
+    if ok:
+        print("ok   - %s" % name)
+    else:
+        failures.append(name)
+        print("FAIL - %s %s" % (name, detail))
+
+
+NVIDIA = "NVIDIA GeForce RTX 4090 (discrete GPU)"
+AMD = "AMD Radeon Graphics (RADV) (integrated GPU)"
+
+
+def row(title, refused, frames=3000, device=NVIDIA, exited_early=False, admitted=0):
+    return {"title": title, "refused_shaders": refused, "admitted_shaders": admitted,
+            "frames": frames, "device": device, "exited_early": exited_early,
+            "elapsed": 150.0, "returncode": None, "reasons": {"0x2 wave-any": refused},
+            "widths": [64] if refused else [], "log": ""}
+
+
+def main() -> int:
+    base = {"device": NVIDIA, "titles": {"PPSA13579": 8, "PPSA02664": 4, "PPSA24651": 0}}
+
+    # ---- the ordinary verdicts ------------------------------------------------------------------
+    ok, why = skip_survey.compare_to_baseline(
+        [row("PPSA13579", 8), row("PPSA02664", 4), row("PPSA24651", 0)], base)
+    check("an unchanged corpus passes", ok, why)
+
+    # A complete row set: only the count under test differs, so the verdict cannot come from
+    # a title being absent. An earlier draft passed one row and went green for that reason.
+    ok, why = skip_survey.compare_to_baseline([row("PPSA13579", 9), row("PPSA02664", 4), row("PPSA24651", 0)], base)
+    check("a title that refuses MORE fails", not ok, why)
+    check("...and the message names the title and both counts",
+          "PPSA13579" in why and "8" in why and "9" in why, why)
+
+    ok, why = skip_survey.compare_to_baseline([row("PPSA13579", 3), row("PPSA02664", 4), row("PPSA24651", 0)], base)
+    check("a title that refuses FEWER passes", ok, why)
+    check("...and says so, so the baseline gets tightened rather than drifting",
+          "3" in why and "8" in why, why)
+
+    # A title going from clean to non-clean is the regression this exists for.
+    ok, why = skip_survey.compare_to_baseline([row("PPSA13579", 8), row("PPSA02664", 4), row("PPSA24651", 1)], base)
+    check("a title regressing from 0 to 1 fails", not ok, why)
+
+    # ---- the verdicts that must not silently pass -------------------------------------------------
+    # A run that never got going has established nothing. Passing it would let a title that stopped
+    # booting read as a title with no dropped shaders.
+    ok, why = skip_survey.compare_to_baseline(
+        [row("PPSA13579", 0, frames=0), row("PPSA02664", 4), row("PPSA24651", 0)], base)
+    check("a run that presented no frames FAILS rather than reading as an improvement", not ok, why)
+    check("...and says it could not be judged, not that it improved",
+          "judge" in why.lower() or "uncomparable" in why.lower(), why)
+
+    ok, why = skip_survey.compare_to_baseline(
+        [row("PPSA13579", 0, exited_early=True), row("PPSA02664", 4),
+         row("PPSA24651", 0)], base)
+    check("a run that exited early FAILS rather than reading as an improvement", not ok, why)
+
+    # A title in the baseline that was not surveyed at all is not evidence of anything.
+    ok, why = skip_survey.compare_to_baseline([row("PPSA13579", 8)], base)
+    check("a baseline title missing from the run FAILS", not ok, why)
+    check("...and names the missing titles", "PPSA02664" in why, why)
+
+    # ---- the host guard, which is the one that would go GREEN while measuring nothing --------------
+    ok, why = skip_survey.compare_to_baseline(
+        [row("PPSA13579", 0, device=AMD), row("PPSA02664", 0, device=AMD),
+         row("PPSA24651", 0, device=AMD)], base)
+    check("a different GPU REFUSES to compare rather than reporting 12 shaders fixed", not ok, why)
+    check("...and names both devices so the reason is obvious",
+          "NVIDIA" in why and "AMD" in why, why)
+
+    # An unknown device is not a matching device.
+    ok, why = skip_survey.compare_to_baseline(
+        [row("PPSA13579", 8, device=""), row("PPSA02664", 4, device=""),
+         row("PPSA24651", 0, device="")], base)
+    check("an unrecorded device refuses to compare", not ok, why)
+
+    # ---- round-trip ------------------------------------------------------------------------------
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "baseline.json"
+        rows = [row("PPSA13579", 8), row("PPSA02664", 4)]
+        skip_survey.write_baseline(rows, path)
+        loaded = json.loads(path.read_text())
+        check("a written baseline records the device", loaded.get("device") == NVIDIA, str(loaded))
+        check("a written baseline records each title's count",
+              loaded.get("titles") == {"PPSA13579": 8, "PPSA02664": 4}, str(loaded))
+        ok, why = skip_survey.compare_to_baseline(rows, loaded)
+        check("a freshly written baseline compares clean against its own run", ok, why)
+
+    print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #3464 (W6). Third in the series after #3466 (census) and #3473 (survey).

## Why

*Blasphemous 2* is **rung 6 with a reviewed snapshot guard** and drops **8 fragment shaders** on this
host while that guard stays green. Two more guarded titles do the same. Nothing in this project can
currently see that class of loss — it took a census to find, and a user report before that.

## Deliberately a baseline, not the zero-assertion #3464 proposed

Five titles refuse shaders today, so `assert zero skip lines` would be **red from birth** — a TODO
wearing a guard's clothes, and the first thing anyone would do is disable it.

A baseline locks in today's counts, reddens the moment one rises, and **becomes** the zero-assertion
for free once W5 lands and the counts fall to zero: a data change, not a code change.

## The two properties that carry it

Both are ways this guard could go green while measuring nothing, which is the only interesting
failure mode a guard has.

**A run that cannot be judged FAILS.** The opposite stance from the survey's own reporting, on
purpose: a survey may say "I could not tell", but a guard that cannot tell has not established the
thing it exists for — so passing would let a title that *stopped booting* read as a title with no
dropped shaders. That is instrument trap 273's family exactly. Presenting no frames, exiting before
the window closes, or being absent from the run are all failures.

**A different GPU refuses to compare at all.** These counts are host-dependent in the extreme: on an
AMD host wave64 is native, nothing is refused, and every count is legitimately `0`. An NVIDIA
baseline compared against a Linux/AMD run would report **every shader as fixed and exit 0** — the
most encouraging possible output for a comparison that measured nothing. The Vulkan device is
recorded and checked; an unrecorded device is not a matching device.

A decrease **passes and says so**, because the repair is to re-record the baseline rather than loosen
it.

## Verification

**On live data, not only fixtures:**

```
ARM 1  unchanged run vs its own baseline    BASELINE OK: 3 titles match exactly      exit 0
ARM 2  same run vs a baseline claiming
       PPSA13579 refused 2                  BASELINE FAILED: refuses 8, baseline 2   exit 1
```

Counts reproduced across independent boots (4, 8, 0 both times) and match the W7 survey on #3473.

**17 unit checks** over the comparison logic, registered as ctest
`skip_baseline_refuses_what_it_cannot_compare` — fixtures only, so no dump, no GPU, no boot, and it
runs in CI (verified `ctest -R skip_` green, 2 of 2 with its sibling).

Three of those arms exist because **an earlier draft of this test passed for the wrong reason**: it
gave a single row against a three-title baseline, so `a title that refuses MORE fails` was green
because a title was *absent*, not because a count rose. Each case now uses a complete row set so only
the property under test differs.

## Scope — three titles, not five

Stated plainly because a partial baseline invites the exact misreading this tooling exists to
prevent. It covers `PPSA13579`, `PPSA02664` and `PPSA24651`. **Evergate and Blue Prince refuse
shaders and are not in it.** Under this guard's own rules a baseline title that does not run is a
failure, so adding them commits every check to five boots (~10 minutes).

Better to widen deliberately than to record five and have someone quietly narrow it later because it
is slow. Widening is a `--write-baseline` run, not a code change.

## Risk

Low — a new comparison mode in an offline tool, a fixtures-only test, and a data file. Nothing
existing changes behaviour; no emulator code is touched. The judgement worth review is whether
"cannot be judged ⇒ FAIL" is implemented everywhere it should be, since that is the property whose
absence would be silent.
