### PR TITLE
fix(gpu): validate DCC metadata before borrowing retained images

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3126,6 +3126,14 @@ if(TARGET prosper_core)
       target_link_libraries(test_renderer_uint_copy PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
       add_test(NAME renderer_uint_copy COMMAND test_renderer_uint_copy)
 
+      add_executable(test_storage_metadata_borrow tests/gpu/execute/test_storage_metadata_borrow.cpp)
+      target_include_directories(test_storage_metadata_borrow PRIVATE tests frontends)
+      target_link_libraries(test_storage_metadata_borrow PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
+      add_test(NAME storage_metadata_borrow COMMAND ${CMAKE_COMMAND} -E env
+               PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB=1 PROSPER_COMPUTE_STORAGE_IMAGE_CACHE_MIN_KB=1
+               $<TARGET_FILE:test_storage_metadata_borrow>)
+      set_tests_properties(storage_metadata_borrow PROPERTIES TIMEOUT 60)
+
       add_executable(test_storage_output_conflicts tests/gpu/execute/test_storage_output_conflicts.cpp)
       target_include_directories(test_storage_output_conflicts PRIVATE tests frontends)
       target_link_libraries(test_storage_output_conflicts PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -353,20 +353,25 @@ resource" and "it saw it and rejected it" produce identical evidence while point
 files. Reach for it before concluding anything about descriptor *recovery*: on Earthion (#1590) it
 overturned exactly that conclusion in one run.
 
-**A DCC-compressed SAMPLED surface's cache identity does NOT include its metadata plane, and folding
-that plane into the key is both unnecessary and — as first attempted — ineffective.** #3150 /
-#3149, 2026-08-31. The persistent compute image cache excluded compressed sampled surfaces on the
-theory that base bytes alone could not determine their content; on Stray that exclusion re-detiled
-one 4K FP16 surface 3,860 times in 110 s (98.9% of all tiling work, `PROSPER_TILECENSUS`). The
-theory is wrong for the *sampled* path: the DCC plane's only consumer there is
-`compute_sampled_dcc_fast_clear_rgba8`, whose materialization the admission gate already excludes
-via `!sampled_dcc_fast_clear`, so a cacheable entry's upload is detile + unpack of the BASE bytes
-alone — which the existing validation already covers. More sharply, `gfx10_dcc_fast_clear_rgba8` is
-the **only** DCC decode function in the tree: prosper has no DCC decompressor, so
-metadata-independence is a property of the codebase rather than of one call graph. **Do not re-derive
-the metadata-in-the-key design**: the first revision of #3150 did, and it was rejected twice over —
-the guard was conjoined into only one of three skip proofs (`watch_unchanged` and `exact_unchanged`
-both examine the base range alone, so the upload was skipped anyway), and the premise was unnecessary
-regardless. The *storage* gate is different and still requires an all-`0xff` plane: a storage
-target's base bytes are not authoritative while a live plane exists. `PROSPER_NO_DCC_IMAGE_CACHE=1`
-restores the old exclusion for bisection.
+**The ordinary sampled base-byte decode cache does not need DCC metadata in its identity;
+retained storage-image borrows require a separate metadata proof.** #3150 / #3149,
+2026-08-31; scope clarified by #3482 / #3484, 2026-09-09. The persistent compute image cache
+excluded compressed sampled surfaces on the theory that base bytes alone could not determine
+the cached upload; on Stray that exclusion re-detiled one 4K FP16 surface 3,860 times in 110 s
+(98.9% of all tiling work, `PROSPER_TILECENSUS`). For the ordinary sampled decode, the current
+supported fast-clear probe runs before reuse and its materialization is excluded by
+`!sampled_dcc_fast_clear`. A cacheable entry therefore serves detile + unpack of the BASE bytes,
+which the existing base-range validation covers. This establishes equality with the uncached
+base-byte fallback, not correct decoding of arbitrary compressed metadata or metadata-independence
+of every image source.
+
+The first metadata-in-the-key revision of #3150 was ineffective too: it guarded only one of three
+skip proofs, while `watch_unchanged` and `exact_unchanged` still inspected only base bytes. Do not
+repeat that design for this ordinary decode cache. A retained STORAGE image is a different source:
+it holds completed producer pixels. Both graphics import and compute storage-to-sampled transfer
+must validate the producer's pixel authority **and** prove the original consumer's current complete
+metadata plane plain before borrowing. A separate metadata allocation may change while base bytes,
+page watches and exact mirrors remain unchanged; a producer-format alias retry must not bypass a
+failed metadata proof. Unsupported or incomplete metadata footprints decline the borrow. The
+storage acquisition gate also keeps its own all-`0xff` requirement. `PROSPER_NO_DCC_IMAGE_CACHE=1`
+restores the historical sampled-cache exclusion for bisection.

--- a/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
+++ b/prosper/frontends/shared/compute/compute_image_borrow_census.hpp
@@ -130,6 +130,7 @@ enum class ComputeImageBorrowOutcome : uint8_t {
     NoImage,             // entry without a VkImage (allocation released)
     AuthorityChanged,    // published, but no proof says guest memory still matches it
     Hit,
+    MetadataUnproven,    // pixel authority passed; current compression metadata did not
     Count,
 };
 
@@ -142,6 +143,7 @@ constexpr const char* compute_image_borrow_outcome_name(ComputeImageBorrowOutcom
     case ComputeImageBorrowOutcome::NoImage:             return "no_image";
     case ComputeImageBorrowOutcome::AuthorityChanged:    return "authority_changed";
     case ComputeImageBorrowOutcome::Hit:                 return "hit";
+    case ComputeImageBorrowOutcome::MetadataUnproven:    return "metadata_unproven";
     case ComputeImageBorrowOutcome::Count:               break;
     }
     return "?";
@@ -505,7 +507,7 @@ private:
 // a saturated census fits, so the marker should never fire -- but a marker that never fires is
 // cheap and a missing line that reads as a zero is not.
 // Worst case, measured by the saturation arm in the test rather than estimated: eleven decline
-// buckets, six outcome buckets, seven publish buckets, twenty-three key-field names and twenty-two
+// buckets, seven outcome buckets, seven publish buckets, twenty-three key-field names and twenty-two
 // scalars, every one of them a twenty-digit u64. 4 KiB clears it with room to spare.
 inline constexpr size_t compute_image_borrow_census_report_bytes = 4096;
 

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -146,6 +146,14 @@ snapshots naturally. Metadata-only writes require an explicit retention veto bec
 does not cover interpretation metadata. Keep sampled metadata dependencies separate from storage
 metadata reset obligations. Include effective hosted and advertised ranges, and fold exact aliases.
 
+Later dispatches can change a separate metadata plane without touching a retained image's pixel
+allocation. Graphics imports and compute transfer seeds therefore recheck the consumer's complete
+supported DCC plane immediately before borrowing. Unknown metadata kinds, unsupported footprints,
+unreadable or truncated planes and non-plain contents decline the borrow. A supplied hosted plane
+never falls back to guest metadata. This fresh check applies to numeric aliases too; neither an
+earlier all-0xff scan nor the pixel journal proves current metadata. Refusal preserves outstanding
+leases and the existing materialization fallback. `storage_metadata_borrow` guards this boundary.
+
 Zero-address internal backing (such as GDS) is not an architectural guest output.
 Notify actual hosted guest destinations as well as advertised architectural ranges, including for cached
 views absent from a dispatch. Prepare page watches before every actual mutation. The production

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1169,6 +1169,7 @@ enum class ComputeTransferBorrowResult : uint8_t {
     NoCache,
     InvalidCache,
     AuthorityChanged,
+    MetadataUnproven,
 };
 
 bool persistent_compute_buffer_enabled(uint32_t bytes) {
@@ -2747,7 +2748,7 @@ struct VulkanComputeContext {
             return false;
         }
         if (!storage_borrow_metadata_proves_plain(consumer)) {
-            set_outcome(Outcome::AuthorityChanged);
+            set_outcome(Outcome::MetadataUnproven);
             return false;
         }
         if (exact_unchanged || watch_unchanged)
@@ -2837,7 +2838,7 @@ struct VulkanComputeContext {
             return false;
         }
         if (!storage_borrow_metadata_proves_plain(consumer)) {
-            if (result) *result = ComputeTransferBorrowResult::AuthorityChanged;
+            if (result) *result = ComputeTransferBorrowResult::MetadataUnproven;
             if (trace)
                 std::fprintf(stderr,
                              "[compute]   native storage transfer miss: metadata authority\n");
@@ -4317,6 +4318,7 @@ const char* compute_transfer_borrow_result_name(ComputeTransferBorrowResult resu
         case ComputeTransferBorrowResult::NoCache: return "no-cache";
         case ComputeTransferBorrowResult::InvalidCache: return "invalid-cache";
         case ComputeTransferBorrowResult::AuthorityChanged: return "authority-changed";
+        case ComputeTransferBorrowResult::MetadataUnproven: return "metadata-unproven";
     }
     return "unknown";
 }
@@ -4362,6 +4364,7 @@ struct ComputeTransferGateStats {
     uint64_t borrow_no_cache = 0;
     uint64_t borrow_invalid_cache = 0;
     uint64_t borrow_authority_changed = 0;
+    uint64_t borrow_metadata_unproven = 0;
 };
 
 void increment_gate_counter(uint64_t& value, bool condition = true) {
@@ -4502,6 +4505,8 @@ public:
                                borrow_result == ComputeTransferBorrowResult::InvalidCache);
         increment_gate_counter(stats.borrow_authority_changed,
                                borrow_result == ComputeTransferBorrowResult::AuthorityChanged);
+        increment_gate_counter(stats.borrow_metadata_unproven,
+                               borrow_result == ComputeTransferBorrowResult::MetadataUnproven);
         if (detail) {
             std::fprintf(stderr,
                          "[compute-transfer-gates] detail role=%s stage=sampled-gates "
@@ -4650,7 +4655,7 @@ private:
                      "sampled-ordinary2d=%llu format-compatible=%llu "
                      "transfer-dimension=%llu hostless=%llu format-match=%llu "
                      "validation=%llu native-defined=%llu borrow-attempts=%llu hits=%llu "
-                     "no-cache=%llu invalid-cache=%llu authority-changed=%llu\n",
+                     "no-cache=%llu invalid-cache=%llu authority-changed=%llu metadata-unproven=%llu\n",
                      compute_transfer_gate_role_name(role),
                      static_cast<unsigned long long>(s.sampled_gate_evaluated),
                      static_cast<unsigned long long>(s.sampled_cache_candidate),
@@ -4666,7 +4671,8 @@ private:
                      static_cast<unsigned long long>(s.borrow_hits),
                      static_cast<unsigned long long>(s.borrow_no_cache),
                      static_cast<unsigned long long>(s.borrow_invalid_cache),
-                     static_cast<unsigned long long>(s.borrow_authority_changed));
+                     static_cast<unsigned long long>(s.borrow_authority_changed),
+                     static_cast<unsigned long long>(s.borrow_metadata_unproven));
     }
 
     ComputeTransferGateSelector selector_;
@@ -8302,7 +8308,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         // misses: Uint32/R32_UINT producer -> Float32/R32_SFLOAT consumer. The
                         // retained source and sampled destination remain distinct images, so an
                         // in-place read/modify/write dispatch cannot alias itself.
-                        if (!borrowed && float32_uint32_transfer_alias &&
+                        if (!borrowed &&
+                            transfer_borrow_result != ComputeTransferBorrowResult::MetadataUnproven &&
+                            float32_uint32_transfer_alias &&
                             compute_transfer_vk_formats_bit_compatible(
                                 r->format, sampled_components,
                                 transfer_alias_storage_format, image_format)) {
@@ -12226,7 +12234,11 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
         sampled_resource.format == prosper::gpu::DataFormat::Float10_11_11 && components == 3;
     const bool packed_r10_uint32_alias =
         sampled_resource.format == prosper::gpu::DataFormat::Unorm2_10_10_10 && components == 4;
-    if (!borrowed && (normalized_uint8_alias || normalized_uint16_alias ||
+    // The metadata proof uses the original consumer for every producer alias. A failed proof
+    // cannot be rescued by changing the producer key; preserve its reason instead of reporting
+    // a later alias lookup miss as though metadata had passed.
+    if (!borrowed && observation.outcome != ComputeImageBorrowOutcome::MetadataUnproven &&
+        (normalized_uint8_alias || normalized_uint16_alias ||
                       float16_uint16_alias ||
                       float32_uint32_alias || packed_r11_uint32_alias ||
                       packed_r10_uint32_alias)) {

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -31,6 +31,7 @@
 #include "gpu/resources/mip_chain_plan.hpp"
 #include "gpu/resources/atomic_image_staging.hpp"  // #3195: the LOGICAL/PHYSICAL atomic-image extent split
 #include "gpu/resources/image_identity.hpp"
+#include "gpu/resources/compressed_source_authority.hpp"
 #include "gpu/resources/spirv_storage_match.hpp"  // #3204: SPIR-V/guest storage agreement  // #3204: named image-identity predicates
 #include "gpu/texture/tile.hpp"
 #include "gpu/capture/writer_provenance.hpp"
@@ -237,6 +238,46 @@ bool pack_live_target_r11g11b10(const prosper::gpu::LiveTargetSnapshot& snapshot
 }
 
 namespace {
+
+// A retained storage image represents the producer's plain pixels. Its base-allocation journal
+// and write watch say nothing about a separate metadata allocation. Recheck the consumer's complete
+// plane at each borrow; address identity or an earlier all-0xff scan cannot prove current contents.
+bool storage_borrow_metadata_proves_plain(const prosper::gpu::ShaderResource& resource) {
+    using namespace prosper::gpu;
+    if (!resource.compression_enabled) return true;
+    // The published DCC footprint describes a single base-level thin 2D plane. Do not use its
+    // all-0xff prefix to certify a selected mip, volume, multisample or layered allocation.
+    if (!resource.metadata_addr || resource.sample_count != 1u ||
+        (resource.img_dim != 1u && resource.img_dim != 5u) || resource.depth != 1u ||
+        resource.declared_mip_levels != 1u || resource.mip_chain_base_level ||
+        resource.mip_chain_max_level || resource.in_mip_tail ||
+        resource.layer_stride_bytes || resource.layer_mip_offset_bytes)
+        return false;
+    const uint32_t components = resource.num_components ? resource.num_components : 1u;
+    const auto kind = classify_compression_metadata_kind({
+        resource.metadata_addr, resource.gpu_addr, resource.format, components, resource.img_dim});
+    if (kind != CompressionMetadataKind::Dcc) return false;
+    const uint64_t bytes = gpu_capture_dcc_metadata_footprint(resource);
+    if (!bytes || bytes > SIZE_MAX || bytes > UINT32_MAX) return false;
+    const uint8_t* metadata = resource.dcc_metadata_host_data;
+    if (metadata) {
+        // A replay-owned plane is the selected source even when truncated. Guest memory at the
+        // same virtual address belongs to a different source and cannot repair this proof.
+        if (resource.dcc_metadata_host_data_size < bytes) return false;
+    } else {
+        if (!guest_readable(resource.metadata_addr, static_cast<uint32_t>(bytes))) return false;
+        metadata = reinterpret_cast<const uint8_t*>(uintptr_t(resource.metadata_addr));
+    }
+    const MetadataPlaneShape shape{
+        .kind = kind, .width = resource.width, .height = resource.height,
+        .depth = resource.depth, .img_dim = resource.img_dim,
+        .sample_count = resource.sample_count, .tile_mode = resource.tile_mode,
+        .format = resource.format, .num_components = components,
+        .meta_pipe_aligned = resource.meta_pipe_aligned,
+    };
+    return resolve_metadata_proof(shape, metadata, static_cast<size_t>(bytes)) ==
+        MetadataProof::ProvesPlain;
+}
 
 const std::array<uint8_t, 65536>& sampled_float16_unorm8_table() {
     static const std::array<uint8_t, 65536> table = [] {
@@ -2646,13 +2687,14 @@ struct VulkanComputeContext {
 #endif
     }
 
-    // `observation`, when supplied, records WHICH of the five declines below fired. It never
+    // `observation`, when supplied, records which admission check declined. It never
     // changes what the function decides and never evaluates a predicate the decision did not
     // already evaluate -- in particular `write_watch.query()` stays behind exactly the same
     // short circuit, because a census that pays for a query the borrow skips would be measuring
     // its own cost. #3307.
     bool borrow_cached_image_for_graphics(
-        const ComputeImageCacheKey& key, VkImage& image, uint64_t& producer_command_order,
+        const ComputeImageCacheKey& key, const prosper::gpu::ShaderResource& consumer,
+        VkImage& image, uint64_t& producer_command_order,
         prosper::frontend::ComputeImageBorrowObservation* observation = nullptr,
         bool scan_near_miss = false) {
         using Outcome = prosper::frontend::ComputeImageBorrowOutcome;
@@ -2704,6 +2746,10 @@ struct VulkanComputeContext {
             }
             return false;
         }
+        if (!storage_borrow_metadata_proves_plain(consumer)) {
+            set_outcome(Outcome::AuthorityChanged);
+            return false;
+        }
         if (exact_unchanged || watch_unchanged)
             cached.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         cached.last_use = ++image_cache_clock;
@@ -2747,6 +2793,7 @@ struct VulkanComputeContext {
     }
 
     bool borrow_cached_image_for_compute_transfer(const ComputeImageCacheKey& key,
+                                                  const prosper::gpu::ShaderResource& consumer,
                                                   VkImage& image, bool trace = false,
                                                   ComputeTransferBorrowResult* result = nullptr) {
         if (result) *result = ComputeTransferBorrowResult::NotAttempted;
@@ -2787,6 +2834,13 @@ struct VulkanComputeContext {
                              "submit-query=%u watch=%u\n",
                              static_cast<unsigned>(submit_query),
                              cached.write_watch ? 1u : 0u);
+            return false;
+        }
+        if (!storage_borrow_metadata_proves_plain(consumer)) {
+            if (result) *result = ComputeTransferBorrowResult::AuthorityChanged;
+            if (trace)
+                std::fprintf(stderr,
+                             "[compute]   native storage transfer miss: metadata authority\n");
             return false;
         }
         if (exact_unchanged)
@@ -8040,9 +8094,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (metadata_bytes && metadata_bytes <= SIZE_MAX &&
                         metadata_bytes <= UINT32_MAX) {
                         sampled_dcc_metadata_bytes = static_cast<size_t>(metadata_bytes);
-                        if (r->dcc_metadata_host_data &&
-                            r->dcc_metadata_host_data_size >= metadata_bytes) {
-                            sampled_dcc_metadata = r->dcc_metadata_host_data;
+                        if (r->dcc_metadata_host_data) {
+                            if (r->dcc_metadata_host_data_size >= metadata_bytes)
+                                sampled_dcc_metadata = r->dcc_metadata_host_data;
                         } else if (guest_readable(
                                        r->metadata_addr,
                                        static_cast<uint32_t>(metadata_bytes))) {
@@ -8147,14 +8201,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // `cache_candidate` gates more than the reuse the argument above covers:
                 // `acquire_cached_image` (replay this decode's result), sampled RETENTION, and
                 // `borrow_cached_image_for_compute_transfer` (seed from a retained STORAGE image --
-                // a different source, not this decode). Widening the gate newly admits compressed
-                // sampled descriptors to that borrow. It is safe, but for its own reason: the
-                // borrow demands `compute_transfer_valid && content_valid` plus a journal, watch or
-                // exact proof over the BASE range since the producing writeback, and the storage
-                // entry it borrows could only have been authorized through the STORAGE gate, which
-                // still requires an all-0xff plane. Diverging would need the plane to go non-0xff
-                // while the base bytes stayed byte-identical, which outside a fast clear -- excluded
-                // upstream -- is not producible.
+                // a different source, not this decode). That borrow separately requires current
+                // plain DCC metadata as well as the producer's base-range authority. Metadata can
+                // change independently after storage writeback, including at a different allocation;
+                // the base-byte decode cache's validation cannot authorize that retained image.
                 //
                 // Kill switch, and it earns its place: this admits a whole class of surface to a
                 // cache it was previously excluded from, so a single variable must restore the old
@@ -8245,7 +8295,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             *r, static_cast<uint32_t>(sampled_guest_need),
                             transfer_native_format);
                         bool borrowed = ctx.borrow_cached_image_for_compute_transfer(
-                            storage_key, bi.compute_transfer_seed, trace,
+                            storage_key, *r, bi.compute_transfer_seed, trace,
                             &transfer_borrow_result);
                         // The producer identity is part of the cache key. Retry only GTA V's exact
                         // one-word numeric-view alias after the consumer's own Float32 identity
@@ -8263,7 +8313,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                 static_cast<uint32_t>(sampled_guest_need),
                                 transfer_alias_storage_format);
                             borrowed = ctx.borrow_cached_image_for_compute_transfer(
-                                storage_key, bi.compute_transfer_seed, trace,
+                                storage_key, *r, bi.compute_transfer_seed, trace,
                                 &transfer_borrow_result);
                             if (borrowed && trace)
                                 std::fprintf(stderr,
@@ -12150,7 +12200,7 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
     uint64_t producer_command_order = 0;
     prosper::frontend::ComputeImageBorrowObservation observation;
     bool borrowed = context->borrow_cached_image_for_graphics(
-        key, image, producer_command_order, &observation, /*scan_near_miss=*/true);
+        key, sampled_resource, image, producer_command_order, &observation, /*scan_near_miss=*/true);
     // The exact key's near-miss result is kept here and recorded once the import's fate is known.
     // Only the EXACT key is scanned: the alias retry below rewrites `format` and `vk_format` by
     // construction, so its mask would name those two on every miss whether or not they are the
@@ -12199,7 +12249,7 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
         observation = {};
         g_image_borrow_census.record_alias_retry();
         borrowed = context->borrow_cached_image_for_graphics(
-            key, image, producer_command_order, &observation, /*scan_near_miss=*/false);
+            key, sampled_resource, image, producer_command_order, &observation, /*scan_near_miss=*/false);
     }
     g_image_borrow_census.record_outcome(observation, guest_bytes);
     // Recorded after the retry, because whether the alias RESCUED this lookup decides whether its

--- a/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
+++ b/prosper/frontends/shared/tests/test_compute_image_borrow_census.cpp
@@ -221,6 +221,34 @@ int main() {
               snapshot.authority_watch_unknown == authority);
     }
 
+    // A metadata refusal follows a successful pixel-authority proof. Default observation fields
+    // must not invent an unarmed journal or absent watch for this separate refusal.
+    {
+        ComputeImageBorrowCensus census;
+        census.record_import(ComputeImageImportDecline::None);
+        ComputeImageBorrowObservation metadata;
+        metadata.outcome = ComputeImageBorrowOutcome::MetadataUnproven;
+        census.record_outcome(metadata, 4096);
+        const auto snapshot = census.snapshot();
+        CHECK(snapshot.outcomes[static_cast<size_t>(ComputeImageBorrowOutcome::MetadataUnproven)] == 1);
+        CHECK(snapshot.outcomes[static_cast<size_t>(ComputeImageBorrowOutcome::AuthorityChanged)] == 0);
+        CHECK(snapshot.miss_bytes == 4096);
+        CHECK(snapshot.hit_bytes == 0);
+        CHECK(snapshot.authority_journal_overlap == 0);
+        CHECK(snapshot.authority_journal_unarmed == 0);
+        CHECK(snapshot.authority_journal_unjournaled == 0);
+        CHECK(snapshot.authority_journal_undecided == 0);
+        CHECK(snapshot.authority_watch_absent == 0);
+        CHECK(snapshot.authority_watch_dirty == 0);
+        CHECK(snapshot.authority_watch_unknown == 0);
+        char report[prosper::frontend::compute_image_borrow_census_report_bytes];
+        const size_t used = format_compute_image_borrow_census(snapshot, report, sizeof report);
+        const std::string text(report, used);
+        CHECK(text.find("attempted=1") != std::string::npos);
+        CHECK(text.find("metadata_unproven=1 (100.0%)") != std::string::npos);
+        CHECK(text.find("authority_changed=0 (0.0%)") != std::string::npos);
+    }
+
     // ---- 5. A hit is counted as spared bytes, and only a hit -------------------------------
     {
         ComputeImageBorrowCensus census;
@@ -326,6 +354,7 @@ int main() {
         // Present even at zero: an outcome bucket that vanishes when empty cannot be told from one
         // the instrument never reached. That ambiguity has already cost this issue a night (#3307).
         CHECK(text.find("no_cache_entry=0") != std::string::npos);
+        CHECK(text.find("metadata_unproven=0 (0.0%)") != std::string::npos);
         CHECK(text.find("hit=0 (0.0%)") != std::string::npos);
         CHECK(text.find("authority_changed=1 (100.0%)") != std::string::npos);
         CHECK(text.find("journal_unarmed=1") != std::string::npos);
@@ -386,6 +415,7 @@ int main() {
         CHECK(widest_used < sizeof full - 1);
         CHECK(std::count(text.begin(), text.end(), '\n') == 4);
         CHECK(text.find("TRUNCATED") == std::string::npos);
+        CHECK(text.find("metadata_unproven=18446744073709551615") != std::string::npos);
         // The widest report the formatter can produce, against the buffer the production reporter
         // declares. Headroom, not a coincidence.
         CHECK(widest_used + 512 < prosper::frontend::compute_image_borrow_census_report_bytes);

--- a/prosper/tests/gpu/execute/test_storage_metadata_borrow.cpp
+++ b/prosper/tests/gpu/execute/test_storage_metadata_borrow.cpp
@@ -1,0 +1,302 @@
+// #3482: a separately changed metadata plane must gate the public retained-image borrow.
+#include "fixtures/render_runner.h"
+#include "fixtures/spirv_triangle.h"
+#include "gpu/capture/gpu_capture.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/texture/tile.hpp"
+#include "shared/live/live_compute.hpp"
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+using namespace prosper::gpu;
+namespace {
+constexpr uint32_t W = 64, H = 16, N = W * H;
+int failures = 0;
+void check(bool ok, const char* message) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; }
+}
+ComputeItem compile(const std::vector<uint32_t>& code, const ShaderResourceTable& resources,
+                    uint64_t address, uint32_t index) {
+    ComputeShaderConfig config;
+    config.user_sgprs.resize(24);
+    config.local_x = W; config.local_y = config.local_z = 1;
+    config.native_storage_format_support = native_storage_format_support_bit(DataFormat::Float16, 4) |
+        native_storage_format_support_bit(DataFormat::Uint16, 1) |
+        native_storage_format_support_bit(DataFormat::Uint32, 1);
+    ComputeItem result;
+    result.spirv = recompile_compute(code.data(), code.size(), &resources, config);
+    result.resources = std::make_shared<ShaderResourceTable>(resources);
+    result.user_sgprs = config.user_sgprs;
+    result.code_addr = address; result.dispatch_index = index; result.command_order = index * 20;
+    result.launch.threads_x = result.launch.local_x = W;
+    result.launch.threads_y = result.launch.threads_z = 1;
+    result.launch.local_y = result.launch.local_z = 1;
+    result.launch.groups_x = result.launch.groups_y = result.launch.groups_z = 1;
+    check(!result.spirv.empty(), "guest shader compiles");
+    return result;
+}
+struct Fixture {
+    bool numeric_alias, transfer_test;
+    ShaderResource image{};
+    std::vector<uint8_t> pixels, metadata, hosted;
+    std::vector<uint32_t> output = std::vector<uint32_t>(N * 4 + 16, 0xdeadbeefu);
+    CompressionMetadataKind kind = CompressionMetadataKind::Dcc;
+    size_t metadata_bytes = 0, pixel_bytes = 0;
+    explicit Fixture(bool alias, bool transfer = false) : numeric_alias(alias), transfer_test(transfer) {
+        image.cls = ResourceClass::StorageImage; image.binding = 5; image.sgpr_base = 8;
+        image.img_dim = 1; image.width = W; image.height = H; image.depth = 1;
+        image.format = transfer ? DataFormat::Uint32 : alias ? DataFormat::Uint16 : DataFormat::Float16;
+        image.num_components = alias ? 1 : 4;
+        for (unsigned c = 0; c < 4; ++c) image.swizzle[c] = 4 + c;
+        image.tile_mode = uint32_t(TileMode::Sw64KbRX);
+        image.compression_enabled = image.write_compress_enabled = image.meta_pipe_aligned = true;
+        image.alpha_is_on_msb = true;
+        pixel_bytes = tiled_surface_bytes(W, H, image.tile_mode, 0, transfer_test ? 4 : numeric_alias ? 2 : 8);
+        pixels.resize(pixel_bytes + 64, 0xc7);
+        image.gpu_addr = reinterpret_cast<uint64_t>(pixels.data()); image.size = pixel_bytes;
+        // Footprint calculation needs a nonzero address, not the eventual allocation contents.
+        image.metadata_addr = image.gpu_addr;
+        metadata_bytes = gpu_capture_dcc_metadata_footprint(image);
+        check(metadata_bytes && metadata_bytes <= 65536 && metadata_bytes % (W * 4) == 0,
+              "fixture has a bounded complete DCC plane writable in whole rows");
+        metadata.resize(metadata_bytes + 64, 0x97);
+        hosted.resize(metadata_bytes + 64, 0x98);
+        std::fill_n(metadata.begin(), metadata_bytes, 0xff);
+        std::fill_n(hosted.begin(), metadata_bytes, 0xff);
+        image.metadata_addr = reinterpret_cast<uint64_t>(metadata.data());
+        image.dcc_metadata_size = metadata_bytes;
+    }
+    ShaderResource sampled() const {
+        auto r = image; r.cls = ResourceClass::Texture; r.format = transfer_test ? DataFormat::Float32 : DataFormat::Float16; return r;
+    }
+    ComputeItem writer() {
+        ShaderResourceTable table; table.resources = {image};
+        const uint32_t one = numeric_alias && !transfer_test ? 0x3c00u : 0x3f800000u;
+        std::vector<uint32_t> code{0x7e080300u, 0x7e0002ffu, one, 0x7e020280u,
+                                  0x7e0402ffu, one, 0x7e0602ffu, one};
+        for (uint32_t y = 0; y < H; ++y)
+            code.insert(code.end(), {0x7e0a0280u + y, numeric_alias ? 0xf0200108u : 0xf0200f08u, 0x00020004u});
+        code.push_back(0xbf810000u);
+        auto result = compile(code, table, numeric_alias ? 0x34820011u : 0x34820001u, 1);
+        const auto reflection = validate_spirv_descriptor_interface(
+            result.spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const auto* d = find_spirv_descriptor_binding(reflection, 0, 5);
+        check(reflection.ok() && reflection.storage_image_writes_complete && d && d->writable &&
+                  !d->readable && (numeric_alias ? d->image_numeric_class == SpirvImageNumericClass::Uint &&
+                                      d->storage_image_format == (transfer_test ? kSpirvImageFormatR32ui : kSpirvImageFormatR16ui)
+                                                : d->storage_float && d->storage_image_format == 0),
+              "producer is the intended native float or integer storage image");
+        return result;
+    }
+    ComputeItem metadata_writer() {
+        ShaderResource buffer{};
+        buffer.cls = ResourceClass::ConstantBuffer; buffer.binding = 2; buffer.sgpr_base = 0;
+        buffer.format = DataFormat::Uint32; buffer.num_components = 1; buffer.stride = 4;
+        buffer.gpu_addr = image.metadata_addr; buffer.size = metadata_bytes;
+        ShaderResourceTable table; table.resources = {buffer};
+        std::vector<uint32_t> code{0x7e1002ffu, 0x40404040u};
+        for (uint32_t row = 0; row < metadata_bytes / (W * 4); ++row)
+            code.insert(code.end(), {0xbe9803ffu, row * W * 4, 0xe0702000u, 0x18000800u});
+        code.push_back(0xbf810000u);
+        return compile(code, table, 0x34820002u, 2);
+    }
+    ComputeItem reader() {
+        ShaderResource buffer{};
+        buffer.cls = ResourceClass::ConstantBuffer; buffer.binding = 2; buffer.sgpr_base = 0;
+        buffer.format = DataFormat::Uint32; buffer.num_components = 1; buffer.stride = 16;
+        buffer.gpu_addr = reinterpret_cast<uint64_t>(output.data()); buffer.size = N * 16;
+        ShaderResourceTable table; table.resources = {buffer, sampled()};
+        std::vector<uint32_t> code{0x7e080300u};
+        for (uint32_t y = 0; y < H; ++y) {
+            code.insert(code.end(), {0x7e0a0280u + y, 0xf0000f08u, 0x00020804u,
+                                    0xbf8c3f70u, 0xbe9803ffu, y * W * 16});
+            for (uint32_t c = 0; c < 4; ++c)
+                code.insert(code.end(), {0xe0702000u | (c * 4u), 0x18000004u | ((8u + c) << 8)});
+        }
+        code.push_back(0xbf810000u);
+        return compile(code, table, 0x34820003u, 3);
+    }
+    prosper::frontend::LiveComputeImageImport borrow(const ShaderResource& r, bool expected,
+                                                     const char* message) {
+        prosper::frontend::LiveComputeImageImport lease;
+        const bool ok = prosper::frontend::import_live_compute_storage_image(r, r.size, lease);
+        check(ok == expected && ok == lease.valid(), message);
+        return lease;
+    }
+    std::vector<uint8_t> draw_lease(const prosper::frontend::LiveComputeImageImport& lease) {
+        if (!lease.valid()) return {};
+        auto r = sampled(); r.binding = 4;
+        ShaderResourceTable table; table.resources = {r};
+        const uint32_t fs[] = {0x7e0002ffu, 0x3e800000u, 0x7e0202ffu, 0x3e800000u,
+                              0xf0800f08u, 0x00820000u, 0xf800000fu, 0x03020100u, 0xbf810000u};
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1; resource.tw = W; resource.th = H;
+        resource.texture_format = static_cast<VkFormat>(lease.native_format);
+        resource.borrowed_compute_image = lease.image;
+        resource.borrowed_compute_device = lease.device;
+        resource.borrowed_compute_image_layout = lease.layout;
+        resource.borrowed_compute_image_lease = lease.lease;
+        prosper::test::BackendDraw draw;
+        draw.vs.assign(std::begin(kTriVertSpv), std::end(kTriVertSpv));
+        draw.fs = recompile_fragment(fs, std::size(fs), &table);
+        draw.vcount = 3; draw.R = {resource};
+        return prosper::test::render_draws_rgba({draw}, W, H);
+    }
+    bool center(const std::vector<uint8_t>& rgba, bool colored) const {
+        const size_t at = (H / 2 * W + W / 2) * 4;
+        return rgba.size() == N * 4 && rgba[at] == (colored ? 255 : 0) &&
+            rgba[at + 1] == 0 && rgba[at + 2] == (colored && !numeric_alias ? 255 : 0) && rgba[at + 3] == 255;
+    }
+    void base_oracle() {
+        std::vector<uint8_t> linear(N * image.num_components * (transfer_test ? 4 : 2));
+        detile_surface(reinterpret_cast<uint8_t*>(linear.data()), pixels.data(), W, H, image.tile_mode, 0, transfer_test ? 4 : numeric_alias ? 2 : 8);
+        bool exact = true;
+        for (size_t i = 0; i < N * image.num_components; ++i) {
+            uint32_t bits = 0;
+            std::memcpy(&bits, linear.data() + i * (transfer_test ? 4 : 2), transfer_test ? 4 : 2);
+            exact &= bits == (transfer_test ? 0x3f800000u : !numeric_alias && i % 4 == 1 ? 0u : 0x3c00u);
+        }
+        check(exact, "every native base texel has the exact expected component bits");
+        check(std::all_of(pixels.begin() + pixel_bytes, pixels.end(), [](uint8_t x) { return x == 0xc7; }),
+              "base allocation tail unchanged");
+    }
+    void guards() {
+        auto r = sampled();
+        borrow(r, true, "restored full-FF metadata permits a fresh borrow");
+        kind = CompressionMetadataKind::Unknown;
+        borrow(r, false, "unknown metadata kind cannot authorize retained base");
+        kind = CompressionMetadataKind::Htile;
+        borrow(r, false, "HTILE interpretation cannot authorize this DCC result");
+        kind = CompressionMetadataKind::Dcc;
+        const auto snapshot = guest_gpu_write_snapshot();
+        metadata[metadata_bytes - 1] = 0x40; // Deliberately no notification for this first probe.
+        check(guest_gpu_writes_since(snapshot, image.gpu_addr, pixel_bytes) == GuestGpuWriteQuery::Unchanged &&
+              guest_gpu_writes_since(snapshot, image.metadata_addr, metadata_bytes) == GuestGpuWriteQuery::Unchanged,
+              "unchanged journal does not observe this unnotified metadata mutation");
+        borrow(r, false, "fresh full-plane proof rejects an unnotified metadata mutation");
+        notify_guest_gpu_write(image.metadata_addr + metadata_bytes - 1, 1);
+        borrow(r, false, "last metadata byte participates in complete-plane proof");
+        metadata[metadata_bytes - 1] = 0xff;
+        notify_guest_gpu_write(image.metadata_addr + metadata_bytes - 1, 1);
+        auto h = r; h.dcc_metadata_host_data = hosted.data(); h.dcc_metadata_host_data_size = metadata_bytes;
+        borrow(h, true, "complete hosted FF plane is accepted");
+        hosted.back() = 0x98; hosted[metadata_bytes - 1] = 0x40;
+        borrow(h, false, "hosted plane is authoritative over unchanged FF guest metadata");
+        hosted[metadata_bytes - 1] = 0xff;
+        h.dcc_metadata_host_data_size = metadata_bytes - 1;
+        borrow(h, false, "short hosted plane cannot fall back to valid guest metadata");
+        auto unsupported = r; unsupported.sample_count = 2;
+        borrow(unsupported, false, "same-key multisample request cannot borrow single-sample compressed content");
+        unsupported = r; unsupported.mip_chain_base_level = 1;
+        borrow(unsupported, false, "same-key selected mip cannot borrow base-level DCC proof");
+        unsupported = r; unsupported.metadata_addr = 0;
+        borrow(unsupported, false, "missing metadata address refuses same pixel cache key");
+        unsupported = r; unsupported.img_dim = 2; unsupported.depth = 2;
+        borrow(unsupported, false, "unsupported compressed shape cannot authorize retained image");
+        borrow(r, true, "failed metadata checks do not consume or invalidate the valid lease");
+    }
+    void run() {
+        if (!metadata_bytes || metadata_bytes > 65536 || metadata_bytes % (W * 4)) return;
+        set_metadata_kind_query([&](const MetadataKindRequest& request) {
+            return request.resource_addr == image.gpu_addr && request.metadata_addr == image.metadata_addr &&
+                   request.num_components == image.num_components && request.img_dim == 1 &&
+                   (request.format == image.format || request.format == sampled().format)
+                       ? kind : CompressionMetadataKind::Unknown;
+        });
+        auto producer = writer(), meta = metadata_writer(), consumer = reader();
+        // Exercise repeated publication before testing public retained-result authority.
+        check(prosper::frontend::execute_live_compute_items({producer}), "producer warmup executes");
+        DrawItem initial, changed;
+        initial.draw_index = 1; initial.command_order = 30;
+        changed.draw_index = 2; changed.command_order = 50;
+        prosper::frontend::LiveComputeImageImport held;
+        std::vector<uint8_t> saved_pixels;
+        unsigned draws = 0;
+        uint64_t transfer_before = 0;
+        std::vector<SubmitOperation> operations{
+            {SubmitOperationKind::Dispatch, 1, 20}, {SubmitOperationKind::Draw, 1, 30},
+            {SubmitOperationKind::Dispatch, 2, 40}, {SubmitOperationKind::Draw, 2, 50}};
+        // The established sampled fast-clear decoder is RGBA16F only. The R16 numeric retry
+        // exercises borrow refusal without inventing a decoded color for its compressed state.
+        if (!numeric_alias || transfer_test) operations.push_back({SubmitOperationKind::Dispatch, 3, 60});
+        const auto result = execute_ordered_items(
+            operations, {initial, changed}, {producer, meta, consumer},
+            [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                if (++draws == 1) {
+                    base_oracle();
+                    held = borrow(sampled(), true, "full-FF native result initially imports");
+                    check(center(draw_lease(held), true), "real GPU draw reads initial imported native color");
+                    saved_pixels = pixels;
+                    if (transfer_test) {
+                        const auto count = prosper::frontend::live_compute_storage_transfer_seeds();
+                        auto first_consumer = consumer;
+                        first_consumer.dispatch_index = 4; first_consumer.command_order = 32;
+                        check(prosper::frontend::execute_live_compute_items({first_consumer}), "initial transfer consumer executes");
+                        check(prosper::frontend::live_compute_storage_transfer_seeds() == count + 1,
+                              "plain R32_UINT result admits the Float32 sampled transfer borrow");
+                        bool red = true;
+                        for (size_t i = 0; i < N * 4; ++i)
+                            red &= output[i] == (i % 4 == 0 || i % 4 == 3 ? 0x3f800000u : 0u);
+                        check(red, "every initial transfer consumer texel is red with alpha one");
+                        std::fill(output.begin(), output.end(), 0xdeadbeefu);
+                    }
+                    uint32_t unrelated = 0;
+                    notify_guest_gpu_write(reinterpret_cast<uint64_t>(&unrelated), sizeof(unrelated));
+                    borrow(sampled(), true, "unrelated write preserves public import");
+                    guards();
+                } else {
+                    check(pixels == saved_pixels, "separate metadata writer leaves complete base allocation unchanged");
+                    check(std::all_of(metadata.begin(), metadata.begin() + metadata_bytes,
+                                      [](uint8_t x) { return x == 0x40; }), "separate writer sets full changed DCC metadata plane");
+                    if (transfer_test) {
+                        // No supported fast-clear materializer applies to Float32. Keep the known
+                        // base-byte fallback and test only whether a retained result is borrowed.
+                        std::fill_n(metadata.begin(), metadata_bytes, 0xff);
+                        metadata[metadata_bytes - 1] = 0x40;
+                        notify_guest_gpu_write(image.metadata_addr, metadata_bytes);
+                    }
+                    transfer_before = prosper::frontend::live_compute_storage_transfer_seeds();
+                    auto rejected = borrow(sampled(), false, "metadata-only write refuses stale public graphics import");
+                    if (rejected.valid() && !numeric_alias) {
+                        const auto stale = draw_lease(rejected);
+                        std::fprintf(stderr, "stale-import-gpu-magenta=%d\n", center(stale, true));
+                        check(center(stale, false), "accepted graphics lease must not expose stale magenta under black-clear metadata");
+                    }
+                    // Already-issued lease keeps the allocation alive; it is not a new authority grant.
+                    check(center(draw_lease(held), true), "outstanding old lease remains usable while new borrow is refused");
+                }
+                return RenderedFrame{};
+            }, [](const std::vector<ComputeItem>& items) { return prosper::frontend::execute_live_compute_items(items); }, W, H);
+        check(result.compute_executed && draws == 2, "all separate dispatches and public consumer boundaries execute");
+        bool black = true;
+        for (size_t i = 0; i < N * 4; ++i) black &= output[i] == (i % 4 == 3 ? 0x3f800000u : 0u);
+        if (transfer_test) {
+            check(prosper::frontend::live_compute_storage_transfer_seeds() == transfer_before,
+                  "changed nonuniform metadata prevents the sampled storage-transfer borrow");
+            bool red = true;
+            for (size_t i = 0; i < N * 4; ++i)
+                red &= output[i] == (i % 4 == 0 || i % 4 == 3 ? 0x3f800000u : 0u);
+            check(red, "unsupported metadata preserves existing Float32 base-byte fallback semantics");
+        }
+        if (!numeric_alias)
+            check(black, "ordinary sampled compute reads every DCC-cleared texel as black with alpha one");
+        check(std::all_of(output.begin() + N * 4, output.end(), [](uint32_t x) { return x == 0xdeadbeefu; }) &&
+              std::all_of(metadata.begin() + metadata_bytes, metadata.end(), [](uint8_t x) { return x == 0x97; }) &&
+              std::all_of(hosted.begin() + metadata_bytes, hosted.end(), [](uint8_t x) { return x == 0x98; }),
+              "metadata and output tails remain untouched");
+        held = {};
+        set_metadata_kind_query({});
+    }
+};
+}
+int main() {
+    if (!prosper::test::render_vk_ctx().ok) return 1;
+    // Keep independent identities alive together; do not let allocator address reuse hide a miss.
+    Fixture exact(false), numeric(true), transfer(true, true);
+    exact.run(); numeric.run(); transfer.run();
+    std::printf("storage_metadata_borrow: %d failures\n", failures);
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/gpu/execute/test_storage_metadata_borrow.cpp
+++ b/prosper/tests/gpu/execute/test_storage_metadata_borrow.cpp
@@ -167,7 +167,16 @@ struct Fixture {
         auto r = sampled();
         borrow(r, true, "restored full-FF metadata permits a fresh borrow");
         kind = CompressionMetadataKind::Unknown;
+        const auto before = prosper::frontend::live_compute_image_borrow_census();
         borrow(r, false, "unknown metadata kind cannot authorize retained base");
+        const auto after = prosper::frontend::live_compute_image_borrow_census();
+        const auto metadata_reason = static_cast<size_t>(
+            prosper::frontend::ComputeImageBorrowOutcome::MetadataUnproven);
+        const auto missing_reason = static_cast<size_t>(
+            prosper::frontend::ComputeImageBorrowOutcome::NoCacheEntry);
+        check(after.outcomes[metadata_reason] == before.outcomes[metadata_reason] + 1 &&
+                  after.outcomes[missing_reason] == before.outcomes[missing_reason],
+              "public metadata refusal is not overwritten by a missing numeric alias");
         kind = CompressionMetadataKind::Htile;
         borrow(r, false, "HTILE interpretation cannot authorize this DCC result");
         kind = CompressionMetadataKind::Dcc;

--- a/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
+++ b/prosper/tests/gpu/execute/test_storage_output_conflicts.cpp
@@ -318,6 +318,14 @@ struct Fixture {
             b.dcc_metadata_host_data = reinterpret_cast<uint8_t *>(guest.data());
             b.dcc_metadata_host_data_size = metadata_bytes;
         }
+        // This fixture created B's DCC plane; authorize only that exact correlation.
+        // A shared backend without a renderer must not guess its metadata aspect.
+        set_metadata_kind_query([&](const MetadataKindRequest& request) {
+            return request.resource_addr == b.gpu_addr && request.metadata_addr == b.metadata_addr &&
+                   request.format == b.format && request.num_components == b.num_components &&
+                   request.img_dim == b.img_dim ? CompressionMetadataKind::Dcc
+                                               : CompressionMetadataKind::Unknown;
+        });
         std::fill(guest.begin(), guest.end(),
                   0xffffffffu); // valid all-uncompressed initial metadata
         for (uint32_t av : {0x13579bdfu, 0x31415926u}) {
@@ -364,6 +372,7 @@ struct Fixture {
                   "hosted DCC preserves advertised metadata backing");
             check_graphics(false);
         }
+        set_metadata_kind_query({});
     }
     void late_metadata() {
         // The first image writes ordinary FP16 magenta and resets DCC to all-0xff.

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -3747,6 +3747,16 @@ int main() {
     dcc_item.launch.groups_y = dcc_item.launch.groups_z = 1;
     dcc_item.code_addr = 0x719dcc;
     if (dcc_shape_ok) {
+        // This standalone fixture owns the DCC plane; no renderer registers its correlation.
+        // Admit only the actual producer identity used by the sampled and graphics consumers.
+        set_metadata_kind_query([&](const MetadataKindRequest& request) {
+            for (const ShaderResource& resource : dcc_rt.resources)
+                if (resource.binding == 5 && request.resource_addr == resource.gpu_addr &&
+                    request.metadata_addr == resource.metadata_addr && request.format == resource.format &&
+                    request.num_components == resource.num_components && request.img_dim == resource.img_dim)
+                    return CompressionMetadataKind::Dcc;
+            return CompressionMetadataKind::Unknown;
+        });
         // Exact current inputs are preserved on the first dispatch too. Completed writeback can
         // immediately promote its exact image; compressed metadata on the next dispatch still
         // forces a fresh seed before re-publishing authority.
@@ -4080,6 +4090,7 @@ int main() {
         CHECK(!prosper::frontend::import_live_compute_storage_image(
                   failed_sampled_output, tiled_bytes, failed_import),
               "failed DCC readback publishes no graphics cache authority");
+        set_metadata_kind_query({});
     }
     // Two storage views may share base texels while only one carries DCC state. They are not safe
     // Vulkan-image aliases: collapsing the compressed view onto an uncompressed owner drops its


### PR DESCRIPTION
A later write to a separately allocated DCC metadata plane can change a surface’s logical pixels while its base bytes remain unchanged. Retained compute-image borrowing previously checked only those base bytes and could return the previous GPU image through the public importer.

Both graphics and compute-transfer borrowing now require a fresh, complete plain-metadata proof for compressed consumers, including numeric aliases. Admission checks the original consumer’s supported shape and typed DCC correlation, respects hosted metadata bounds, and declines missing, truncated, unsupported or non-plain metadata. Existing pixel authority checks and outstanding image leases remain intact. Metadata refusal has its own diagnostic outcome rather than being reported as a pixel-journal failure.

The new GPU regression produces a magenta RGBA16F storage image, then changes only its separate metadata plane to the supported black/opaque clear. The old production implementation returns visibly stale magenta through the public importer; the fix refuses that lease while ordinary sampled compute still materializes the correct clear. Additional controls cover numeric aliases, complete metadata tails, hosted truncation, unknown/HTILE classification, descriptor changes, unrelated writes and restored plain metadata. Existing compressed-handoff fixtures explicitly identify their owned DCC planes and retain successful handoff assertions.

Production-code validation on `f36fb4238f380cc03d80327a18c079ad63c6c53f` (final follow-up changes documentation only):

- Full Release build and 448/448 CTest passed (116.15s).
- Strict Vulkan synchronization scan: 20/20 passed, zero messages with an empty allowlist. The loader and deliberate write-after-write controls both worked.
- Rebuilding the previous `47aa2ca1` live-compute implementation against the current test ABI produced 35 intended failures, including GPU-observed stale magenta. Restoring the implementation passed with the identical fixture object.
- Production Sonic/GTA captures completed. GTA presentation rate was essentially unchanged; two Sonic comparisons recorded lower candidate presentation counts at different guest timer states. Both adverse comparisons are retained.
- A reviewed private F8 observer then measured 1,903 Sonic borrow checks, all uncompressed, totaling 0.054407 ms inside the guards; no metadata classification, resolution or hosted-plane lookup occurred at the instrumented boundaries. In the same window, 132 scaled RTT snapshot materializations took 103.240 ms. This separates the expensive path in that diagnostic run; it does not prove the earlier differences were noise or establish performance neutrality.
- The final change after the tested production revision is documentation only: narrow the historical metadata-independence claim to ordinary sampled decoding. Private observers were removed from production sources.

Commands: `ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure -j1`; focused sync via `python3 prosper/tools/vkval/vk_validation_scan.py --build-dir prosper/build-linux --sync --allowlist /dev/null --ctest-arg=-j1 --ctest-arg=-R --ctest-arg='^(storage_metadata_borrow|storage_output_conflicts.*|storage_rtt_.*|storage_readonly.*|near_full_storage_.*|renderer_uint_copy|compute_image_borrow_census|compressed_source_authority|metadata_kind_correlation)$'`.

[Initial game comparison](https://github.com/mattias800/prosper/pull/3484#issuecomment-5594116444) and [fresh diagnostic pair](https://github.com/mattias800/prosper/pull/3484#issuecomment-5594550470). Sonic performance variability and repeated RTT materialization remain under #3407. Newly rendered frame counts are unavailable, and presentations are not counted as new renders.

This fixes the shared borrowing contract. The current graphics caller and supported RGBA16F sampled-compute clear already had their own protections. It does not implement arbitrary DCC decompression, fix Sonic’s title/cloud or black-world defects, or establish an FPS improvement. Unclassified/unsupported compressed surfaces conservatively fall back; NVIDIA/Windows runtime execution is not locally verified.

Fixes #3482. Related to #3407; its remaining performance scope stays open.
