### PR TITLE
perf(rtt): remove per-pixel division from exact nearest-neighbor scaling

### DIFF
--- a/prosper/frontends/shared/rtt/AGENTS.md
+++ b/prosper/frontends/shared/rtt/AGENTS.md
@@ -1,0 +1,12 @@
+# `shared/rtt` — render-target binding, extent and pixel policies
+
+Shared render-to-texture rules belong here: multiple-target binding and extent selection,
+renderer/consumer shape compatibility, CPU/GPU representation authority, and native-format CPU
+pixel filling and nearest-neighbor scaling. Snapshot materialization may retain immutable CPU
+owners, but these helpers do not acquire Vulkan resources or establish completion or freshness.
+
+Live publication, invalidation, image imports, leases and synchronization belong in `shared/live`
+and its renderer/backend integration. A matching extent or byte layout alone does not authorize
+borrowing a live image. Generic format decoding belongs in `shared/texture`. CPU byte-oracle and
+policy tests belong in `shared/tests`; device ownership and ordered producer/consumer behavior
+need the corresponding live GPU integration tests.

--- a/prosper/frontends/shared/rtt/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt/rtt_injection.hpp
@@ -56,6 +56,8 @@ inline void inject_scaled_rtt_rows(uint8_t* dst, uint32_t dst_w, uint32_t dst_h,
     // millions of tiny variable-sized memcpy calls and integer divisions in the old per-texel loop.
     const uint32_t integer_x_scale = dst_w >= src_w && dst_w % src_w == 0
         ? dst_w / src_w : 0;
+    const uint32_t step = src_w == dst_w || integer_x_scale ? 0 : src_w / dst_w;
+    const uint32_t remainder = src_w == dst_w || integer_x_scale ? 0 : src_w % dst_w;
     for (uint32_t y = 0; y < dst_h; ++y) {
         const uint32_t sy = static_cast<uint32_t>(static_cast<uint64_t>(y) * src_h / dst_h);
         uint8_t* dst_row = dst + static_cast<size_t>(y) * dst_row_bytes;
@@ -77,15 +79,21 @@ inline void inject_scaled_rtt_rows(uint8_t* dst, uint32_t dst_w, uint32_t dst_h,
                                 pixel, BytesPerPixel);
             }
         } else {
-            // Precomputing x offsets once would require a scratch allocation. The uncommon
-            // non-integer path instead uses a division per output texel, but still specializes the
-            // copy width so the compiler emits a scalar load/store rather than a libc call.
+            // At each copy, sx=floor(x*src_w/dst_w) and error=(x*src_w)%dst_w.
+            // Carrying the remainder once advances exactly, without a per-pixel divide or scratch
+            // allocation. The sum stays below 2*dst_w, so use 64 bits even for 32-bit dimensions.
+            uint32_t sx = 0;
+            uint64_t error = 0;
             for (uint32_t x = 0; x < dst_w; ++x) {
-                const uint32_t sx = static_cast<uint32_t>(
-                    static_cast<uint64_t>(x) * src_w / dst_w);
                 std::memcpy(dst_row + static_cast<size_t>(x) * BytesPerPixel,
                             src_row + static_cast<size_t>(sx) * BytesPerPixel,
                             BytesPerPixel);
+                sx += step;
+                error += remainder;
+                if (error >= dst_w) {
+                    error -= dst_w;
+                    ++sx;
+                }
             }
         }
         previous_sy = sy;

--- a/prosper/frontends/shared/tests/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/tests/test_rtt_injection.cpp
@@ -13,7 +13,86 @@ static int failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
 
