### PR TITLE
perf(gpu): retain completed renderer-seeded storage results

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3117,7 +3117,17 @@ if(TARGET prosper_core)
                --unset=PROSPER_NO_STANDALONE_RTT_SEED $<TARGET_FILE:test_storage_rtt_gpu_seed>)
       add_test(NAME storage_rtt_cpu_seed COMMAND ${CMAKE_COMMAND} -E env
                PROSPER_NO_STANDALONE_RTT_SEED=1 $<TARGET_FILE:test_storage_rtt_gpu_seed> --cpu)
-      set_tests_properties(storage_rtt_gpu_seed storage_rtt_cpu_seed PROPERTIES TIMEOUT 60)
+      add_test(NAME storage_rtt_result_retention COMMAND ${CMAKE_COMMAND} -E env
+               --unset=PROSPER_NO_STANDALONE_RTT_SEED
+               --unset=PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE
+               $<TARGET_FILE:test_storage_rtt_gpu_seed> --retention)
+      add_test(NAME storage_rtt_result_retention_off COMMAND ${CMAKE_COMMAND} -E env
+               --unset=PROSPER_NO_STANDALONE_RTT_SEED
+               PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE=1
+               $<TARGET_FILE:test_storage_rtt_gpu_seed> --retention-off)
+      set_tests_properties(storage_rtt_gpu_seed storage_rtt_cpu_seed
+                           storage_rtt_result_retention storage_rtt_result_retention_off
+                           PROPERTIES TIMEOUT 60)
 
       add_executable(test_near_full_storage_authority
                      tests/gpu/execute/test_near_full_storage_authority.cpp)

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -158,7 +158,10 @@ guest writeback. Missing or incompatible imports fall back to current snapshots;
 address nor matching texel width alone authorizes this copy (#3407).
 
 After successful ordinary writeback, that private native RGBA8 result can be retained for the
-existing validated storage-to-sampled transfer path and compatible graphics exports. This does not
+existing validated storage-to-sampled transfer path. This promotion does not authorize graphics
+exports: in the measured workload, repeated page-watch registration outweighed the conversion saving.
+Linux consumers without ordered-journal authority fall back to guest preparation; Windows retains
+its existing exact guest mirror. This does not
 authorize input reuse by a later renderer-owned producer. Retention refuses overlapping writes from
 independent image owners or any metadata reset, using effective host/guest destinations rather than
 advertised addresses alone. Publication waits for all writebacks, and guest mutation still invalidates

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -157,6 +157,14 @@ dispatches copy that source into a private writable image, restore its layout, a
 guest writeback. Missing or incompatible imports fall back to current snapshots; neither a matching
 address nor matching texel width alone authorizes this copy (#3407).
 
+After successful ordinary writeback, that private native RGBA8 result can be retained for the
+existing validated storage-to-sampled transfer path and compatible graphics exports. This does not
+authorize input reuse by a later renderer-owned producer. Retention refuses overlapping writes from
+independent image owners or any metadata reset, using effective host/guest destinations rather than
+advertised addresses alone. Publication waits for all writebacks, and guest mutation still invalidates
+consumer authority. Existing budget and pin rules apply; failure invalidates retained authority.
+The control `PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE=1` restores transient result ownership.
+
 ### Write-watch alias protection
 
 Storage-result and texture caches may reuse a physical-page watch while other registrations still

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -129,3 +129,14 @@ returns to its incoming layout (or an earlier sampled borrower's GENERAL layout)
 destination still writes back guest bytes. Release every acquired pin, including folded aliases,
 only after completion is established. `PROSPER_NO_STANDALONE_RTT_SEED` selects the CPU control;
 F8-gated `compute-rtt-seed` rows distinguish admission from recorded copies.
+
+A completed private renderer-seeded native RGBA8 image may be retained under the existing image
+budget for validated storage-to-sampled transfers and compatible graphics consumers. Input cache
+reuse remains excluded for renderer owners: their next dispatch acquires the current renderer image.
+Retain only after ordinary guest/DCC writeback; publish authority only after every writeback succeeds.
+Refuse a result if another independent storage owner's effective writeback destination or any DCC
+reset overlaps its guest bytes, including host backing and its own metadata. Exact folded aliases
+share one owner. Pinned replacement refusal and failure invalidation retain their existing contracts.
+No separate comparison baseline is created for this consumer source. The control
+`PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE=1` disables this promotion; F8 writeback rows report
+`renderer-result-retained` separately from input cache hits.

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -131,7 +131,9 @@ only after completion is established. `PROSPER_NO_STANDALONE_RTT_SEED` selects t
 F8-gated `compute-rtt-seed` rows distinguish admission from recorded copies.
 
 A completed private renderer-seeded native RGBA8 image may be retained under the existing image
-budget for validated storage-to-sampled transfers and compatible graphics consumers. Input cache
+budget for validated storage-to-sampled transfers. This new result does not authorize graphics
+export or create its page watch: Linux uses the ordered journal and declines outside its authority;
+Windows retains its exact guest mirror. Ordinary graphics preparation remains the fallback. Input cache
 reuse remains excluded for renderer owners: their next dispatch acquires the current renderer image.
 Retain only after ordinary guest/DCC writeback; publish authority only after every writeback succeeds.
 Refuse a result if another independent storage owner's effective writeback destination or any DCC

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -11476,8 +11476,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         image.resource->gpu_addr, image.guest_bytes),
                     authorized);
             }
