### PR TITLE
fix(gpu): preserve authority across overlapping output writebacks

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3120,6 +3120,27 @@ if(TARGET prosper_core)
       target_link_libraries(test_renderer_uint_copy PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
       add_test(NAME renderer_uint_copy COMMAND test_renderer_uint_copy)
 
+      add_executable(test_storage_output_conflicts tests/gpu/execute/test_storage_output_conflicts.cpp)
+      target_include_directories(test_storage_output_conflicts PRIVATE tests frontends)
+      target_link_libraries(test_storage_output_conflicts PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
+      add_test(NAME storage_output_conflicts COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts>)
+      add_test(NAME storage_output_conflicts_unjournaled COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts> --unjournaled)
+      add_test(NAME storage_output_conflicts_overflow COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts> --overflow)
+      add_test(NAME storage_output_conflicts_submit_failure COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1
+               $<TARGET_FILE:test_storage_output_conflicts> --submit-failure)
+      if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_test(NAME storage_output_conflicts_watched COMMAND ${CMAKE_COMMAND} -E env
+                 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1
+                 $<TARGET_FILE:test_storage_output_conflicts> --watched)
+        set_tests_properties(storage_output_conflicts_watched PROPERTIES TIMEOUT 60)
+      endif()
+      set_tests_properties(storage_output_conflicts storage_output_conflicts_unjournaled
+                           storage_output_conflicts_overflow storage_output_conflicts_submit_failure PROPERTIES TIMEOUT 60)
+
       add_executable(test_storage_readonly tests/gpu/execute/test_storage_readonly.cpp)
       target_include_directories(test_storage_readonly PRIVATE tests frontends)
       target_link_libraries(test_storage_readonly PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3124,17 +3124,17 @@ if(TARGET prosper_core)
       target_include_directories(test_storage_output_conflicts PRIVATE tests frontends)
       target_link_libraries(test_storage_output_conflicts PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
       add_test(NAME storage_output_conflicts COMMAND ${CMAKE_COMMAND} -E env
-               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts>)
+               PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts>)
       add_test(NAME storage_output_conflicts_unjournaled COMMAND ${CMAKE_COMMAND} -E env
-               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts> --unjournaled)
+               PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts> --unjournaled)
       add_test(NAME storage_output_conflicts_overflow COMMAND ${CMAKE_COMMAND} -E env
-               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts> --overflow)
+               PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB=1 $<TARGET_FILE:test_storage_output_conflicts> --overflow)
       add_test(NAME storage_output_conflicts_submit_failure COMMAND ${CMAKE_COMMAND} -E env
-               PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1
+               PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1
                $<TARGET_FILE:test_storage_output_conflicts> --submit-failure)
       if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_test(NAME storage_output_conflicts_watched COMMAND ${CMAKE_COMMAND} -E env
-                 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1
+                 PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1
                  $<TARGET_FILE:test_storage_output_conflicts> --watched)
         set_tests_properties(storage_output_conflicts_watched PROPERTIES TIMEOUT 60)
       endif()

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -168,6 +168,35 @@ advertised addresses alone. Publication waits for all writebacks, and guest muta
 consumer authority. Existing budget and pin rules apply; failure invalidates retained authority.
 The control `PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE=1` restores transient result ownership.
 
+### Overlapping synchronous outputs
+
+Distinct Vulkan images can describe overlapping guest bytes without being exact aliases. Their
+synchronous writebacks form an ordered composite: a retained private image may therefore be stale
+before final publication. A fresh journal snapshot, rearmed watch or late Windows mirror does not
+prove that the private image contains that composite (#3476).
+
+The completed output plan compares advertised and effective host ranges for independent images,
+writable buffers and DCC resets, including self-overlapping metadata. Conflicting images revoke
+source and consumer authority before recording, keep their allocations and existing pins, and use
+ordinary writeback without result-equality shortcuts or final cache publication. Independent
+conflicting buffers likewise decline GPU result-equality skipping; their CPU fallback compares the
+current destination at its own writeback turn. Exact folded aliases still have one output owner.
+
+Hosted outputs notify both their advertised architectural range and the actual destination. This
+also invalidates views absent from the current dispatch; checking only currently bound owners would
+miss them. Host-write watch preparation precedes mutations, including DCC resets. CPU fill preserves
+the declared architectural notification while bounding the separate hosted notification to the
+actual written extent.
+
+`storage_output_conflicts` drives the production Vulkan backend with full guest-byte and dependent
+sampled-image-to-SSBO oracles. It covers cold and prewarmed CPU/GPU results, distinct and folded
+aliases, effective hosted overlap, DCC metadata against another image and itself, buffer/image and
+buffer/buffer writebacks, and outstanding graphics leases. Companion cases exercise absent and
+overflowed journals, failed submission and Linux registered page watches across submit boundaries.
+Safe heap-backed imports may decline on Linux without journal authority; Windows may validate its
+exact mirror. These fixtures establish the ownership contract, not a diagnosis of a game's pixels
+or a performance improvement.
+
 ### Write-watch alias protection
 
 Storage-result and texture caches may reuse a physical-page watch while other registrations still

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -162,9 +162,9 @@ existing validated storage-to-sampled transfer path. This promotion does not aut
 exports: in the measured workload, repeated page-watch registration outweighed the conversion saving.
 Linux consumers without ordered-journal authority fall back to guest preparation; Windows retains
 its existing exact guest mirror. This does not
-authorize input reuse by a later renderer-owned producer. Retention refuses overlapping writes from
-independent image owners or any metadata reset, using effective host/guest destinations rather than
-advertised addresses alone. Publication waits for all writebacks, and guest mutation still invalidates
+authorize input reuse by a later renderer-owned producer. Retention refuses later overlapping writes from
+independent image owners and self-overlapping metadata resets, using effective host/guest destinations
+rather than advertised addresses alone. Publication waits for all writebacks, and guest mutation still invalidates
 consumer authority. Existing budget and pin rules apply; failure invalidates retained authority.
 The control `PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE=1` restores transient result ownership.
 
@@ -175,12 +175,17 @@ synchronous writebacks form an ordered composite: a retained private image may t
 before final publication. A fresh journal snapshot, rearmed watch or late Windows mirror does not
 prove that the private image contains that composite (#3476).
 
-The completed output plan compares advertised and effective host ranges for independent images,
-writable buffers and DCC resets, including self-overlapping metadata. Conflicting images revoke
-source and consumer authority before recording, keep their allocations and existing pins, and use
-ordinary writeback without result-equality shortcuts or final cache publication. Independent
-conflicting buffers likewise decline GPU result-equality skipping; their CPU fallback compares the
-current destination at its own writeback turn. Exact folded aliases still have one output owner.
+The completed output plan compares advertised and effective host ranges in writeback order: all
+unique buffers, then each unique image's pixels and DCC reset. Earlier writes to either pixels or
+metadata disable setup-time result-equality shortcuts. Later writes to either dependency, and a reset
+overlapping its own pixels, revoke image source/consumer authority before recording and prevent final
+retention/publication. Allocations and pins remain intact. A last writer may restore its full result
+and retain it normally. Buffer GPU equality likewise requires no overlapping earlier buffer write;
+its CPU fallback compares the current destination at its own turn. Exact folded aliases have one owner.
+
+Input-only images retain before guest writeback. Subsequent pixel notifications invalidate their
+original snapshots without discarding safe input reuse up front. Metadata-only overlap requires an
+explicit retention veto because pixel watches and snapshots do not cover metadata interpretation.
 
 Hosted guest outputs notify both their advertised architectural range and the actual destination.
 Zero-address internal backing, such as GDS, remains outside guest publication and conflict checks. This
@@ -190,7 +195,7 @@ the declared architectural notification while bounding the separate hosted notif
 actual written extent.
 
 `storage_output_conflicts` drives the production Vulkan backend with full guest-byte and dependent
-sampled-image-to-SSBO oracles. It covers cold and prewarmed CPU/GPU results, distinct and folded
+sampled-image-to-SSBO oracles. It covers cold and prewarmed CPU/GPU results, last-writer reuse, warm metadata resets, distinct and folded
 aliases, effective hosted overlap, DCC metadata against another image and itself, buffer/image and
 buffer/buffer writebacks, and outstanding graphics leases. Companion cases exercise absent and
 overflowed journals, failed submission and Linux registered page watches across submit boundaries.

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -182,7 +182,8 @@ ordinary writeback without result-equality shortcuts or final cache publication.
 conflicting buffers likewise decline GPU result-equality skipping; their CPU fallback compares the
 current destination at its own writeback turn. Exact folded aliases still have one output owner.
 
-Hosted outputs notify both their advertised architectural range and the actual destination. This
+Hosted guest outputs notify both their advertised architectural range and the actual destination.
+Zero-address internal backing, such as GDS, remains outside guest publication and conflict checks. This
 also invalidates views absent from the current dispatch; checking only currently bound owners would
 miss them. Host-write watch preparation precedes mutations, including DCC resets. CPU fill preserves
 the declared architectural notification while bounding the separate hosted notification to the

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -129,6 +129,20 @@ writeback obligation and actual staging bytes for each unique materialized stora
 comparison later finds an identical result. These are preparation records, not completion or timing
 measurements. Join submit/dispatch/order/program identity with completed dispatch records.
 
+## Overlapping output authority
+
+An allocation pin proves lifetime, not current guest content. Independent output owners can write
+an overlapping composite, so setup-time validation cannot authorize a later identical-result skip.
+Build the complete output conflict plan before recording. Include effective hosted destinations,
+writable buffers and metadata resets, including self-overlap. Revoke conflicting image source and
+consumer authority without releasing handles or pins; failed completion deliberately skips cleanup.
+Do not refresh that authority during final publication. Buffer GPU comparisons also require disjoint
+independent output owners; their ordinary CPU fallback checks current destination bytes.
+
+Notify actual hosted destinations as well as advertised architectural ranges, including for cached
+views absent from a dispatch. Prepare page watches before every actual mutation. The production
+`storage_output_conflicts` tests and companion journal/failure/watch cases guard this contract.
+
 ## Untouched storage pixels
 
 A previous dispatch's coverage cannot authorize discarding current inputs. Native images retain

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -131,13 +131,20 @@ measurements. Join submit/dispatch/order/program identity with completed dispatc
 
 ## Overlapping output authority
 
-An allocation pin proves lifetime, not current guest content. Independent output owners can write
-an overlapping composite, so setup-time validation cannot authorize a later identical-result skip.
-Build the complete output conflict plan before recording. Include effective hosted destinations,
-writable buffers and metadata resets, including self-overlap. Revoke conflicting image source and
-consumer authority without releasing handles or pins; failed completion deliberately skips cleanup.
-Do not refresh that authority during final publication. Buffer GPU comparisons also require disjoint
-independent output owners; their ordinary CPU fallback checks current destination bytes.
+An allocation pin proves lifetime, not current guest content. Build the complete output plan before
+recording, following actual writeback order: all unique buffers, then each unique image's pixels and
+DCC reset. Earlier pixel or metadata writes veto setup-time equality skips. Later writes to either
+dependency, and a reset overlapping its own pixels, veto final retention/publication and revoke
+source/consumer authority before recording without releasing handles or pins. Failed completion
+skips cleanup. Earlier-only image conflicts keep their source proof; ordinary pre-submit export
+revocation and successful writeback govern their next publication. The final writer may retain its
+complete result. Buffer GPU comparisons require no earlier overlapping buffer; their CPU fallback
+checks current destination bytes.
+
+Input-only retention precedes guest writeback, so later pixel notifications invalidate its original
+snapshots naturally. Metadata-only writes require an explicit retention veto because pixel authority
+does not cover interpretation metadata. Keep sampled metadata dependencies separate from storage
+metadata reset obligations. Include effective hosted and advertised ranges, and fold exact aliases.
 
 Zero-address internal backing (such as GDS) is not an architectural guest output.
 Notify actual hosted guest destinations as well as advertised architectural ranges, including for cached
@@ -172,8 +179,8 @@ export or create its page watch: Linux uses the ordered journal and declines out
 Windows retains its exact guest mirror. Ordinary graphics preparation remains the fallback. Input cache
 reuse remains excluded for renderer owners: their next dispatch acquires the current renderer image.
 Retain only after ordinary guest/DCC writeback; publish authority only after every writeback succeeds.
-Refuse a result if another independent storage owner's effective writeback destination or any DCC
-reset overlaps its guest bytes, including host backing and its own metadata. Exact folded aliases
+Refuse a result if a later independent output changes its pixels or interpretation metadata, or its
+own metadata reset changes its pixels. Include effective host backing and advertised ranges. Exact folded aliases
 share one owner. Pinned replacement refusal and failure invalidation retain their existing contracts.
 No separate comparison baseline is created for this consumer source. The control
 `PROSPER_NO_RENDERER_SEEDED_RESULT_CACHE=1` disables this promotion; F8 writeback rows report

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -139,7 +139,8 @@ consumer authority without releasing handles or pins; failed completion delibera
 Do not refresh that authority during final publication. Buffer GPU comparisons also require disjoint
 independent output owners; their ordinary CPU fallback checks current destination bytes.
 
-Notify actual hosted destinations as well as advertised architectural ranges, including for cached
+Zero-address internal backing (such as GDS) is not an architectural guest output.
+Notify actual hosted guest destinations as well as advertised architectural ranges, including for cached
 views absent from a dispatch. Prepare page watches before every actual mutation. The production
 `storage_output_conflicts` tests and companion journal/failure/watch cases guard this contract.
 

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3427,6 +3427,21 @@ struct BorrowedComputeImageLease {
     }
 };
 
+// Hosted/replay resources can write a different live allocation than their advertised range.
+// Both identities matter to renderer aliases and to the ordered journal, including cached views
+// absent from this dispatch. Do not duplicate the normal guest-backed notification.
+void notify_output_write(uint64_t advertised, const void* destination, uint64_t bytes,
+                         bool preserving_bytes = false) {
+    const auto notify = [&](uint64_t address) {
+        if (!address || !bytes) return;
+        if (preserving_bytes) prosper::gpu::notify_guest_gpu_write_preserving_bytes(address, bytes);
+        else prosper::gpu::notify_guest_gpu_write(address, bytes);
+    };
+    notify(advertised);
+    const uint64_t effective = reinterpret_cast<uintptr_t>(destination);
+    if (effective != advertised) notify(effective);
+}
+
 struct BoundBuffer {
     const prosper::gpu::ShaderResource* resource = nullptr;
     size_t descriptor_index = SIZE_MAX; // reflected binding that owns this flattened table entry
@@ -3435,6 +3450,7 @@ struct BoundBuffer {
     size_t alias_of = SIZE_MAX;         // exact guest range sharing an earlier storage buffer
     size_t bytes = 0;                   // Vulkan buffer bytes (may be a detiled image view)
     size_t guest_bytes = 0;             // physical guest backing (may exceed logical image bytes)
+    bool output_conflict = false;       // independent buffer writeback can overwrite this range
     bool writable = false;              // reflected OpStore/writing-atomic reachability
     bool atomic_image = false;           // R32_UINT StorageImage exposed as a linear atomic SSBO
     uint32_t atomic_layers = 1;          // #2265: array layers staged for that view (1 when plain 2D)
@@ -3485,6 +3501,7 @@ struct BoundImage {
     GpuRetileParameters retile_parameters{};
     bool storage = false;               // descriptor/representation, independent of access
     bool storage_writeback = false;     // whole-alias output obligation, conservatively proven
+    bool output_conflict = false;       // another effective output can overwrite this guest view
     bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
     bool native_uint_storage = false;   // exact guest-width integer texels
     bool packed_r11_storage = false;    // shader packs exact R11G11B10 words into typed R32_UINT
@@ -5354,8 +5371,8 @@ std::optional<bool> execute_cpu_broadcast_fill(const prosper::gpu::ComputeItem& 
 
     notify_compute_authority_boundary({ComputeAuthorityBoundaryKind::Compute,
         item.submit_no, item.command_order, target->gpu_addr, bytes, true});
-    if (!target->host_data)
-        prosper::host::guest_write_watch_notify_host_write(target->gpu_addr, static_cast<size_t>(bytes));
+    prosper::host::guest_write_watch_notify_host_write(
+        reinterpret_cast<uintptr_t>(destination), static_cast<size_t>(bytes));
     if (!value) {
         std::memset(destination, 0, static_cast<size_t>(bytes));
     } else {
@@ -5366,7 +5383,7 @@ std::optional<bool> execute_cpu_broadcast_fill(const prosper::gpu::ComputeItem& 
     // suppress invalidation of renderer-owned depth written earlier in the same present.
     const char* previous_origin = guest_gpu_write_origin();
     set_guest_gpu_write_origin("compute-writeback(cpu-broadcast)");
-    notify_guest_gpu_write(target->gpu_addr, bytes);
+    notify_output_write(target->gpu_addr, destination, bytes);
     set_guest_gpu_write_origin(previous_origin);
     if (!target->host_data && writer_provenance_enabled())
         record_guest_write(GuestWriterKind::ComputeBuffer, target->gpu_addr, bytes,
@@ -5433,9 +5450,8 @@ std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item)
         item.submit_no, item.command_order, resource->gpu_addr, written_bytes,
         authority_range_known});
 
-    if (!resource->host_data && resource->gpu_addr)
-        prosper::host::guest_write_watch_notify_host_write(
-            resource->gpu_addr, static_cast<size_t>(written_bytes));
+    prosper::host::guest_write_watch_notify_host_write(
+        reinterpret_cast<uintptr_t>(destination), static_cast<size_t>(written_bytes));
     const uint32_t pattern[4] = {
         item.user_sgprs[4], item.user_sgprs[5], item.user_sgprs[6], item.user_sgprs[7]};
     const bool zero_fill = !(pattern[0] | pattern[1] | pattern[2] | pattern[3]);
@@ -5459,9 +5475,14 @@ std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item)
     }
     // Match the Vulkan path's conservative invalidation contract: padding beyond the exact launch
     // remains untouched, but every alias of the declared resource must be considered stale.
-    if (resource->gpu_addr) {
+    if (resource->gpu_addr || resource->host_data) {
         prosper::gpu::set_guest_gpu_write_origin("compute-writeback(cpu-fill)");
-        prosper::gpu::notify_guest_gpu_write(resource->gpu_addr, resource->size);
+        if (resource->gpu_addr)
+            prosper::gpu::notify_guest_gpu_write(resource->gpu_addr, resource->size);
+        // Hosted storage can be bounded by the launch rather than the declared descriptor size.
+        if (reinterpret_cast<uintptr_t>(destination) != resource->gpu_addr)
+            prosper::gpu::notify_guest_gpu_write(
+                reinterpret_cast<uintptr_t>(destination), written_bytes);
         prosper::gpu::set_guest_gpu_write_origin(nullptr);
     }
     if (!resource->host_data && prosper::gpu::writer_provenance_enabled())
@@ -9397,38 +9418,80 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
         }
 
-        // Final cache publication runs after all image writebacks. A different Vulkan image can
-        // describe overlapping guest bytes without folding into this exact alias owner. Its
-        // writeback (or even our own overlapping DCC metadata reset) would make this private image
-        // stale before publication. Keep this result transient rather than refreshing authority
-        // over somebody else's pixels. Use the completed whole-alias output plan, including
-        // ordinary fallback for modules whose image-write provenance is incomplete.
-        // Compare effective destinations: replay host backing may alias guest pixels even when
-        // the advertised guest addresses differ. This candidate itself is always guest-backed.
-        for (auto& image : images) {
-            if (!image.renderer_seeded_result_candidate) continue;
-            const uint64_t address = image.resource->gpu_addr;
-            if (!address || !image.guest_bytes || image.guest_bytes > UINT64_MAX - address) {
-                image.renderer_seeded_result_candidate = false;
-                continue;
+        // Distinct Vulkan owners can write overlapping architectural bytes. Setup-time input
+        // validation then cannot authorize a later identical-result skip, and final publication
+        // must not rearm a watch or move a journal snapshot over those intervening writes. Include
+        // sampled/read-only inputs and effective replay backing, not just advertised guest ranges.
+        const auto ranges_conflict = [](uint64_t a, uint64_t an, uint64_t b, uint64_t bn) {
+            if (!an || !bn) return false;
+            if (!a || !b || an > UINT64_MAX - a || bn > UINT64_MAX - b) return true;
+            return a < b + bn && b < a + an;
+        };
+        for (auto& buffer : buffers) {
+            if (!buffer.writable || buffer.alias_of != SIZE_MAX || !buffer.resource) continue;
+            const uint64_t guest = buffer.resource->gpu_addr;
+            const uint64_t effective = reinterpret_cast<uintptr_t>(
+                resource_bytes_for(buffer.resource, buffer.guest_bytes));
+            for (const auto& other : buffers) {
+                if (&other == &buffer || !other.writable || other.alias_of != SIZE_MAX ||
+                    !other.resource) continue;
+                const uint64_t other_effective = reinterpret_cast<uintptr_t>(
+                    resource_bytes_for(other.resource, other.guest_bytes));
+                if (ranges_conflict(guest, buffer.guest_bytes, other.resource->gpu_addr, other.guest_bytes) ||
+                    ranges_conflict(effective, buffer.guest_bytes, other.resource->gpu_addr, other.guest_bytes) ||
+                    ranges_conflict(guest, buffer.guest_bytes, other_effective, other.guest_bytes) ||
+                    ranges_conflict(effective, buffer.guest_bytes, other_effective, other.guest_bytes)) {
+                    buffer.output_conflict = true;
+                    break;
+                }
             }
-            const auto overlaps_or_invalid = [&](uint64_t other, uint64_t bytes) {
-                if (!bytes) return false;
-                if (!other || bytes > UINT64_MAX - other) return true;
-                return address < other + bytes && other < address + image.guest_bytes;
+        }
+        for (auto& image : images) {
+            if (image.alias_of != SIZE_MAX || !image.resource) continue;
+            const uint64_t guest = image.resource->gpu_addr;
+            const uint64_t effective = reinterpret_cast<uintptr_t>(
+                resource_bytes_for(image.resource, image.guest_bytes));
+            const auto conflicts = [&](uint64_t address, uint64_t bytes) {
+                return ranges_conflict(guest, image.guest_bytes, address, bytes) ||
+                       ranges_conflict(effective, image.guest_bytes, address, bytes);
             };
             for (const auto& other : images) {
                 if (!other.storage_writeback || other.alias_of != SIZE_MAX || !other.resource) continue;
                 if ((&other != &image &&
-                     (overlaps_or_invalid(other.resource->gpu_addr, other.guest_bytes) ||
-                      overlaps_or_invalid(reinterpret_cast<uintptr_t>(resource_bytes_for(
+                     (conflicts(other.resource->gpu_addr, other.guest_bytes) ||
+                      conflicts(reinterpret_cast<uintptr_t>(resource_bytes_for(
                           other.resource, other.guest_bytes)), other.guest_bytes))) ||
-                    overlaps_or_invalid(other.resource->metadata_addr, other.dcc_metadata_bytes) ||
-                    overlaps_or_invalid(reinterpret_cast<uintptr_t>(other.dcc_metadata),
-                                        other.dcc_metadata_bytes)) {
-                    image.renderer_seeded_result_candidate = false;
+                    conflicts(other.resource->metadata_addr, other.dcc_metadata_bytes) ||
+                    conflicts(reinterpret_cast<uintptr_t>(other.dcc_metadata), other.dcc_metadata_bytes)) {
+                    image.output_conflict = true;
                     break;
                 }
+            }
+            for (const auto& buffer : buffers) {
+                if (!buffer.writable || buffer.alias_of != SIZE_MAX || !buffer.resource) continue;
+                if (conflicts(buffer.resource->gpu_addr, buffer.guest_bytes) ||
+                    conflicts(reinterpret_cast<uintptr_t>(resource_bytes_for(
+                        buffer.resource, buffer.guest_bytes)), buffer.guest_bytes)) {
+                    image.output_conflict = true;
+                    break;
+                }
+            }
+            if (image.output_conflict) {
+                // Revoke before recording: resource cleanup is deliberately skipped when GPU
+                // completion is unproven, but graphics must not borrow conflicted authority then.
+                // These calls preserve every allocation, comparison handle and outstanding pin.
+                ctx.invalidate_cached_image_source(image.cache_key);
+                if (image.compute_transfer_seed_borrowed)
+                    ctx.invalidate_cached_image_source(image.compute_transfer_seed_key);
+                image.renderer_seeded_result_candidate = false;
+                image.post_writeback_promotion_candidate = false;
+                if (image_timing)
+                    std::fprintf(stderr,
+                        "[compute-output-conflict] submit=%llu dispatch=%llu order=%llu "
+                        "binding=%u storage=%u writeback=%u bytes=%zu\n",
+                        (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
+                        (unsigned long long)item.command_order, image.binding,
+                        image.storage ? 1u : 0u, image.storage_writeback ? 1u : 0u, image.guest_bytes);
             }
         }
 
@@ -9755,7 +9818,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         std::vector<CompareTarget> compare_targets;
         for (BoundBuffer& buffer : buffers) {
             buffer.timing.gpu_compare = "ineligible";
-            if (buffer.alias_of == SIZE_MAX && buffer.writable && buffer.persistent &&
+            if (buffer.alias_of == SIZE_MAX && buffer.writable && !buffer.output_conflict &&
+                buffer.persistent &&
                 buffer.upload_skipped && buffer.result_baseline && buffer.resource->size &&
                 !(buffer.resource->size & 15u)) {
                 buffer.timing.gpu_compare = "eligible";
@@ -9766,8 +9830,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         for (size_t i = 0; i < images.size(); ++i) {
             BoundImage& image = images[i];
-            if (image.storage_writeback && image.cache_candidate && image.persistent &&
-                image.upload_skipped &&
+            if (image.storage_writeback && !image.output_conflict &&
+                image.cache_candidate && image.persistent && image.upload_skipped &&
                 image.result_baseline && image.exact_result_bytes &&
                 image.exact_result_bytes <= max_gpu_compare_image_bytes() &&
                 !(image.exact_result_bytes & 15u) && staging[i])
@@ -10758,8 +10822,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
         // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
         for (BoundImage& image : images) {
-            if (image.storage_writeback || image.imported || image.alias_of != SIZE_MAX ||
-                !image.cache_candidate)
+            if (image.storage_writeback || image.output_conflict || image.imported ||
+                image.alias_of != SIZE_MAX || !image.cache_candidate)
                 continue;
             // When this dispatch samples and writes the same guest view through distinct bindings,
             // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
@@ -10814,7 +10878,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // validation independently proved that the guest mirror still contains that baseline.
             // Preserve architectural write notification, but avoid mapping and scanning the whole
             // host-visible buffer merely to rediscover equality.
-            if (buffer.gpu_result_unchanged) {
+            if (!buffer.output_conflict && buffer.gpu_result_unchanged) {
                 timing.writeback = "gpu-unchanged";
                 g_buffer_gpu_result_skips.fetch_add(1, std::memory_order_relaxed);
                 if (trace)
@@ -10824,10 +10888,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  buffer.resource->binding,
                                  (unsigned long long)buffer.resource->gpu_addr,
                                  buffer.resource->size);
-                if (buffer.resource->gpu_addr) {
+                if (buffer.resource->gpu_addr || buffer.resource->host_data) {
                     ComputeBufferCostScope cost(timing.enabled, timing.notify_ms);
-                    notify_guest_gpu_write_preserving_bytes(
-                        buffer.resource->gpu_addr, buffer.resource->size);
+                    notify_output_write(buffer.resource->gpu_addr,
+                        resource_bytes_for(buffer.resource, buffer.guest_bytes),
+                        buffer.resource->size, true);
                 }
                 if (buffer.persistent) {
                     ComputeBufferCostScope cost(timing.enabled, timing.source_validation_ms);
@@ -10865,10 +10930,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     for (size_t i = 0; i < buffer.bytes; ++i)
                         buffer.changed_bytes += buffer.linear_seed[i] != result[i];
                 }
-                if (!buffer.resource->host_data && buffer.resource->gpu_addr) {
+                {
                     ComputeBufferCostScope cost(timing.enabled, timing.result_watch_ms);
                     prosper::host::guest_write_watch_notify_host_write(
-                        buffer.resource->gpu_addr, buffer.guest_bytes);
+                        reinterpret_cast<uintptr_t>(destination), buffer.guest_bytes);
                 }
                 // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
                 const size_t layer_linear_bytes =
@@ -10895,10 +10960,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     ComputeBufferCostScope cost(timing.enabled, timing.result_map_ms);
                     ctx.unmap_memory(buffer.memory);
                 }
-                if (buffer.resource->gpu_addr) {
+                if (buffer.resource->gpu_addr || buffer.resource->host_data) {
                     ComputeBufferCostScope cost(timing.enabled, timing.notify_ms);
                     set_guest_gpu_write_origin("compute-writeback(buffer-guest-bytes)");
-                    notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
+                    notify_output_write(buffer.resource->gpu_addr, destination, buffer.guest_bytes);
                     set_guest_gpu_write_origin(nullptr);
                 }
                 if (!buffer.resource->host_data && writer_provenance_enabled()) {
@@ -10989,10 +11054,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // invalidation and writer provenance remain unconditional: renderer-resident state can
             // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
             if (changed) {
-                if (!buffer.resource->host_data && buffer.resource->gpu_addr) {
+                {
                     ComputeBufferCostScope cost(timing.enabled, timing.result_watch_ms);
                     prosper::host::guest_write_watch_notify_host_write(
-                        buffer.resource->gpu_addr, buffer.resource->size);
+                        reinterpret_cast<uintptr_t>(destination), buffer.resource->size);
                 }
                 {
                     ComputeBufferCostScope cost(timing.enabled, timing.guest_copy_ms);
@@ -11012,15 +11077,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 ComputeBufferCostScope cost(timing.enabled, timing.result_map_ms);
                 ctx.unmap_memory(buffer.memory);
             }
-            if (buffer.resource->gpu_addr) {
+            if (buffer.resource->gpu_addr || buffer.resource->host_data) {
                 ComputeBufferCostScope cost(timing.enabled, timing.notify_ms);
                 if (changed) {
                     set_guest_gpu_write_origin("compute-writeback(buffer-full)");
-                    notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+                    notify_output_write(buffer.resource->gpu_addr, destination, buffer.resource->size);
                     set_guest_gpu_write_origin(nullptr);
                 } else {
-                    notify_guest_gpu_write_preserving_bytes(
-                        buffer.resource->gpu_addr, buffer.resource->size);
+                    notify_output_write(buffer.resource->gpu_addr,
+                        resource_bytes_for(buffer.resource, buffer.guest_bytes),
+                        buffer.resource->size, true);
                 }
             }
             if (buffer.persistent) {
@@ -11061,15 +11127,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
             // independently proved that the guest mirror still contains that baseline. This path
             // therefore needs neither a large staging mapping nor a CPU memory pass.
-            if (bi.gpu_result_unchanged && bi.upload_skipped) {
+            if (!bi.output_conflict && bi.gpu_result_unchanged && bi.upload_skipped) {
                 if (trace)
                     std::fprintf(stderr,
                                  "[compute]   skipped GPU-identical storage writeback binding=%u "
                                  "addr=0x%llx bytes=%llu\n",
                                  bi.binding, (unsigned long long)r->gpu_addr,
                                  (unsigned long long)bi.exact_result_bytes);
-                if (r->gpu_addr)
-                    notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                if (r->gpu_addr || r->host_data)
+                    notify_output_write(r->gpu_addr, destination, bi.guest_bytes, true);
                 continue;
             }
             void* mapped = nullptr;
@@ -11110,7 +11176,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
             // that guest memory still contains the prior result, and this dispatch reproduced the
             // same row-major bytes. If either comparison fails, take the ordinary writeback below.
-            const bool repeated_output = bi.cache_candidate && bi.persistent &&
+            const bool repeated_output = !bi.output_conflict && bi.cache_candidate && bi.persistent &&
                 bi.upload_skipped && bi.exact_storage_bytes() &&
                 ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
             const auto prepare_done = ComputeClock::now();
@@ -11122,16 +11188,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, (unsigned long long)r->gpu_addr,
                                  (unsigned long long)bi.exact_result_bytes);
                 ctx.unmap_memory(staging_memory[i]);
-                if (r->gpu_addr)
-                    notify_guest_gpu_write_preserving_bytes(r->gpu_addr, bi.guest_bytes);
+                if (r->gpu_addr || r->host_data)
+                    notify_output_write(r->gpu_addr, destination, bi.guest_bytes, true);
                 continue;
             }
             // Notify page-based dirty trackers only when bytes will actually be written. Doing this
             // before the exact repeated-output check dirtied and rearmed tens of thousands of pages
             // even on the no-write path, defeating the validation that made that path safe.
-            if (!r->host_data && r->gpu_addr)
-                prosper::host::guest_write_watch_notify_host_write(
-                    r->gpu_addr, bi.guest_bytes);
+            prosper::host::guest_write_watch_notify_host_write(
+                reinterpret_cast<uintptr_t>(destination), bi.guest_bytes);
             const auto watch_done = ComputeClock::now();
             if (trace) {
                 if (bi.exact_storage_bytes()) {
@@ -11281,7 +11346,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // emulator is invalidating its own caches. Everything reaching the DS invalidation path
             // used to report the default `gpu`, which cannot distinguish them.
             set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
-            notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+            notify_output_write(r->gpu_addr, destination, bi.guest_bytes);
             set_guest_gpu_write_origin(nullptr);
             if (!r->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
@@ -11293,6 +11358,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     g_leave_next_dcc_metadata_compressed_for_test.exchange(
                         false, std::memory_order_acq_rel);
                 if (!leave_compressed_for_test) {
+                    prosper::host::guest_write_watch_notify_host_write(
+                        reinterpret_cast<uintptr_t>(bi.dcc_metadata), bi.dcc_metadata_bytes);
                     std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
                     // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
                     // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
@@ -11301,7 +11368,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
                     // separate question that needs the operation's real HTILE semantics proven.
                     set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
-                    notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                    notify_output_write(r->metadata_addr, bi.dcc_metadata, bi.dcc_metadata_bytes);
                     set_guest_gpu_write_origin(nullptr);
                     if (!r->dcc_metadata_host_data && writer_provenance_enabled())
                         record_guest_write(GuestWriterKind::ComputeBuffer,
@@ -11392,7 +11459,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
                 ctx.invalidate_cached_image_source(bi.cache_key);
-            if (bi.cache_candidate) {
+            if (bi.cache_candidate && !bi.output_conflict) {
                 if (bi.persistent && !promoted_after_writeback) {
                     // Successful writeback establishes the new packed-input authority. A missing
                     // optional source snapshot is safe: the next acquisition must either validate
@@ -11519,7 +11586,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
         // also be exported directly to graphics. Raw interchange images are compatible with neither.
         for (const BoundImage& image : images) {
-            if (!image.storage_writeback) continue;
+            if (!image.storage_writeback || image.output_conflict) continue;
             const bool unique = image.alias_of == SIZE_MAX;
             const bool native_exact_storage = image.native_float_storage ||
                 image.native_uint_storage || image.packed_r11_storage;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3503,7 +3503,8 @@ struct BoundImage {
     GpuRetileParameters retile_parameters{};
     bool storage = false;               // descriptor/representation, independent of access
     bool storage_writeback = false;     // whole-alias output obligation, conservatively proven
-    bool output_conflict = false;       // another effective output can overwrite this guest view
+    bool prior_output_conflict = false; // earlier writeback can invalidate setup-time equality
+    bool final_output_conflict = false; // later writeback or self metadata changes final interpretation
     bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
     bool native_uint_storage = false;   // exact guest-width integer texels
     bool packed_r11_storage = false;    // shader packs exact R11G11B10 words into typed R32_UINT
@@ -3531,6 +3532,8 @@ struct BoundImage {
     size_t alias_of = SIZE_MAX;         // exact sampled/storage binding sharing an earlier image/view
     uint8_t* dcc_metadata = nullptr;    // DCC control bytes to mark uncompressed after writeback
     size_t dcc_metadata_bytes = 0;
+    const uint8_t* sampled_metadata = nullptr; // input dependency, never a reset obligation
+    size_t sampled_metadata_bytes = 0;
     // Borrowed renderer-owned image bound in place (#1095). `image` is then owned by the live
     // renderer: it must not be destroyed here, its layout must be restored, and the pin taken at
     // import time must be released.
@@ -8048,6 +8051,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         }
                     }
                 }
+                bi.sampled_metadata = sampled_dcc_metadata;
+                bi.sampled_metadata_bytes = sampled_dcc_metadata_bytes;
                 uint8_t sampled_dcc_clear_pixel[4]{};
                 uint8_t sampled_dcc_clear_code = 0;
                 sampled_dcc_fast_clear = compute_sampled_dcc_fast_clear_rgba8(
@@ -9420,10 +9425,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
         }
 
-        // Distinct Vulkan owners can write overlapping architectural bytes. Setup-time input
-        // validation then cannot authorize a later identical-result skip, and final publication
-        // must not rearm a watch or move a journal snapshot over those intervening writes. Include
-        // sampled/read-only inputs and effective replay backing, not just advertised guest ranges.
+        // Guest writeback is ordered: all unique buffers, then each unique image's pixels
+        // and DCC reset. Earlier writes veto setup-time equality; later writes veto final
+        // authority. The last writer can restore its complete result and retain it normally.
         const auto ranges_conflict = [](uint64_t a, uint64_t an, uint64_t b, uint64_t bn) {
             if (!an || !bn) return false;
             if (!a || !b || an > UINT64_MAX - a || bn > UINT64_MAX - b) return true;
@@ -9436,7 +9440,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const uint64_t effective = reinterpret_cast<uintptr_t>(
                 resource_bytes_for(buffer.resource, buffer.guest_bytes));
             for (const auto& other : buffers) {
-                if (&other == &buffer || !other.writable || other.alias_of != SIZE_MAX ||
+                if (&other == &buffer) break;
+                if (!other.writable || other.alias_of != SIZE_MAX ||
                     !other.resource || !other.resource->gpu_addr) continue;
                 const uint64_t other_effective = reinterpret_cast<uintptr_t>(
                     resource_bytes_for(other.resource, other.guest_bytes));
@@ -9449,54 +9454,74 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
             }
         }
-        for (auto& image : images) {
+        for (size_t i = 0; i < images.size(); ++i) {
+            auto& image = images[i];
             if (image.alias_of != SIZE_MAX || !image.resource) continue;
             const uint64_t guest = image.resource->gpu_addr;
             const uint64_t effective = reinterpret_cast<uintptr_t>(
                 resource_bytes_for(image.resource, image.guest_bytes));
-            const auto conflicts = [&](uint64_t address, uint64_t bytes) {
+            const auto pixel_conflict = [&](uint64_t address, uint64_t bytes) {
                 return ranges_conflict(guest, image.guest_bytes, address, bytes) ||
                        ranges_conflict(effective, image.guest_bytes, address, bytes);
             };
-            for (const auto& other : images) {
+            const uint64_t metadata_bytes = image.storage
+                ? image.dcc_metadata_bytes : image.sampled_metadata_bytes;
+            const uint64_t metadata_effective = reinterpret_cast<uintptr_t>(image.storage
+                ? image.dcc_metadata : image.sampled_metadata);
+            const auto conflicts = [&](uint64_t address, uint64_t bytes) {
+                // Inputs are retained before guest writeback. Pixel notifications invalidate
+                // their old snapshots naturally, but pixel-only watches cannot see metadata.
+                return (image.storage_writeback && pixel_conflict(address, bytes)) ||
+                       ranges_conflict(image.resource->metadata_addr, metadata_bytes, address, bytes) ||
+                       ranges_conflict(metadata_effective, metadata_bytes, address, bytes);
+            };
+            for (size_t j = 0; j < images.size(); ++j) {
+                const auto& other = images[j];
                 if (!other.storage_writeback || other.alias_of != SIZE_MAX || !other.resource) continue;
-                if ((&other != &image &&
-                     (conflicts(other.resource->gpu_addr, other.guest_bytes) ||
-                      conflicts(reinterpret_cast<uintptr_t>(resource_bytes_for(
-                          other.resource, other.guest_bytes)), other.guest_bytes))) ||
+                if (j == i) {
+                    // A reset overlapping its own pixels changes the completed image's bytes.
+                    image.final_output_conflict |=
+                        pixel_conflict(other.resource->metadata_addr, other.dcc_metadata_bytes) ||
+                        pixel_conflict(reinterpret_cast<uintptr_t>(other.dcc_metadata), other.dcc_metadata_bytes);
+                    continue;
+                }
+                if (conflicts(other.resource->gpu_addr, other.guest_bytes) ||
+                    conflicts(reinterpret_cast<uintptr_t>(resource_bytes_for(
+                        other.resource, other.guest_bytes)), other.guest_bytes) ||
                     conflicts(other.resource->metadata_addr, other.dcc_metadata_bytes) ||
                     conflicts(reinterpret_cast<uintptr_t>(other.dcc_metadata), other.dcc_metadata_bytes)) {
-                    image.output_conflict = true;
-                    break;
+                    if (image.storage_writeback && j < i) image.prior_output_conflict = true;
+                    else image.final_output_conflict = true;
                 }
             }
             for (const auto& buffer : buffers) {
                 if (!buffer.writable || buffer.alias_of != SIZE_MAX || !buffer.resource ||
-                !buffer.resource->gpu_addr) continue;
+                    !buffer.resource->gpu_addr) continue;
                 if (conflicts(buffer.resource->gpu_addr, buffer.guest_bytes) ||
                     conflicts(reinterpret_cast<uintptr_t>(resource_bytes_for(
                         buffer.resource, buffer.guest_bytes)), buffer.guest_bytes)) {
-                    image.output_conflict = true;
-                    break;
+                    if (image.storage_writeback) image.prior_output_conflict = true;
+                    else image.final_output_conflict = true;
                 }
             }
-            if (image.output_conflict) {
-                // Revoke before recording: resource cleanup is deliberately skipped when GPU
-                // completion is unproven, but graphics must not borrow conflicted authority then.
-                // These calls preserve every allocation, comparison handle and outstanding pin.
+            if (image.final_output_conflict) {
+                // Revoke before recording: unproven completion deliberately skips cleanup.
+                // Keep handles and pins. Earlier-only writers use the ordinary pre-submit
+                // export revocation and may restore source authority after successful writeback.
                 ctx.invalidate_cached_image_source(image.cache_key);
                 if (image.compute_transfer_seed_borrowed)
                     ctx.invalidate_cached_image_source(image.compute_transfer_seed_key);
                 image.renderer_seeded_result_candidate = false;
                 image.post_writeback_promotion_candidate = false;
-                if (image_timing)
-                    std::fprintf(stderr,
-                        "[compute-output-conflict] submit=%llu dispatch=%llu order=%llu "
-                        "binding=%u storage=%u writeback=%u bytes=%zu\n",
-                        (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
-                        (unsigned long long)item.command_order, image.binding,
-                        image.storage ? 1u : 0u, image.storage_writeback ? 1u : 0u, image.guest_bytes);
             }
+            if (image_timing && (image.prior_output_conflict || image.final_output_conflict))
+                std::fprintf(stderr,
+                    "[compute-output-conflict] submit=%llu dispatch=%llu order=%llu "
+                    "binding=%u storage=%u writeback=%u bytes=%zu prior=%u final=%u\n",
+                    (unsigned long long)item.submit_no, (unsigned long long)item.dispatch_index,
+                    (unsigned long long)item.command_order, image.binding,
+                    image.storage ? 1u : 0u, image.storage_writeback ? 1u : 0u, image.guest_bytes,
+                    image.prior_output_conflict ? 1u : 0u, image.final_output_conflict ? 1u : 0u);
         }
 
         // Exact 2D and standard 3D tiling runs after image transfer in this same submission. Keep
@@ -9834,7 +9859,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         for (size_t i = 0; i < images.size(); ++i) {
             BoundImage& image = images[i];
-            if (image.storage_writeback && !image.output_conflict &&
+            if (image.storage_writeback && !image.prior_output_conflict &&
                 image.cache_candidate && image.persistent && image.upload_skipped &&
                 image.result_baseline && image.exact_result_bytes &&
                 image.exact_result_bytes <= max_gpu_compare_image_bytes() &&
@@ -10826,7 +10851,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
         // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
         for (BoundImage& image : images) {
-            if (image.storage_writeback || image.output_conflict || image.imported ||
+            if (image.storage_writeback || image.final_output_conflict || image.imported ||
                 image.alias_of != SIZE_MAX || !image.cache_candidate)
                 continue;
             // When this dispatch samples and writes the same guest view through distinct bindings,
@@ -11131,7 +11156,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // GPU comparison is an exact word-for-word equality reduction and acquire_cached_image
             // independently proved that the guest mirror still contains that baseline. This path
             // therefore needs neither a large staging mapping nor a CPU memory pass.
-            if (!bi.output_conflict && bi.gpu_result_unchanged && bi.upload_skipped) {
+            if (!bi.prior_output_conflict && bi.gpu_result_unchanged && bi.upload_skipped) {
                 if (trace)
                     std::fprintf(stderr,
                                  "[compute]   skipped GPU-identical storage writeback binding=%u "
@@ -11180,7 +11205,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // invalidation when BOTH sides of the contract are exact: acquire_cached_image proved
             // that guest memory still contains the prior result, and this dispatch reproduced the
             // same row-major bytes. If either comparison fails, take the ordinary writeback below.
-            const bool repeated_output = !bi.output_conflict && bi.cache_candidate && bi.persistent &&
+            const bool repeated_output = !bi.prior_output_conflict && bi.cache_candidate && bi.persistent &&
                 bi.upload_skipped && bi.exact_storage_bytes() &&
                 ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
             const auto prepare_done = ComputeClock::now();
@@ -11463,7 +11488,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
                 ctx.invalidate_cached_image_source(bi.cache_key);
-            if (bi.cache_candidate && !bi.output_conflict) {
+            if (bi.cache_candidate && !bi.final_output_conflict) {
                 if (bi.persistent && !promoted_after_writeback) {
                     // Successful writeback establishes the new packed-input authority. A missing
                     // optional source snapshot is safe: the next acquisition must either validate
@@ -11590,7 +11615,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // sampled cache with a device-local copy; exact 2D/3D images created with SAMPLED usage may
         // also be exported directly to graphics. Raw interchange images are compatible with neither.
         for (const BoundImage& image : images) {
-            if (!image.storage_writeback || image.output_conflict) continue;
+            if (!image.storage_writeback || image.final_output_conflict) continue;
             const bool unique = image.alias_of == SIZE_MAX;
             const bool native_exact_storage = image.native_float_storage ||
                 image.native_uint_storage || image.packed_r11_storage;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3432,6 +3432,8 @@ struct BorrowedComputeImageLease {
 // absent from this dispatch. Do not duplicate the normal guest-backed notification.
 void notify_output_write(uint64_t advertised, const void* destination, uint64_t bytes,
                          bool preserving_bytes = false) {
+    // Zero-address backing is GPU-internal state (for example GDS), not a guest output.
+    if (!advertised) return;
     const auto notify = [&](uint64_t address) {
         if (!address || !bytes) return;
         if (preserving_bytes) prosper::gpu::notify_guest_gpu_write_preserving_bytes(address, bytes);
@@ -5475,7 +5477,7 @@ std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item)
     }
     // Match the Vulkan path's conservative invalidation contract: padding beyond the exact launch
     // remains untouched, but every alias of the declared resource must be considered stale.
-    if (resource->gpu_addr || resource->host_data) {
+    if (resource->gpu_addr) {
         prosper::gpu::set_guest_gpu_write_origin("compute-writeback(cpu-fill)");
         if (resource->gpu_addr)
             prosper::gpu::notify_guest_gpu_write(resource->gpu_addr, resource->size);
@@ -9428,13 +9430,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             return a < b + bn && b < a + an;
         };
         for (auto& buffer : buffers) {
-            if (!buffer.writable || buffer.alias_of != SIZE_MAX || !buffer.resource) continue;
+            if (!buffer.writable || buffer.alias_of != SIZE_MAX || !buffer.resource ||
+                !buffer.resource->gpu_addr) continue;
             const uint64_t guest = buffer.resource->gpu_addr;
             const uint64_t effective = reinterpret_cast<uintptr_t>(
                 resource_bytes_for(buffer.resource, buffer.guest_bytes));
             for (const auto& other : buffers) {
                 if (&other == &buffer || !other.writable || other.alias_of != SIZE_MAX ||
-                    !other.resource) continue;
+                    !other.resource || !other.resource->gpu_addr) continue;
                 const uint64_t other_effective = reinterpret_cast<uintptr_t>(
                     resource_bytes_for(other.resource, other.guest_bytes));
                 if (ranges_conflict(guest, buffer.guest_bytes, other.resource->gpu_addr, other.guest_bytes) ||
@@ -9468,7 +9471,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
             }
             for (const auto& buffer : buffers) {
-                if (!buffer.writable || buffer.alias_of != SIZE_MAX || !buffer.resource) continue;
+                if (!buffer.writable || buffer.alias_of != SIZE_MAX || !buffer.resource ||
+                !buffer.resource->gpu_addr) continue;
                 if (conflicts(buffer.resource->gpu_addr, buffer.guest_bytes) ||
                     conflicts(reinterpret_cast<uintptr_t>(resource_bytes_for(
                         buffer.resource, buffer.guest_bytes)), buffer.guest_bytes)) {
@@ -10930,7 +10934,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     for (size_t i = 0; i < buffer.bytes; ++i)
                         buffer.changed_bytes += buffer.linear_seed[i] != result[i];
                 }
-                {
+                if (buffer.resource->gpu_addr) {
                     ComputeBufferCostScope cost(timing.enabled, timing.result_watch_ms);
                     prosper::host::guest_write_watch_notify_host_write(
                         reinterpret_cast<uintptr_t>(destination), buffer.guest_bytes);
@@ -11054,7 +11058,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // invalidation and writer provenance remain unconditional: renderer-resident state can
             // differ from guest RAM even when consecutive compute readbacks contain identical bytes.
             if (changed) {
-                {
+                if (buffer.resource->gpu_addr) {
                     ComputeBufferCostScope cost(timing.enabled, timing.result_watch_ms);
                     prosper::host::guest_write_watch_notify_host_write(
                         reinterpret_cast<uintptr_t>(destination), buffer.resource->size);

--- a/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
+++ b/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
@@ -429,6 +429,41 @@ struct Fixture {
                               [](uint32_t v) { return v == 0x13579bdfu; }),
               "unchanged image must restore bytes overwritten by earlier buffer writeback");
     }
+    void internal_output() {
+        std::vector<uint32_t> internal(texels, 0xccccccccu);
+        auto producer = buffer_writer(true);
+        auto table = std::make_shared<ShaderResourceTable>(*producer.resources);
+        table->resources[0].gpu_addr = 0; // Same convention as GDS and private storage masks.
+        table->resources[0].host_data = reinterpret_cast<uint8_t *>(internal.data());
+        table->resources[0].host_data_size = internal.size() * 4;
+        producer.resources = table;
+        unsigned private_notifications = 0, calls = 0;
+        set_guest_gpu_write_observer([&](uint64_t address, uint64_t, const char *) {
+            if (!address || address == reinterpret_cast<uint64_t>(internal.data()))
+                ++private_notifications;
+        });
+        execute_sequence({producer, reader()}, [&](const std::vector<ComputeItem> &items) {
+            ++calls;
+            const bool ok = prosper::frontend::execute_live_compute_items(items);
+            check(ok, "internal output and unrelated guest image execute");
+            if (calls == 1) {
+                prepare_borrow();
+                check_graphics(can_retain(journal == Journal::Overflow));
+            }
+            return ok;
+        });
+        set_guest_gpu_write_observer({});
+        check(calls == 2 && private_notifications == 0,
+              "internal backing neither announces guest writes nor blocks unrelated publication");
+        check(std::all_of(internal.begin(), internal.begin() + texels / 2,
+                          [](uint32_t v) { return v == 0x2468ace0u; }) &&
+                  std::all_of(internal.begin() + texels / 2, internal.end(),
+                              [](uint32_t v) { return v == 0xccccccccu; }),
+              "internal output writes exact bytes and preserves its tail");
+        check(std::all_of(observed.begin(), observed.end(),
+                          [](uint32_t v) { return v == 0x13579bdfu; }),
+              "unrelated image remains a current sampled result");
+    }
     void submission_failure() {
         unsigned calls = 0;
         execute_sequence(
@@ -477,8 +512,8 @@ struct Fixture {
 #if defined(__linux__)
 void watch_fault(int signal, siginfo_t *info, void *context) {
 #if defined(__x86_64__)
-    const bool write_fault = context &&
-        (static_cast<ucontext_t *>(context)->uc_mcontext.gregs[REG_ERR] & 2) != 0;
+    const bool write_fault =
+        context && (static_cast<ucontext_t *>(context)->uc_mcontext.gregs[REG_ERR] & 2) != 0;
 #else
     const bool write_fault = context != nullptr;
 #endif
@@ -636,6 +671,8 @@ int main(int argc, char **argv) {
     buffer_unbound.unbound_hosted(true);
     buffer_gpu.image_after_buffer(false);
     buffer_cpu.image_after_buffer(true);
+    Fixture internal(false, false);
+    internal.internal_output();
     BufferFixture buffers(true);
     buffers.run();
     return failures ? 1 : 0;

--- a/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
+++ b/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
@@ -1,0 +1,642 @@
+// Independent storage outputs must publish the final overlapping guest bytes.
+#include "gpu/capture/gpu_capture.hpp"
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/resources/shader_resources.hpp"
+#include "gpu/texture/tile.hpp"
+#include "shared/live/live_compute.hpp"
+#if defined(__linux__)
+#include "host/memory/guest_write_watch.hpp"
+#include <csignal>
+#include <sys/mman.h>
+#include <sys/ucontext.h>
+#include <unistd.h>
+#endif
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+using namespace prosper::gpu;
+namespace {
+constexpr uint32_t width = 64, height = 16, texels = width * height;
+enum class Journal { Active, Inactive, Overflow };
+Journal journal = Journal::Active;
+// Heap backings deliberately have no registered guest page watch. Without a usable
+// journal Linux declines a safe borrow; Windows can prove it with its exact mirror.
+bool can_retain(bool history_exhausted = false) {
+#if defined(_WIN32)
+    return true;
+#else
+    return journal != Journal::Inactive && !history_exhausted;
+#endif
+}
+int failures = 0;
+void check(bool ok, const char *message) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        ++failures;
+    }
+}
+ComputeItem item(const std::vector<uint32_t> &code, const ShaderResourceTable &resources,
+                 uint64_t address, uint32_t index) {
+    ComputeShaderConfig config;
+    config.user_sgprs.resize(24);
+    config.local_x = width;
+    config.local_y = config.local_z = 1;
+    config.tidig_comp_cnt = 0;
+    config.native_storage_format_support = native_storage_format_support_bit(DataFormat::Uint32, 1);
+    ComputeItem result;
+    result.spirv = recompile_compute(code.data(), code.size(), &resources, config);
+    result.user_sgprs = config.user_sgprs;
+    result.resources = std::make_shared<ShaderResourceTable>(resources);
+    result.code_addr = address;
+    result.dispatch_index = index;
+    result.command_order = index * 10;
+    result.launch.threads_x = result.launch.local_x = width;
+    result.launch.threads_y = result.launch.threads_z = 1;
+    result.launch.local_y = result.launch.local_z = 1;
+    result.launch.groups_x = result.launch.groups_y = result.launch.groups_z = 1;
+    return result;
+}
+
+template <class Callback> void execute_sequence(std::vector<ComputeItem> items, Callback callback) {
+    std::vector<SubmitOperation> operations;
+    for (size_t i = 0; i < items.size(); ++i) {
+        items[i].dispatch_index = i + 1;
+        items[i].command_order = (i + 1) * 10;
+        operations.push_back(
+            {SubmitOperationKind::Dispatch, uint32_t(i + 1), uint32_t((i + 1) * 10)});
+    }
+    if (journal == Journal::Inactive) {
+        check(!guest_gpu_write_tracking_active(),
+              "inactive journal arm really has no ordered scope");
+        for (const auto &i : items)
+            callback(std::vector<ComputeItem>{i});
+    } else {
+        execute_ordered_items(
+            operations, {}, items,
+            [](const std::vector<DrawItem> &, uint32_t, uint32_t) { return RenderedFrame{}; },
+            callback, 1, 1);
+    }
+}
+struct Fixture {
+    std::vector<uint32_t> guest = std::vector<uint32_t>(texels + 16, 0xccccccccu);
+    std::vector<uint32_t> other = std::vector<uint32_t>(texels + 16, 0xeeeeeeeeu);
+    std::vector<uint32_t> observed = std::vector<uint32_t>(texels, 0xdeadbeefu);
+    ShaderResource a{}, b{};
+    bool overlap, alias, hosted;
+    uint32_t noise = 0;
+    Fixture(bool overlap_, bool alias_, bool hosted_ = false)
+        : overlap(overlap_), alias(alias_), hosted(hosted_) {
+        a.cls = ResourceClass::StorageImage;
+        a.binding = 5;
+        a.sgpr_base = 8;
+        a.img_dim = 1;
+        a.format = DataFormat::Uint32;
+        a.num_components = 1;
+        a.width = width;
+        a.height = height;
+        a.depth = 1;
+        a.size = texels * 4;
+        a.gpu_addr = reinterpret_cast<uint64_t>(guest.data());
+        for (unsigned c = 0; c < 4; ++c)
+            a.swizzle[c] = 4 + c;
+        b = a;
+        b.binding = 6;
+        b.sgpr_base = 16;
+        if (!alias) {
+            b.height = height / 2;
+            b.size = texels * 2;
+        }
+        if (!overlap || hosted)
+            b.gpu_addr = reinterpret_cast<uint64_t>(other.data());
+        if (hosted) {
+            b.host_data = reinterpret_cast<uint8_t *>(guest.data());
+            b.host_data_size = b.size;
+        }
+    }
+    ComputeItem writer(uint32_t av, uint32_t bv, int only = -1) {
+        ShaderResourceTable table;
+        if (only != 1)
+            table.resources.push_back(a);
+        if (only != 0)
+            table.resources.push_back(b);
+        std::vector<uint32_t> code{0x7e080300u};
+        for (unsigned output = 0; output < 2; ++output) {
+            if (only >= 0 && output != unsigned(only))
+                continue;
+            code.insert(code.end(), {0x7e0002ffu, output ? bv : av});
+            for (uint32_t y = 0; y < (output ? b.height : a.height); ++y)
+                code.insert(code.end(),
+                            {0x7e0a0280u + y, 0xf0200108u, output ? 0x00040004u : 0x00020004u});
+        }
+        code.push_back(0xbf810000u);
+        auto result = item(code, table, 0x34760001u, 1);
+        const auto reflection = validate_spirv_descriptor_interface(
+            result.spirv, &table, 0, SpirvShaderStage::Compute, false);
+        check(reflection.ok() && reflection.storage_image_writes_complete,
+              "complete writer reflection");
+        for (const auto &r : table.resources) {
+            const auto *d = find_spirv_descriptor_binding(reflection, 0, r.binding);
+            check(d && d->writable && !d->readable &&
+                      d->storage_image_format == kSpirvImageFormatR32ui,
+                  "each output really is native typed R32_UINT storage");
+        }
+        return result;
+    }
+    ShaderResource sampled() {
+        auto r = a;
+        r.cls = ResourceClass::Texture;
+        return r;
+    }
+    ComputeItem reader() {
+        ShaderResource output{};
+        output.cls = ResourceClass::ConstantBuffer;
+        output.binding = 2;
+        output.sgpr_base = 0;
+        output.format = DataFormat::Uint32;
+        output.num_components = 1;
+        output.stride = 4;
+        output.size = texels * 4;
+        output.gpu_addr = reinterpret_cast<uint64_t>(observed.data());
+        ShaderResourceTable table;
+        table.resources = {output, sampled()};
+        std::vector<uint32_t> code{0x7e080300u};
+        for (uint32_t y = 0; y < height; ++y)
+            code.insert(code.end(), {0x7e0a0280u + y, 0xf0000108u, 0x00020804u, 0xbf8c3f70u,
+                                     0xe0702000u | (y * width * 4u), 0x80000804u});
+        code.push_back(0xbf810000u);
+        return item(code, table, 0x34760002u, 2);
+    }
+    void prepare_borrow() {
+        if (journal != Journal::Overflow)
+            return;
+        check(guest_gpu_write_tracking_active(), "overflow arm has an active journal");
+        const auto snapshot = guest_gpu_write_snapshot();
+        for (size_t i = 0; i <= kGuestGpuWriteJournalCapacity; ++i) {
+            ++noise;
+            notify_guest_gpu_write(reinterpret_cast<uint64_t>(&noise), sizeof(noise));
+        }
+        check(guest_gpu_writes_since(snapshot, a.gpu_addr, a.size) == GuestGpuWriteQuery::Unknown,
+              "overflow arm really exhausts journal authority");
+    }
+    void check_graphics(bool expected) {
+        prosper::frontend::LiveComputeImageImport imported;
+        const bool borrowed =
+            prosper::frontend::import_live_compute_storage_image(sampled(), a.size, imported);
+        check(borrowed == expected && borrowed == imported.valid(),
+              "graphics export requires a current exact result and valid lease");
+    }
+    void run(uint32_t av, uint32_t bv) {
+        if (alias)
+            bv = av; // Folded descriptors store the same value, without conflicting invocations.
+        auto producer = writer(av, bv), consumer = reader();
+        check(!producer.spirv.empty() && !consumer.spirv.empty(),
+              "real writer and dependent reader compile");
+        std::vector<uint32_t> expected(texels, av);
+        if (overlap)
+            std::fill_n(expected.begin(), b.width * b.height, bv);
+        std::fill(observed.begin(), observed.end(), 0xdeadbeefu);
+        bool ok = true;
+        unsigned calls = 0;
+        const auto before = prosper::frontend::live_compute_storage_transfer_seeds();
+        execute_sequence({producer, consumer}, [&](const std::vector<ComputeItem> &items) {
+            ++calls;
+            const bool executed = prosper::frontend::execute_live_compute_items(items);
+            ok &= executed;
+            if (calls == 1) {
+                check(std::equal(expected.begin(), expected.end(), guest.begin()),
+                      "guest bytes contain the final ordered output composite");
+                if (!overlap) {
+                    check(std::all_of(other.begin(), other.begin() + b.width * b.height,
+                                      [&](uint32_t v) { return v == bv; }),
+                          "disjoint B publishes every texel");
+                    check(std::all_of(other.begin() + b.width * b.height, other.end(),
+                                      [](uint32_t v) { return v == 0xeeeeeeeeu; }),
+                          "disjoint B preserves padding/tail");
+                } else if (hosted) {
+                    check(std::all_of(other.begin(), other.end(),
+                                      [](uint32_t v) { return v == 0xeeeeeeeeu; }),
+                          "host-backed output leaves its advertised storage untouched");
+                }
+                prepare_borrow();
+                check_graphics((!overlap || alias) && can_retain(journal == Journal::Overflow));
+            }
+            return executed;
+        });
+        if (overlap && !alias)
+            check_graphics(false);
+        check(ok && calls == 2, "producer and sampled GPU consumer both execute");
+        check(observed == expected, "every sampled GPU output matches final guest bytes");
+        const auto transfers = prosper::frontend::live_compute_storage_transfer_seeds() - before;
+        check((transfers > 0) == ((!overlap || alias) && can_retain(journal == Journal::Overflow)),
+              "only an exact retained result authorizes GPU transfer");
+        check(std::all_of(guest.begin() + texels, guest.end(),
+                          [](uint32_t v) { return v == 0xccccccccu; }),
+              "output preserves guest backing tail");
+    }
+    void prewarm_b(bool host_baseline) {
+        const auto before = prosper::frontend::live_compute_image_result_snapshot_bytes();
+        if (host_baseline)
+            prosper::frontend::live_compute_force_next_image_result_host_fallback_for_test();
+        check(prosper::frontend::execute_live_compute_items({writer(0, 0x2468ace0u, 1)}),
+              "late B establishes its independent result before overlapping A exists");
+        check(prosper::frontend::live_compute_image_result_snapshot_bytes() - before ==
+                  (host_baseline ? b.size : 0u),
+              "late B establishes requested CPU or GPU baseline");
+    }
+    void dcc_overlap(bool hosted_metadata) {
+        // A is linear; B's separate tiled pixels use a metadata plane overlapping A.
+        b.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        const size_t tiled_bytes = tiled_surface_bytes(width, b.height, b.tile_mode, 0, 4);
+        other.resize(tiled_bytes / 4 + 16, 0xeeeeeeeeu);
+        b.gpu_addr = reinterpret_cast<uint64_t>(other.data());
+        b.size = tiled_bytes;
+        b.compression_enabled = b.write_compress_enabled = b.meta_pipe_aligned = true;
+        b.metadata_addr = a.gpu_addr;
+        const size_t metadata_bytes = gpu_capture_dcc_metadata_footprint(b);
+        check(metadata_bytes && metadata_bytes <= a.size && !(metadata_bytes % 4),
+              "bounded real DCC footprint overlaps A");
+        if (!metadata_bytes || metadata_bytes > a.size || metadata_bytes % 4)
+            return;
+        b.dcc_metadata_size = metadata_bytes;
+        if (hosted_metadata) {
+            b.metadata_addr = reinterpret_cast<uint64_t>(advertised_metadata.data());
+            b.dcc_metadata_host_data = reinterpret_cast<uint8_t *>(guest.data());
+            b.dcc_metadata_host_data_size = metadata_bytes;
+        }
+        std::fill(guest.begin(), guest.end(),
+                  0xffffffffu); // valid all-uncompressed initial metadata
+        std::vector<uint32_t> expected(texels, 0x13579bdfu);
+        std::fill_n(expected.begin(), metadata_bytes / 4, 0xffffffffu);
+        unsigned calls = 0;
+        bool ok = true;
+        execute_sequence({writer(0x13579bdfu, 0x2468ace0u), reader()},
+                         [&](const std::vector<ComputeItem> &items) {
+                             ++calls;
+                             const bool executed =
+                                 prosper::frontend::execute_live_compute_items(items);
+                             ok &= executed;
+                             if (calls == 1) {
+                                 check(std::equal(expected.begin(), expected.end(), guest.begin()),
+                                       "DCC reset is part of final A composite");
+                                 prepare_borrow();
+                                 check_graphics(false);
+                             }
+                             return executed;
+                         });
+        check(ok && calls == 2 && observed == expected,
+              "sampled A observes overlapping DCC metadata reset");
+        std::vector<uint32_t> linear(width * b.height);
+        detile_surface(reinterpret_cast<uint8_t *>(linear.data()),
+                       reinterpret_cast<const uint8_t *>(other.data()), width, b.height,
+                       b.tile_mode, 0, 4);
+        check(
+            std::all_of(linear.begin(), linear.end(), [](uint32_t v) { return v == 0x2468ace0u; }),
+            "separate DCC pixel owner publishes its own exact output");
+        check(std::all_of(advertised_metadata.begin(), advertised_metadata.end(),
+                          [](uint8_t v) { return v == 0x97; }),
+              "hosted DCC preserves advertised metadata backing");
+        check_graphics(false);
+    }
+    std::vector<uint8_t> advertised_metadata = std::vector<uint8_t>(65536, 0x97);
+    void self_dcc() {
+        a.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        const size_t tiled_bytes = tiled_surface_bytes(width, height, a.tile_mode, 0, 4);
+        guest.resize(tiled_bytes / 4 + 16, 0xffffffffu);
+        std::fill(guest.begin(), guest.end(), 0xffffffffu);
+        a.gpu_addr = reinterpret_cast<uint64_t>(guest.data());
+        a.size = tiled_bytes;
+        a.compression_enabled = a.write_compress_enabled = a.meta_pipe_aligned = true;
+        a.metadata_addr = a.gpu_addr;
+        const size_t metadata_bytes = gpu_capture_dcc_metadata_footprint(a);
+        check(metadata_bytes && metadata_bytes < tiled_bytes,
+              "bounded self-overlapping DCC metadata");
+        if (!metadata_bytes || metadata_bytes >= tiled_bytes)
+            return;
+        a.dcc_metadata_size = metadata_bytes;
+        std::vector<uint32_t> expected(texels);
+        unsigned calls = 0;
+        bool ok = true;
+        execute_sequence(
+            {writer(0x13579bdfu, 0, 0), reader()}, [&](const std::vector<ComputeItem> &items) {
+                ++calls;
+                const bool executed = prosper::frontend::execute_live_compute_items(items);
+                ok &= executed;
+                if (calls == 1) {
+                    check(std::all_of(reinterpret_cast<uint8_t *>(guest.data()),
+                                      reinterpret_cast<uint8_t *>(guest.data()) + metadata_bytes,
+                                      [](uint8_t v) { return v == 0xff; }),
+                          "self-overlapping metadata reset changes stored pixels");
+                    detile_surface(reinterpret_cast<uint8_t *>(expected.data()),
+                                   reinterpret_cast<uint8_t *>(guest.data()), width, height,
+                                   a.tile_mode, 0, 4);
+                    check(expected.front() == 0xffffffffu &&
+                              std::find(expected.begin(), expected.end(), 0x13579bdfu) !=
+                                  expected.end(),
+                          "self-DCC oracle distinguishes reset bytes from original private image");
+                    prepare_borrow();
+                    check_graphics(false);
+                }
+                return executed;
+            });
+        check(ok && calls == 2 && observed == expected,
+              "sampled self-DCC view observes final physical guest composite");
+        check_graphics(false);
+    }
+    void pinned_overlap() {
+        prosper::frontend::LiveComputeImageImport pinned;
+        unsigned calls = 0;
+        bool ok = true;
+        std::vector<uint32_t> expected(texels, 0x31415926u);
+        std::fill_n(expected.begin(), b.width * b.height, 0x2468ace0u);
+        execute_sequence({writer(0x13579bdfu, 0, 0), writer(0x31415926u, 0x2468ace0u), reader()},
+                         [&](const std::vector<ComputeItem> &items) {
+                             ++calls;
+                             const bool executed =
+                                 prosper::frontend::execute_live_compute_items(items);
+                             ok &= executed;
+                             if (calls == 1)
+                                 check(prosper::frontend::import_live_compute_storage_image(
+                                           sampled(), a.size, pinned) == can_retain(),
+                                       "hold real graphics lease across overlapping dispatch");
+                             if (calls == 2) {
+                                 prepare_borrow();
+                                 check_graphics(false);
+                             }
+                             return executed;
+                         });
+        check(ok && calls == 3 && observed == expected,
+              "pinned allocation survives conflict while new consumers see current bytes");
+        check(pinned.valid() == can_retain(),
+              "authority invalidation preserves outstanding lease lifetime");
+    }
+    ComputeItem buffer_writer(bool alongside_image) {
+        ShaderResource output{};
+        output.cls = ResourceClass::ConstantBuffer;
+        output.binding = 2;
+        output.sgpr_base = 0;
+        output.format = DataFormat::Uint32;
+        output.num_components = 1;
+        output.stride = 4;
+        output.size = b.width * b.height * 4;
+        output.gpu_addr = b.gpu_addr;
+        output.host_data = b.host_data;
+        output.host_data_size = b.host_data_size;
+        ShaderResourceTable table;
+        table.resources = {output};
+        std::vector<uint32_t> code{0x7e080300u, 0x7e1002ffu, 0x2468ace0u};
+        for (uint32_t y = 0; y < b.height; ++y)
+            code.insert(code.end(), {0xe0702000u | (y * width * 4u), 0x80000804u});
+        if (alongside_image) {
+            table.resources.push_back(a);
+            code.insert(code.end(), {0x7e0002ffu, 0x13579bdfu});
+            for (uint32_t y = 0; y < a.height; ++y)
+                code.insert(code.end(), {0x7e0a0280u + y, 0xf0200108u, 0x00020004u});
+        }
+        code.push_back(0xbf810000u);
+        return item(code, table, 0x34760004u, 1);
+    }
+    void image_after_buffer(bool host_baseline) {
+        const auto before = prosper::frontend::live_compute_image_result_snapshot_bytes();
+        if (host_baseline)
+            prosper::frontend::live_compute_force_next_image_result_host_fallback_for_test();
+        unsigned calls = 0;
+        bool ok = true;
+        execute_sequence(
+            {writer(0x13579bdfu, 0, 0), buffer_writer(true), reader()},
+            [&](const std::vector<ComputeItem> &items) {
+                ++calls;
+                const bool executed = prosper::frontend::execute_live_compute_items(items);
+                ok &= executed;
+                if (calls == 1) {
+                    check(prosper::frontend::live_compute_image_result_snapshot_bytes() - before ==
+                              (host_baseline ? a.size : 0u),
+                          "A establishes requested baseline before buffer conflict");
+                    check_graphics(can_retain());
+                }
+                if (calls == 2) {
+                    prepare_borrow();
+                    check_graphics(false);
+                }
+                return executed;
+            });
+        check(ok && calls == 3, "image after overlapping buffer executes");
+        check(std::all_of(guest.begin(), guest.begin() + texels,
+                          [](uint32_t v) { return v == 0x13579bdfu; }) &&
+                  std::all_of(observed.begin(), observed.end(),
+                              [](uint32_t v) { return v == 0x13579bdfu; }),
+              "unchanged image must restore bytes overwritten by earlier buffer writeback");
+    }
+    void submission_failure() {
+        unsigned calls = 0;
+        execute_sequence(
+            {writer(0x13579bdfu, 0, 0), writer(0x31415926u, 0x2468ace0u)},
+            [&](const std::vector<ComputeItem> &items) {
+                ++calls;
+                if (calls == 2)
+                    prosper::frontend::live_compute_force_next_queue_submit_device_lost_for_test();
+                const bool executed = prosper::frontend::execute_live_compute_items(items);
+                check(executed == (calls == 1),
+                      "device-loss arm reaches the real failed submit branch");
+                check_graphics(calls == 1);
+                return executed;
+            });
+        check(calls == 2, "failure is injected after successful retained A");
+        check_graphics(false);
+    }
+    void unbound_hosted(bool buffer = false) {
+        check(hosted, "unbound regression has an effective hosted overlap");
+        constexpr uint32_t av = 0x13579bdfu, bv = 0x2468ace0u;
+        auto first = writer(av, bv, 0), second = buffer ? buffer_writer(false) : writer(av, bv, 1),
+             consumer = reader();
+        std::vector<uint32_t> expected(texels, av);
+        std::fill_n(expected.begin(), b.width * b.height, bv);
+        unsigned calls = 0;
+        bool ok = true;
+        execute_sequence({first, second, consumer}, [&](const std::vector<ComputeItem> &items) {
+            ++calls;
+            const bool executed = prosper::frontend::execute_live_compute_items(items);
+            ok &= executed;
+            if (calls == 1)
+                check_graphics(can_retain()); // Actual retained A positive before it is absent.
+            if (calls == 2) {
+                check(std::equal(expected.begin(), expected.end(), guest.begin()),
+                      "hosted-only writer creates guest composite");
+                prepare_borrow();
+                check_graphics(false);
+            }
+            return executed;
+        });
+        check(ok && calls == 3 && observed == expected,
+              "unbound cached view observes actual hosted destination writes");
+        check_graphics(false);
+    }
+};
+#if defined(__linux__)
+void watch_fault(int signal, siginfo_t *info, void *context) {
+#if defined(__x86_64__)
+    const bool write_fault = context &&
+        (static_cast<ucontext_t *>(context)->uc_mcontext.gregs[REG_ERR] & 2) != 0;
+#else
+    const bool write_fault = context != nullptr;
+#endif
+    if (signal == SIGSEGV && write_fault && info && info->si_addr &&
+        prosper::host::guest_write_watch_handle_fault(reinterpret_cast<uint64_t>(info->si_addr)))
+        return;
+    _exit(86);
+}
+void watched_cross_submit() {
+    static uint8_t stack_memory[256 * 1024];
+    stack_t stack{};
+    stack.ss_sp = stack_memory;
+    stack.ss_size = sizeof(stack_memory);
+    struct sigaction action{};
+    action.sa_sigaction = watch_fault;
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&action.sa_mask);
+    const bool installed =
+        sigaltstack(&stack, nullptr) == 0 && sigaction(SIGSEGV, &action, nullptr) == 0;
+    check(installed, "install red-zone-safe real write-watch fault handler");
+    if (!installed)
+        return;
+    prosper::host::guest_write_watch_set_fault_onstack(true);
+    constexpr size_t bytes = 8192;
+    void *mapping =
+        mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    check(mapping != MAP_FAILED, "allocate actual registered guest mapping");
+    if (mapping == MAP_FAILED)
+        return;
+    const uint64_t address = reinterpret_cast<uint64_t>(mapping);
+    prosper::host::guest_write_watch_notify_direct_mapping_added(address, bytes, 0x347600000ull,
+                                                                 0x3);
+    std::fill_n(static_cast<uint32_t *>(mapping), bytes / 4, 0xccccccccu);
+    {
+        Fixture f(true, false);
+        f.a.gpu_addr = f.b.gpu_addr = address;
+        const auto before = prosper::host::guest_write_watch_stats();
+        execute_sequence({f.writer(0x13579bdfu, 0, 0)}, [](const std::vector<ComputeItem> &items) {
+            const bool ok = prosper::frontend::execute_live_compute_items(items);
+            check(ok, "watched producer executes");
+            return ok;
+        });
+        check(!guest_gpu_write_tracking_active(), "producer journal ended before watched borrow");
+        f.check_graphics(true);
+        const auto after = prosper::host::guest_write_watch_stats();
+        check(after.registrations > before.registrations && after.unchanged > before.unchanged,
+              "cross-submit positive really uses a registered unchanged page watch");
+        execute_sequence({f.writer(0x31415926u, 0x2468ace0u)},
+                         [](const std::vector<ComputeItem> &items) {
+                             const bool ok = prosper::frontend::execute_live_compute_items(items);
+                             check(ok, "watched conflict executes");
+                             return ok;
+                         });
+        f.check_graphics(false);
+        check(prosper::frontend::execute_live_compute_items({f.reader()}),
+              "cross-submit watched consumer executes");
+        for (size_t i = 0; i < texels; ++i) {
+            const uint32_t expected = i < texels / 2 ? 0x2468ace0u : 0x31415926u;
+            if (static_cast<uint32_t *>(mapping)[i] != expected || f.observed[i] != expected) {
+                check(false, "watched guest and sampled consumer preserve final composite");
+                break;
+            }
+        }
+    }
+    prosper::host::guest_write_watch_notify_direct_mapping_removed(address, bytes);
+    munmap(mapping, bytes);
+}
+#endif
+struct BufferFixture {
+    static constexpr size_t words = 1024 * 1024 / 4;
+    std::vector<uint32_t> guest = std::vector<uint32_t>(words + 64, 0xccccccccu);
+    ShaderResource a{}, b{};
+    explicit BufferFixture(bool overlap) {
+        a.cls = ResourceClass::ConstantBuffer;
+        a.binding = 2;
+        a.sgpr_base = 0;
+        a.format = DataFormat::Uint32;
+        a.num_components = 1;
+        a.stride = 4;
+        a.size = words * 4;
+        a.gpu_addr = reinterpret_cast<uint64_t>(guest.data());
+        b = a;
+        b.binding = 3;
+        b.sgpr_base = 4;
+        b.gpu_addr += overlap ? 128 : 0;
+    }
+    ComputeItem writer(bool both, uint32_t av = 0x13579bdfu) {
+        ShaderResourceTable table;
+        table.resources = both ? std::vector<ShaderResource>{a, b} : std::vector<ShaderResource>{b};
+        std::vector<uint32_t> code{0x7e080300u};
+        if (both)
+            code.insert(code.end(), {0x7e1002ffu, av, 0xe0702000u, 0x80000804u});
+        code.insert(code.end(), {0x7e1002ffu, 0x2468ace0u, 0xe0702000u, 0x80010804u, 0xbf810000u});
+        return item(code, table, 0x34760003u, 1);
+    }
+    void run() {
+        const auto before = prosper::frontend::live_compute_buffer_gpu_result_skips();
+        execute_sequence({writer(false), writer(false), writer(true)},
+                         [&](const std::vector<ComputeItem> &items) {
+                             const bool ok = prosper::frontend::execute_live_compute_items(items);
+                             check(ok, "overlapping buffer writer executes");
+                             return ok;
+                         });
+        check(prosper::frontend::live_compute_buffer_gpu_result_skips() == before + 1,
+              "unchanged isolated B skips once; conflicting B must restore its bytes");
+        for (size_t i = 0; i < guest.size(); ++i) {
+            const uint32_t expected = i < 32 ? 0x13579bdfu : i < 96 ? 0x2468ace0u : 0xccccccccu;
+            if (guest[i] != expected) {
+                check(false, "buffer composite and full untouched tail are exact");
+                break;
+            }
+        }
+    }
+};
+} // namespace
+int main(int argc, char **argv) {
+#if defined(__linux__)
+    if (argc == 2 && !std::strcmp(argv[1], "--watched")) {
+        watched_cross_submit();
+        return failures ? 1 : 0;
+    }
+#endif
+    if (argc == 2 && !std::strcmp(argv[1], "--submit-failure")) {
+        Fixture failure(true, false);
+        failure.submission_failure();
+        return failures ? 1 : 0;
+    }
+    if (argc == 2 && !std::strcmp(argv[1], "--unjournaled"))
+        journal = Journal::Inactive;
+    else if (argc == 2 && !std::strcmp(argv[1], "--overflow"))
+        journal = Journal::Overflow;
+    else if (argc != 1)
+        return 2;
+    // Simultaneous identities prevent a prior arm's cached sampled view from hiding publication.
+    Fixture conflict(true, false), disjoint(false, false), alias(true, true),
+        hosted(true, false, true), unbound(true, false, true);
+    for (auto *f : {&conflict, &disjoint, &alias, &hosted}) {
+        f->run(0x13579bdfu, 0x2468ace0u);
+        f->run(0x31415926u, 0x2468ace0u); // Changed early A, unchanged overlapping late B.
+    }
+    unbound.unbound_hosted();
+    Fixture gpu_baseline(true, false), host_baseline(true, false), dcc(false, false),
+        hosted_dcc(false, false);
+    gpu_baseline.prewarm_b(false);
+    gpu_baseline.run(0x13579bdfu, 0x2468ace0u);
+    host_baseline.prewarm_b(true);
+    host_baseline.run(0x13579bdfu, 0x2468ace0u);
+    dcc.dcc_overlap(false);
+    hosted_dcc.dcc_overlap(true);
+    Fixture self(true, false), pinned(true, false);
+    self.self_dcc();
+    pinned.pinned_overlap();
+    Fixture buffer_unbound(true, false, true), buffer_gpu(true, false, true),
+        buffer_cpu(true, false, true);
+    buffer_unbound.unbound_hosted(true);
+    buffer_gpu.image_after_buffer(false);
+    buffer_cpu.image_after_buffer(true);
+    BufferFixture buffers(true);
+    buffers.run();
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
+++ b/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
@@ -39,13 +39,15 @@ void check(bool ok, const char *message) {
     }
 }
 ComputeItem item(const std::vector<uint32_t> &code, const ShaderResourceTable &resources,
-                 uint64_t address, uint32_t index) {
+                 uint64_t address, uint32_t index, bool include_rgba16 = false) {
     ComputeShaderConfig config;
     config.user_sgprs.resize(24);
     config.local_x = width;
     config.local_y = config.local_z = 1;
     config.tidig_comp_cnt = 0;
     config.native_storage_format_support = native_storage_format_support_bit(DataFormat::Uint32, 1);
+    if (include_rgba16)
+        config.native_storage_format_support |= native_storage_format_support_bit(DataFormat::Float16, 4);
     ComputeItem result;
     result.spirv = recompile_compute(code.data(), code.size(), &resources, config);
     result.user_sgprs = config.user_sgprs;
@@ -84,6 +86,7 @@ struct Fixture {
     std::vector<uint32_t> guest = std::vector<uint32_t>(texels + 16, 0xccccccccu);
     std::vector<uint32_t> other = std::vector<uint32_t>(texels + 16, 0xeeeeeeeeu);
     std::vector<uint32_t> observed = std::vector<uint32_t>(texels, 0xdeadbeefu);
+    std::vector<uint32_t> observed_b = std::vector<uint32_t>(texels + 16, 0xdeadbeefu);
     ShaderResource a{}, b{};
     bool overlap, alias, hosted;
     uint32_t noise = 0;
@@ -145,12 +148,15 @@ struct Fixture {
         }
         return result;
     }
-    ShaderResource sampled() {
-        auto r = a;
+    ShaderResource sampled(bool late = false) {
+        auto r = late ? b : a;
         r.cls = ResourceClass::Texture;
+        r.binding = 5;
+        r.sgpr_base = 8;
         return r;
     }
-    ComputeItem reader() {
+    ComputeItem reader(bool late = false) {
+        const auto input = sampled(late);
         ShaderResource output{};
         output.cls = ResourceClass::ConstantBuffer;
         output.binding = 2;
@@ -158,12 +164,12 @@ struct Fixture {
         output.format = DataFormat::Uint32;
         output.num_components = 1;
         output.stride = 4;
-        output.size = texels * 4;
-        output.gpu_addr = reinterpret_cast<uint64_t>(observed.data());
+        output.size = input.width * input.height * 4;
+        output.gpu_addr = reinterpret_cast<uint64_t>(late ? observed_b.data() : observed.data());
         ShaderResourceTable table;
-        table.resources = {output, sampled()};
+        table.resources = {output, input};
         std::vector<uint32_t> code{0x7e080300u};
-        for (uint32_t y = 0; y < height; ++y)
+        for (uint32_t y = 0; y < input.height; ++y)
             code.insert(code.end(), {0x7e0a0280u + y, 0xf0000108u, 0x00020804u, 0xbf8c3f70u,
                                      0xe0702000u | (y * width * 4u), 0x80000804u});
         code.push_back(0xbf810000u);
@@ -181,10 +187,11 @@ struct Fixture {
         check(guest_gpu_writes_since(snapshot, a.gpu_addr, a.size) == GuestGpuWriteQuery::Unknown,
               "overflow arm really exhausts journal authority");
     }
-    void check_graphics(bool expected) {
+    void check_graphics(bool expected, bool late = false) {
+        const auto input = sampled(late);
         prosper::frontend::LiveComputeImageImport imported;
         const bool borrowed =
-            prosper::frontend::import_live_compute_storage_image(sampled(), a.size, imported);
+            prosper::frontend::import_live_compute_storage_image(input, input.size, imported);
         check(borrowed == expected && borrowed == imported.valid(),
               "graphics export requires a current exact result and valid lease");
     }
@@ -236,6 +243,51 @@ struct Fixture {
                           [](uint32_t v) { return v == 0xccccccccu; }),
               "output preserves guest backing tail");
     }
+    void check_b_pixels(uint32_t value) {
+        const size_t count = b.width * b.height;
+        check(std::all_of(observed_b.begin(), observed_b.begin() + count,
+                          [&](uint32_t v) { return v == value; }) &&
+                  std::all_of(observed_b.begin() + count, observed_b.end(),
+                              [](uint32_t v) { return v == 0xdeadbeefu; }),
+              "late B sampled GPU consumer reads every current texel and preserves output tail");
+    }
+    void late_output() {
+        // Dedicated identity: no preceding A sampled cache can satisfy this B consumer.
+        for (uint32_t av : {0x13579bdfu, 0x31415926u}) {
+            constexpr uint32_t bv = 0x2468ace0u;
+            std::vector<uint32_t> expected(texels, av);
+            std::fill_n(expected.begin(), b.width * b.height, bv);
+            std::fill(observed_b.begin(), observed_b.end(), 0xdeadbeefu);
+            unsigned calls = 0;
+            bool ok = true;
+            const auto before = prosper::frontend::live_compute_storage_transfer_seeds();
+            execute_sequence({writer(av, bv), reader(true)},
+                             [&](const std::vector<ComputeItem> &items) {
+                                 ++calls;
+                                 const bool executed = prosper::frontend::execute_live_compute_items(items);
+                                 ok &= executed;
+                                 if (calls == 1) {
+                                     check(std::equal(expected.begin(), expected.end(), guest.begin()),
+                                           "last writer B restores the exact final guest composite");
+                                     prepare_borrow();
+                                     check_graphics(false);
+                                     check_graphics(can_retain(journal == Journal::Overflow), true);
+                                 }
+                                 return executed;
+                             });
+            check(ok && calls == 2, "producer and final B consumer execute");
+            check_b_pixels(bv);
+            // The first B consumer has no sampled allocation to reuse: a retained route must
+            // perform a real storage-to-sampled transfer. Warm output remains checked above.
+            if (av == 0x13579bdfu)
+                check((prosper::frontend::live_compute_storage_transfer_seeds() > before) ==
+                          can_retain(journal == Journal::Overflow),
+                      "last conflict-free B retains the real compute transfer path");
+            check(std::all_of(guest.begin() + texels, guest.end(),
+                              [](uint32_t v) { return v == 0xccccccccu; }),
+                  "last-output regression preserves guest tail");
+        }
+    }
     void prewarm_b(bool host_baseline) {
         const auto before = prosper::frontend::live_compute_image_result_snapshot_bytes();
         if (host_baseline)
@@ -268,36 +320,170 @@ struct Fixture {
         }
         std::fill(guest.begin(), guest.end(),
                   0xffffffffu); // valid all-uncompressed initial metadata
-        std::vector<uint32_t> expected(texels, 0x13579bdfu);
-        std::fill_n(expected.begin(), metadata_bytes / 4, 0xffffffffu);
+        for (uint32_t av : {0x13579bdfu, 0x31415926u}) {
+            // Warm round changes only A. B's pixels are identical, but A overwrites B's
+            // metadata before B's turn, so a result-equality skip must not omit its reset.
+            std::vector<uint32_t> expected(texels, av);
+            std::fill_n(expected.begin(), metadata_bytes / 4, 0xffffffffu);
+            std::fill(observed.begin(), observed.end(), 0xdeadbeefu);
+            std::fill(observed_b.begin(), observed_b.end(), 0xdeadbeefu);
+            unsigned calls = 0;
+            bool ok = true;
+            execute_sequence({writer(av, 0x2468ace0u), reader(), reader(true)},
+                             [&](const std::vector<ComputeItem> &items) {
+                                 ++calls;
+                                 const bool executed =
+                                     prosper::frontend::execute_live_compute_items(items);
+                                 ok &= executed;
+                                 if (calls == 1) {
+                                     check(std::equal(expected.begin(), expected.end(), guest.begin()),
+                                           "cold and warm DCC reset complete the final A composite");
+                                     prepare_borrow();
+                                     check_graphics(false);
+                                     check_graphics(can_retain(journal == Journal::Overflow), true);
+                                 }
+                                 return executed;
+                             });
+            check(ok && calls == 3 && observed == expected,
+                  "sampled A observes overlapping DCC metadata reset in both rounds");
+            check_b_pixels(0x2468ace0u);
+            std::vector<uint32_t> linear(width * b.height);
+            detile_surface(reinterpret_cast<uint8_t *>(linear.data()),
+                           reinterpret_cast<const uint8_t *>(other.data()), width, b.height,
+                           b.tile_mode, 0, 4);
+            check(std::all_of(linear.begin(), linear.end(),
+                              [](uint32_t v) { return v == 0x2468ace0u; }),
+                  "separate DCC pixel owner publishes its own exact output");
+            check(std::all_of(other.begin() + tiled_bytes / 4, other.end(),
+                              [](uint32_t v) { return v == 0xeeeeeeeeu; }) &&
+                      std::all_of(guest.begin() + texels, guest.end(),
+                                  [](uint32_t v) { return v == 0xffffffffu; }),
+                  "DCC output and metadata reset preserve both independent tails");
+            check(std::all_of(advertised_metadata.begin(), advertised_metadata.end(),
+                              [](uint8_t v) { return v == 0x97; }),
+                  "hosted DCC preserves advertised metadata backing");
+            check_graphics(false);
+        }
+    }
+    void late_metadata() {
+        // The first image writes ordinary FP16 magenta and resets DCC to all-0xff.
+        // The later independent image writes a valid DCC_CLEAR_0001 plane, without
+        // touching those pixels. Its final interpretation is black with alpha one.
+        a.format = DataFormat::Float16;
+        a.num_components = 4;
+        a.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        a.compression_enabled = a.write_compress_enabled = a.meta_pipe_aligned = true;
+        a.alpha_is_on_msb = true;
+        const size_t tiled_bytes = tiled_surface_bytes(width, height, a.tile_mode, 0, 8);
+        guest.resize(tiled_bytes / 4 + 16, 0xccccccccu);
+        a.gpu_addr = reinterpret_cast<uint64_t>(guest.data());
+        a.size = tiled_bytes;
+        a.metadata_addr = reinterpret_cast<uint64_t>(other.data());
+        const size_t metadata_bytes = gpu_capture_dcc_metadata_footprint(a);
+        check(metadata_bytes && metadata_bytes <= 65536,
+              "late metadata fixture has a bounded real RGBA16F DCC footprint");
+        if (!metadata_bytes || metadata_bytes > 65536) return;
+        // The metadata writer owns whole rows; its declared padding is real backing,
+        // separate from the guard beyond that writer's exact extent.
+        const size_t metadata_writer_bytes = ((metadata_bytes + width * 4 - 1) / (width * 4)) * width * 4;
+        other.resize(metadata_writer_bytes / 4 + 16, 0xeeeeeeeeu);
+        std::fill_n(other.begin(), metadata_writer_bytes / 4, 0xffffffffu);
+        a.metadata_addr = reinterpret_cast<uint64_t>(other.data());
+        a.dcc_metadata_size = metadata_bytes;
+        b.gpu_addr = a.metadata_addr;
+        b.width = width;
+        b.height = metadata_writer_bytes / (width * 4);
+        b.size = metadata_writer_bytes;
+        ShaderResourceTable producer_table;
+        producer_table.resources = {a, b};
+        std::vector<uint32_t> code{
+            0x7e080300u, 0x7e0002ffu, 0x3f800000u, 0x7e020280u,
+            0x7e0402ffu, 0x3f800000u, 0x7e0602ffu, 0x3f800000u};
+        for (uint32_t y = 0; y < height; ++y)
+            code.insert(code.end(), {0x7e0a0280u + y, 0xf0200f08u, 0x00020004u});
+        code.insert(code.end(), {0x7e0002ffu, 0x40404040u});
+        for (uint32_t y = 0; y < b.height; ++y)
+            code.insert(code.end(), {0x7e0a02ffu, y, 0xf0200108u, 0x00040004u});
+        code.push_back(0xbf810000u);
+        const auto producer = item(code, producer_table, 0x34760005u, 1, true);
+        const auto reflection = validate_spirv_descriptor_interface(
+            producer.spirv, &producer_table, 0, SpirvShaderStage::Compute, false);
+        const auto* first = find_spirv_descriptor_binding(reflection, 0, 5);
+        const auto* last = find_spirv_descriptor_binding(reflection, 0, 6);
+        // Native float storage deliberately uses SPIR-V Format=Unknown; the backend selects
+        // RGBA16F from the guest descriptor. The raw interchange fallback has a Uint sampled type.
+        check(reflection.ok() && reflection.storage_image_writes_complete && first && last &&
+                  first->kind == SpirvDescriptorKind::StorageImage && first->writable && !first->readable &&
+                  first->storage_float && first->image_numeric_class == SpirvImageNumericClass::Float &&
+                  first->storage_image_format == 0 && a.format == DataFormat::Float16 && a.num_components == 4 &&
+                  last->kind == SpirvDescriptorKind::StorageImage && last->writable &&
+                  last->storage_image_format == kSpirvImageFormatR32ui,
+              "late metadata producer has native RGBA16F and R32_UINT image outputs");
+        observed.resize(texels * 4 + 16, 0xdeadbeefu);
+        std::fill(observed.begin(), observed.end(), 0xdeadbeefu);
+        ShaderResource output{};
+        output.cls = ResourceClass::ConstantBuffer;
+        output.binding = 2;
+        output.sgpr_base = 0;
+        output.format = DataFormat::Uint32;
+        output.num_components = 1;
+        output.stride = 16;
+        output.size = texels * 16;
+        output.gpu_addr = reinterpret_cast<uint64_t>(observed.data());
+        ShaderResourceTable consumer_table;
+        consumer_table.resources = {output, sampled()};
+        std::vector<uint32_t> reads{0x7e080300u};
+        for (uint32_t y = 0; y < height; ++y) {
+            reads.insert(reads.end(), {0x7e0a0280u + y, 0xf0000f08u, 0x00020804u,
+                                       0xbf8c3f70u, 0xbe9803ffu, y * width * 16u});
+            for (uint32_t c = 0; c < 4; ++c)
+                reads.insert(reads.end(), {0xe0702000u | (c * 4u),
+                                           0x18000004u | ((8u + c) << 8)});
+        }
+        reads.push_back(0xbf810000u);
+        const auto consumer = item(reads, consumer_table, 0x34760006u, 2);
         unsigned calls = 0;
         bool ok = true;
-        execute_sequence({writer(0x13579bdfu, 0x2468ace0u), reader()},
-                         [&](const std::vector<ComputeItem> &items) {
-                             ++calls;
-                             const bool executed =
-                                 prosper::frontend::execute_live_compute_items(items);
-                             ok &= executed;
-                             if (calls == 1) {
-                                 check(std::equal(expected.begin(), expected.end(), guest.begin()),
-                                       "DCC reset is part of final A composite");
-                                 prepare_borrow();
-                                 check_graphics(false);
-                             }
-                             return executed;
-                         });
-        check(ok && calls == 2 && observed == expected,
-              "sampled A observes overlapping DCC metadata reset");
-        std::vector<uint32_t> linear(width * b.height);
-        detile_surface(reinterpret_cast<uint8_t *>(linear.data()),
-                       reinterpret_cast<const uint8_t *>(other.data()), width, b.height,
-                       b.tile_mode, 0, 4);
-        check(
-            std::all_of(linear.begin(), linear.end(), [](uint32_t v) { return v == 0x2468ace0u; }),
-            "separate DCC pixel owner publishes its own exact output");
-        check(std::all_of(advertised_metadata.begin(), advertised_metadata.end(),
-                          [](uint8_t v) { return v == 0x97; }),
-              "hosted DCC preserves advertised metadata backing");
+        execute_sequence({producer, consumer}, [&](const std::vector<ComputeItem>& items) {
+            ++calls;
+            const bool executed = prosper::frontend::execute_live_compute_items(items);
+            ok &= executed;
+            if (calls == 1) {
+                check(std::all_of(other.begin(), other.begin() + metadata_writer_bytes / 4,
+                                  [](uint32_t v) { return v == 0x40404040u; }),
+                      "last image writes the complete valid DCC clear plane");
+                std::vector<uint16_t> linear(texels * 4);
+                detile_surface(reinterpret_cast<uint8_t*>(linear.data()),
+                               reinterpret_cast<const uint8_t*>(guest.data()),
+                               width, height, a.tile_mode, 0, 8);
+                bool magenta = true;
+                for (size_t i = 0; i < linear.size(); ++i)
+                    magenta &= linear[i] == (i % 4 == 1 ? 0u : 0x3c00u);
+                check(magenta, "metadata-only last writer leaves first image base exactly FP16 magenta");
+                uint8_t clear[4]{}, clear_code = 0;
+                check(prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                          sampled(), true, false, false, clear, 1,
+                          reinterpret_cast<const uint8_t*>(other.data()), metadata_bytes, &clear_code) &&
+                          clear_code == 0x40 && clear[0] == 0 && clear[1] == 0 &&
+                          clear[2] == 0 && clear[3] == 255,
+                      "final metadata has established black/alpha-one semantics");
+                prepare_borrow();
+                check_graphics(false);
+            }
+            return executed;
+        });
+        bool black_alpha_one = true;
+        for (size_t i = 0; i < texels * 4; ++i)
+            black_alpha_one &= observed[i] == (i % 4 == 3 ? 0x3f800000u : 0u);
+        check(ok && calls == 2 && black_alpha_one,
+              "real sampled consumer observes final clear semantics rather than stale magenta");
+        check(std::all_of(observed.begin() + texels * 4, observed.end(),
+                          [](uint32_t v) { return v == 0xdeadbeefu; }) &&
+                  std::all_of(guest.begin() + tiled_bytes / 4, guest.end(),
+                              [](uint32_t v) { return v == 0xccccccccu; }) &&
+                  std::all_of(other.begin() + metadata_writer_bytes / 4, other.end(),
+                              [](uint32_t v) { return v == 0xeeeeeeeeu; }),
+              "late metadata case preserves pixel, metadata and SSBO tails");
         check_graphics(false);
     }
     std::vector<uint8_t> advertised_metadata = std::vector<uint8_t>(65536, 0x97);
@@ -418,7 +604,7 @@ struct Fixture {
                 }
                 if (calls == 2) {
                     prepare_borrow();
-                    check_graphics(false);
+                    check_graphics(can_retain(journal == Journal::Overflow));
                 }
                 return executed;
             });
@@ -654,6 +840,8 @@ int main(int argc, char **argv) {
         f->run(0x13579bdfu, 0x2468ace0u);
         f->run(0x31415926u, 0x2468ace0u); // Changed early A, unchanged overlapping late B.
     }
+    Fixture late(true, false);
+    late.late_output();
     unbound.unbound_hosted();
     Fixture gpu_baseline(true, false), host_baseline(true, false), dcc(false, false),
         hosted_dcc(false, false);
@@ -663,6 +851,8 @@ int main(int argc, char **argv) {
     host_baseline.run(0x13579bdfu, 0x2468ace0u);
     dcc.dcc_overlap(false);
     hosted_dcc.dcc_overlap(true);
+    Fixture late_metadata(false, false);
+    late_metadata.late_metadata();
     Fixture self(true, false), pinned(true, false);
     self.self_dcc();
     pinned.pinned_overlap();


### PR DESCRIPTION
Independent Vulkan outputs can overlap in guest memory. After A then B write back, final publication could bless stale A with a fresh journal snapshot or watch. An unchanged B could also skip restoring pixels or DCC metadata changed by earlier A. Hosted writes could leave absent cached views unaware of their actual destination.

Follow actual writeback order: all unique buffers, then each unique image's pixels and metadata reset. Earlier conflicts disable equality shortcuts; later conflicts and self-overlapping metadata prevent final retention/publication. The last writer can restore its complete result and retain normal reuse. Input-only retention remains available before guest writes, with an explicit metadata-dependency veto. Hosted outputs notify actual destinations as well as advertised ranges, while zero-address internal GDS/private buffers preserve their separate semantics and resource pins remain intact.

The production Vulkan fixture checks complete guest bytes, actual sampled-image-to-SSBO results, graphics leases, both result-baseline kinds, final-writer reuse, warm DCC resets, valid late RGBA16F clear semantics, hosted/self overlap, buffer/image and buffer/buffer writes, missing/overflowed journals, cross-submit watches and failed submission. It contains ordinary reuse and independently writable internal-buffer positives. The original backend and isolated guard removals serve as negative controls.

Validated exact head `e3b73f238ee5c6c7ac9f1be9fef69ab404f2b795`: Release app/all targets build, **446/446 tests pass**, and **60/60 focused synchronization cases pass with zero messages**, following layer-load and deliberate-hazard controls. The expanded fixture fails against original main and the superseded conservative implementation; all six isolated guard-removal controls fail as intended. [Commands and exact control results](https://github.com/mattias800/prosper/pull/3481#issuecomment-5592726362).

[Matched final Sonic/GTA captures](https://github.com/mattias800/prosper/pull/3481#issuecomment-5592923048) preserve baseline presentation throughput: host-present counts are39→39 and31→31 in the short windows. Newly rendered FPS remains unavailable. Sonic's normalized enclosing compute cost increases; GTA's is approximately flat. GTA's bank scene is consistent, while Sonic retains its known black-world/HUD defect with differing state. No game-specific diagnosis or general speedup is claimed. [Audio remains separate](https://github.com/mattias800/prosper/pull/3481#issuecomment-5592923168): quiet/F8 main-output shortages are zero, but F9-associated gaps and GTA's intro-output cluster remain.

Independent exact-head source/fixture, production/docs and capture reviews are registered. All seven required Linux/general CI checks are green; Windows/macOS are outside the owner's merge gate. The first conservative implementation was refined before merge to preserve safe last-writer/input reuse and cover warm DCC reset dependencies.

Commands from the repository root with the configured game library and Vulkan toolchain:

```sh
cmake --build prosper/build-linux -j6
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure -j1
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure -R '^storage_output_conflicts'
```

Fixes #3476. Related to #3407. Future independently changed metadata at the shared borrowing boundary remains #3482; this PR repairs synchronous publication ordering.
