### PR TITLE
perf(capture): stream bundle files with checked atomic replacement

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2213,6 +2213,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_capture_bundle PRIVATE prosper_core)
   add_test(NAME gpu_capture_bundle_roundtrip COMMAND test_gpu_capture_bundle)
 
+  add_executable(test_gpu_capture_bundle_streaming tests/gpu/capture/test_gpu_capture_bundle_streaming.cpp)
+  target_include_directories(test_gpu_capture_bundle_streaming PRIVATE tests)
+  target_link_libraries(test_gpu_capture_bundle_streaming PRIVATE prosper_core)
+  add_test(NAME gpu_capture_bundle_streaming COMMAND test_gpu_capture_bundle_streaming)
+  set_tests_properties(gpu_capture_bundle_streaming PROPERTIES TIMEOUT 60)
+
   add_executable(test_interactive_capture_writer tests/gpu/capture/test_interactive_capture_writer.cpp)
   target_include_directories(test_interactive_capture_writer PRIVATE tests)
   target_link_libraries(test_interactive_capture_writer PRIVATE prosper_core)

--- a/prosper/src/gpu/capture/AGENTS.md
+++ b/prosper/src/gpu/capture/AGENTS.md
@@ -21,3 +21,16 @@ resource's `host_data` at a different buffer must reset that field with it.
 
 **A manifest strips payloads by design.** Validators and consumers must not assume a referenced
 payload is present; several were fixed for dereferencing exactly what the manifest omits.
+
+
+**Bundle serialization keeps only the owned chunk store in memory.** `write_gpu_capture_bundle`
+streams the existing v1/v2 layout into a private temporary file and computes its trailing checksum
+incrementally. Keep the historical checksum basis and exclude the trailer from its own hash. Preserve
+chunk/resource integrity checks and the complete-file size bound; removing a duplicate allocation
+does not authorize raising collection limits.
+
+Install only after successful writes, flush and close. Failed validation or I/O must preserve an
+existing destination and clean only this writer's private temporary. Concurrent writers may replace
+one another with complete valid files; they must never share a truncatable temporary or delete the
+previous destination to recover from a failed rename. The collector retains payload ownership until
+the asynchronous writer completes, including failure and shutdown.