+            // Renderer-result retention serves the ordered compute handoff. Exporting these
+            // freshly replaced entries to graphics creates/destroys a full guest-page watch on
+            // every dispatch, exceeding the avoided conversion cost in the measured workload. Keep that path
+            // disabled here: compute uses the existing journal (or Windows exact mirror), and
+            // a borrower without current authority falls back to ordinary guest preparation.
             const bool graphics_export_authorized = publish_eligible &&
-                image.graphics_sampled_usage &&
+                !image.renderer_seeded_result_candidate && image.graphics_sampled_usage &&
                 ctx.authorize_cached_image_export(image.cache_key, item.command_order);
             // #3307: the producer half of the borrow partition. Without it, a consumer that finds
             // no cache entry cannot tell a producer that declined to publish from a producer that

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -10311,7 +10311,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0,
                                      nullptr, 1, &mirror_to_general);
             }
-            if (bi.cache_candidate || bi.persistent ||
+            // Promotion is decided after host writeback, but a possible retained result must
+            // already have the GENERAL layout promised to both compute and graphics consumers.
+            if (bi.cache_candidate || bi.persistent || bi.renderer_seeded_result_candidate ||
                 bi.post_writeback_promotion_candidate) {
                 VkImageMemoryBarrier to_general = to_src;
                 to_general.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3521,6 +3521,7 @@ struct BoundImage {
     bool persistent = false;            // guest-backed sampled image retained across dispatches
     bool cache_candidate = false;
     bool post_writeback_promotion_candidate = false;
+    bool renderer_seeded_result_candidate = false;
     // Exact cached allocation leased for a DCC-unsafe producer. Source authority was invalidated,
     // upload_skipped remains false, and cache publication still waits for post-writeback metadata.
     bool forced_seed_allocation_reused = false;
@@ -8420,6 +8421,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     *r, static_cast<uint32_t>(guest_bytes), image_format);
                 bi.cache_candidate =
                     compute_storage_cache_gate_candidate(storage_cache_gates);
+                // Renderer ownership still excludes INPUT reuse. Once ordinary writeback has
+                // published this private image's exact result, however, it can become a source
+                // for the existing validated storage-to-sampled transfer path. The next renderer
+                // producer must acquire and seed from its current renderer image again.
+                static const bool renderer_seeded_result_cache_enabled =
+                    std::getenv("PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE") == nullptr;
+                bi.renderer_seeded_result_candidate = renderer_seeded_result_cache_enabled &&
+                    renderer_owned && bi.standalone_seed.valid() && bi.native_float_storage &&
+                    r->format == DataFormat::Unorm8 && descriptor_components == 4 &&
+                    storage_cache_gates.persistent_enabled && !bi.storage_write_mask &&
+                    bi.alias_of == SIZE_MAX && !r->host_data;
                 if (storage_gate_census_enabled()) {
                     // Report periodically as well as at exit: a bounded run ends in SIGTERM, whose
                     // default action skips atexit handlers entirely.
@@ -9324,6 +9336,41 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  ComputeClock::now() - image_start).count());
         }
         if (!images_ready) break;
+
+        // Final cache publication runs after all image writebacks. A different Vulkan image can
+        // describe overlapping guest bytes without folding into this exact alias owner. Its
+        // writeback (or even our own overlapping DCC metadata reset) would make this private image
+        // stale before publication. Keep this result transient rather than refreshing authority
+        // over somebody else's pixels. Check the completed resource plan, not descriptor access
+        // flags: the backend currently writes back read-only StorageImage descriptors too.
+        // Compare effective destinations: replay host backing may alias guest pixels even when
+        // the advertised guest addresses differ. This candidate itself is always guest-backed.
+        for (auto& image : images) {
+            if (!image.renderer_seeded_result_candidate) continue;
+            const uint64_t address = image.resource->gpu_addr;
+            if (!address || !image.guest_bytes || image.guest_bytes > UINT64_MAX - address) {
+                image.renderer_seeded_result_candidate = false;
+                continue;
+            }
+            const auto overlaps_or_invalid = [&](uint64_t other, uint64_t bytes) {
+                if (!bytes) return false;
+                if (!other || bytes > UINT64_MAX - other) return true;
+                return address < other + bytes && other < address + image.guest_bytes;
+            };
+            for (const auto& other : images) {
+                if (!other.storage || other.alias_of != SIZE_MAX || !other.resource) continue;
+                if ((&other != &image &&
+                     (overlaps_or_invalid(other.resource->gpu_addr, other.guest_bytes) ||
+                      overlaps_or_invalid(reinterpret_cast<uintptr_t>(resource_bytes_for(
+                          other.resource, other.guest_bytes)), other.guest_bytes))) ||
+                    overlaps_or_invalid(other.resource->metadata_addr, other.dcc_metadata_bytes) ||
+                    overlaps_or_invalid(reinterpret_cast<uintptr_t>(other.dcc_metadata),
+                                        other.dcc_metadata_bytes)) {
+                    image.renderer_seeded_result_candidate = false;
+                    break;
+                }
+            }
+        }
 
         // Exact 2D and standard 3D tiling runs after image transfer in this same submission. Keep
         // the original linear result for cache comparison and publication; the
@@ -11225,9 +11272,24 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const auto notify_done = ComputeClock::now();
             bool retain_gpu_result_baseline = false;
             bool promoted_after_writeback = false;