+static void check_scale(uint32_t src_w, uint32_t src_h, uint32_t dst_w, uint32_t dst_h,
+                        uint32_t bpp) {
+    std::vector<uint8_t> source(static_cast<size_t>(src_w) * src_h * bpp);
+    // Mix every coordinate and channel, including the high x bits in the wide-row cases.
+    uint32_t state = 0x73a921e5u;
+    for (auto& byte : source) {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        byte = static_cast<uint8_t>(state);
+    }
+    const auto original_source = source;
+    std::vector<uint8_t> actual(7, 0xcd);
+    CHECK(inject_rtt_pixels(actual, dst_w, dst_h, source, src_w, src_h, bpp));
+    std::vector<uint8_t> expected(static_cast<size_t>(dst_w) * dst_h * bpp);
+    // Independent byte oracle: direct division for each coordinate, including repeated rows.
+    // Do not share the production quotient/remainder recurrence or pixel-copy specializations.
+    for (uint32_t y = 0; y < dst_h; ++y) {
+        for (uint32_t x = 0; x < dst_w; ++x) {
+            const uint64_t sy = uint64_t{y} * src_h / dst_h;
+            const uint64_t sx = uint64_t{x} * src_w / dst_w;
+            for (uint32_t c = 0; c < bpp; ++c)
+                expected[(static_cast<size_t>(y) * dst_w + x) * bpp + c] =
+                    source[(static_cast<size_t>(sy) * src_w + sx) * bpp + c];
+        }
+    }
+    if (actual != expected) {
+        std::fprintf(stderr, "scale mismatch: %ux%u -> %ux%u, %u bytes/pixel\n",
+                     src_w, src_h, dst_w, dst_h, bpp);
+        ++failures;
+    }
+    CHECK(source == original_source);
+}
+
+static void check_scaling_shapes() {
+    for (uint32_t bpp : {1u, 2u, 3u, 4u, 8u, 16u}) {
+        // Exact/integer/noninteger and up/down scaling in both axes; 3-byte pixels exercise the
+        // variable-width fallback beside every specialized width. Alternation also catches state
+        // accidentally retained between calls with different ratios.
+        for (uint32_t sw = 1; sw <= 17; ++sw)
+            for (uint32_t dw = 1; dw <= 17; ++dw)
+                for (uint32_t sh = 1; sh <= 9; ++sh)
+                    for (uint32_t dh = 1; dh <= 9; ++dh)
+                        check_scale(sw, sh, dw, dh, bpp);
+        for (uint32_t width : {32u, 64u, 128u, 256u, 1024u}) {
+            check_scale(width - 1, 7, width + 1, 11, bpp);
+            check_scale(width + 1, 11, width - 1, 7, bpp);
+        }
+        // Near-coprime large widths cross the 32-bit x*src_w boundary without huge buffers.
+        check_scale(65537, 1, 65539, 1, bpp);
+        check_scale(65539, 1, 65537, 1, bpp);
+    }
+}
+
+static void check_scaling_rejections() {
+    const std::vector<uint8_t> source(2 * 3 * 4, 0x57);
+    const std::vector<uint8_t> fallback = {0xa1, 0xb2, 0xc3};
+    auto reject = [&](uint32_t dw, uint32_t dh, uint32_t sw, uint32_t sh, uint32_t bpp,
+                      const std::vector<uint8_t>& input) {
+        auto output = fallback;
+        CHECK(!inject_rtt_pixels(output, dw, dh, input, sw, sh, bpp));
+        CHECK(output == fallback);
+    };
+    reject(0, 5, 2, 3, 4, source);
+    reject(5, 0, 2, 3, 4, source);
+    reject(5, 5, 0, 3, 4, source);
+    reject(5, 5, 2, 0, 4, source);
+    reject(5, 5, 2, 3, 0, source);
+    reject(5, 5, 2, 3, 4, {});
+    reject(5, 5, 2, 3, 4, std::vector<uint8_t>(source.size() - 1));
+    reject(5, 5, 2, 3, 4, std::vector<uint8_t>(source.size() + 1));
+    // Each byte-size product overflows size_t on both supported 32- and 64-bit hosts. These must
+    // fail before resizing or reading, independently for the source and destination dimensions.
+    reject(UINT32_MAX, UINT32_MAX, 2, 3, 4, source);
+    reject(5, 5, UINT32_MAX, UINT32_MAX, 4, source);
+}
+
 int main() {
+    check_scaling_shapes();
+    check_scaling_rejections();
     const uint8_t rgba_pixel[] = {0x12, 0x34, 0x56, 0x78};
     std::vector<uint8_t> repeated_rgba(5 * sizeof(rgba_pixel));
     CHECK(fill_repeating_pixel(


### PR DESCRIPTION
Non-integer render-target scaling currently divides a 64-bit coordinate for every copied texel. Advance that coordinate with a quotient/remainder carry, preserving exact nearest-neighbor pixels without scratch allocation. The shared helper keeps its existing exact-copy, integer-upscale, repeated-row, uncommon pixel-width, refusal and resource-ownership contracts.

The actual production helper's warm-buffer mean falls **0.796799→0.158483 ms** for RGBA8 3840×2160→1280×449, and **0.072817→0.027490 ms** for 1400×96→512×512. Complete independent byte oracles verify both implementations; a private carry-condition mutation fails 17,820 cases. [Exact benchmark source, commands and original results](https://github.com/mattias800/prosper/pull/3487#issuecomment-5595064234).

Matched normal Sonic/GTA runs on the integrated head give a narrower game result: Sonic RTT preparation totals **14.884655→3.561278 ms**, but overall guest presentation throughput stays about 7.57/s and independently varying persistent-invalid work prevents attributing the whole frontend saving to scaling. GTA RTT totals **207.078490→215.833309 ms**, with slightly higher enclosing costs and changed work counts; guest presentations stay about 6.17/s. No general game speedup or performance neutrality is claimed. Newly rendered FPS is unavailable (#3486).

All four captures completed with matched environments, immutable executable/source receipts, complete F8 records, isolated profiling and retained original F9 images. GTA retains the bank checkpoint's visible geometry and lighting. Sonic retains its known black-world/HUD defect (#2790); title/cloud/modal correctness is not claimed. Raw audio audit found no new main-output shortfalls in the sampled post-F9 tails; startup and GTA intro shortages remain, so this is not an audio fix.

Validation at `d1f372f7f8d1d6ee08f6f328c3f2fac16d2cec09`, including current main #3485: full Release build and **452/452 local tests pass**. The committed fixture covers 140,454 small combinations, 72 width-boundary cases and refusal/overflow behavior. Two focused CPU cases and six core/synchronization cases pass; the latter ran before the audio-only main integration, with zero messages after layer-load/deliberate-hazard controls and an empty allowlist. The scaling header and fixture remain byte-identical across integration. All seven required Linux/general CI checks pass. Windows MinGW has the independently checked existing #3470 capture timeout; its RTT test passes, as do Windows App and both macOS jobs.

[Exact-head author verification, paired measurements, audio/perf limits and reproduction commands](https://github.com/mattias800/prosper/pull/3487#issuecomment-5595377434). Reproduce the full suite with `cmake --build prosper/build-linux -j6` and `ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure`, using the configured dump root and an existing disk-backed `TMPDIR`. Both independent source/verification and final game/evidence approvals are registered on this head. Merged as `6d47eedfb50b487b773c9041d6fef7d5d59dd2b9` after fresh-head and required CI checks.

Advances #3407; remaining conversion, materialization and writeback scope stays open. This change introduces no game-specific policy or experimental driver dependency.