--- a/prosper/src/gpu/capture/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/capture/gpu_capture_bundle.cpp
@@ -1,12 +1,21 @@
 #include "gpu/capture/gpu_capture_bundle.hpp"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
 
 namespace prosper::gpu {
 namespace {
@@ -18,11 +27,33 @@ constexpr uint32_t kMaxChunks = 1u << 20;
 constexpr uint32_t kMaxSubmits = 4096;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 
+// The chunk store already owns the payload. Serialize directly to the temporary file;
+// retaining another whole-file vector would double resident payload and copy it on growth.
 struct Writer {
-    std::vector<uint8_t> data;
-    void raw(const void* p, size_t n) {
-        if (!n) return;
-        const auto* b = static_cast<const uint8_t*>(p); data.insert(data.end(), b, b + n);
+    std::ofstream& file;
+    std::string& error;
+    uint64_t written = 0;
+    uint64_t hash = 1469598103934665603ull; // Preserve the historical bundle checksum basis.
+    bool valid = true;
+
+    bool good() const { return valid; }
+    void raw(const void* p, size_t n, bool trailer = false) {
+        if (!valid || !n) return;
+        const uint64_t limit = kMaxFileBytes - (trailer ? 0 : sizeof(uint64_t));
+        if (written > limit || n > limit - written ||
+            n > static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+            error = "bundle exceeds 4 GiB"; valid = false; return;
+        }
+        if (!trailer) {
+            const auto* bytes = static_cast<const uint8_t*>(p);
+            for (size_t i = 0; i < n; ++i) {
+                hash ^= bytes[i];
+                hash *= 1099511628211ull;
+            }
+        }
+        file.write(static_cast<const char*>(p), static_cast<std::streamsize>(n));
+        if (!file) { error = "cannot write bundle temporary file"; valid = false; return; }
+        written += n;
     }
     void u32(uint32_t v) {
         uint8_t b[4]; for (int i = 0; i < 4; ++i) b[i] = static_cast<uint8_t>(v >> (i * 8)); raw(b, 4);
@@ -30,7 +61,17 @@ struct Writer {
     void u64(uint64_t v) {
         uint8_t b[8]; for (int i = 0; i < 8; ++i) b[i] = static_cast<uint8_t>(v >> (i * 8)); raw(b, 8);
     }
-    void bytes(const std::vector<uint8_t>& v) { u32(static_cast<uint32_t>(v.size())); raw(v.data(), v.size()); }
+    void bytes(const std::vector<uint8_t>& v) {
+        if (v.size() > UINT32_MAX) {
+            error = "bundle chunk exceeds length field"; valid = false; return;
+        }
+        u32(static_cast<uint32_t>(v.size())); raw(v.data(), v.size());
+    }
+    void finish() {
+        uint8_t b[8];
+        for (int i = 0; i < 8; ++i) b[i] = static_cast<uint8_t>(hash >> (i * 8));
+        raw(b, sizeof(b), true); // The trailer is excluded from its own checksum.
+    }
 };
 
 struct Reader {
@@ -52,20 +93,64 @@ struct Reader {
     }
 };
 
-bool install_file(const std::string& path, const std::vector<uint8_t>& bytes, std::string& error) {
-    std::filesystem::path target(path), temp = target; temp += ".tmp";
-    std::error_code ec;
-    if (target.has_parent_path()) std::filesystem::create_directories(target.parent_path(), ec);
-    std::ofstream file(temp, std::ios::binary | std::ios::trunc);
-    if (!file || !file.write(reinterpret_cast<const char*>(bytes.data()),
-                             static_cast<std::streamsize>(bytes.size()))) {
-        error = "cannot write bundle temporary file"; return false;
+struct TemporaryBundleFile {
+    std::filesystem::path target;
+    std::filesystem::path directory;
+    std::filesystem::path payload;
+    std::ofstream file;
+
+    explicit TemporaryBundleFile(const std::string& path) : target(path) {}
+    ~TemporaryBundleFile() {
+        if (file.is_open()) file.close();
+        if (!directory.empty()) {
+            std::error_code ignored;
+            std::filesystem::remove_all(directory, ignored);
+        }
     }
-    file.close(); std::filesystem::rename(temp, target, ec);
-    if (ec) { std::filesystem::remove(target, ec); ec.clear(); std::filesystem::rename(temp, target, ec); }
-    if (ec) { error = "cannot install bundle: " + ec.message(); return false; }
-    return true;
-}
+    bool open(std::string& error) {
+        std::error_code ec;
+        if (target.has_parent_path()) {
+            std::filesystem::create_directories(target.parent_path(), ec);
+            if (ec) { error = "cannot create bundle directory: " + ec.message(); return false; }
+        }
+        // Reserve a private sibling, also across processes. Never truncate another writer's
+        // temporary file, and never remove the existing destination to make replacement succeed.
+        static std::atomic<uint64_t> serial{0};
+        for (unsigned attempt = 0; attempt < 16; ++attempt) {
+            auto candidate = target;
+            candidate += ".tmp-" + std::to_string(
+                std::chrono::steady_clock::now().time_since_epoch().count()) + "-" +
+                std::to_string(serial.fetch_add(1, std::memory_order_relaxed));
+            if (std::filesystem::create_directory(candidate, ec)) {
+                directory = std::move(candidate);
+                break;
+            }
+            if (ec) { error = "cannot reserve bundle temporary: " + ec.message(); return false; }
+        }
+        if (directory.empty()) { error = "cannot reserve bundle temporary"; return false; }
+        payload = directory / "bundle";
+        file.open(payload, std::ios::binary | std::ios::trunc);
+        if (!file) { error = "cannot open bundle temporary file"; return false; }
+        return true;
+    }
+    bool install(std::string& error) {
+        file.flush();
+        const bool flushed = static_cast<bool>(file);
+        file.close();
+        if (!flushed || !file) { error = "cannot finish bundle temporary file"; return false; }
+#ifdef _WIN32
+        if (!MoveFileExW(payload.c_str(), target.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+            error = "cannot install bundle: Windows error " + std::to_string(GetLastError());
+            return false;
+        }
+#else
+        std::error_code ec;
+        std::filesystem::rename(payload, target, ec);
+        if (ec) { error = "cannot install bundle: " + ec.message(); return false; }
+#endif
+        return true;
+    }
+};
 
 uint64_t gear_value(uint8_t byte) {
     uint64_t value = static_cast<uint64_t>(byte) + 0x9e3779b97f4a7c15ull;
@@ -549,16 +634,22 @@ bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& b
         bundle.submits.size() > kMaxSubmits || bundle.version < 1 || bundle.version > kVersion) {
         error = "invalid bundle structure"; return false;
     }
-    Writer writer; writer.raw(kMagic, sizeof(kMagic)); writer.u32(bundle.version); writer.u32(kEndian);
+    TemporaryBundleFile temporary(path);
+    if (!temporary.open(error)) return false;
+    Writer writer{temporary.file, error};
+    writer.raw(kMagic, sizeof(kMagic)); writer.u32(bundle.version); writer.u32(kEndian);
     writer.u32(bundle.chunk_bytes); writer.u64(bundle.logical_bytes);
     writer.u32(static_cast<uint32_t>(bundle.chunks.size()));
+    if (!writer.good()) return false;
     for (size_t i = 0; i < bundle.chunks.size(); ++i) {
         const uint64_t hash = gpu_capture_hash(bundle.chunks[i]);
         if (bundle.chunk_hashes[i] != hash) { error = "bundle chunk hash mismatch"; return false; }
         writer.u64(hash); writer.bytes(bundle.chunks[i]);
+        if (!writer.good()) return false;
     }
     if (bundle.version >= 2) {
         writer.u32(static_cast<uint32_t>(bundle.resources.size()));
+        if (!writer.good()) return false;
         for (const auto& resource : bundle.resources) {
             bool valid = false;
             const uint64_t hash = resource_hash(bundle, resource, valid);
@@ -569,16 +660,19 @@ bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& b
             writer.u64(hash);
             writer.u64(resource.logical_bytes);
             writer.u32(static_cast<uint32_t>(resource.chunk_indices.size()));
+            if (!writer.good()) return false;
             for (uint32_t index : resource.chunk_indices) {
                 if (index >= bundle.chunks.size()) {
                     error = "bundle resource references an invalid chunk";
                     return false;
                 }
                 writer.u32(index);
+                if (!writer.good()) return false;
             }
         }
     }
     writer.u32(static_cast<uint32_t>(bundle.submits.size()));
+    if (!writer.good()) return false;
     for (const auto& submit : bundle.submits) {
         uint64_t reconstructed_bytes = 0;
         for (uint32_t index : submit.chunk_indices) {
@@ -598,9 +692,11 @@ bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& b
         writer.u64(submit.submit_index); writer.u64(submit.logical_bytes);
         if (bundle.version >= 2) writer.u64(submit.manifest_bytes);
         writer.u32(static_cast<uint32_t>(submit.chunk_indices.size()));
+        if (!writer.good()) return false;
         for (uint32_t index : submit.chunk_indices) {
             if (index >= bundle.chunks.size()) { error = "bundle references an invalid chunk"; return false; }
             writer.u32(index);
+            if (!writer.good()) return false;
         }
         if (bundle.version >= 2) {
             if (submit.blob_resource_indices.size() != submit.blob_bytes_read.size()) {
@@ -615,6 +711,7 @@ bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& b
                 }
                 writer.u32(submit.blob_resource_indices[i]);
                 writer.u64(submit.blob_bytes_read[i]);
+                if (!writer.good()) return false;
                 if (reconstructed_bytes > UINT64_MAX -
                         bundle.resources[submit.blob_resource_indices[i]].logical_bytes) {
                     error = "bundle submit logical size overflow";
@@ -624,15 +721,14 @@ bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& b
                     bundle.resources[submit.blob_resource_indices[i]].logical_bytes;
             }
         }
+        if (!writer.good()) return false;
         if (reconstructed_bytes != submit.logical_bytes) {
             error = "bundle submit logical size mismatch";
             return false;
         }
     }
-    const uint64_t manifest_hash = gpu_capture_hash(writer.data);
-    writer.u64(manifest_hash);
-    if (writer.data.size() > kMaxFileBytes) { error = "bundle exceeds 4 GiB"; return false; }
-    return install_file(path, writer.data, error);
+    writer.finish();
+    return writer.good() && temporary.install(error);
 }
 
 bool read_gpu_capture_bundle(const std::string& path, GpuCaptureBundle& bundle,

--- a/prosper/tests/gpu/capture/test_gpu_capture_bundle_streaming.cpp
+++ b/prosper/tests/gpu/capture/test_gpu_capture_bundle_streaming.cpp
@@ -1,0 +1,270 @@
+#include "gpu/capture/gpu_capture_bundle.hpp"
+#include "fixtures/test_scratch.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <new>
+#include <thread>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#elif defined(__linux__)
+#include <csignal>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+// Measure requested ordinary C++ allocations only during write_gpu_capture_bundle. Input
+// collection, reader allocations, libc/aligned allocation and physical RSS are not bounded here.
+namespace {
+std::atomic<bool> measuring{false};
+std::atomic<size_t> allocation_bytes{0}, largest_allocation{0};
+void record_allocation(size_t bytes) {
+    if (!measuring.load(std::memory_order_relaxed)) return;
+    allocation_bytes.fetch_add(bytes, std::memory_order_relaxed);
+    size_t previous = largest_allocation.load(std::memory_order_relaxed);
+    while (previous < bytes && !largest_allocation.compare_exchange_weak(
+        previous, bytes, std::memory_order_relaxed)) {}
+}
+}
+void* operator new(size_t bytes) {
+    void* p = std::malloc(bytes ? bytes : 1);
+    if (!p) throw std::bad_alloc();
+    record_allocation(bytes);
+    return p;
+}
+void* operator new[](size_t bytes) { return ::operator new(bytes); }
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete(void* p, size_t) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete[](void* p, size_t) noexcept { std::free(p); }
+
+using namespace prosper::gpu;
+namespace {
+int failures = 0;
+#define CHECK(c, message) do { if (!(c)) { \
+    std::fprintf(stderr, "FAIL: %s (line %d)\n", message, __LINE__); ++failures; } } while (0)
+
+std::vector<uint8_t> read_bytes(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+void put_bytes(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+    std::ofstream file(path, std::ios::binary | std::ios::trunc);
+    file.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    file.close();
+    CHECK(file.good(), "fixture file closes successfully");
+}
+std::vector<uint8_t> hex_bytes(const char* text) {
+    std::vector<uint8_t> bytes;
+    for (; *text; text += 2) {
+        const auto digit = [](char c) { return c <= '9' ? c - '0' : c - 'a' + 10; };
+        bytes.push_back(static_cast<uint8_t>(digit(text[0]) * 16 + digit(text[1])));
+    }
+    return bytes;
+}
+// Frozen wire bytes, independently encoded from the legacy little-endian format, including
+// its historical nonstandard FNV basis and checksum trailer. Never derive expected bytes by
+// invoking the writer under test. Tiny chunks intentionally test framing, not capture parsing.
+const char* const wire_v1 =
+    "505247424e444c0001000000040302010000040003000000000000000100000075e41c394f4e8da7"
+    "030000000081ff01000000290000000000000003000000000000000100000000000000ddcbdec4af56e141";
+const char* const wire_v2 =
+    "505247424e444c0002000000040302010000040008000000000000000200000075e41c394f4e8da7"
+    "030000000081ff9a2a8baa89d6af41050000000102030405010000009a2a8baa89d6af410500000000"
+    "000000010000000100000001000000290000000000000008000000000000000300000000000000"
+    "01000000000000000100000000000000050000000000000008f9c4afb1551a0e";
+
+GpuCaptureBundle tiny(uint32_t version) {
+    GpuCaptureBundle bundle;
+    bundle.version = version;
+    bundle.logical_bytes = version == 1 ? 3 : 8;
+    bundle.chunks = {{0, 0x81, 0xff}};
+    if (version == 2) bundle.chunks.push_back({1, 2, 3, 4, 5});
+    for (const auto& chunk : bundle.chunks) bundle.chunk_hashes.push_back(gpu_capture_hash(chunk));
+    GpuCaptureBundleSubmit submit;
+    submit.submit_index = 41;
+    submit.logical_bytes = bundle.logical_bytes;
+    submit.manifest_bytes = 3;
+    submit.chunk_indices = {0};
+    if (version == 2) {
+        bundle.resources.push_back({bundle.chunk_hashes[1], 5, {1}});
+        submit.blob_resource_indices = {0};
+        submit.blob_bytes_read = {5};
+    }
+    bundle.submits.push_back(std::move(submit));
+    return bundle;
+}
+
+// Every test uses an otherwise empty private directory. No spelling of the implementation's
+// temporary filename is assumed; all unexpected sibling files/directories are detected.
+bool only_target(const std::filesystem::path& directory, const std::filesystem::path& target) {
+    size_t entries = 0;
+    for (const auto& entry : std::filesystem::directory_iterator(directory)) {
+        if (entry.path() != target) return false;
+        ++entries;
+    }
+    return entries == 1;
+}
+void expect_failure(const std::filesystem::path& directory, const GpuCaptureBundle& bundle,
+                    const std::vector<uint8_t>& original, const char* label) {
+    const auto target = directory / "target.prgbundle";
+    put_bytes(target, original);
+    std::string error;
+    CHECK(!write_gpu_capture_bundle(target.string(), bundle, error) && !error.empty(), label);
+    CHECK(read_bytes(target) == original, "failed write preserves entire previous destination and tail");
+    CHECK(only_target(directory, target), "failed write removes every temporary artifact");
+}
+}
+
+int main() {
+    const auto directory = prosper_test::test_scratch_dir() / "streamed-bundle";
+    std::filesystem::create_directory(directory);
+    const auto target = directory / "target.prgbundle";
+    const auto target_string = target.string();
+    const auto first = tiny(1), second = tiny(2);
+    const auto expected_first = hex_bytes(wire_v1), expected_second = hex_bytes(wire_v2);
+    std::string error;
+
+    for (uint32_t version : {1u, 2u}) {
+        const auto& expected = version == 1 ? expected_first : expected_second;
+        const auto& bundle = version == 1 ? first : second;
+        CHECK(write_gpu_capture_bundle(target_string, bundle, error), "frozen fixture writes");
+        CHECK(read_bytes(target) == expected, "wire version matches every frozen byte including trailer");
+        put_bytes(target, expected);
+        GpuCaptureBundle loaded;
+        CHECK(read_gpu_capture_bundle(target_string, loaded, error) &&
+              loaded.version == version && loaded.chunks == bundle.chunks &&
+              loaded.chunk_hashes == bundle.chunk_hashes && loaded.logical_bytes == bundle.logical_bytes &&
+              loaded.submits.size() == 1 && loaded.submits[0].submit_index == 41 &&
+              loaded.submits[0].blob_resource_indices == bundle.submits[0].blob_resource_indices,
+              "reader accepts independent frozen legacy bytes and resource references");
+    }
+
+    // Prebuild both payloads and path/error storage. The growing output-vector implementation
+    // exceeds both fixed ceilings even for the smaller input; streaming must not scale with bytes.
+    std::vector<GpuCaptureBundle> payloads;
+    for (size_t size : {size_t{1} << 20, size_t{16} << 20}) {
+        GpuCaptureBundle bundle = tiny(1);
+        bundle.chunk_bytes = 16u << 20;
+        bundle.chunks[0].resize(size);
+        for (size_t i = 0; i < size; ++i) bundle.chunks[0][i] = static_cast<uint8_t>((i * 29) ^ (i >> 9));
+        bundle.chunk_hashes[0] = gpu_capture_hash(bundle.chunks[0]);
+        bundle.logical_bytes = size;
+        bundle.submits[0].logical_bytes = bundle.submits[0].manifest_bytes = size;
+        payloads.push_back(std::move(bundle));
+    }
+    error.reserve(1024);
+    allocation_bytes = 0; largest_allocation = 0; measuring = true;
+    void* observed = ::operator new(12345);
+    measuring = false;
+    ::operator delete(observed);
+    CHECK(allocation_bytes == 12345 && largest_allocation == 12345,
+          "allocation observer detects a deliberate allocation");
+    for (const auto& bundle : payloads) {
+        allocation_bytes = 0; largest_allocation = 0; measuring = true;
+        const bool written = write_gpu_capture_bundle(target_string, bundle, error);
+        measuring = false;
+        const auto total = allocation_bytes.load(), largest = largest_allocation.load();
+        std::printf("payload=%zu write-allocation-total=%zu largest=%zu\n",
+                    bundle.chunks[0].size(), total, largest);
+        CHECK(written, "prebuilt payload writes within allocation measurement");
+        CHECK(total < 512 * 1024 && largest < 128 * 1024,
+              "write allocations stay bounded independently of prebuilt payload size");
+        GpuCaptureBundle loaded;
+        CHECK(read_gpu_capture_bundle(target_string, loaded, error) && loaded.chunks == bundle.chunks &&
+              loaded.logical_bytes == bundle.logical_bytes, "large payload and tail survive checked readback");
+    }
+
+    auto invalid = second;
+    invalid.submits[0].blob_resource_indices[0] = 1;
+    expect_failure(directory, invalid, expected_second, "late invalid resource reference refuses installation");
+    invalid = second; invalid.resources[0].content_hash ^= 1;
+    expect_failure(directory, invalid, expected_second, "resource checksum mismatch refuses installation");
+    invalid = second; invalid.chunks[1].back() ^= 1;
+    expect_failure(directory, invalid, expected_second, "later chunk corruption refuses installation");
+    invalid = second; invalid.submits[0].chunk_indices[0] = 2;
+    expect_failure(directory, invalid, expected_second, "late invalid manifest chunk refuses installation");
+
+#ifdef __linux__
+    // A real OS short write/flush failure in a child, without a process memory limit or any
+    // production injection hook. _exit prevents the child's scratch destructor deleting ours.
+    for (bool buffered : {false, true}) {
+        put_bytes(target, expected_second);
+        const pid_t child = fork();
+        if (child == 0) {
+            std::signal(SIGXFSZ, SIG_IGN);
+            // The 152-byte wire fixture fits the stream buffer but exceeds the 64-byte
+            // file limit, exercising deferred flush failure on buffered implementations.
+            const rlim_t maximum = buffered ? 64 : 4096;
+            const rlimit limit{maximum, maximum};
+            if (setrlimit(RLIMIT_FSIZE, &limit) != 0) _exit(20);
+            std::string failure;
+            const bool ok = write_gpu_capture_bundle(target_string,
+                buffered ? second : payloads[0], failure);
+            _exit(!ok && !failure.empty() ? 0 : 21);
+        }
+        int status = 0;
+        CHECK(child > 0 && waitpid(child, &status, 0) == child && WIFEXITED(status) && WEXITSTATUS(status) == 0,
+              "OS file-size failure is reported without killing the writer child");
+        CHECK(read_bytes(target) == expected_second, "real OS failure preserves previous complete file");
+        CHECK(only_target(directory, target), "real OS failure cleans temporary file and directory");
+    }
+#elif defined(_WIN32)
+    put_bytes(target, expected_second);
+    HANDLE held = CreateFileW(target.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    CHECK(held != INVALID_HANDLE_VALUE, "hold destination without delete sharing");
+    if (held != INVALID_HANDLE_VALUE) {
+        CHECK(!write_gpu_capture_bundle(target_string, first, error) && !error.empty(),
+              "OS sharing restriction refuses replacement");
+        CHECK(read_bytes(target) == expected_second, "denied replacement preserves complete destination");
+        CHECK(only_target(directory, target), "denied replacement cleans all temporary artifacts");
+        CloseHandle(held);
+    }
+#endif
+    CHECK(write_gpu_capture_bundle(target_string, first, error) && read_bytes(target) == expected_first,
+          "retry replaces longer old destination without a stale tail");
+    CHECK(only_target(directory, target), "successful replacement leaves only destination");
+
+    // An obstruction exercises installation failure on every platform.
+    std::filesystem::remove(target);
+    std::filesystem::create_directory(target);
+    put_bytes(target / "keep", expected_second);
+    CHECK(!write_gpu_capture_bundle(target_string, first, error) && !error.empty(),
+          "nonempty directory destination refuses installation");
+    CHECK(read_bytes(target / "keep") == expected_second && only_target(directory, target),
+          "installation failure preserves obstruction and cleans temporary artifacts");
+    std::filesystem::remove_all(target);
+
+    // Simultaneous writers must reserve separate temporaries and publish one complete file.
+    std::atomic<unsigned> ready{0};
+    std::atomic<bool> go{false};
+    bool success[2] = {false, false};
+    std::thread writers[2];
+    for (unsigned i = 0; i < 2; ++i) writers[i] = std::thread([&, i] {
+        ready.fetch_add(1);
+        while (!go.load()) std::this_thread::yield();
+        std::string local_error;
+        success[i] = write_gpu_capture_bundle(target_string, i == 0 ? first : second, local_error);
+    });
+    while (ready.load() != 2) std::this_thread::yield();
+    go = true;
+    for (auto& writer : writers) writer.join();
+    const auto concurrent = read_bytes(target);
+    CHECK(success[0] && success[1], "both concurrent independent writes complete");
+    CHECK(concurrent == expected_first || concurrent == expected_second,
+          "concurrent installation leaves one entire wire file, never mixed bytes");
+    CHECK(only_target(directory, target), "concurrent writers clean their private temporary paths");
+    std::printf("gpu_capture_bundle_streaming: %d failures\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Capture bundle writing previously accumulated another complete serialized copy beside the owned chunk store. A delayed file error could also go unnoticed at close and allow truncated output to replace an existing capture.

Stream the unchanged v1/v2 format into an exclusively owned temporary file, computing the historical checksum incrementally. Preserve integrity checks and the 4 GiB file bound. Check writes, flush and close before replacing the destination; failed validation or I/O preserves the previous file and cleans only this writer’s temporary. POSIX and Windows replacement paths are covered by platform-specific guards. This adds normal completion/failure safety, not power-loss durability.

The public-API regression fixture checks frozen format bytes, complete readback, bounded allocation requests, corrupt late references/checksums, replacement/retry, temporary cleanup, real Linux file-size failures, Windows sharing denial and concurrent-write smoke coverage. The same fixture linked against the pre-change core passes format checks and fails the allocation/failure guards.

Release build and 447/447 tests pass. All 64 selected Vulkan synchronization-validation cases pass with zero messages after layer-load and deliberate-hazard controls. Independent source, fixture and completed-measurement reviews approve the exact head. In three alternating 512 MiB writer experiments, old peak RSS grows about 1 GiB; streamed-writer peak growth is 0.25–0.50 MiB. All six files have identical size and SHA-256. Wall time varies, so no stable speedup is claimed. [Commands, controls, regression allocation totals and reproducible memory experiment](https://github.com/mattias800/prosper/pull/3483#issuecomment-5593117525).

Completed Sonic/GTA captures retain the same normalized routes/environment, immutable binaries and complete F8 records. GTA’s bank lighting/geometry remains consistent; Sonic’s known black-world/HUD and title defects remain. Graphics rates are roughly unchanged. Both candidate main outputs have only initial-interval input-demand shortfalls, with none later during capture, versus writer-associated deficits in the retained baselines. These single pairs do not establish an audio fix or hardware-XRUN improvement; repeated controls remain #3435. Every output/channel retains its independent PCM buffer. [Game evidence](https://github.com/mattias800/prosper/pull/3483#issuecomment-5593279462), [per-output audio evidence and limits](https://github.com/mattias800/prosper/pull/3483#issuecomment-5593279665).

Fixes #1648. Related to #3435 and the capture tooling used for #3407.