+            bool renderer_result_retained = false;
             const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
                 std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
                             [](uint8_t value) { return value == 0xff; });
+            if (bi.renderer_seeded_result_candidate &&
+                (!r->compression_enabled || final_dcc_cache_safe) &&
+                bi.image && bi.memory && bi.allocation_bytes &&
+                ctx.replace_or_retain_image(bi.cache_key, bi.image, bi.memory,
+                                            bi.allocation_bytes, nullptr)) {
+                // Publication below still waits for every writeback to succeed. Failure cleanup
+                // invalidates a retained entry, and replacement refuses a pinned prior owner.
+                // Linux validates through the journal/watch; Windows publication installs the
+                // existing exact guest mirror before authorizing a later transfer.
+                bi.cache_candidate = true;
+                bi.persistent = true;
+                promoted_after_writeback = true;
+                renderer_result_retained = true;
+            }
             if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
                 const uint8_t* retained_source =
                     (adaptive_storage_result_validation_enabled() &&
@@ -11293,7 +11355,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             native_3d_transfer_enabled(),
                         bi.graphics_sampled_usage && bi.exact_storage_bytes(),
                         r->depth, ~0ULL, layer_stride, selected_slice);
-                } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                } else if (!bi.persistent && bi.image && bi.memory && bi.allocation_bytes &&
                            ctx.retain_image(bi.cache_key, bi.image, bi.memory,
                                             bi.allocation_bytes,
                                             (adaptive_storage_result_validation_enabled() &&
@@ -11316,16 +11378,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // setup keeps the exact current host fallback; a failed ownership attempt invalidates
                 // any older fallback so the next dispatch takes the ordinary writeback path.
                 const bool force_host_result_fallback =
-                    bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
+                    !renderer_result_retained && bi.persistent &&
+                    !bi.result_baseline && bi.exact_result_bytes &&
                     !(bi.exact_result_bytes & 15u) &&
                     g_force_next_image_result_host_fallback_for_test.exchange(
                         false, std::memory_order_acq_rel);
-                retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
+                retain_gpu_result_baseline = !renderer_result_retained &&
+                    bi.persistent && !bi.result_baseline &&
                     bi.exact_result_bytes &&
                     bi.exact_result_bytes <= max_gpu_compare_image_bytes() &&
                     !(bi.exact_result_bytes & 15u) &&
                     !force_host_result_fallback && ctx.prepare_compare_pipeline();
-                if (bi.persistent && !retain_gpu_result_baseline &&
+                // This result serves later consumers; the next renderer producer still seeds a
+                // private image. A second result baseline would add a full-image copy without
+                // enabling repeated-output comparison on that producer.
+                if (!renderer_result_retained && bi.persistent && !retain_gpu_result_baseline &&
                     (force_host_result_fallback || bi.exact_result_bytes <= max_gpu_compare_image_bytes()))
                     ctx.remember_cached_image_result(
                         bi.cache_key, native_texels,
@@ -11360,6 +11427,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              "binding=%u addr=0x%llx "
                              "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u write-only=%u "
                              "poison=%u gpu-retile=%u dim=%u layers=%u texel-depth=%u "
+                             "renderer-result-retained=%u "
                              "map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
                              "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
                              "total_ms=%.3f\n",
@@ -11369,6 +11437,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
                              bi.storage_write_only ? 1u : 0u, 0u, bi.retile_buffer ? 1u : 0u,
                              r->img_dim, bi.array_layers, bi.texel_depth,
+                             renderer_result_retained ? 1u : 0u,
                              image_milliseconds(map_start, map_done),
                              image_milliseconds(map_done, prepare_done),
                              image_milliseconds(prepare_done, watch_done),

--- a/prosper/tests/gpu/execute/test_storage_rtt_gpu_seed.cpp
+++ b/prosper/tests/gpu/execute/test_storage_rtt_gpu_seed.cpp
@@ -391,6 +391,18 @@ int main(int argc, char** argv) {
                             } else {
                                 check(std::equal(expected.begin(), expected.end(), guest.begin()),
                                       "ordered producer publishes every expected renderer-seeded channel");
+                                {
+                                    // This completed result is for ordered compute transfer only.
+                                    // Even an exact graphics descriptor must not promote it into
+                                    // graphics-export/watch ownership. Release an unexpected lease
+                                    // before the consumer so the negative control keeps running.
+                                    prosper::frontend::LiveComputeImageImport graphics_import;
+                                    const bool exported = prosper::frontend::import_live_compute_storage_image(
+                                        normalized_table.resources.back(), guest_bytes, graphics_import);
+                                    check(!exported && !graphics_import.valid(),
+                                          "renderer-seeded completed result refuses graphics export");
+                                    graphics_import = {};
+                                }
                                 if (guest_mutation) {
                                     // A real intervening write invalidates the submit journal.
                                     constexpr size_t changed = 13 * width * 4 + 7;
@@ -433,6 +445,32 @@ int main(int argc, char** argv) {
                   "ordered retained result preserves the independent guest tail");
             source_preserved();
         }
+        // No ordered-submit journal survives this boundary. The completed result
+        // must not conceal an unnotified CPU mutation: Linux has no new export
+        // watch here, and the Windows exact mirror must reject changed bytes.
+        check(!guest_gpu_write_tracking_active(), "outside-submit mutation has no active ordered journal");
+        constexpr size_t outside_changed = 11 * width * 4 + 3;
+        guest[outside_changed] ^= 0x63;
+        expected[outside_changed] ^= 0x63;
+        const auto outside_guest = guest;
+        std::fill(observed.begin(), observed.end(), 0xccccccccu);
+        const auto before_outside_transfers = prosper::frontend::live_compute_storage_transfer_seeds();
+        renderer_visible = false;
+        const bool outside_ok = prosper::frontend::execute_live_compute_items({normalized_consumer});
+        renderer_visible = true;
+        bool outside_pixels_ok = true;
+        for (size_t i = 0; i < observed.size(); ++i) {
+            const float value = std::bit_cast<float>(observed[i]);
+            outside_pixels_ok &= std::isfinite(value) &&
+                std::abs(value - expected[i] / 255.0f) <= 0.000001f;
+        }
+        check(outside_ok && outside_pixels_ok && guest == outside_guest &&
+                  std::equal(expected.begin(), expected.end(), guest.begin()),
+              "outside-submit sampled fallback sees unnotified guest mutation on every channel");
+        check(prosper::frontend::live_compute_storage_transfer_seeds() == before_outside_transfers,
+              "unnotified guest mutation refuses completed-result transfer outside ordered submit");
+        source_preserved();
+
         // These descriptors overlap guest bytes but differ in extent, so they are
         // independent writable owners rather than one folded alias. A's private
         // completed image cannot represent the final A+B guest composite.

--- a/prosper/tests/gpu/execute/test_storage_rtt_gpu_seed.cpp
+++ b/prosper/tests/gpu/execute/test_storage_rtt_gpu_seed.cpp
@@ -2,6 +2,9 @@
 #include "fixtures/render_runner.h"
 #include "fixtures/spirv_triangle.h"
 #include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/capture/gpu_capture.hpp"
+#include "gpu/texture/tile.hpp"
 #include "shared/live/live_compute.hpp"
 
 #include <algorithm>
@@ -14,7 +17,7 @@
 
 using namespace prosper::gpu;
 namespace {
-constexpr uint32_t width = 64, height = 4, texels = width * height;
+constexpr uint32_t width = 64, height = 16, texels = width * height;
 constexpr uint32_t guest_bytes = texels * 4;
 int failures = 0;
 void check(bool ok, const char* message) {
@@ -52,8 +55,16 @@ enum class Miss { None, Usage, Extent, PixelFormat, NativeFormat, Device, Layout
 } // namespace
 
 int main(int argc, char** argv) {
-    if (argc > 2 || (argc == 2 && std::strcmp(argv[1], "--cpu"))) return 2;
-    const bool cpu_control = argc == 2;
+    if (argc > 2) return 2;
+    const bool cpu_control = argc == 2 && std::strcmp(argv[1], "--cpu") == 0;
+    const bool retention_off = argc == 2 && std::strcmp(argv[1], "--retention-off") == 0;
+    const bool retention_test = retention_off ||
+        (argc == 2 && std::strcmp(argv[1], "--retention") == 0);
+    if (argc == 2 && !cpu_control && !retention_test) return 2;
+    if (retention_off && !std::getenv("PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE")) {
+        std::fprintf(stderr, "--retention-off requires PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE\n");
+        return 2;
+    }
     if (cpu_control && !std::getenv("PROSPER_NO_STANDALONE_RTT_SEED")) {
         std::fprintf(stderr, "--cpu requires PROSPER_NO_STANDALONE_RTT_SEED\n");
         return 2;
@@ -63,6 +74,10 @@ int main(int argc, char** argv) {
     // Reserve a real wider backing for the value-equivalent RGBA16 sampled alias.
     // The writable RGBA8 view only owns the first half; the tail is a bounds guard.
     std::vector<uint8_t> guest(texels * 8, 0xc7), expected(guest_bytes);
+    // The final retention arm needs a real complete tiled allocation plus an
+    // independent tail. Reserve it now so its later resize preserves descriptor addresses.
+    if (retention_test) guest.reserve(tiled_surface_bytes(
+        width, height, static_cast<uint32_t>(TileMode::Sw64KbRX), 0, 4) + guest_bytes);
     auto source = std::make_shared<std::vector<uint8_t>>(texels * 4);
     std::vector<uint32_t> mask(width), observed(texels * 4, 0xccccccccu);
     std::vector<uint32_t> sampled_values(texels * 4, 0xccccccccu);
@@ -149,10 +164,11 @@ int main(int argc, char** argv) {
         for (uint32_t y = 0; y < height; ++y) {
             code.push_back(0x7e0a0280u + y);
             if (sampled_sibling) {
-                code.insert(code.end(), {0xf0000f08u, 0x00040c04u, 0xbf8c3f70u});
+                code.insert(code.end(), {0xf0000f08u, 0x00040c04u, 0xbf8c3f70u,
+                                         0xbe9803ffu, y * width * 16u}); // s24 = output row offset
                 for (uint32_t c = 0; c < 4; ++c)
-                    code.insert(code.end(), {0xe0702000u | (y * width * 16u + c * 4u),
-                                            0x80010004u | ((12u + c) << 8)});
+                    code.insert(code.end(), {0xe0702000u | (c * 4u),
+                                            0x18010004u | ((12u + c) << 8)});
             }
             code.insert(code.end(), {0xf0200f08u, 0x00020004u});
         }
@@ -175,10 +191,13 @@ int main(int argc, char** argv) {
     reader_table.resources = {buffer(observed.data(), observed.size() * 4, 2, 0, 16), sampled};
     std::vector<uint32_t> reader{0x7e080300u};
     for (uint32_t y = 0; y < height; ++y) {
-        reader.insert(reader.end(), {0x7e0a0280u + y, 0xf0000f08u, 0x00020804u, 0xbf8c3f70u});
+        // A full cache-eligible image exceeds MUBUF's 12-bit immediate range.
+        // Keep only the channel in the immediate and the full row offset in s24.
+        reader.insert(reader.end(), {0x7e0a0280u + y, 0xf0000f08u, 0x00020804u, 0xbf8c3f70u,
+                                     0xbe9803ffu, y * width * 16u});
         for (uint32_t c = 0; c < 4; ++c)
-            reader.insert(reader.end(), {0xe0702000u | (y * width * 16u + c * 4u),
-                                        0x80000004u | ((8u + c) << 8)});
+            reader.insert(reader.end(), {0xe0702000u | (c * 4u),
+                                        0x18000004u | ((8u + c) << 8)});
     }
     reader.push_back(0xbf810000u);
     const auto consumer = compile(reader, reader_table, 0x340746702u);
@@ -207,12 +226,15 @@ int main(int argc, char** argv) {
                   address, width, height, VK_FORMAT_R8G8B8A8_UNORM, pixels, error) && pixels == *source,
               "private storage writes preserve every renderer source byte and its usable layout");
     };
-    auto observe_guest = [&] {
+    auto expected_producer = [&] {
         expected = *source;
         constexpr uint8_t written[4]{255, 0, 255, 255};
         for (uint32_t y = 0; y < height; ++y) for (uint32_t x = 0; x < width; ++x)
             if (mask[x]) for (uint32_t c = 0; c < 4; ++c)
                 expected[(y * width + x) * 4 + c] = written[c];
+    };
+    auto observe_guest = [&] {
+        expected_producer();
         check(std::equal(expected.begin(), expected.end(), guest.begin()),
               "every written and untouched guest channel uses the current renderer seed");
         check(std::all_of(guest.begin() + guest_bytes, guest.end(), [](uint8_t byte) { return byte == 0xc7; }),
@@ -310,6 +332,288 @@ int main(int argc, char** argv) {
         }
         check(sampled_ok, "the sampled sibling observes every original renderer channel");
         observe_guest(); source_preserved();
+    }
+    if (retention_test) {
+        // UINT aliases intentionally use a different sampled format in observe_guest().
+        // This observer instead asks for the exact normalized format of the retained
+        // storage result, and reads every channel independently on the GPU.
+        auto normalized_table = reader_table;
+        normalized_table.resources.back().format = DataFormat::Unorm8;
+        auto normalized_consumer = compile(reader, normalized_table, 0x340746720u);
+        normalized_consumer.dispatch_index = 102;
+        normalized_consumer.command_order = 20;
+        auto ordered_producer = producer;
+        ordered_producer.dispatch_index = 101;
+        ordered_producer.command_order = 10;
+        const auto normalized_report = validate_spirv_descriptor_interface(
+            normalized_consumer.spirv, &normalized_table, 0, SpirvShaderStage::Compute, false);
+        const auto* normalized_binding = find_spirv_descriptor_binding(normalized_report, 0, 5);
+        check(normalized_report.ok() && normalized_binding &&
+                  normalized_binding->image_numeric_class == SpirvImageNumericClass::Float,
+              "retention consumer reflects the producer's exact normalized sampled format");
+        check(prosper::frontend::compute_image_cache_default_eligible(
+                  guest_bytes, prosper::frontend::ComputeImageCacheClass::storage) &&
+                  prosper::frontend::compute_image_cache_default_eligible(
+                      guest_bytes, prosper::frontend::ComputeImageCacheClass::sampled),
+              "retention fixture reaches both real image-cache size thresholds");
+        // Each round replaces the renderer source while preserving the same addresses,
+        // shader identities and launch. A cached completed result must never replace
+        // that fresh source during the next storage setup.
+        for (unsigned round = 0; round < 7; ++round) {
+            refresh(60 + round);
+            for (uint32_t x = 0; x < width; ++x)
+                mask[x] = round == 0 ? 0 : round == 2 ? 1 : uint32_t(x % 3 != 0);
+            expected_producer();
+            const bool guest_mutation = round == 4;
+            const bool readback_failure = round == 5;
+            const auto before_guest = guest;
+            const auto before_reads = reads, before_imports = imports;
+            const auto before_publications = publications;
+            const auto before_transfers = prosper::frontend::live_compute_storage_transfer_seeds();
+            unsigned producers = 0, consumers = 0;
+            std::fill(observed.begin(), observed.end(), 0xccccccccu);
+            if (readback_failure) prosper::frontend::live_compute_fail_next_storage_readback_for_test();
+            const auto result = execute_ordered_items(
+                {{SubmitOperationKind::Dispatch, ordered_producer.dispatch_index, 10},
+                 {SubmitOperationKind::Dispatch, normalized_consumer.dispatch_index, 20}},
+                {}, {ordered_producer, normalized_consumer},
+                [](const std::vector<DrawItem>&, uint32_t, uint32_t) { return RenderedFrame{}; },
+                [&](const std::vector<ComputeItem>& items) {
+                    for (const auto& item : items) {
+                        if (item.dispatch_index == ordered_producer.dispatch_index) {
+                            ++producers;
+                            const bool ok = prosper::frontend::execute_live_compute_items({item});
+                            check(ok != readback_failure, "ordered producer reports actual success or injected readback failure");
+                            if (readback_failure) {
+                                check(guest == before_guest && publications == before_publications,
+                                      "failed completed result changes neither guest bytes nor publication");
+                                expected.assign(before_guest.begin(), before_guest.begin() + guest_bytes);
+                            } else {
+                                check(std::equal(expected.begin(), expected.end(), guest.begin()),
+                                      "ordered producer publishes every expected renderer-seeded channel");
+                                if (guest_mutation) {
+                                    // A real intervening write invalidates the submit journal.
+                                    constexpr size_t changed = 13 * width * 4 + 7;
+                                    guest[changed] ^= 0x5a;
+                                    expected[changed] ^= 0x5a;
+                                    notify_guest_gpu_write(address + changed, 1);
+                                }
+                            }
+                            renderer_visible = false;
+                            // Deliberately continue after this *expected* injected failure to
+                            // inspect whether an invalid result was wrongly published. The
+                            // independently asserted producer return remains the failure oracle.
+                        } else {
+                            ++consumers;
+                            check(prosper::frontend::execute_live_compute_items({item}),
+                                  "ordered normalized GPU consumer executes");
+                        }
+                    }
+                    return true;
+                }, 1, 1);
+            renderer_visible = true;
+            check(result.compute_executed && producers == 1 && consumers == 1,
+                  "ordered regression executes exactly one producer then one consumer");
+            check(reads == before_reads && imports == before_imports + 1 && imports == releases,
+                  "retained output never bypasses fresh renderer seed or leaks its source pin");
+            bool pixels_ok = true;
+            for (size_t i = 0; i < observed.size(); ++i) {
+                const float value = std::bit_cast<float>(observed[i]);
+                pixels_ok &= std::isfinite(value) &&
+                    std::abs(value - expected[i] / 255.0f) <= 0.000001f;
+            }
+            check(pixels_ok && std::equal(expected.begin(), expected.end(), guest.begin()),
+                  "retained transfer or fallback preserves all GPU-observed and guest channels");
+            const auto transfers = prosper::frontend::live_compute_storage_transfer_seeds() - before_transfers;
+            const bool should_transfer = !retention_off && !guest_mutation && !readback_failure;
+            check(transfers == uint64_t(should_transfer),
+                  "only valid completed results take exactly one storage-to-sampled GPU transfer");
+            check(std::all_of(guest.begin() + guest_bytes, guest.end(),
+                              [](uint8_t byte) { return byte == 0xc7; }),
+                  "ordered retained result preserves the independent guest tail");
+            source_preserved();
+        }
+        // These descriptors overlap guest bytes but differ in extent, so they are
+        // independent writable owners rather than one folded alias. A's private
+        // completed image cannot represent the final A+B guest composite.
+        // Hosted aliases keep their advertised range disjoint; writeback still
+        // targets A through host_data. Distinct colors also invalidate a prior sampled result.
+        for (bool hosted_alias : {false, true}) {
+            std::fprintf(stderr, "[rtt-retention] owner-overlap hosted=%u\n", unsigned(hosted_alias));
+            refresh(90 + unsigned(hosted_alias));
+            std::vector<uint8_t> advertised(guest_bytes, 0x69);
+            auto overlap_table = table;
+            auto overlap_b = image;
+            overlap_b.binding = 6; overlap_b.sgpr_base = 16;
+            overlap_b.height = height / 2;
+            overlap_b.size = guest_bytes / 2;
+            if (hosted_alias) {
+                overlap_b.gpu_addr = reinterpret_cast<uint64_t>(advertised.data());
+                overlap_b.host_data = guest.data();
+                overlap_b.host_data_size = overlap_b.size;
+                check(overlap_b.gpu_addr + overlap_b.size <= address ||
+                          address + guest_bytes <= overlap_b.gpu_addr,
+                      "hosted output advertises a real disjoint GPU range");
+            }
+            overlap_table.resources.push_back(overlap_b);
+            std::vector<uint32_t> overlap_words{
+                0x7e080300u, 0x7e0002ffu, 0x3f800000u, 0x7e020280u,
+                0x7e0402ffu, 0x3f800000u, 0x7e0602ffu, 0x3f800000u};
+            for (uint32_t y = 0; y < height; ++y)
+                overlap_words.insert(overlap_words.end(), {0x7e0a0280u + y, 0xf0200f08u, 0x00020004u});
+            overlap_words.push_back(0x7e000280u);
+            if (hosted_alias) overlap_words.push_back(0x7e020280u);
+            else overlap_words.insert(overlap_words.end(), {0x7e0202ffu, 0x3f800000u});
+            for (uint32_t y = 0; y < height / 2; ++y)
+                overlap_words.insert(overlap_words.end(), {0x7e0a0280u + y, 0xf0200f08u, 0x00040004u});
+            overlap_words.push_back(0xbf810000u);
+            auto overlap_producer = compile(overlap_words, overlap_table, 0x340746721u);
+            overlap_producer.dispatch_index = ordered_producer.dispatch_index;
+            overlap_producer.command_order = 10;
+            for (uint32_t y = 0; y < height; ++y) for (uint32_t x = 0; x < width; ++x) {
+                const uint8_t color[4]{uint8_t(y < height / 2 ? 0 : 255),
+                                       uint8_t(y < height / 2 && !hosted_alias ? 255 : 0), 255, 255};
+                for (uint32_t c = 0; c < 4; ++c) expected[(y * width + x) * 4 + c] = color[c];
+            }
+            std::fill(observed.begin(), observed.end(), 0xccccccccu);
+            const auto before_overlap_transfers = prosper::frontend::live_compute_storage_transfer_seeds();
+            unsigned overlap_producers = 0, overlap_consumers = 0;
+            const auto overlap_result = execute_ordered_items(
+                {{SubmitOperationKind::Dispatch, overlap_producer.dispatch_index, 10},
+                 {SubmitOperationKind::Dispatch, normalized_consumer.dispatch_index, 20}},
+                {}, {overlap_producer, normalized_consumer},
+                [](const std::vector<DrawItem>&, uint32_t, uint32_t) { return RenderedFrame{}; },
+                [&](const std::vector<ComputeItem>& items) {
+                    for (const auto& item : items) {
+                        const bool is_producer = item.dispatch_index == overlap_producer.dispatch_index;
+                        check(prosper::frontend::execute_live_compute_items({item}),
+                              "independent overlapping output and sampled consumer execute");
+                        if (is_producer) {
+                            ++overlap_producers;
+                            check(std::equal(expected.begin(), expected.end(), guest.begin()),
+                                  "ordinary overlapping writeback publishes B overlap plus A remainder");
+                            renderer_visible = false;
+                        } else ++overlap_consumers;
+                    }
+                    return true;
+                }, 1, 1);
+            renderer_visible = true;
+            bool overlap_pixels_ok = true;
+            for (size_t i = 0; i < observed.size(); ++i) {
+                const float value = std::bit_cast<float>(observed[i]);
+                overlap_pixels_ok &= std::isfinite(value) &&
+                    std::abs(value - expected[i] / 255.0f) <= 0.000001f;
+            }
+            check(overlap_result.compute_executed && overlap_producers == 1 && overlap_consumers == 1 &&
+                      overlap_pixels_ok && std::equal(expected.begin(), expected.end(), guest.begin()),
+                  "GPU sampled observer sees final overlapping composite, never stale private A");
+            check(prosper::frontend::live_compute_storage_transfer_seeds() == before_overlap_transfers,
+                  "independent overlapping storage owner excludes completed-result promotion");
+            check(std::all_of(guest.begin() + guest_bytes, guest.end(),
+                              [](uint8_t byte) { return byte == 0xc7; }),
+                  "overlapping storage views preserve the independent guest tail");
+            check(std::all_of(advertised.begin(), advertised.end(),
+                              [](uint8_t byte) { return byte == 0x69; }),
+                  "hosted write targets the effective backing, never its advertised allocation");
+            source_preserved();
+        }
+
+        // The producer's own metadata reset is another write to guest memory.
+        // With DCC stored inside its base allocation, the private rendered image
+        // represents the pre-reset pixels and must not become a sampled source.
+        for (bool hosted_metadata : {false, true}) {
+            std::fprintf(stderr, "[rtt-retention] metadata-overlap hosted=%u\n", unsigned(hosted_metadata));
+            refresh(93 + unsigned(hosted_metadata));
+            for (uint32_t x = 0; x < width; ++x)
+                mask[x] = !hosted_metadata || x % 3 != 0;
+            expected_producer();
+            auto dcc_table = table;
+            auto& dcc_image = dcc_table.resources.back();
+            dcc_image.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbRX);
+            const size_t dcc_tiled_bytes = tiled_surface_bytes(
+                width, height, dcc_image.tile_mode, 0, 4);
+            dcc_image.size = static_cast<uint32_t>(dcc_tiled_bytes);
+            dcc_image.compression_enabled = true;
+            dcc_image.write_compress_enabled = true;
+            dcc_image.meta_pipe_aligned = true;
+            std::vector<uint8_t> advertised_metadata(dcc_tiled_bytes, 0x69);
+            dcc_image.metadata_addr = hosted_metadata
+                ? reinterpret_cast<uint64_t>(advertised_metadata.data()) : address;
+            const uint64_t metadata_bytes = gpu_capture_dcc_metadata_footprint(dcc_image);
+            const bool bounded_metadata = metadata_bytes && metadata_bytes <= dcc_tiled_bytes;
+            check(bounded_metadata, "production DCC footprint fits the real aliased base allocation");
+            if (bounded_metadata) {
+                dcc_image.dcc_metadata_size = metadata_bytes;
+                if (hosted_metadata) {
+                    dcc_image.dcc_metadata_host_data = guest.data();
+                    dcc_image.dcc_metadata_host_data_size = metadata_bytes;
+                    check(dcc_image.metadata_addr + metadata_bytes <= address ||
+                              address + dcc_tiled_bytes <= dcc_image.metadata_addr,
+                          "hosted DCC advertises a real disjoint metadata range");
+                }
+                guest.resize(dcc_tiled_bytes + guest_bytes, 0xc7);
+                check(reinterpret_cast<uint64_t>(guest.data()) == address,
+                      "DCC fixture resizing retains all resource and renderer addresses");
+                std::vector<uint8_t> expected_tiled(guest.size(), 0xc7);
+                tile_surface(expected_tiled.data(), expected.data(), width, height,
+                             dcc_image.tile_mode, 0, 4);
+                std::fill_n(expected_tiled.begin(), static_cast<size_t>(metadata_bytes), uint8_t{0xff});
+                std::vector<uint8_t> expected_reset(guest_bytes);
+                detile_surface(expected_reset.data(), expected_tiled.data(), width, height,
+                               dcc_image.tile_mode, 0, 4);
+                check(expected_reset != expected,
+                      "own metadata reset changes visible texels and distinguishes stale private output");
+                auto dcc_producer = compile(writer_words(false), dcc_table, 0x340746722u);
+                dcc_producer.dispatch_index = ordered_producer.dispatch_index;
+                dcc_producer.command_order = 10;
+                auto dcc_reader_table = normalized_table;
+                dcc_reader_table.resources.back().tile_mode = dcc_image.tile_mode;
+                dcc_reader_table.resources.back().size = dcc_image.size;
+                auto dcc_consumer = compile(reader, dcc_reader_table, 0x340746723u);
+                dcc_consumer.dispatch_index = normalized_consumer.dispatch_index;
+                dcc_consumer.command_order = 20;
+                std::fill(observed.begin(), observed.end(), 0xccccccccu);
+                const auto before_dcc_transfers = prosper::frontend::live_compute_storage_transfer_seeds();
+                const auto before_dcc_reads = reads, before_dcc_imports = imports;
+                unsigned dcc_producers = 0, dcc_consumers = 0;
+                const auto dcc_result = execute_ordered_items(
+                    {{SubmitOperationKind::Dispatch, dcc_producer.dispatch_index, 10},
+                     {SubmitOperationKind::Dispatch, dcc_consumer.dispatch_index, 20}},
+                    {}, {dcc_producer, dcc_consumer},
+                    [](const std::vector<DrawItem>&, uint32_t, uint32_t) { return RenderedFrame{}; },
+                    [&](const std::vector<ComputeItem>& items) {
+                        for (const auto& item : items) {
+                            check(prosper::frontend::execute_live_compute_items({item}),
+                                  "own-DCC-overlap producer and sampled observer execute");
+                            if (item.dispatch_index == dcc_producer.dispatch_index) {
+                                ++dcc_producers;
+                                check(guest == expected_tiled,
+                                      "real image writeback then metadata reset preserves every expected tiled byte");
+                                renderer_visible = false;
+                            } else ++dcc_consumers;
+                        }
+                        return true;
+                    }, 1, 1);
+                renderer_visible = true;
+                bool reset_pixels_ok = true;
+                for (size_t i = 0; i < observed.size(); ++i) {
+                    const float value = std::bit_cast<float>(observed[i]);
+                    reset_pixels_ok &= std::isfinite(value) &&
+                        std::abs(value - expected_reset[i] / 255.0f) <= 0.000001f;
+                }
+                check(dcc_result.compute_executed && dcc_producers == 1 && dcc_consumers == 1 &&
+                          reset_pixels_ok && guest == expected_tiled,
+                      "normalized GPU observer sees actual metadata-reset pixels and the complete guest tail");
+                check(reads == before_dcc_reads && imports == before_dcc_imports + 1 && imports == releases,
+                      "DCC overlap case takes exact renderer seeding and releases its real source pin");
+                check(prosper::frontend::live_compute_storage_transfer_seeds() == before_dcc_transfers,
+                      "own overlapping DCC metadata reset excludes completed-result retention");
+                check(std::all_of(advertised_metadata.begin(), advertised_metadata.end(),
+                                  [](uint8_t byte) { return byte == 0x69; }),
+                      "hosted reset targets the effective DCC backing, never its advertised allocation");
+                source_preserved();
+            }
+        }
     }
     set_guest_gpu_write_observer({});
     set_live_target_image_importer({}, {});


### PR DESCRIPTION
Renderer-owned native RGBA8 compute results were discarded after guest writeback, forcing a later sampled consumer to detile and upload them again. Retain eligible completed images under the existing budget for validated storage-to-sampled transfers. Every renderer-owned producer still seeds from its current renderer image.

These new results authorize compute transfer only. Linux uses ordered-journal authority and otherwise falls back; Windows retains its exact guest mirror. Excluding graphics export avoids repeatedly rebuilding page-watch registrations. Overlapping guest/host image writes and DCC resets decline retention; failure, pin and layout contracts remain enforced. No title or shader identity selects behavior.

In the matched Sonic captures, the producer/consumer pair fell **14.477→7.285 ms** and sampled-image preparation **5.356→0.005 ms**. Guest/host presentations were 7.171→7.368/s in this pair; newly rendered FPS is unavailable. Both screenshots retain the known black-world/HUD problem. GTA remained at about 6.18 presentations/s with matching bank geometry, lighting and HUD in the inspected checkpoints. This is a measured component improvement, not a library-wide speedup or rendering/audio fix.

Validation on `00e3b499263ce4c1a986482e0b62ab12f19a2717`: **438 tests passed**, plus **37 Vulkan core/synchronization tests with zero messages**, empty allowlist and positive controls. Identical-object old-backend controls detect missing transfers and unwanted graphics export. Mutation controls expose actual stale GPU pixels for independent image/DCC overlaps, including host aliases. The fixture also checks fresh renderer inputs, guest mutation, failure/retry, full guest tails and unnotified CPU writes outside the ordered journal. NVIDIA hardware and Windows runtime were not exercised locally.

The final main integration adds only offline shader tools and a Python test; runtime sources/build flags match the explicitly labelled 4e game captures.

Refs #3407. The broader overlapping-publication issue #3476 remains open. Detailed validation and capture evidence are in the PR comments.
