### PR TITLE
feat(audio): trace output retirement and final consumption demand

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -869,6 +869,10 @@ if(TARGET prosper_core)
              COMMAND "${Python3_EXECUTABLE}"
                      "${CMAKE_SOURCE_DIR}/tests/hle/audio/test_audio_flow_publication.py"
                      $<TARGET_FILE:test_audio>)
+    add_test(NAME audio_lifecycle_publication
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_SOURCE_DIR}/tests/hle/audio/test_audio_lifecycle.py"
+                     $<TARGET_FILE:test_audio>)
   endif()
 
   # NGS2 waveform-block streaming (#1059/#1060 part 3): a fed block makes the voice Playing and advances
@@ -3831,6 +3835,14 @@ if(PROSPER_AUDIO_SDL3 AND TARGET SDL3::SDL3)
   target_link_libraries(test_audio_demand PRIVATE prosper_audio_sdl3)
   add_test(NAME audio_demand COMMAND test_audio_demand)
   set_tests_properties(audio_demand PROPERTIES ENVIRONMENT "SDL_AUDIO_DRIVER=dummy")
+  add_test(NAME audio_lifecycle_destroy_race COMMAND test_audio_demand lifecycle-race)
+  set_tests_properties(audio_lifecycle_destroy_race PROPERTIES ENVIRONMENT "SDL_AUDIO_DRIVER=dummy" TIMEOUT 15)
+  add_test(NAME audio_lifecycle_sink COMMAND test_audio_demand lifecycle-sink)
+  set_tests_properties(audio_lifecycle_sink PROPERTIES
+    ENVIRONMENT "SDL_AUDIO_DRIVER=dummy;PROSPER_AUDIO_DEMAND=1;PROSPER_AUDIO_LIFECYCLE=1")
+  add_test(NAME audio_lifecycle_sink_disabled COMMAND test_audio_demand lifecycle-sink)
+  set_tests_properties(audio_lifecycle_sink_disabled PROPERTIES
+    ENVIRONMENT "SDL_AUDIO_DRIVER=dummy;PROSPER_AUDIO_DEMAND=1;PROSPER_AUDIO_LIFECYCLE=0")
   add_test(NAME audio_demand_return_open COMMAND test_audio_demand return-open)
   add_test(NAME audio_demand_ordered_quit COMMAND test_audio_demand ordered-quit)
   set_tests_properties(audio_demand_return_open audio_demand_ordered_quit PROPERTIES

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -43,6 +43,27 @@ consumption demand with guest FLOW, scheduling and backend measurements before c
 Frontend owners must stop guest producers and call `shutdown_sdl3_audio_sink()` before SDL teardown;
 it joins the sampler and destroys streams before their callback state goes away.
 
+## Output lifecycle measurements (#3435)
+
+Enable `PROSPER_AUDIO_LIFECYCLE=1` with `PROSPER_AUDIO_DEMAND=1` to distinguish production
+stopping from stream retirement. AudioOut2 port/context retirement records preserve the last
+attribute publication, last successfully copied PCM, publication counts, format and generation.
+SDL records successful Put counts and their last timestamp, then final demand totals after normal
+stream destruction has ended callbacks. Failed Puts do not advance these observations. Diagnostic
+allocation failure leaves teardown intact and explicitly marks unavailable port snapshots.
+
+Join guest handles/context generations with the reported sink number and its separate open
+generation. HLE/Put timestamps use `steady_clock`; demand callbacks use SDL ticks. Each SDL
+observation includes a cross-clock reading bracket. That bracket bounds reading latency, not drift
+between the clocks over an earlier interval. Per-second snapshots do not timestamp individual
+shortfalls. No logging or outer sink lock is added to the consumption callback.
+
+The frontend can exit through `_Exit`, so a still-open stream may have only periodic observations.
+Missing final records are an unknown shutdown remainder, not zero demand. The existing delivery
+report consumes periodic snapshots; inspect `audio-demand-final` separately for quiesced close
+totals. These diagnostics do not establish whether a production stop was intentional, physical
+XRUNs, or audible continuity. They leave PCM ownership, mixing and pacing unchanged.
+
 ## Layers
 
 | Layer | File | In `prosper_core`? |

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -63,6 +63,8 @@ Missing final records are an unknown shutdown remainder, not zero demand. The ex
 report consumes periodic snapshots; inspect `audio-demand-final` separately for quiesced close
 totals. These diagnostics do not establish whether a production stop was intentional, physical
 XRUNs, or audible continuity. They leave PCM ownership, mixing and pacing unchanged.
+The 2026-09-09 GTA intro trace rules out delayed stream teardown after guest port retirement
+for that measured run; see [GTA V's ruled-out record](GTA5_STATUS.md#ruled-out) and #3435.
 
 ## Layers
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -5130,6 +5130,16 @@ One line per falsified hypothesis, the evidence that killed it, and where. **Rea
 a new one** — and note which entries are *solid* versus *void*, because a void result is not a
 falsification.
 
+- **GTA intro output 18 shortages come from leaving its SDL stream alive after guest
+  `PortDestroy`.** Ruled out for the 2026-09-09 30-second `ea80d412` lifecycle trace (#3435).
+  Guest port 77 and sink 18/open generation 1 each recorded 2,814 valid PCM publications/Puts.
+  The last Put preceded the recorded `PortDestroy` boundary by 961.181 ms; SDL destruction
+  returned 24.526 microseconds after that boundary (timestamped just before clearing the port).
+  Final demand was 45 shortage callbacks out of 748, with the last callback approximately
+  18 ms before that boundary. The production stop
+  preceded retirement, but its intent or scheduling cause is not established. This does not
+  establish smooth playback or justify a buffering change.
+
 - **The HTILE `gpu-preserving` suppression is load-bearing for GTA V's picture.** FALSE, measured
   2026-08-28 (#3089). **And it should never have shipped: the answer was already recorded above in
   this same document** -- "should a write that provably preserves guest bytes invalidate a detached

--- a/prosper/frontends/audio_sdl3/AGENTS.md
+++ b/prosper/frontends/audio_sdl3/AGENTS.md
@@ -7,3 +7,11 @@ Diagnostics must distinguish queued input, SDL consumption demand and backend XR
 Callbacks run under SDL's stream lock: never take the sink mutex or log from them.
 The dummy-device tests cover lifecycle; unbound stream tests can verify consumption without
 depending on a physical device or scheduler timing.
+
+`PROSPER_AUDIO_LIFECYCLE=1` adds successful submission and stream-retirement observations.
+Use it with `PROSPER_AUDIO_DEMAND=1` for per-generation callback totals. Final demand snapshots
+are taken after normal stream destruction has ended callbacks and before meter reuse; emit logs
+after releasing the sink lock. Periodic observations cover streams still open when the frontend
+takes `_Exit`. SDL callback times and HLE steady-clock times have different origins: use the
+reported clock brackets when comparing them. These observations do not establish hardware XRUNs
+or whether demand after a guest port retires was audible.

--- a/prosper/frontends/audio_sdl3/audio_demand.hpp
+++ b/prosper/frontends/audio_sdl3/audio_demand.hpp
@@ -39,6 +39,15 @@ public:
         // The caller protects stream lifetime. This lock makes the set of atomic
         // counters consistent; the callback never acquires the outer sink lock.
         if (!SDL_LockAudioStream(stream)) return false;
+        snapshot_quiesced(out);
+        SDL_UnlockAudioStream(stream);
+        return true;
+    }
+
+    // Caller must hold the stream lock OR have destroyed the stream while excluding all
+    // external users. In the latter case SDL callbacks have ended and userdata remains owned;
+    // this is an exact final set, not a pre-destroy snapshot that may miss a racing callback.
+    void snapshot_quiesced(Sdl3AudioDemandSnapshot& out) const {
         for (unsigned i = 0; i < counts_.size(); ++i) {
             const auto& c = counts_[i];
             out.phases[i] = {c.calls.load(std::memory_order_relaxed),
@@ -46,8 +55,6 @@ public:
                 c.additional.load(std::memory_order_relaxed), c.first.load(std::memory_order_relaxed),
                 c.last.load(std::memory_order_relaxed)};
         }
-        SDL_UnlockAudioStream(stream);
-        return true;
     }
 private:
     struct Counts {

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -53,6 +53,17 @@ int queue_timeline_ms() {
     return ms;
 }
 
+bool audio_lifecycle() {
+    static const bool enabled = [] {
+        const char* value = getenv("PROSPER_AUDIO_LIFECYCLE");
+        return value && std::string(value) == "1";
+    }();
+    return enabled;
+}
+uint64_t lifecycle_steady_ns() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
 bool audio_debug() {
     static const bool on = getenv("PROSPER_AUDIO_DEBUG") != nullptr;
     return on;
@@ -255,9 +266,10 @@ public:
 
     bool open(int port, const AudioPortInfo& info) override {
         if (port < 1 || port > kMaxPorts) return false;
+        ClosedObservation retired;
         std::lock_guard<std::mutex> lk(mx_);
         Slot& s = slots_[port - 1];
-        if (s.stream) { SDL_DestroyAudioStream(s.stream); s.stream = nullptr; }
+        if (s.stream) destroy_stream_locked(s, port, "reopen", retired);
         SDL_AudioSpec spec{};
         spec.format   = to_sdl_format(info.fmt);
         spec.channels = info.channels;
@@ -272,6 +284,8 @@ public:
         s.demand_started = false;
         s.demand_enabled = false;
         ++s.generation;
+        s.lifecycle_puts = s.lifecycle_last_put_ns = 0;
+        s.lifecycle_last_put_frames = 0;
         if (audio_demand()) {
             s.demand.reset(paused_ ? AudioDemandPhase::Paused : AudioDemandPhase::Startup);
             s.demand_enabled = SDL_SetAudioStreamGetCallback(s.stream, AudioDemandMeter::consume,
@@ -398,6 +412,11 @@ public:
                 s.demand.set_phase(paused_ ? AudioDemandPhase::Paused : AudioDemandPhase::Active);
             }
             if (locked) SDL_UnlockAudioStream(s.stream);
+            if (put_ok && audio_lifecycle()) {
+                ++s.lifecycle_puts;
+                s.lifecycle_last_put_ns = lifecycle_steady_ns();
+                s.lifecycle_last_put_frames = frames;
+            }
             s.dump.write(pcm, frames, s.channels, s.f32);
             // PROSPER_AUDIO_QUEUE_TRACE=1: input queue depth after each handoff.
             // The minimum exposes queue variation hidden by averages, but converted
@@ -484,6 +503,8 @@ public:
             int port = 0, queued = -1, grain = 0;
             bool demand_available = false;
             Sdl3AudioDemandSnapshot demand{};
+            uint64_t puts = 0, last_put_ns = 0;
+            int last_put_frames = 0;
         };
         const bool queue_enabled = queue_timeline_ms() > 0;
         auto demand_last = t0;
@@ -515,6 +536,11 @@ public:
                     if (queue_enabled) sample.queued = SDL_GetAudioStreamQueued(slots_[i].stream);
                     if (report_demand && slots_[i].demand_enabled) {
                         sample.demand.generation = slots_[i].generation;
+                        if (audio_lifecycle()) {
+                            sample.puts = slots_[i].lifecycle_puts;
+                            sample.last_put_ns = slots_[i].lifecycle_last_put_ns;
+                            sample.last_put_frames = slots_[i].lifecycle_last_put_frames;
+                        }
                         sample.demand_available = slots_[i].demand.snapshot(slots_[i].stream, sample.demand);
                     }
                 }
@@ -530,6 +556,18 @@ public:
                     SDL_Log("[audio-queue] t_us=%llu port=%d queued=%d grain=%d",
                             (unsigned long long)t_us, samples[i].port, samples[i].queued, samples[i].grain);
                 if (samples[i].demand_available) {
+                    if (audio_lifecycle()) {
+                        const uint64_t before_ns = lifecycle_steady_ns();
+                        const uint64_t ticks_ns = SDL_GetTicksNS();
+                        const uint64_t after_ns = lifecycle_steady_ns();
+                        SDL_Log("[audio-lifecycle-sink] event=sample port=%d generation=%llu "
+                            "puts=%llu last_put_ns=%llu last_put_frames=%d anchor_before_ns=%llu "
+                            "sdl_ticks_ns=%llu anchor_after_ns=%llu",
+                            samples[i].port, (unsigned long long)samples[i].demand.generation,
+                            (unsigned long long)samples[i].puts, (unsigned long long)samples[i].last_put_ns,
+                            samples[i].last_put_frames, (unsigned long long)before_ns,
+                            (unsigned long long)ticks_ns, (unsigned long long)after_ns);
+                    }
                     const char* phases[] = {"startup", "active", "paused"};
                     for (unsigned phase = 0; phase < 3; ++phase) {
                         const auto& c = samples[i].demand.phases[phase];
@@ -620,9 +658,10 @@ public:
 
     void close(int port) override {
         if (port < 1 || port > kMaxPorts) return;
+        ClosedObservation retired;
         std::lock_guard<std::mutex> lk(mx_);
         Slot& s = slots_[port - 1];
-        if (s.stream) { SDL_DestroyAudioStream(s.stream); s.stream = nullptr; }
+        if (s.stream) destroy_stream_locked(s, port, "close", retired);
         s.demand_enabled = false;
         s.frame_bytes = s.grain_bytes = 0;
         s.dump.finalize();   // a closed port's capture is complete
@@ -664,6 +703,8 @@ private:
     struct Slot { SDL_AudioStream* stream = nullptr; int frame_bytes = 0; int grain_bytes = 0;
                   AudioDemandMeter demand;
                   uint64_t generation = 0;
+                  uint64_t lifecycle_puts = 0, lifecycle_last_put_ns = 0;
+                  int lifecycle_last_put_frames = 0;
                   bool demand_enabled = false, demand_started = false;
                   bool put_failed = false;
                   int freq = 0;                                     // port sample rate for pacing
@@ -687,6 +728,60 @@ private:
                   // copy-construct path, which WavDump's deleted copy would reject.
                   Slot() = default;
     };
+    struct ClosedObservation {
+        int port = 0, last_put_frames = 0;
+        const char* reason = nullptr;
+        uint64_t generation = 0, puts = 0, last_put_ns = 0, begin_ns = 0, end_ns = 0;
+        uint64_t anchor_before_ns = 0, sdl_ticks_ns = 0, anchor_after_ns = 0;
+        bool demand_available = false;
+        Sdl3AudioDemandSnapshot demand{};
+        ~ClosedObservation() {
+            if (!reason) return;
+            SDL_Log("[audio-lifecycle-sink] event=%s port=%d generation=%llu begin_ns=%llu "
+                "destroy_return_ns=%llu puts=%llu last_put_ns=%llu last_put_frames=%d "
+                "anchor_before_ns=%llu sdl_ticks_ns=%llu anchor_after_ns=%llu demand_available=%u",
+                reason, port, (unsigned long long)generation, (unsigned long long)begin_ns,
+                (unsigned long long)end_ns, (unsigned long long)puts, (unsigned long long)last_put_ns,
+                last_put_frames, (unsigned long long)anchor_before_ns, (unsigned long long)sdl_ticks_ns,
+                (unsigned long long)anchor_after_ns, unsigned(demand_available));
+            if (demand_available) {
+                const char* phases[] = {"startup", "active", "paused"};
+                for (unsigned i = 0; i < demand.phases.size(); ++i) {
+                    const auto& c = demand.phases[i];
+                    SDL_Log("[audio-demand-final] port=%d generation=%llu phase=%s calls=%llu "
+                        "requested_bytes=%llu shortfall_calls=%llu additional_bytes=%llu first_ns=%llu last_ns=%llu",
+                        port, (unsigned long long)generation, phases[i], (unsigned long long)c.calls,
+                        (unsigned long long)c.requested_bytes, (unsigned long long)c.shortfall_calls,
+                        (unsigned long long)c.additional_bytes, (unsigned long long)c.first_ns,
+                        (unsigned long long)c.last_ns);
+                }
+            }
+        }
+    };
+    // mx_ excludes output/sampler/reopen while SDL's normal destruction synchronizes its
+    // callbacks. Never lock/detach/pause solely to measure, and never log under a stream lock.
+    void destroy_stream_locked(Slot& s, int port, const char* reason, ClosedObservation& out) {
+        const bool observe = audio_lifecycle();
+        if (observe) {
+            out.reason = reason; out.port = port; out.generation = s.generation;
+            out.puts = s.lifecycle_puts; out.last_put_ns = s.lifecycle_last_put_ns;
+            out.last_put_frames = s.lifecycle_last_put_frames;
+            out.begin_ns = lifecycle_steady_ns();
+        }
+        SDL_DestroyAudioStream(s.stream);
+        s.stream = nullptr;
+        if (observe) {
+            out.end_ns = lifecycle_steady_ns();
+            out.demand_available = s.demand_enabled;
+            out.demand.generation = s.generation;
+            if (out.demand_available) s.demand.snapshot_quiesced(out.demand);
+            // Explicit bounded cross-clock anchor: core timestamps are steady_clock;
+            // demand callback timestamps use SDL_GetTicksNS (an SDL-relative origin).
+            out.anchor_before_ns = lifecycle_steady_ns();
+            out.sdl_ticks_ns = SDL_GetTicksNS();
+            out.anchor_after_ns = lifecycle_steady_ns();
+        }
+    }
     std::mutex mx_;
     std::array<Slot, kMaxPorts> slots_{};
     // Set when the timeline starts, cleared by stop_queue_timeline(), which then JOINS. Both

--- a/prosper/frontends/audio_sdl3/test_audio_demand.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_demand.cpp
@@ -1,5 +1,10 @@
 #include "audio_demand.hpp"
 #include "hle/audio/audio.hpp"
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <vector>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -10,7 +15,189 @@ using namespace prosper;
 static int failures = 0;
 #define CHECK(c) do { if (!(c)) { std::printf("FAIL line %d: %s\n", __LINE__, #c); ++failures; } } while (0)
 
+
+// A real device callback remains inside SDL's stream/device synchronization while Destroy
+// starts. The fixture gate is test-owned; it never calls the sink or logs from the callback.
+static int lifecycle_destroy_race(bool pre_destroy_control) {
+    CHECK(SDL_InitSubSystem(SDL_INIT_AUDIO));
+    const SDL_AudioSpec spec{SDL_AUDIO_F32, 2, 48000};
+    SDL_AudioStream* stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, nullptr, nullptr);
+    CHECK(stream);
+    if (!stream) return 1;
+    struct Gate {
+        AudioDemandMeter meter;
+        std::mutex mutex;
+        std::condition_variable condition;
+        bool entered = false, release = false, timed_out = false;
+        std::atomic<uint64_t> completed{0};
+    } gate;
+    gate.meter.reset(AudioDemandPhase::Active);
+    const auto callback = [](void* data, SDL_AudioStream* current, int additional, int total) {
+        auto& g = *static_cast<Gate*>(data);
+        {
+            std::unique_lock lock(g.mutex);
+            g.entered = true;
+            g.condition.notify_all();
+            if (!g.condition.wait_for(lock, std::chrono::seconds(3), [&] { return g.release; }))
+                g.timed_out = true;
+        }
+        AudioDemandMeter::consume(&g.meter, current, additional, total);
+        g.completed.fetch_add(1, std::memory_order_release);
+    };
+    CHECK(SDL_SetAudioStreamGetCallback(stream, callback, &gate));
+    Sdl3AudioDemandSnapshot prior{}, final{};
+    CHECK(gate.meter.snapshot(stream, prior)); // device starts paused; no callback yet
+    CHECK(prior.phases[1].calls == 0);
+    CHECK(SDL_ResumeAudioStreamDevice(stream));
+    bool entered = false;
+    {
+        std::unique_lock lock(gate.mutex);
+        entered = gate.condition.wait_for(lock, std::chrono::seconds(2), [&] { return gate.entered; });
+    }
+    CHECK(entered);
+    std::atomic<bool> destroying{false}, destroyed{false};
+    std::thread destroyer([&] {
+        destroying.store(true, std::memory_order_release);
+        SDL_DestroyAudioStream(stream);
+        gate.meter.snapshot_quiesced(final);
+        destroyed.store(true, std::memory_order_release);
+    });
+    while (!destroying.load(std::memory_order_acquire)) std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    if (entered) CHECK(!destroyed.load(std::memory_order_acquire));
+    {
+        std::lock_guard lock(gate.mutex);
+        gate.release = true;
+        gate.condition.notify_all();
+    }
+    destroyer.join();
+    CHECK(!gate.timed_out);
+    CHECK(gate.completed.load() > 0);
+    const auto& observed = pre_destroy_control ? prior : final;
+    CHECK(observed.phases[1].calls == gate.completed.load());
+    CHECK(observed.phases[1].shortfall_calls > 0 && observed.phases[1].additional_bytes > 0);
+    CHECK(final.phases[1].last_ns >= final.phases[1].first_ns && final.phases[1].first_ns > 0);
+    CHECK(prior.phases[1].calls < final.phases[1].calls); // pre-destroy observation really omitted a callback
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    return failures ? 1 : 0;
+}
+
+struct LifecycleLogs {
+    std::mutex mutex;
+    std::vector<std::string> lines;
+    static void SDLCALL output(void* data, int, SDL_LogPriority, const char* text) {
+        auto& self = *static_cast<LifecycleLogs*>(data);
+        std::lock_guard lock(self.mutex);
+        self.lines.emplace_back(text);
+    }
+};
+static uint64_t lifecycle_field(const std::string& line, const char* name) {
+    const std::string needle = std::string(" ") + name + "=";
+    const auto offset = line.find(needle);
+    CHECK(offset != std::string::npos);
+    return offset == std::string::npos ? 0 : std::strtoull(line.c_str() + offset + needle.size(), nullptr, 0);
+}
+static uint64_t lifecycle_now() {
+    return uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+static int lifecycle_actual_sink() {
+    // The invalid-Put control must not pass a null pointer to an unrelated WAV dump.
+#ifdef _WIN32
+    _putenv_s("PROSPER_AUDIO_DUMP_WAV", "");
+#else
+    unsetenv("PROSPER_AUDIO_DUMP_WAV");
+#endif
+    LifecycleLogs logs;
+    SDL_LogOutputFunction previous = nullptr;
+    void* previous_data = nullptr;
+    SDL_GetLogOutputFunction(&previous, &previous_data);
+    SDL_SetLogOutputFunction(LifecycleLogs::output, &logs);
+    CHECK(install_sdl3_audio_sink());
+    // Pause only this test's device to make the final demand sets deterministic; the core's
+    // producer pause gate remains open, so real SDL_PutAudioStreamData is still exercised.
+    set_sdl3_audio_paused(true);
+    auto* sink = audio_sink();
+    AudioPortInfo info;
+    info.grain = 1;
+    int16_t pcm[2] = {123, -321};
+    CHECK(sink->open(27, info));
+    CHECK(sink->open(28, info));
+    Sdl3AudioDemandSnapshot a{}, b{};
+    CHECK(sdl3_audio_demand_snapshot(27, a));
+    CHECK(sdl3_audio_demand_snapshot(28, b));
+    sink->output(27, pcm, 1);
+    const uint64_t before_second = lifecycle_now();
+    sink->output(27, pcm, 1);
+    const uint64_t after_second = lifecycle_now();
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    const uint64_t failure_begin = lifecycle_now();
+    sink->output(27, nullptr, 1); // SDL rejects nonzero length with a null data pointer
+    sink->output(28, pcm, 1);
+    CHECK(sink->open(27, info)); // closes generation a while preserving its observation
+    Sdl3AudioDemandSnapshot reopened{};
+    CHECK(sdl3_audio_demand_snapshot(27, reopened));
+    CHECK(reopened.generation > a.generation);
+    sink->output(27, pcm, 1);
+    sink->close(27);
+    sink->close(27); // no second final record for an already-closed generation
+    sink->close(28);
+    shutdown_sdl3_audio_sink();
+    SDL_SetLogOutputFunction(previous, previous_data);
+    const char* gate = std::getenv("PROSPER_AUDIO_LIFECYCLE");
+    const bool enabled = gate && std::strcmp(gate, "1") == 0;
+    std::vector<std::string> closed, final;
+    for (const auto& line : logs.lines) {
+        if (line.find("[audio-lifecycle-sink] event=close ") == 0 ||
+            line.find("[audio-lifecycle-sink] event=reopen ") == 0) closed.push_back(line);
+        if (line.find("[audio-demand-final] ") == 0) final.push_back(line);
+    }
+    if (!enabled) {
+        CHECK(closed.empty() && final.empty());
+        return failures ? 1 : 0;
+    }
+    CHECK(closed.size() == 3 && final.size() == 9);
+    bool old_seen = false, new_seen = false, peer_seen = false;
+    for (const auto& line : closed) {
+        const auto port = lifecycle_field(line, "port"), generation = lifecycle_field(line, "generation");
+        const auto puts = lifecycle_field(line, "puts");
+        CHECK(lifecycle_field(line, "demand_available") == 1);
+        CHECK(lifecycle_field(line, "last_put_frames") == 1);
+        CHECK(lifecycle_field(line, "last_put_ns") <= lifecycle_field(line, "begin_ns"));
+        CHECK(lifecycle_field(line, "begin_ns") <= lifecycle_field(line, "destroy_return_ns"));
+        CHECK(lifecycle_field(line, "destroy_return_ns") <= lifecycle_field(line, "anchor_before_ns"));
+        CHECK(lifecycle_field(line, "anchor_before_ns") <= lifecycle_field(line, "anchor_after_ns"));
+        CHECK(lifecycle_field(line, "sdl_ticks_ns") > 0);
+        if (port == 27 && generation == a.generation) {
+            old_seen = true;
+            CHECK(line.find("event=reopen ") != std::string::npos && puts == 2);
+            const auto last = lifecycle_field(line, "last_put_ns");
+            CHECK(before_second <= last && last <= after_second && last < failure_begin);
+        } else if (port == 27 && generation == reopened.generation) {
+            new_seen = true; CHECK(puts == 1);
+        } else if (port == 28 && generation == b.generation) {
+            peer_seen = true; CHECK(puts == 1);
+        } else CHECK(false);
+        unsigned phase_count = 0;
+        for (const auto& row : final) {
+            if (lifecycle_field(row, "port") != port || lifecycle_field(row, "generation") != generation) continue;
+            ++phase_count;
+            CHECK(lifecycle_field(row, "calls") == 0 && lifecycle_field(row, "shortfall_calls") == 0);
+            CHECK(lifecycle_field(row, "first_ns") == 0 && lifecycle_field(row, "last_ns") == 0);
+        }
+        CHECK(phase_count == 3);
+    }
+    CHECK(old_seen && new_seen && peer_seen);
+    return failures ? 1 : 0;
+}
+
 int main(int argc, char** argv) {
+    if (argc == 2 && (std::strcmp(argv[1], "lifecycle-race") == 0 ||
+                      std::strcmp(argv[1], "lifecycle-race-precontrol") == 0))
+        return lifecycle_destroy_race(std::strcmp(argv[1], "lifecycle-race-precontrol") == 0);
+    if (argc == 2 && std::strcmp(argv[1], "lifecycle-sink") == 0)
+        return lifecycle_actual_sink();
     // Separate processes exercise static destruction, which cannot be tested by
     // explicitly shutting down the same sink earlier in the ordinary test.
     if (argc == 2) {

--- a/prosper/src/hle/audio/hle_audio.cpp
+++ b/prosper/src/hle/audio/hle_audio.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <map>
 #include <mutex>
+#include <new>
 #include <set>
 #include <thread>
 #include <vector>
@@ -1812,7 +1813,16 @@ HLE(audio2_ctx_destroy) {
     // Keep diagnostic snapshots off the guest thread's stack, including when disabled. Reserve
     // once before taking the sink/state locks; no allocation is needed while retiring ports.
     std::vector<A2LifecyclePort> retired;
-    if (lifecycle) retired.reserve(kA2MaxPorts);
+    bool snapshots_unavailable = false;
+    if (lifecycle) {
+        try {
+            retired.reserve(kA2MaxPorts);
+        } catch (const std::bad_alloc&) {
+            // Diagnostic memory pressure must not prevent guest state and sink teardown.
+            snapshots_unavailable = true;
+        }
+    }
+    size_t implicit_ports = 0;
     std::unique_lock<std::mutex> sink_lk(g_a2_sink_mx[context_slot]);
     bool close_sink = false;
     uint64_t cleared_ns = 0;
@@ -1826,7 +1836,9 @@ HLE(audio2_ctx_destroy) {
         for (uint32_t i = 0; i < kA2MaxPorts; ++i) {
             auto& port = g_a2_port_state[i];
             if (port.used && port.context == a0) {
-                if (lifecycle) retired.push_back(audio_lifecycle_port(port, i, cleared_ns));
+                ++implicit_ports;
+                if (lifecycle && !snapshots_unavailable)
+                    retired.push_back(audio_lifecycle_port(port, i, cleared_ns));
                 audio2_clear_slot(port);
             }
         }
@@ -1839,10 +1851,11 @@ HLE(audio2_ctx_destroy) {
     if (lifecycle) {
         std::fprintf(stderr, "[audio-lifecycle-context] event=destroy context=0x%llx "
             "generation=%u sink=%u entered_ns=%llu cleared_ns=%llu close_return_ns=%llu "
-            "sink_was_open=%u implicit_ports=%zu\n", (unsigned long long)a0,
+            "sink_was_open=%u implicit_ports=%zu snapshots_unavailable=%u\n", (unsigned long long)a0,
             uint32_t(a0 >> 16), unsigned(kA2SinkPortBase + context_slot),
             (unsigned long long)entered_ns, (unsigned long long)cleared_ns,
-            (unsigned long long)closed_ns, unsigned(close_sink), retired.size());
+            (unsigned long long)closed_ns, unsigned(close_sink), implicit_ports,
+            unsigned(snapshots_unavailable));
         for (const auto& port : retired) audio_lifecycle_emit(port, "context-destroy");
     }
     return 0;

--- a/prosper/src/hle/audio/hle_audio.cpp
+++ b/prosper/src/hle/audio/hle_audio.cpp
@@ -1809,10 +1809,12 @@ HLE(audio2_ctx_destroy) {
     const uint32_t context_slot = one_based_index - 1;
     const bool lifecycle = audio_lifecycle();
     const uint64_t entered_ns = lifecycle ? audio_lifecycle_now_ns() : 0;
+    // Keep diagnostic snapshots off the guest thread's stack, including when disabled. Reserve
+    // once before taking the sink/state locks; no allocation is needed while retiring ports.
+    std::vector<A2LifecyclePort> retired;
+    if (lifecycle) retired.reserve(kA2MaxPorts);
     std::unique_lock<std::mutex> sink_lk(g_a2_sink_mx[context_slot]);
     bool close_sink = false;
-    std::array<A2LifecyclePort, kA2MaxPorts> retired{};
-    size_t retired_count = 0;
     uint64_t cleared_ns = 0;
     {
         std::lock_guard<std::mutex> lk(g_a2_mx);
@@ -1824,7 +1826,7 @@ HLE(audio2_ctx_destroy) {
         for (uint32_t i = 0; i < kA2MaxPorts; ++i) {
             auto& port = g_a2_port_state[i];
             if (port.used && port.context == a0) {
-                if (lifecycle) retired[retired_count++] = audio_lifecycle_port(port, i, cleared_ns);
+                if (lifecycle) retired.push_back(audio_lifecycle_port(port, i, cleared_ns));
                 audio2_clear_slot(port);
             }
         }
@@ -1840,8 +1842,8 @@ HLE(audio2_ctx_destroy) {
             "sink_was_open=%u implicit_ports=%zu\n", (unsigned long long)a0,
             uint32_t(a0 >> 16), unsigned(kA2SinkPortBase + context_slot),
             (unsigned long long)entered_ns, (unsigned long long)cleared_ns,
-            (unsigned long long)closed_ns, unsigned(close_sink), retired_count);
-        for (size_t i = 0; i < retired_count; ++i) audio_lifecycle_emit(retired[i], "context-destroy");
+            (unsigned long long)closed_ns, unsigned(close_sink), retired.size());
+        for (const auto& port : retired) audio_lifecycle_emit(port, "context-destroy");
     }
     return 0;
 }

--- a/prosper/src/hle/audio/hle_audio.cpp
+++ b/prosper/src/hle/audio/hle_audio.cpp
@@ -628,7 +628,21 @@ uint32_t   g_a2_users = 0;
 // interleaved PCM (grain frames from the context param, 256 live). ContextAdvance
 // advances engine state and ContextPush submits the grain to the device. SetAttributes must copy
 // each grain: guests reuse one scratch buffer for multiple ports before Advance/Push (#3411).
+// Opt-in lifecycle-only output. No per-grain log, allocation, routing or pacing change.
+bool audio_lifecycle() {
+    static const bool enabled = [] {
+        const char* value = std::getenv("PROSPER_AUDIO_LIFECYCLE");
+        return value && std::strcmp(value, "1") == 0;
+    }();
+    return enabled;
+}
+uint64_t audio_lifecycle_now_ns() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
 struct A2PortState {
+    uint64_t lifecycle_last_attribute_ns = 0, lifecycle_last_pcm_ns = 0;
+    uint64_t lifecycle_publications = 0, lifecycle_valid_publications = 0;
     bool     used = false;
     uint32_t generation = 0;
     uint64_t context = 0;      // owning context; Push must not submit another context's ports
@@ -1107,6 +1121,33 @@ uint32_t audio2_next_generation(uint32_t generation) {
 
 uint64_t audio2_make_handle(uint64_t tag, uint32_t generation, uint32_t one_based_index) {
     return tag | ((uint64_t)generation << 16) | one_based_index;
+}
+
+// POD snapshots survive slot clearing without copying PCM vectors. All reads occur under
+// g_a2_mx; printing occurs after that lock is released. Explicit and implicit destroys share it.
+struct A2LifecyclePort {
+    uint64_t port = 0, context = 0, event_ns = 0, last_attribute_ns = 0, last_pcm_ns = 0;
+    uint64_t publications = 0, valid_publications = 0;
+    uint32_t frames = 0, type = 0, data_format = 0;
+    bool pending = false;
+};
+A2LifecyclePort audio_lifecycle_port(const A2PortState& port, uint32_t index, uint64_t event_ns) {
+    return {audio2_make_handle(kA2PortTag, port.generation, index + 1), port.context,
+            event_ns, port.lifecycle_last_attribute_ns, port.lifecycle_last_pcm_ns,
+            port.lifecycle_publications, port.lifecycle_valid_publications,
+            port.pcm_frames, port.type, port.data_format, port.pcm_pending};
+}
+void audio_lifecycle_emit(const A2LifecyclePort& p, const char* reason) {
+    if (!p.port) return;
+    std::fprintf(stderr, "[audio-lifecycle-port] event=%s steady_ns=%llu port=0x%llx "
+        "generation=%u context=0x%llx context_generation=%u sink=%u "
+        "last_attribute_ns=%llu last_valid_pcm_ns=%llu publications=%llu valid_publications=%llu "
+        "pending=%u frames=%u type=%u data_format=0x%x\n", reason, (unsigned long long)p.event_ns,
+        (unsigned long long)p.port, uint32_t(p.port >> 16), (unsigned long long)p.context,
+        uint32_t(p.context >> 16), unsigned(kA2SinkPortBase + (p.context & kA2HandleIndexMask) - 1),
+        (unsigned long long)p.last_attribute_ns, (unsigned long long)p.last_pcm_ns,
+        (unsigned long long)p.publications, (unsigned long long)p.valid_publications,
+        unsigned(p.pending), p.frames, p.type, p.data_format);
 }
 
 template <typename Slot>
@@ -1766,19 +1807,42 @@ HLE(audio2_ctx_destroy) {
     if ((a0 & kA2HandleTagMask) != kA2CtxTag || one_based_index < 1 ||
         one_based_index > std::size(g_a2_ctx)) return kA2ErrInvalidParam;
     const uint32_t context_slot = one_based_index - 1;
-    std::lock_guard<std::mutex> sink_lk(g_a2_sink_mx[context_slot]);
+    const bool lifecycle = audio_lifecycle();
+    const uint64_t entered_ns = lifecycle ? audio_lifecycle_now_ns() : 0;
+    std::unique_lock<std::mutex> sink_lk(g_a2_sink_mx[context_slot]);
     bool close_sink = false;
+    std::array<A2LifecyclePort, kA2MaxPorts> retired{};
+    size_t retired_count = 0;
+    uint64_t cleared_ns = 0;
     {
         std::lock_guard<std::mutex> lk(g_a2_mx);
         A2Context* context = audio2_context_locked(a0);
         if (!context) return kA2ErrInvalidParam;
         close_sink = context->sink_opened;
+        if (lifecycle) cleared_ns = audio_lifecycle_now_ns();
         audio2_clear_slot(*context);
-        for (auto& port : g_a2_port_state)
-            if (port.used && port.context == a0) audio2_clear_slot(port);
+        for (uint32_t i = 0; i < kA2MaxPorts; ++i) {
+            auto& port = g_a2_port_state[i];
+            if (port.used && port.context == a0) {
+                if (lifecycle) retired[retired_count++] = audio_lifecycle_port(port, i, cleared_ns);
+                audio2_clear_slot(port);
+            }
+        }
     }
     if (close_sink)
         if (AudioSink* sink = audio_sink()) sink->close(kA2SinkPortBase + (int)context_slot);
+    const uint64_t closed_ns = lifecycle ? audio_lifecycle_now_ns() : 0;
+    sink_lk.unlock();
+    // Emit after actual sink closure: diagnostics must not extend this stream's draining tail.
+    if (lifecycle) {
+        std::fprintf(stderr, "[audio-lifecycle-context] event=destroy context=0x%llx "
+            "generation=%u sink=%u entered_ns=%llu cleared_ns=%llu close_return_ns=%llu "
+            "sink_was_open=%u implicit_ports=%zu\n", (unsigned long long)a0,
+            uint32_t(a0 >> 16), unsigned(kA2SinkPortBase + context_slot),
+            (unsigned long long)entered_ns, (unsigned long long)cleared_ns,
+            (unsigned long long)closed_ns, unsigned(close_sink), retired_count);
+        for (size_t i = 0; i < retired_count; ++i) audio_lifecycle_emit(retired[i], "context-destroy");
+    }
     return 0;
 }
 
@@ -1838,10 +1902,16 @@ HLE(audio2_port_destroy) {
     A2LOG("sceAudioOut2PortDestroy");
     // Clear the slot so a destroyed port stops being mixed (its guest PCM buffer may be freed and
     // reused) and the slot is reusable by the next PortCreate.
-    std::lock_guard<std::mutex> lk(g_a2_mx);
-    A2PortState* port = audio2_port_locked(a0);
-    if (!port) return kA2ErrInvalidParam;
-    audio2_clear_slot(*port);
+    A2LifecyclePort retired{};
+    {
+        std::lock_guard<std::mutex> lk(g_a2_mx);
+        uint32_t index = 0;
+        A2PortState* port = audio2_port_locked(a0, &index);
+        if (!port) return kA2ErrInvalidParam;
+        if (audio_lifecycle()) retired = audio_lifecycle_port(*port, index, audio_lifecycle_now_ns());
+        audio2_clear_slot(*port);
+    }
+    audio_lifecycle_emit(retired, "port-destroy");
     return 0;
 }
 
@@ -1933,6 +2003,15 @@ HLE(audio2_port_set_attr) {
                                 output[frame] = value * (1.0f / 32768.0f);
                             }
                         }
+                    }
+                }
+                if (audio_lifecycle()) {
+                    const uint64_t now_ns = audio_lifecycle_now_ns();
+                    port->lifecycle_last_attribute_ns = now_ns; // includes explicit null publication
+                    if (pcm) ++port->lifecycle_publications;
+                    if (pcm && port->pcm_frames) {
+                        ++port->lifecycle_valid_publications;
+                        port->lifecycle_last_pcm_ns = now_ns;
                     }
                 }
                 // Reached-ness: the guest handing us a PCM buffer address is the last step before

--- a/prosper/tests/hle/audio/AGENTS.md
+++ b/prosper/tests/hle/audio/AGENTS.md
@@ -1,0 +1,10 @@
+# Guest audio contract tests
+
+These fixtures call the real HLE dispatch boundary with owned guest buffers and a recording sink.
+They check handle generations, port/context lifetimes, publication failures, and independent PCM
+ownership through scratch-buffer reuse. SDL device scheduling and callback synchronization belong
+to `frontends/audio_sdl3/` tests; a recording sink cannot establish those behaviors.
+
+The lifecycle log verifier runs separate enabled and disabled processes and checks teardown
+observations against actual delivered PCM. Missing observations are a failed measurement, not zero
+activity. Keep guest handles and sink generations distinct when checking recycled slots.

--- a/prosper/tests/hle/audio/test_audio.cpp
+++ b/prosper/tests/hle/audio/test_audio.cpp
@@ -547,11 +547,77 @@ static int test_flow_publication() {
     return fails ? 1 : 0;
 }
 
+
+// The Python driver checks actual lifecycle records in enabled/disabled processes. PCM remains
+// independently checked here: scratch reuse after publication must not alter the supplied grain.
+static int test_lifecycle_publication() {
+    audio_reset();
+    CapturingSink sink;
+    audio_set_sink(&sink);
+    uint8_t context_param[0x40]{};
+    CHECK(call("sceAudioOut2ContextResetParam", PTR(context_param)) == 0);
+    *(uint32_t*)(context_param + 0x10) = 64;
+    uint64_t context = 0, old_port = 0, new_port = 0, aux = 0, next_context = 0, next_port = 0;
+    CHECK(call("sceAudioOut2ContextCreate", PTR(context_param), 0, 0, PTR(&context)) == 0);
+    struct PortParam {
+        uint16_t type, pad;
+        uint32_t format, rate, flags;
+        uint64_t user;
+        uint32_t reserved[10];
+    } param{};
+    param.format = 0x200; param.rate = 48000;
+    CHECK(call("sceAudioOut2PortCreate", context, PTR(&param), PTR(&old_port)) == 0);
+    std::vector<float> pcm(128);
+    for (size_t i = 0; i < pcm.size(); ++i) pcm[i] = i % 2 ? -0.5f : 0.25f;
+    const auto original = pcm;
+    uint64_t pointer = PTR(pcm.data());
+    struct Attribute { uint32_t id, reserved; uint64_t value, size; } attr{0, 0, PTR(&pointer), 8};
+    CHECK(call("sceAudioOut2PortSetAttributes", old_port, PTR(&attr), 1) == 0);
+    std::fill(pcm.begin(), pcm.end(), 0.75f); // guest scratch is reused before Push
+    CHECK(call("sceAudioOut2ContextPush", context, 1) == 0);
+    CHECK(sink.outs.size() == 1);
+    if (sink.outs.size() == 1) CHECK(sink.outs[0].pcm.size() == 512 &&
+        std::memcmp(sink.outs[0].pcm.data(), original.data(), 512) == 0);
+    pointer = 0;
+    CHECK(call("sceAudioOut2PortSetAttributes", old_port, PTR(&attr), 1) == 0);
+    pointer = 1; // fault-safe unreadable guest address: nonnull attempt, zero captured frames
+    CHECK(call("sceAudioOut2PortSetAttributes", old_port, PTR(&attr), 1) == 0);
+    CHECK(call("sceAudioOut2PortDestroy", old_port) == 0);
+    CHECK(sink.closes.empty()); // a port retirement must not silently close the context output
+    CHECK(call("sceAudioOut2PortCreate", context, PTR(&param), PTR(&new_port)) == 0);
+    CHECK((new_port & 0xffff) == (old_port & 0xffff) && new_port != old_port);
+    pointer = PTR(pcm.data());
+    CHECK(call("sceAudioOut2PortSetAttributes", new_port, PTR(&attr), 1) == 0);
+    CHECK(call("sceAudioOut2ContextPush", context, 1) == 0);
+    CHECK(sink.outs.size() == 2);
+    if (sink.outs.size() == 2) CHECK(sink.outs[1].pcm.size() == 512 &&
+        std::memcmp(sink.outs[1].pcm.data(), pcm.data(), 512) == 0);
+    param.type = 1; // implicit auxiliary retirement must remain distinguishable from MAIN
+    CHECK(call("sceAudioOut2PortCreate", context, PTR(&param), PTR(&aux)) == 0);
+    CHECK(call("sceAudioOut2PortSetAttributes", aux, PTR(&attr), 1) == 0);
+    CHECK(call("sceAudioOut2ContextDestroy", context) == 0);
+    CHECK(sink.closes.size() == 1 && sink.closes[0] == 17);
+    CHECK(call("sceAudioOut2ContextCreate", PTR(context_param), 0, 0, PTR(&next_context)) == 0);
+    CHECK((next_context & 0xffff) == (context & 0xffff) && next_context != context);
+    param.type = 0;
+    CHECK(call("sceAudioOut2PortCreate", next_context, PTR(&param), PTR(&next_port)) == 0);
+    CHECK(call("sceAudioOut2ContextDestroy", next_context) == 0);
+    CHECK(sink.closes.size() == 1 && sink.outs.size() == 2); // diagnostics cannot synthesize output
+    std::printf("[lifecycle-fixture] context=0x%llx old=0x%llx new=0x%llx aux=0x%llx "
+                "next_context=0x%llx next_port=0x%llx\n", (unsigned long long)context,
+                (unsigned long long)old_port, (unsigned long long)new_port, (unsigned long long)aux,
+                (unsigned long long)next_context, (unsigned long long)next_port);
+    audio_reset();
+    return fails ? 1 : 0;
+}
+
 int main(int argc, char** argv) {
     printf("== test_audio ==\n");
     register_builtin_hle();
     if (argc == 2 && std::strcmp(argv[1], "--flow-publication") == 0)
         return test_flow_publication();
+    if (argc == 2 && std::strcmp(argv[1], "--lifecycle-publication") == 0)
+        return test_lifecycle_publication();
     test_signal_stats();
     test_stereo_downmix();
     test_stamped_grain_verdicts();

--- a/prosper/tests/hle/audio/test_audio.cpp
+++ b/prosper/tests/hle/audio/test_audio.cpp
@@ -14,11 +14,36 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <mutex>
+#include <new>
 #include <thread>
 #include <vector>
+
+// Confined fixture injection: arm only around one already-resolved HLE handler on this thread.
+// Other threads and all ordinary fixture operations retain normal allocation behavior. This
+// observes the real diagnostic vector reserve without a production test hook or mirrored size.
+namespace {
+thread_local bool fail_next_audio_allocation = false;
+thread_local size_t failed_audio_allocation_bytes = 0;
+}
+void* operator new(size_t bytes) {
+    if (fail_next_audio_allocation) {
+        fail_next_audio_allocation = false;
+        failed_audio_allocation_bytes = bytes;
+        throw std::bad_alloc();
+    }
+    void* p = std::malloc(bytes ? bytes : 1);
+    if (!p) throw std::bad_alloc();
+    return p;
+}
+void* operator new[](size_t bytes) { return ::operator new(bytes); }
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete(void* p, size_t) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete[](void* p, size_t) noexcept { std::free(p); }
 
 using namespace prosper;
 
@@ -550,7 +575,7 @@ static int test_flow_publication() {
 
 // The Python driver checks actual lifecycle records in enabled/disabled processes. PCM remains
 // independently checked here: scratch reuse after publication must not alter the supplied grain.
-static int test_lifecycle_publication() {
+static int test_lifecycle_publication(bool fail_reserve = false) {
     audio_reset();
     CapturingSink sink;
     audio_set_sink(&sink);
@@ -595,7 +620,33 @@ static int test_lifecycle_publication() {
     param.type = 1; // implicit auxiliary retirement must remain distinguishable from MAIN
     CHECK(call("sceAudioOut2PortCreate", context, PTR(&param), PTR(&aux)) == 0);
     CHECK(call("sceAudioOut2PortSetAttributes", aux, PTR(&attr), 1) == 0);
-    CHECK(call("sceAudioOut2ContextDestroy", context) == 0);
+    if (fail_reserve) {
+        // Avoid lookup/sink-recording allocations in the fault scope. The first allocation is
+        // the production lifecycle snapshot reserve; teardown itself must still close this sink.
+        HleFn destroy = FN("sceAudioOut2ContextDestroy");
+        CHECK(destroy != nullptr);
+        sink.closes.reserve(1);
+        failed_audio_allocation_bytes = 0;
+        fail_next_audio_allocation = true;
+        bool threw = false;
+        int64_t result = -1;
+        try {
+            if (destroy) result = (int64_t)destroy(context, 0, 0, 0, 0, 0);
+        } catch (const std::bad_alloc&) {
+            threw = true;
+        }
+        const bool consumed = !fail_next_audio_allocation;
+        fail_next_audio_allocation = false;
+        CHECK(consumed && failed_audio_allocation_bytes > 0);
+        CHECK(!threw && result == 0);
+        // Old uncaught-reserve code fails above; clean up so later ownership checks still run.
+        if (threw) CHECK(call("sceAudioOut2ContextDestroy", context) == 0);
+        CHECK(call("sceAudioOut2PortDestroy", new_port) < 0);
+        CHECK(call("sceAudioOut2PortDestroy", aux) < 0);
+        CHECK(call("sceAudioOut2ContextDestroy", context) < 0);
+    } else {
+        CHECK(call("sceAudioOut2ContextDestroy", context) == 0);
+    }
     CHECK(sink.closes.size() == 1 && sink.closes[0] == 17);
     CHECK(call("sceAudioOut2ContextCreate", PTR(context_param), 0, 0, PTR(&next_context)) == 0);
     CHECK((next_context & 0xffff) == (context & 0xffff) && next_context != context);
@@ -604,9 +655,9 @@ static int test_lifecycle_publication() {
     CHECK(call("sceAudioOut2ContextDestroy", next_context) == 0);
     CHECK(sink.closes.size() == 1 && sink.outs.size() == 2); // diagnostics cannot synthesize output
     std::printf("[lifecycle-fixture] context=0x%llx old=0x%llx new=0x%llx aux=0x%llx "
-                "next_context=0x%llx next_port=0x%llx\n", (unsigned long long)context,
+                "next_context=0x%llx next_port=0x%llx reserve_fault=%u\n", (unsigned long long)context,
                 (unsigned long long)old_port, (unsigned long long)new_port, (unsigned long long)aux,
-                (unsigned long long)next_context, (unsigned long long)next_port);
+                (unsigned long long)next_context, (unsigned long long)next_port, unsigned(fail_reserve));
     audio_reset();
     return fails ? 1 : 0;
 }
@@ -618,6 +669,8 @@ int main(int argc, char** argv) {
         return test_flow_publication();
     if (argc == 2 && std::strcmp(argv[1], "--lifecycle-publication") == 0)
         return test_lifecycle_publication();
+    if (argc == 2 && std::strcmp(argv[1], "--lifecycle-publication-failalloc") == 0)
+        return test_lifecycle_publication(true);
     test_signal_stats();
     test_stereo_downmix();
     test_stamped_grain_verdicts();

--- a/prosper/tests/hle/audio/test_audio_lifecycle.py
+++ b/prosper/tests/hle/audio/test_audio_lifecycle.py
@@ -13,12 +13,13 @@ def number(row, key):
     return int(row[key], 0)
 
 
-for enabled in (False, True):
+for enabled, fail_reserve in ((False, False), (True, False), (True, True)):
     env = {key: value for key, value in os.environ.items() if not key.startswith("PROSPER_AUDIO")}
     env["PROSPER_AUDIO_LIFECYCLE"] = "1" if enabled else "0"
     if "--negative-disabled" in sys.argv:
         env["PROSPER_AUDIO_LIFECYCLE"] = "0"
-    result = subprocess.run([sys.argv[1], "--lifecycle-publication"], env=env,
+    mode = "--lifecycle-publication-failalloc" if fail_reserve else "--lifecycle-publication"
+    result = subprocess.run([sys.argv[1], mode], env=env,
                             capture_output=True, text=True, timeout=30, check=True)
     expected = fields(next(line for line in result.stdout.splitlines() if line.startswith("[lifecycle-fixture]")))
     ports = [fields(line) for line in result.stderr.splitlines() if line.startswith("[audio-lifecycle-port]")]
@@ -26,13 +27,17 @@ for enabled in (False, True):
     if not enabled:
         assert not ports and not contexts, result.stderr
         continue
-    assert len(ports) == 4 and len(contexts) == 2, result.stderr
+    assert number(expected, "reserve_fault") == fail_reserve
+    assert len(ports) == (2 if fail_reserve else 4) and len(contexts) == 2, result.stderr
     by_port = {number(row, "port"): row for row in ports}
-    assert len(by_port) == 4
+    assert len(by_port) == len(ports)
     for name, publications, valid, kind, reason in (
             ("old", 2, 1, 0, "port-destroy"), ("new", 1, 1, 0, "context-destroy"),
             ("aux", 1, 1, 1, "context-destroy"), ("next_port", 0, 0, 0, "context-destroy")):
         handle = number(expected, name)
+        if fail_reserve and name in ("new", "aux"):
+            assert handle not in by_port  # unavailable POD detail must not masquerade as zero activity
+            continue
         row = by_port[handle]
         context = number(expected, "next_context" if name == "next_port" else "context")
         assert number(row, "context") == context and number(row, "sink") == 17
@@ -47,11 +52,13 @@ for enabled in (False, True):
             assert number(row, "last_valid_pcm_ns") == number(row, "last_attribute_ns") == 0
     assert number(by_port[number(expected, "old")], "frames") == 0
     assert number(by_port[number(expected, "old")], "pending") == 1
-    assert number(by_port[number(expected, "new")], "frames") == 64
-    assert number(by_port[number(expected, "new")], "pending") == 0
-    assert number(by_port[number(expected, "aux")], "pending") == 1
+    if not fail_reserve:
+        assert number(by_port[number(expected, "new")], "frames") == 64
+        assert number(by_port[number(expected, "new")], "pending") == 0
+        assert number(by_port[number(expected, "aux")], "pending") == 1
     for row in contexts:
         assert number(row, "entered_ns") <= number(row, "cleared_ns") <= number(row, "close_return_ns")
     assert [number(row, "implicit_ports") for row in contexts] == [2, 1]
     assert [number(row, "sink_was_open") for row in contexts] == [1, 0]
-print("Lifecycle observer: real HLE publication/retirement records and unchanged PCM verified on/off")
+    assert [number(row, "snapshots_unavailable") for row in contexts] == [int(fail_reserve), 0]
+print("Lifecycle observer: real HLE publication/retirement records and unchanged PCM verified on/off and allocation failure")

--- a/prosper/tests/hle/audio/test_audio_lifecycle.py
+++ b/prosper/tests/hle/audio/test_audio_lifecycle.py
@@ -1,0 +1,57 @@
+"""Check actual lifecycle records and exact PCM fixture with instrumentation on and off."""
+import os
+import re
+import subprocess
+import sys
+
+
+def fields(line):
+    return dict(re.findall(r"([a-zA-Z_]+)=([^\s]+)", line))
+
+
+def number(row, key):
+    return int(row[key], 0)
+
+
+for enabled in (False, True):
+    env = {key: value for key, value in os.environ.items() if not key.startswith("PROSPER_AUDIO")}
+    env["PROSPER_AUDIO_LIFECYCLE"] = "1" if enabled else "0"
+    if "--negative-disabled" in sys.argv:
+        env["PROSPER_AUDIO_LIFECYCLE"] = "0"
+    result = subprocess.run([sys.argv[1], "--lifecycle-publication"], env=env,
+                            capture_output=True, text=True, timeout=30, check=True)
+    expected = fields(next(line for line in result.stdout.splitlines() if line.startswith("[lifecycle-fixture]")))
+    ports = [fields(line) for line in result.stderr.splitlines() if line.startswith("[audio-lifecycle-port]")]
+    contexts = [fields(line) for line in result.stderr.splitlines() if line.startswith("[audio-lifecycle-context]")]
+    if not enabled:
+        assert not ports and not contexts, result.stderr
+        continue
+    assert len(ports) == 4 and len(contexts) == 2, result.stderr
+    by_port = {number(row, "port"): row for row in ports}
+    assert len(by_port) == 4
+    for name, publications, valid, kind, reason in (
+            ("old", 2, 1, 0, "port-destroy"), ("new", 1, 1, 0, "context-destroy"),
+            ("aux", 1, 1, 1, "context-destroy"), ("next_port", 0, 0, 0, "context-destroy")):
+        handle = number(expected, name)
+        row = by_port[handle]
+        context = number(expected, "next_context" if name == "next_port" else "context")
+        assert number(row, "context") == context and number(row, "sink") == 17
+        assert number(row, "generation") == (handle >> 16) & 0xffffffff
+        assert number(row, "context_generation") == (context >> 16) & 0xffffffff
+        assert number(row, "type") == kind and number(row, "data_format") == 0x200
+        assert row["event"] == reason and number(row, "publications") == publications
+        assert number(row, "valid_publications") == valid
+        if valid:
+            assert 0 < number(row, "last_valid_pcm_ns") <= number(row, "last_attribute_ns") <= number(row, "steady_ns")
+        else:
+            assert number(row, "last_valid_pcm_ns") == number(row, "last_attribute_ns") == 0
+    assert number(by_port[number(expected, "old")], "frames") == 0
+    assert number(by_port[number(expected, "old")], "pending") == 1
+    assert number(by_port[number(expected, "new")], "frames") == 64
+    assert number(by_port[number(expected, "new")], "pending") == 0
+    assert number(by_port[number(expected, "aux")], "pending") == 1
+    for row in contexts:
+        assert number(row, "entered_ns") <= number(row, "cleared_ns") <= number(row, "close_return_ns")
+    assert [number(row, "implicit_ports") for row in contexts] == [2, 1]
+    assert [number(row, "sink_was_open") for row in contexts] == [1, 0]
+print("Lifecycle observer: real HLE publication/retirement records and unchanged PCM verified on/off")


### PR DESCRIPTION
Periodic audio-demand snapshots omit callbacks that occur between the last sample and stream destruction, and they cannot distinguish guest production stopping from delayed output teardown. Add opt-in lifecycle observations tying each guest port/context generation to its sink, last valid PCM publication, successful SDL Put and quiesced final demand totals.

`PROSPER_AUDIO_LIFECYCLE=1` enables retirement records; combine it with `PROSPER_AUDIO_DEMAND=1` for periodic observations. Formatting happens outside HLE/sink locks, and no logging is added to the consumption callback. Per-output/channel PCM ownership and mixing remain independently controlled. Failed SDL Puts do not advance publication observations. Diagnostic snapshots stay off guest thread stacks, and allocation failure preserves actual teardown while explicitly marking unavailable snapshots.

A retained GTA intro trace recorded 2,814 valid publications/Puts. Production stopped about 0.961 seconds before the recorded PortDestroy boundary; SDL destruction returned about 24.5 microseconds after that boundary. Final accounting included 45 shortfalls/748 callbacks, six beyond the last periodic sample. This rules out delayed post-retirement stream destruction for that trace, while leaving the reason for the earlier production stop unresolved. No playback, scheduling or buffering fix is claimed.

Validation before latest-main integration: full Release build and 451/451 CTest on `aac189db40fb1ddd8a656ee80c83119d5dbd2f40`; subsequent commits change documentation only. Production fault controls catch lost final callbacks, falsely counting failed Puts, and an uncaught diagnostic-allocation failure; restored source passes. The allocation control uses an identical fixture object against the previous and corrected HLE implementations.

Latest main is integrated at `2d150f6fe279761ed0f2e36a8a2f54c7469b62e2`; the full Release build passed. The first integrated CTest run passed 451/452 tests: `file_binary_roundtrip` failed because the invocation pointed `TMPDIR` at a nonexistent directory. The corrected invocation passed **452/452 tests**, exit 0, in 55.50 seconds. All seven required Linux/general CI checks passed on the exact reviewed head; Windows/macOS builds were not waited on. This contributes diagnostics and a demonstrated exclusion to #3435; it does not close the residual-audio issue. Cross-clock brackets bound read latency, not historical clock drift; `_Exit` may omit final observations for still-open streams.

Reproduce local verification with `cmake --build prosper/build-linux -j6` and `ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure -j2`, using an existing disk-backed `TMPDIR` and the configured game-dump root. Focused tests include `audio_lifecycle_publication` and the SDL lifecycle cases registered in `prosper/CMakeLists.txt`. [GTA trace and independent accounting](https://github.com/mattias800/prosper/issues/3435#issuecomment-5594019232) and [six-arm Sonic comparison](https://github.com/mattias800/prosper/issues/3435#issuecomment-5593956888) retain the measured scope and remaining uncertainty.
