### PR TITLE
perf(gpu): retile native 16-bit storage arrays in the compute submission

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -3517,10 +3517,20 @@ if(TARGET prosper_live_renderer AND TARGET Vulkan::Vulkan)
   add_test(NAME gpu_retile_volume_cpu COMMAND test_gpu_retile --volume-cpu)
   add_test(NAME gpu_retile_volume_allocation_fallback COMMAND test_gpu_retile --volume-alloc-oom)
   add_test(NAME gpu_retile_volume_mapping_loss COMMAND test_gpu_retile --volume-map-loss)
+  add_test(NAME gpu_retile_array16 COMMAND test_gpu_retile --array16)
+  add_test(NAME gpu_retile_array16_shape_refusal COMMAND test_gpu_retile --array16-shape-refusal)
+  add_test(NAME gpu_retile_array16_cpu COMMAND test_gpu_retile --array16-cpu)
+  add_test(NAME gpu_retile_array16_allocation_fallback COMMAND test_gpu_retile --array16-alloc-oom)
+  add_test(NAME gpu_retile_array16_mapping_fallback COMMAND test_gpu_retile --array16-map-oom)
+  add_test(NAME gpu_retile_array16_allocation_loss COMMAND test_gpu_retile --array16-alloc-loss)
+  add_test(NAME gpu_retile_array16_mapping_loss COMMAND test_gpu_retile --array16-map-loss)
+  set_tests_properties(gpu_retile_array16 gpu_retile_array16_cpu gpu_retile_array16_shape_refusal
+      gpu_retile_array16_allocation_fallback gpu_retile_array16_mapping_fallback
+      gpu_retile_array16_allocation_loss gpu_retile_array16_mapping_loss PROPERTIES TIMEOUT 120)
   set_tests_properties(gpu_retile_mixed gpu_retile_volume gpu_retile_volume_cpu
                        gpu_retile_volume_allocation_fallback gpu_retile_volume_mapping_loss
                        PROPERTIES TIMEOUT 120)
-  set_tests_properties(gpu_retile_cpu gpu_retile_volume_cpu
+  set_tests_properties(gpu_retile_cpu gpu_retile_volume_cpu gpu_retile_array16_cpu
                        PROPERTIES ENVIRONMENT "PROSPER_NO_GPU_RETILE=1")
   add_executable(test_gpu_detile_render tests/gpu/execute/test_gpu_detile_render.cpp)
   target_include_directories(test_gpu_detile_render PRIVATE tests frontends)

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -18,8 +18,10 @@ found Vulkan.
   guest compute submission. 3D SW_4KB_S/SW_64KB_S uses a separate pipeline variant and checks
   padded XYZ dispatch limits. A separate mode-24 variant packs even-x native two-byte texels
   into ordinary 32-bit stores across independent 2D array layers; no 16-bit storage feature is
-  required. Odd widths, ambiguous strides/mips and other sub-word layouts retain CPU conversion.
-  Keeps linear comparison baselines separate from the tiled host-read buffer.
+  required. Current multi-layer codegen exposes native Uint16; RG8/R16F arrays retain raw
+  interchange storage and CPU conversion. Odd widths, ambiguous strides/mips and other sub-word
+  layouts also retain CPU conversion. Keeps linear comparison baselines separate from the tiled
+  host-read buffer.
 - `packed_rtt_conversion.hpp` — device-owned RGBA8→packed-10-bit sampled conversion.
   Records transfers and conversion into the guest compute submission; setup failures retain their
   `VkResult` so optional fallback cannot hide device loss.

--- a/prosper/frontends/shared/live/AGENTS.md
+++ b/prosper/frontends/shared/live/AGENTS.md
@@ -16,7 +16,10 @@ found Vulkan.
   memory, dispatched, and written back into guest memory synchronously.
 - `gpu_retile.hpp` — exact 2D and standard 3D storage-image writeback layout conversion in the
   guest compute submission. 3D SW_4KB_S/SW_64KB_S uses a separate pipeline variant and checks
-  padded XYZ dispatch limits; unsupported layouts or sub-word texels retain CPU conversion. Keeps linear comparison baselines separate from the tiled host-read buffer.
+  padded XYZ dispatch limits. A separate mode-24 variant packs even-x native two-byte texels
+  into ordinary 32-bit stores across independent 2D array layers; no 16-bit storage feature is
+  required. Odd widths, ambiguous strides/mips and other sub-word layouts retain CPU conversion.
+  Keeps linear comparison baselines separate from the tiled host-read buffer.
 - `packed_rtt_conversion.hpp` — device-owned RGBA8→packed-10-bit sampled conversion.
   Records transfers and conversion into the guest compute submission; setup failures retain their
   `VkResult` so optional fallback cannot hide device loss.

--- a/prosper/frontends/shared/live/gpu_retile.hpp
+++ b/prosper/frontends/shared/live/gpu_retile.hpp
@@ -24,7 +24,7 @@ struct GpuRetileParameters {
     std::array<uint32_t, 26> words{};
     uint64_t linear_bytes = 0, tiled_bytes = 0;
     uint32_t groups_x = 0, groups_y = 0, groups_z = 1;
-    bool volume = false;
+    prosper::gpu::RetileShaderKind kind = prosper::gpu::RetileShaderKind::Words2D;
 
     bool initialize(uint32_t width, uint32_t height, uint32_t bpe, uint32_t mode,
                     const VkPhysicalDeviceLimits& limits) {
@@ -61,6 +61,38 @@ struct GpuRetileParameters {
         groups_y = uint32_t(padded_height);
         return true;
     }
+    bool initialize_paired16_array(uint32_t width, uint32_t height, uint32_t layers,
+                                   uint32_t mode, const VkPhysicalDeviceLimits& limits) {
+        *this = {};
+        std::array<uint32_t, 16> equation{};
+        uint32_t bw = 0, bh = 0;
+        if (!width || (width & 1) || !height || !layers ||
+            !prosper::gpu::tile64_paired16_equation(mode, equation, bw, bh)) return false;
+        const uint64_t row_words = width / 2;
+        const uint64_t bx = (uint64_t(width) + bw - 1) / bw;
+        const uint64_t by = (uint64_t(height) + bh - 1) / bh;
+        // Bound each product before multiplication, including every array layer.
+        // Conservative byte bounds also keep all shader word indices representable.
+        if (row_words > UINT32_MAX / 4u / uint64_t(height) ||
+            row_words * height > UINT32_MAX / 4u / uint64_t(layers) ||
+            bx > UINT32_MAX / 65536u / by ||
+            bx * by > UINT32_MAX / 65536u / uint64_t(layers)) return false;
+        const uint64_t linear_words = row_words * height, tiled_words = bx * by * 16384;
+        linear_bytes = linear_words * layers * 4; tiled_bytes = tiled_words * layers * 4;
+        const uint64_t gx = (bx * (bw / 2) + 127) / 128, gy = by * bh;
+        if (linear_bytes > limits.maxStorageBufferRange || tiled_bytes > limits.maxStorageBufferRange ||
+            limits.maxComputeWorkGroupSize[0] < 128 || limits.maxComputeWorkGroupInvocations < 128 ||
+            limits.maxPushConstantsSize < sizeof(words) || gx > limits.maxComputeWorkGroupCount[0] ||
+            gy > limits.maxComputeWorkGroupCount[1] || layers > limits.maxComputeWorkGroupCount[2])
+            return false;
+        words[0] = width; words[1] = height;
+        words[3] = std::countr_zero(bw); words[4] = std::countr_zero(bh); words[5] = uint32_t(bx);
+        std::copy(equation.begin(), equation.end(), words.begin() + 6);
+        words[22] = layers; words[23] = uint32_t(linear_words); words[24] = uint32_t(tiled_words);
+        groups_x = uint32_t(gx); groups_y = uint32_t(gy); groups_z = layers;
+        kind = prosper::gpu::RetileShaderKind::Paired16Array;
+        return true;
+    }
     bool initialize_volume(uint32_t width, uint32_t height, uint32_t depth,
                            uint32_t bpe, uint32_t mode, const VkPhysicalDeviceLimits& limits) {
         *this = {};
@@ -95,7 +127,7 @@ struct GpuRetileParameters {
         words[22] = depth; words[23] = std::countr_zero(bd); words[24] = uint32_t(by);
         words[25] = bits - 2; // Word offset of a whole block.
         groups_x = uint32_t(gx); groups_y = uint32_t(gy); groups_z = uint32_t(gz);
-        volume = true;
+        kind = prosper::gpu::RetileShaderKind::Volume3D;
         return true;
     }
 };
@@ -115,7 +147,8 @@ struct GpuRetilePipeline {
         if (descriptors) vkDestroyDescriptorSetLayout(device, descriptors, nullptr);
         pipeline = VK_NULL_HANDLE; layout = VK_NULL_HANDLE; descriptors = VK_NULL_HANDLE;
     }
-    VkResult initialize(VkDevice dev, VkPipelineCache cache, bool volume = false) {
+    VkResult initialize(VkDevice dev, VkPipelineCache cache,
+                        prosper::gpu::RetileShaderKind kind = prosper::gpu::RetileShaderKind::Words2D) {
         if (attempted) return setup_result;
         attempted = true; device = dev;
         const VkDescriptorSetLayoutBinding bindings[]{
@@ -131,7 +164,7 @@ struct GpuRetilePipeline {
         lci.pushConstantRangeCount = 1; lci.pPushConstantRanges = &push;
         setup_result = vkCreatePipelineLayout(device, &lci, nullptr, &layout);
         if (setup_result != VK_SUCCESS) { destroy(); return setup_result; }
-        const auto words = prosper::gpu::build_compute_retile_words(volume);
+        const auto words = prosper::gpu::build_compute_retile_words(kind);
         VkShaderModuleCreateInfo sci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
         sci.codeSize = words.size() * sizeof(uint32_t); sci.pCode = words.data();
         VkShaderModule shader = VK_NULL_HANDLE;

--- a/prosper/frontends/shared/live/gpu_retile.hpp
+++ b/prosper/frontends/shared/live/gpu_retile.hpp
@@ -2,6 +2,7 @@
 #pragma once
 #include "gpu/recompiler/spirv_builder.hpp"
 #include "gpu/texture/tile.hpp"
+#include "gpu/resources/shader_resources.hpp"
 #include "gpu/execute/host_read_barrier.hpp"
 #include <vulkan/vulkan.h>
 #include <array>
@@ -18,6 +19,22 @@ inline std::atomic<uint64_t>& gpu_retile_recordings() {
 inline std::atomic<bool>& gpu_retile_poison_output_for_test() {
     static std::atomic<bool> enabled{false};
     return enabled;
+}
+
+// Descriptor-only admission for the paired array path. Dimensionality, selected-layer offset,
+// exact backend representation and byte/stride bounds are checked by the caller.
+// Keep this separate from layout math: a valid base-level fallback does not prove
+// that the descriptor declares only that level or sample.
+inline bool gpu_retile_paired16_descriptor_supported(const prosper::gpu::ShaderResource& resource,
+                                                     uint32_t bpe, uint32_t materialized_mip_levels) {
+    return !(bpe != 2 || resource.sample_count != 1 || resource.declared_mip_levels != 1 ||
+        materialized_mip_levels != 1 || resource.mip_chain_base_level || resource.mip_chain_max_level ||
+        resource.linear_row_pitch_bytes || resource.mip_tail_offset || resource.mip_tail_bytes ||
+        resource.mip_tail_x || resource.mip_tail_y || resource.compression_enabled ||
+        resource.write_compress_enabled || resource.metadata_addr || resource.dcc_metadata_host_data ||
+        (resource.mip_chain_element_width && resource.mip_chain_element_width != resource.width) ||
+        (resource.mip_chain_element_height && resource.mip_chain_element_height != resource.height) ||
+        (resource.mip_chain_bytes_per_block && resource.mip_chain_bytes_per_block != bpe));
 }
 
 struct GpuRetileParameters {

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -3569,7 +3569,7 @@ struct BoundImage {
     bool exact_storage_bytes() const {
         return native_float_storage || native_uint_storage || packed_r11_storage;
     }
-    uint32_t texel_depth = 1;           // logical Z/layer count represented in the staging buffer
+    uint32_t texel_depth = 1;           // realized 3D depth; ordinary array layers are counted separately
     uint32_t array_layers = 1;           // Vulkan array-layer count (3D depth remains one layer)
     // #3048: the guest-declared mip chain this image materializes, and where each level past zero
     // begins in the staging buffer. 1 (with an empty offset table) is the historical single-level
@@ -9599,7 +9599,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     r->layer_mip_offset_bytes || !staging[i]) continue;
                 const bool volume = r->img_dim == 2 && r->depth > 1 && bi.texel_depth == r->depth;
                 const bool array = r->img_dim == 5 && r->depth > 1 &&
-                    bi.array_layers == r->depth && bi.texel_depth == r->depth;
+                    bi.array_layers == r->depth && bi.texel_depth == 1;
                 if (!array && (bi.array_layers != 1 || (!volume &&
                     (r->depth != 1 || (r->img_dim != 1 && r->img_dim != 5) || bi.texel_depth != 1))))
                     continue;

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -1489,7 +1489,7 @@ struct VulkanComputeContext {
     VkPipelineLayout compare_pipeline_layout = VK_NULL_HANDLE;
     VkPipeline compare_pipeline = VK_NULL_HANDLE;
     PackedRttConversion packed_rtt_conversion;
-    GpuRetilePipeline retile_pipeline, volume_retile_pipeline;
+    GpuRetilePipeline retile_pipeline, volume_retile_pipeline, paired16_retile_pipeline;
     // Storage-image support (#590): the recompiler's storage path declares the
     // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
     // tests/fixtures/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
@@ -1675,6 +1675,7 @@ struct VulkanComputeContext {
         packed_rtt_conversion.destroy();
         retile_pipeline.destroy();
         volume_retile_pipeline.destroy();
+        paired16_retile_pipeline.destroy();
         if (compare_pipeline) vkDestroyPipeline(device, compare_pipeline, nullptr);
         if (compare_pipeline_layout)
             vkDestroyPipelineLayout(device, compare_pipeline_layout, nullptr);
@@ -9594,27 +9595,46 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const auto* r = bi.resource;
                 if (!bi.storage_writeback || bi.alias_of != SIZE_MAX || bi.imported || bi.storage_write_mask ||
                     !bi.exact_storage_bytes() || !r ||
-                    bi.array_layers != 1 || r->in_mip_tail ||
+                    r->in_mip_tail ||
                     r->layer_mip_offset_bytes || !staging[i]) continue;
                 const bool volume = r->img_dim == 2 && r->depth > 1 && bi.texel_depth == r->depth;
-                if (!volume && (r->depth != 1 || (r->img_dim != 1 && r->img_dim != 5) ||
-                                bi.texel_depth != 1)) continue;
+                const bool array = r->img_dim == 5 && r->depth > 1 &&
+                    bi.array_layers == r->depth && bi.texel_depth == r->depth;
+                if (!array && (bi.array_layers != 1 || (!volume &&
+                    (r->depth != 1 || (r->img_dim != 1 && r->img_dim != 5) || bi.texel_depth != 1))))
+                    continue;
                 // One-layer array descriptors use the same physical 2D tiling,
                 // with either an ordinary or a reflected one-layer array view.
                 const uint32_t bpe = r->format == DataFormat::Float10_11_11 ||
                     r->format == DataFormat::Unorm2_10_10_10 ? 4u :
                     data_format_bytes(r->format) * (r->num_components ? r->num_components : 1u);
-                const bool layout_ok = volume
+                // Paired halfwords require a tight, single-mip ordinary array. An
+                // ambiguous view/stride retains the established CPU layout path.
+                if (array && (bpe != 2 || r->sample_count != 1 || r->declared_mip_levels != 1 ||
+                    bi.mip_levels != 1 || r->mip_chain_base_level || r->mip_chain_max_level ||
+                    r->linear_row_pitch_bytes || r->mip_tail_offset || r->mip_tail_bytes ||
+                    r->mip_tail_x || r->mip_tail_y || r->compression_enabled ||
+                    r->write_compress_enabled || r->metadata_addr || r->dcc_metadata_host_data ||
+                    (r->mip_chain_element_width && r->mip_chain_element_width != r->width) ||
+                    (r->mip_chain_element_height && r->mip_chain_element_height != r->height) ||
+                    (r->mip_chain_bytes_per_block && r->mip_chain_bytes_per_block != bpe))) continue;
+                const bool layout_ok = array
+                    ? bi.retile_parameters.initialize_paired16_array(r->width, r->height, r->depth,
+                        r->tile_mode, properties.limits)
+                    : volume
                     ? bi.retile_parameters.initialize_volume(r->width, r->height, r->depth,
                         bpe, r->tile_mode, properties.limits)
                     : bi.retile_parameters.initialize(r->width, r->height, bpe,
                         r->tile_mode, properties.limits);
                 if (!layout_ok ||
                     bi.retile_parameters.tiled_bytes != bi.guest_bytes ||
-                    bi.retile_parameters.linear_bytes != staging_bytes[i]) continue;
-                auto& retile = volume ? ctx.volume_retile_pipeline : ctx.retile_pipeline;
+                    bi.retile_parameters.linear_bytes != staging_bytes[i] ||
+                    (array && r->layer_stride_bytes && r->layer_stride_bytes !=
+                        bi.retile_parameters.tiled_bytes / r->depth)) continue;
+                auto& retile = array ? ctx.paired16_retile_pipeline :
+                    volume ? ctx.volume_retile_pipeline : ctx.retile_pipeline;
                 auto prepare = [&] {
-                    if (!vk_soft_ok(retile.initialize(ctx.device, ctx.pipeline_cache, volume),
+                    if (!vk_soft_ok(retile.initialize(ctx.device, ctx.pipeline_cache, bi.retile_parameters.kind),
                                     "retile-pipeline")) return false;
                     VkBufferCreateInfo ci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                     ci.size = bi.retile_parameters.tiled_bytes;
@@ -10489,7 +10509,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // buffer, and the source scope has to name the write that actually produced the bytes.
             prosper::gpu::record_host_read_barrier(command, staging[i]);
             if (bi.retile_buffer)
-                (bi.retile_parameters.volume ? ctx.volume_retile_pipeline : ctx.retile_pipeline)
+                (bi.retile_parameters.kind == RetileShaderKind::Paired16Array ? ctx.paired16_retile_pipeline :
+                 bi.retile_parameters.kind == RetileShaderKind::Volume3D ? ctx.volume_retile_pipeline : ctx.retile_pipeline)
                     .record(command, staging[i], bi.retile_buffer,
                             bi.retile_set, bi.retile_parameters);
             if (bi.mirror_result_to_imported) {

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -9610,14 +9610,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     data_format_bytes(r->format) * (r->num_components ? r->num_components : 1u);
                 // Paired halfwords require a tight, single-mip ordinary array. An
                 // ambiguous view/stride retains the established CPU layout path.
-                if (array && (bpe != 2 || r->sample_count != 1 || r->declared_mip_levels != 1 ||
-                    bi.mip_levels != 1 || r->mip_chain_base_level || r->mip_chain_max_level ||
-                    r->linear_row_pitch_bytes || r->mip_tail_offset || r->mip_tail_bytes ||
-                    r->mip_tail_x || r->mip_tail_y || r->compression_enabled ||
-                    r->write_compress_enabled || r->metadata_addr || r->dcc_metadata_host_data ||
-                    (r->mip_chain_element_width && r->mip_chain_element_width != r->width) ||
-                    (r->mip_chain_element_height && r->mip_chain_element_height != r->height) ||
-                    (r->mip_chain_bytes_per_block && r->mip_chain_bytes_per_block != bpe))) continue;
+                if (array && !gpu_retile_paired16_descriptor_supported(*r, bpe, bi.mip_levels))
+                    continue;
                 const bool layout_ok = array
                     ? bi.retile_parameters.initialize_paired16_array(r->width, r->height, r->depth,
                         r->tile_mode, properties.limits)

--- a/prosper/src/gpu/recompiler/spirv_builder.cpp
+++ b/prosper/src/gpu/recompiler/spirv_builder.cpp
@@ -433,7 +433,9 @@ std::vector<uint32_t> build_compute_detile_rgba16f() {
   return e.assemble();
 }
 
-std::vector<uint32_t> build_compute_retile_words(bool volume) {
+std::vector<uint32_t> build_compute_retile_words(RetileShaderKind kind) {
+    const bool volume = kind == RetileShaderKind::Volume3D;
+    const bool paired = kind == RetileShaderKind::Paired16Array;
     Emitter e;
     const auto void_t = e.id(), fn_t = e.id(), bool_t = e.id(), uint_t = e.id();
     const auto v3_t = e.id(), input_ptr = e.id(), gid = e.id();
@@ -503,18 +505,26 @@ std::vector<uint32_t> build_compute_retile_words(bool volume) {
         blocks_y = load(push, push_word, constant(24));
         block_shift = load(push, push_word, constant(25));
     }
+    uint32_t linear_layer_words = 0, tiled_layer_words = 0;
+    if (paired) {
+        depth = load(push, push_word, constant(22));
+        linear_layer_words = load(push, push_word, constant(23));
+        tiled_layer_words = load(push, push_word, constant(24));
+    }
     const auto id3 = e.id(), word_x = e.id(), y = e.id();
     uint32_t z = 0;
     Emitter::put(e.code, Op_Load, {v3_t, id3, gid});
     Emitter::put(e.code, Op_CompositeExtract, {uint_t, word_x, id3, 0});
     Emitter::put(e.code, Op_CompositeExtract, {uint_t, y, id3, 1});
-    if (volume) {
+    if (volume || paired) {
         z = e.id();
         Emitter::put(e.code, Op_CompositeExtract, {uint_t, z, id3, 2});
     }
-    const auto row_words = binary(Op_ShiftLeftLogical, params[0], params[2]);
+    const auto row_words = paired ? binary(Op_ShiftRightLogical, params[0], constant(1))
+        : binary(Op_ShiftLeftLogical, params[0], params[2]);
     const auto padded_row_words = binary(Op_ShiftLeftLogical, params[5],
-        binary(Op_IAdd, params[3], params[2]));
+        paired ? binary(Op_ISub, params[3], constant(1))
+               : binary(Op_IAdd, params[3], params[2]));
     const auto height_mask = binary(Op_ISub,
         binary(Op_ShiftLeftLogical, constant(1), params[4]), constant(1));
     const auto padded_height = binary(Op_ShiftLeftLogical,
@@ -523,13 +533,20 @@ std::vector<uint32_t> build_compute_retile_words(bool volume) {
     Emitter::put(e.code, Op_ULessThan, {bool_t, x_valid, word_x, padded_row_words});
     Emitter::put(e.code, Op_ULessThan, {bool_t, y_valid, y, padded_height});
     Emitter::put(e.code, Op_LogicalAnd, {bool_t, valid, x_valid, y_valid});
+    auto in_bounds = valid;
+    if (paired) {
+        const auto layer_valid = e.id(); in_bounds = e.id();
+        Emitter::put(e.code, Op_ULessThan, {bool_t, layer_valid, z, depth});
+        Emitter::put(e.code, Op_LogicalAnd, {bool_t, in_bounds, valid, layer_valid});
+    }
     Emitter::put(e.code, Op_SelectionMerge, {done, 0});
-    Emitter::put(e.code, Op_BranchConditional, {valid, body, done});
+    Emitter::put(e.code, Op_BranchConditional, {in_bounds, body, done});
     Emitter::put(e.code, Op_Label, {body});
-    const auto x = binary(Op_ShiftRightLogical, word_x, params[2]);
+    const auto x = paired ? binary(Op_ShiftLeftLogical, word_x, constant(1))
+                          : binary(Op_ShiftRightLogical, word_x, params[2]);
     const auto component_mask = binary(Op_ISub,
         binary(Op_ShiftLeftLogical, constant(1), params[2]), constant(1));
-    const auto component = binary(Op_BitwiseAnd, word_x, component_mask);
+    const auto component = paired ? constant(0) : binary(Op_BitwiseAnd, word_x, component_mask);
     auto block_row = binary(Op_ShiftRightLogical, y, params[4]);
     if (volume)
         block_row = binary(Op_IAdd, block_row,
@@ -557,8 +574,9 @@ std::vector<uint32_t> build_compute_retile_words(bool volume) {
         byte_offset = binary(Op_BitwiseOr, byte_offset,
             binary(Op_ShiftLeftLogical, binary(Op_BitwiseAnd, population, constant(1)), constant(bit)));
     }
-    const auto address = binary(Op_IAdd, binary(Op_ShiftLeftLogical, block, block_shift),
+    auto address = binary(Op_IAdd, binary(Op_ShiftLeftLogical, block, block_shift),
         binary(Op_ShiftRightLogical, byte_offset, constant(2)));
+    if (paired) address = binary(Op_IAdd, address, binary(Op_IMul, z, tiled_layer_words));
     // Padding has no source texel. Branch before the load; selecting zero AFTER
     // an out-of-range read would still violate the source descriptor's bounds.
     const auto pixel_x = e.id(), pixel_y = e.id();
@@ -576,7 +594,8 @@ std::vector<uint32_t> build_compute_retile_words(bool volume) {
     Emitter::put(e.code, Op_BranchConditional, {pixel_valid, read_pixel, pixel_done});
     Emitter::put(e.code, Op_Label, {read_pixel});
     const auto row = volume ? binary(Op_IAdd, binary(Op_IMul, z, params[1]), y) : y;
-    const auto linear = binary(Op_IAdd, binary(Op_IMul, row, row_words), word_x);
+    auto linear = binary(Op_IAdd, binary(Op_IMul, row, row_words), word_x);
+    if (paired) linear = binary(Op_IAdd, linear, binary(Op_IMul, z, linear_layer_words));
     const auto loaded = load(source, word_ptr, linear);
     Emitter::put(e.code, Op_Branch, {pixel_done});
     Emitter::put(e.code, Op_Label, {pixel_done});

--- a/prosper/src/gpu/recompiler/spirv_builder.hpp
+++ b/prosper/src/gpu/recompiler/spirv_builder.hpp
@@ -42,6 +42,9 @@ std::vector<uint32_t> build_compute_rgba8_to_packed10();
 // blocks/row, then 16 packed x/y (or x/y/z) equation masks. Volume words 22..25:
 // depth, log2(block depth), block rows/plane, log2(words/block). Dispatch the full
 // padded rectangle/volume; out-of-image texels write zero without reading the source.
-std::vector<uint32_t> build_compute_retile_words(bool volume = false);
+// Paired16Array uses width/2 input words per row; words 22..24 are layer count,
+// linear words/layer and tiled words/layer. Each layer is an ordinary 2D tile plane.
+enum class RetileShaderKind { Words2D, Volume3D, Paired16Array };
+std::vector<uint32_t> build_compute_retile_words(RetileShaderKind kind = RetileShaderKind::Words2D);
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/texture/tile.cpp
+++ b/prosper/src/gpu/texture/tile.cpp
@@ -1251,6 +1251,20 @@ std::array<uint32_t, 16> tile27_rgba16f_equation() {
     return result;
 }
 
+bool tile64_paired16_equation(uint32_t mode, std::array<uint32_t, 16>& equation,
+                              uint32_t& block_width, uint32_t& block_height) {
+    if (mode != uint32_t(TileMode::Sw64KbZX)) return false;
+    const auto* pattern = sw64kb_pattern(mode, 1);
+    if (pattern[0].x || pattern[0].y || pattern[1].x != 1 || pattern[1].y)
+        return false;
+    for (size_t bit = 2; bit < equation.size(); ++bit)
+        if (pattern[bit].x & 1) return false;
+    sw64kb_dims(1, block_width, block_height);
+    for (size_t bit = 0; bit < equation.size(); ++bit)
+        equation[bit] = uint32_t(pattern[bit].x) | (uint32_t(pattern[bit].y) << 16);
+    return true;
+}
+
 bool tile64_word_equation(uint32_t mode, uint32_t bpe,
                           std::array<uint32_t, 16>& equation,
                           uint32_t& block_width, uint32_t& block_height) {

--- a/prosper/src/gpu/texture/tile.hpp
+++ b/prosper/src/gpu/texture/tile.hpp
@@ -44,6 +44,11 @@ bool tile_mode_is_tiled(uint32_t tile_mode);
 // are 128x64 texels / 64 KiB; this is not the volume or mip-tail equation.
 std::array<uint32_t, 16> tile27_rgba16f_equation();
 
+// Mode 24, two-byte texels: even-x pairs own one aligned 32-bit word.
+// Bit 1 is x0 alone; all higher address bits exclude x0. No 16-bit stores needed.
+bool tile64_paired16_equation(uint32_t tile_mode, std::array<uint32_t, 16>& equation,
+                              uint32_t& block_width, uint32_t& block_height);
+
 // Exact 2D 64 KiB equation used by tile_surface, for word-addressable texels.
 // Rejects other layouts; callers must separately exclude volume/mip-tail views.
 bool tile64_word_equation(uint32_t tile_mode, uint32_t bytes_per_texel,

--- a/prosper/tests/gpu/execute/test_gpu_retile.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_retile.cpp
@@ -21,13 +21,14 @@ static bool equation_covers_block(uint32_t mode, uint32_t bpe, uint32_t bx,
                                  uint32_t by, bool broken = false) {
     std::array<uint32_t, 16> equation{};
     uint32_t bw = 0, bh = 0;
-    if (!tile64_word_equation(mode, bpe, equation, bw, bh)) return false;
+    if (!(bpe == 2 ? tile64_paired16_equation(mode, equation, bw, bh)
+                   : tile64_word_equation(mode, bpe, equation, bw, bh))) return false;
     if (broken) equation[15] = 0; // deliberately collapse one address bit
     std::vector<bool> seen(65536 / 4);
     size_t written = 0;
     for (uint32_t y = by * bh; y < (by + 1) * bh; ++y)
-    for (uint32_t x = bx * bw; x < (bx + 1) * bw; ++x)
-    for (uint32_t component = 0; component < bpe / 4; ++component) {
+    for (uint32_t x = bx * bw; x < (bx + 1) * bw; x += bpe == 2 ? 2 : 1)
+    for (uint32_t component = 0; component < std::max(1u, bpe / 4); ++component) {
         uint32_t offset = component * 4;
         for (uint32_t bit = 2; bit < 16; ++bit) {
             const uint32_t parity = std::popcount(
@@ -63,6 +64,8 @@ static bool volume_equation_covers_block(uint32_t mode, uint32_t bpe, bool colla
 int run_case(int argc, char** argv) {
     const bool mixed = argc == 2 && std::strstr(argv[1], "mixed");
     const bool volume = argc == 2 && std::strstr(argv[1], "volume");
+    const bool array16 = argc == 2 && std::strstr(argv[1], "array16");
+    const bool shape_refusal = array16 && std::strstr(argv[1], "shape-refusal");
     const bool cpu = argc == 2 && std::strstr(argv[1], "cpu");
     const bool clean = argc == 2 && std::strcmp(argv[1], "--clean") == 0;
     const bool mapping = argc == 2 && std::strstr(argv[1], "map-");
@@ -114,8 +117,38 @@ int run_case(int argc, char** argv) {
               "3D equation writes every physical word exactly once");
     check(!volume_equation_covers_block(9, 8, true),
           "3D coverage guard rejects a collapsed coordinate bit");
+    check(params.initialize_paired16_array(512, 512, 6, 24, limits) &&
+          params.linear_bytes == 3145728 && params.tiled_bytes == 3145728 &&
+          params.words[23] == 131072 && params.words[24] == 131072 &&
+          params.groups_x == 2 && params.groups_y == 512 && params.groups_z == 6,
+          "six ordinary R16 layers have exact independent word strides");
+    check(!params.initialize_paired16_array(511, 512, 6, 24, limits) &&
+          !params.initialize_paired16_array(512, 512, 0, 24, limits) &&
+          !params.initialize_paired16_array(0, 512, 6, 24, limits) &&
+          !params.initialize_paired16_array(512, 0, 6, 24, limits) &&
+          !params.initialize_paired16_array(512, 512, 6, 27, limits) &&
+          !params.initialize_paired16_array(UINT32_MAX - 1, UINT32_MAX, UINT32_MAX, 24, limits) &&
+          !params.initialize_paired16_array(512, 512, UINT32_MAX, 24, limits),
+          "unpaired rows, unsupported modes, zero shape and overflow decline");
+    for (unsigned field = 0; field < 7; ++field) {
+        auto reduced = limits;
+        if (field == 0) reduced.maxStorageBufferRange = 3145727;
+        if (field == 1) reduced.maxPushConstantsSize = 103;
+        if (field == 2) reduced.maxComputeWorkGroupInvocations = 127;
+        if (field == 3) reduced.maxComputeWorkGroupCount[0] = 1;
+        if (field == 4) reduced.maxComputeWorkGroupCount[1] = 511;
+        if (field == 5) reduced.maxComputeWorkGroupCount[2] = 5;
+        if (field == 6) reduced.maxComputeWorkGroupSize[0] = 127;
+        check(!params.initialize_paired16_array(512, 512, 6, 24, reduced),
+              "paired array respects every device range and dispatch limit");
+    }
+    for (auto [bx, by] : {std::pair{0u, 0u}, std::pair{1u, 1u},
+                          std::pair{3u, 5u}, std::pair{17u, 33u}})
+        check(equation_covers_block(24, 2, bx, by), "paired words cover each complete tile without overlap");
+    check(!equation_covers_block(24, 2, 0, 0, true), "paired permutation guard detects a collapsed bit");
     struct Format { DataFormat format; uint32_t components, bpe; };
-    constexpr Format formats[]{ {DataFormat::Uint32, 1, 4}, {DataFormat::Uint8, 4, 4},
+    const std::vector<Format> formats = array16 ? std::vector<Format>{{DataFormat::Uint16, 1, 2},
+        {DataFormat::Unorm8, 2, 2}, {DataFormat::Float16, 1, 2}} : std::vector<Format>{ {DataFormat::Uint32, 1, 4}, {DataFormat::Uint8, 4, 4},
         {DataFormat::Unorm8, 4, 4}, {DataFormat::Float16, 4, 8}, {DataFormat::Float32, 4, 16} };
     check(params.initialize_volume(64, 64, 128, 8, 9, limits) &&
               params.linear_bytes == 4194304 && params.tiled_bytes == 4194304 &&
@@ -127,38 +160,45 @@ int run_case(int argc, char** argv) {
     auto depth_limits = limits; depth_limits.maxComputeWorkGroupCount[2] = 21;
     check(!params.initialize_volume(67, 19, 21, 8, 9, depth_limits),
           "3D workgroup limit applies to padded depth");
-    const std::vector<uint32_t> modes = mixed ? std::vector<uint32_t>{9} : volume ? std::vector<uint32_t>{5, 9}
+    const std::vector<uint32_t> modes = array16 ? std::vector<uint32_t>{24} : mixed ? std::vector<uint32_t>{9} : volume ? std::vector<uint32_t>{5, 9}
                                               : std::vector<uint32_t>{9, 24, 27};
-    const std::vector<std::pair<uint32_t, uint32_t>> extents = mixed
+    const std::vector<std::pair<uint32_t, uint32_t>> extents = array16
+        ? (shape_refusal ? std::vector<std::pair<uint32_t, uint32_t>>{{257, 131}, {258, 131}}
+                         : std::vector<std::pair<uint32_t, uint32_t>>{{258, 131}, {512, 512}}) : mixed
         ? std::vector<std::pair<uint32_t, uint32_t>>{{67, 19}} : volume
         ? std::vector<std::pair<uint32_t, uint32_t>>{{67, 19}, {128, 64}}
         : std::vector<std::pair<uint32_t, uint32_t>>{{257, 131}, {384, 256}};
     uint64_t code = 0x34070000;
     for (uint32_t mode : modes) for (auto format : formats)
     for (auto [width, height] : extents)
-    for (uint32_t view = 0; view < ((volume || mixed) ? 1u : 3u); ++view) {
-        if (mixed && format.format != DataFormat::Float16) continue;
+    for (uint32_t view = 0; view < ((volume || mixed || array16) ? 1u : 3u); ++view) {
+        if (mixed && !array16 && format.format != DataFormat::Float16) continue;
         // Integer 3D images still use the existing raw interchange path. Its packing fallback
         // remains covered; this retile change does not broaden native storage declarations.
         const bool native_volume = native_storage_3d_format_support_bit(
             format.format, format.components) != 0;
-        const bool gpu = !cpu && (!volume || native_volume);
+        const bool gpu = !cpu && !shape_refusal && (!volume || native_volume);
         if (fault_mode && volume && !native_volume) continue;
         // A one-layer array descriptor may be consumed through either a plain
         // 2D instruction or an array instruction retaining its layer coordinate.
-        const uint32_t resource_dim = volume ? 2u : view ? 5u : 1u;
-        const uint32_t instruction_dim = volume ? 2u : view == 2 ? 5u : 1u;
-        const uint32_t depth = volume ? (width == 67 ? 21u : 32u) : 1u;
+        const uint32_t resource_dim = volume ? 2u : (array16 || view) ? 5u : 1u;
+        const uint32_t instruction_dim = volume ? 2u : (array16 || view == 2) ? 5u : 1u;
+        const uint32_t depth = array16 ? 6u : volume ? (width == 67 ? 21u : 32u) : 1u;
         const size_t linear_bytes = size_t(width) * height * depth * format.bpe;
+        const size_t tile_slice = tiled_surface_bytes(width, height, mode, 0, format.bpe);
+        const size_t layer_stride = tile_slice + (shape_refusal && !(width & 1) ? 65536 : 0);
         const size_t tiled_bytes = volume ? tiled_volume_bytes(width, height, depth, mode, format.bpe)
-                                           : tiled_surface_bytes(width, height, mode, 0, format.bpe);
+                                         : layer_stride * (depth - 1) + tile_slice;
         auto tile = [&](uint8_t* dst, const uint8_t* src) {
             if (volume) check(tile_volume(dst, tiled_bytes, src, width, height, depth, mode, format.bpe),
                               "CPU volume layout supports the test resource");
-            else tile_surface(dst, src, width, height, mode, 0, format.bpe);
+            else for (uint32_t layer = 0; layer < depth; ++layer)
+                tile_surface(dst + layer * layer_stride,
+                             src + size_t(layer) * width * height * format.bpe,
+                             width, height, mode, 0, format.bpe);
         };
         std::vector<uint8_t> source_linear(linear_bytes), expected_linear(linear_bytes);
-        std::vector<uint8_t> source(tiled_bytes), destination(tiled_bytes + 64, 0xcc);
+        std::vector<uint8_t> source(tiled_bytes, 0xb7), destination(tiled_bytes + 64, 0xcc);
         auto fill = [&](std::vector<uint8_t>& bytes, uint32_t salt) {
             auto mixed = [&](uint32_t index) {
                 uint32_t v = index + salt * 0x9e3779b9u;
@@ -198,6 +238,12 @@ int run_case(int argc, char** argv) {
             r.width = width; r.height = height; r.depth = depth;
             r.format = format.format; r.num_components = format.components; r.tile_mode = mode;
             r.size = uint32_t(tiled_bytes);
+            if (array16) {
+                // Both inferred and explicit exact strides occur in decoded resources.
+                r.layer_stride_bytes = (width == 512 || shape_refusal) ? uint32_t(layer_stride) : 0;
+                r.mip_chain_element_width = width; r.mip_chain_element_height = height;
+                r.mip_chain_bytes_per_block = format.bpe;
+            }
             r.gpu_addr = reinterpret_cast<uint64_t>(binding == 4 ? source.data() : destination.data());
             resources.resources.push_back(r);
         }
@@ -208,7 +254,8 @@ int run_case(int argc, char** argv) {
             fill(source_linear, 7 + round * 31);
             tile(source.data(), source_linear.data());
             const uint32_t row = round == 0 ? 0 : round == 1 ? height / 2 : height - 1;
-            const uint32_t first_x = round == 2 ? width - 64 : 0;
+            // Odd starts/ends independently update the high and low halves of paired stores.
+            const uint32_t first_x = round == 2 ? width - 64 : (array16 && round == 1 ? 1 : 0);
             const uint32_t slice = round == 0 ? 0 : round == 1 ? depth / 2 : depth - 1;
             const uint32_t shader[]{
                 0x4A0800FFu, first_x, // v_add_nc_u32 v4, first_x, v0
@@ -232,7 +279,7 @@ int run_case(int argc, char** argv) {
             for (const auto& descriptor : reflection.descriptors)
                 if (descriptor.kind == SpirvDescriptorKind::StorageImage &&
                     (descriptor.binding == 4 || descriptor.binding == 5) &&
-                    descriptor.image_dim == (volume ? 2u : 1u) && descriptor.image_arrayed == (view == 2))
+                    descriptor.image_dim == (volume ? 2u : 1u) && descriptor.image_arrayed == (array16 || view == 2))
                     ++matching_views;
             check(reflection.ok() && matching_views == 2,
                   "both storage views reflect the intended ordinary or array shader type");
@@ -275,7 +322,7 @@ int run_case(int argc, char** argv) {
                 std::copy_n(source_linear.data() + ((size_t(slice) * height + row) * width + x) * format.bpe,
                             format.bpe, expected_linear.data() + ((size_t(slice) * height + row) * width + x) * format.bpe);
             }
-            std::vector<uint8_t> expected(tiled_bytes);
+            std::vector<uint8_t> expected(tiled_bytes, 0xcc);
             tile(expected.data(), expected_linear.data());
             check(std::equal(expected.begin(), expected.end(), destination.begin()),
                   "every guest byte matches CPU tiling, including untouched texels and padding");
@@ -296,7 +343,7 @@ int run_case(int argc, char** argv) {
 int main(int argc, char** argv) {
     if (argc == 2 && std::strcmp(argv[1], "--mixed") == 0) {
         // All three use the same retained live context and its immutable retile pipelines.
-        for (const char* option : {"--mixed-2d", "--mixed-volume", "--mixed-2d"}) {
+        for (const char* option : {"--mixed-2d", "--mixed-volume", "--mixed-array16", "--mixed-2d"}) {
             char* args[]{argv[0], const_cast<char*>(option)};
             if (run_case(2, args)) return 1;
         }

--- a/prosper/tests/gpu/execute/test_gpu_retile.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_retile.cpp
@@ -214,7 +214,10 @@ int run_case(int argc, char** argv) {
         // remains covered; this retile change does not broaden native storage declarations.
         const bool native_volume = native_storage_3d_format_support_bit(
             format.format, format.components) != 0;
-        const bool gpu = !cpu && !shape_refusal && (!volume || native_volume);
+        // Multi-layer native float storage is not admitted by the existing recompiler.
+        // Keep RG8/R16F arrays as raw CPU fallback coverage, without widening codegen.
+        const bool native_array = !array16 || format.format == DataFormat::Uint16;
+        const bool gpu = !cpu && !shape_refusal && native_array && (!volume || native_volume);
         if (fault_mode && volume && !native_volume) continue;
         // A one-layer array descriptor may be consumed through either a plain
         // 2D instruction or an array instruction retaining its layer coordinate.
@@ -320,6 +323,18 @@ int run_case(int argc, char** argv) {
                     ++matching_views;
             check(reflection.ok() && matching_views == 2,
                   "both storage views reflect the intended ordinary or array shader type");
+            if (array16) {
+                size_t matching_formats = 0;
+                for (const auto& descriptor : reflection.descriptors)
+                    if (descriptor.kind == SpirvDescriptorKind::StorageImage &&
+                        (descriptor.binding == 4 || descriptor.binding == 5) &&
+                        descriptor.image_numeric_class == SpirvImageNumericClass::Uint &&
+                        descriptor.storage_image_format == (native_array ? kSpirvImageFormatR16ui : 0u))
+                        ++matching_formats;
+                check(reflection.ok() && matching_formats == 2,
+                      native_array ? "R16 array source and destination reflect exact native R16ui storage"
+                                   : "RG8/R16F arrays explicitly retain raw unsigned interchange storage");
+            }
             const auto* source_access = find_spirv_descriptor_binding(reflection, 0, 4);
             const auto* destination_access = find_spirv_descriptor_binding(reflection, 0, 5);
             check(reflection.storage_image_writes_complete && source_access && destination_access &&

--- a/prosper/tests/gpu/execute/test_gpu_retile.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_retile.cpp
@@ -117,6 +117,43 @@ int run_case(int argc, char** argv) {
               "3D equation writes every physical word exactly once");
     check(!volume_equation_covers_block(9, 8, true),
           "3D coverage guard rejects a collapsed coordinate bit");
+    // Metadata-only predicate checks, not execution of a multi-mip/MSAA image.
+    // Real GPU/CPU integration below separately covers bytes, strides and widths.
+    ShaderResource descriptor{};
+    descriptor.width = descriptor.height = 512;
+    check(gpu_retile_paired16_descriptor_supported(descriptor, 2, 1),
+          "descriptor predicate accepts unspecified allocation hints for an ordinary base view");
+    descriptor.mip_chain_element_width = descriptor.mip_chain_element_height = 512;
+    descriptor.mip_chain_bytes_per_block = 2;
+    check(gpu_retile_paired16_descriptor_supported(descriptor, 2, 1),
+          "descriptor predicate accepts exact allocation hints");
+    check(!gpu_retile_paired16_descriptor_supported(descriptor, 4, 1) &&
+          !gpu_retile_paired16_descriptor_supported(descriptor, 2, 2),
+          "descriptor predicate excludes other native widths and backend mip counts");
+    uint8_t metadata_byte = 0xff;
+    for (unsigned field = 0; field < 16; ++field) {
+        auto changed = descriptor;
+        switch (field) {
+        case 0: changed.sample_count = 2; break;
+        case 1: changed.declared_mip_levels = 2; break;
+        case 2: changed.mip_chain_base_level = 1; break;
+        case 3: changed.mip_chain_max_level = 1; break;
+        case 4: changed.linear_row_pitch_bytes = 1024; break;
+        case 5: changed.mip_tail_offset = 4; break;
+        case 6: changed.mip_tail_bytes = 65536; break;
+        case 7: changed.mip_tail_x = 1; break;
+        case 8: changed.mip_tail_y = 1; break;
+        case 9: changed.compression_enabled = true; break;
+        case 10: changed.write_compress_enabled = true; break;
+        case 11: changed.metadata_addr = reinterpret_cast<uint64_t>(&metadata_byte); break;
+        case 12: changed.dcc_metadata_host_data = &metadata_byte; break;
+        case 13: changed.mip_chain_element_width = 256; break;
+        case 14: changed.mip_chain_element_height = 256; break;
+        case 15: changed.mip_chain_bytes_per_block = 4; break;
+        }
+        check(!gpu_retile_paired16_descriptor_supported(changed, 2, 1),
+              "descriptor-only sample/mip/metadata/pitch/hint change refuses paired retile");
+    }
     check(params.initialize_paired16_array(512, 512, 6, 24, limits) &&
           params.linear_bytes == 3145728 && params.tiled_bytes == 3145728 &&
           params.words[23] == 131072 && params.words[24] == 131072 &&

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -762,7 +762,9 @@ int main(int argc, char** argv) {
          "build_compute_detile_rgba16f");
     dump(dir, "builder_retile_words", build_compute_retile_words(),
          "build_compute_retile_words");
-    dump(dir, "builder_retile_volume_words", build_compute_retile_words(true),
+    dump(dir, "builder_retile_paired16_array", build_compute_retile_words(RetileShaderKind::Paired16Array),
+         "build_compute_retile_words");
+    dump(dir, "builder_retile_volume_words", build_compute_retile_words(RetileShaderKind::Volume3D),
          "build_compute_retile_words");
     dump(dir, "builder_rgba8_to_packed10", build_compute_rgba8_to_packed10(),
          "build_compute_rgba8_to_packed10");


### PR DESCRIPTION
Native Uint16 storage arrays currently copy completed linear GPU output to the host and run mode-24 layout conversion on the CPU. This change records the conversion in the existing compute submission, then preserves ordinary synchronous guest writeback from the completed tiled buffer. The original linear result remains available for comparison and publication.

The shader handles even-x pairs with ordinary 32-bit loads/stores and independent checked array-layer strides. It writes padding without out-of-range input loads. Admission requires an exact native two-byte array, even width, one mip, tight or exact layer stride, supported limits and unambiguous metadata. RG8/R16F arrays retain their existing raw CPU conversion. Completion pins, host-read dependencies, guest visibility, allocation/map fallback and sticky device loss are preserved. No game-specific admission, extra submission/wait, experimental driver flag or 16-bit storage feature is added.

At exact head `39bd220f87b31cd60c43947b5b6126f7c398b311`:

- **459/459 local tests**, emitted-SPIR-V validation and **20/20 strict Vulkan core/synchronization cases with zero messages** pass. Actual native R16ui fixtures check every guest byte, all six layers, padding and partially untouched neighboring halfwords. Real GPU-path recordings are required separately from correct CPU-fallback bytes.
- GPU-disable controls fail path expectations while retaining correct bytes. Valid-SPIR-V missing-padding and missing-layer-offset mutations fail 3 and 6 complete-byte checks; restored source, fixtures, SPIR-V and the fully relinked application pass. Mixed pipeline reuse, descriptor refusal and allocation/map/device-loss cases are covered.
- GTA’s exact target has 160 dispatches in each normal F8 window. Enclosing CPU cost falls **136.37 → 94.68 ms (30.57%)**, including increased wait **31.45 → 39.10 ms**. GPU device cost rises **12.83 → 20.84 ms**, overlapping that wait. Guest presentations remain 31 → 31; no game-wide FPS gain is claimed. The bank captures retain geometry, lighting, reflections and HUD.
- All four Sonic runs are retained in baseline/candidate/candidate/baseline order: guest presentations **39/35/39/38**, host **39/36/39/38** over approximately five seconds each. The first candidate has more RTT/persistent-invalid preparation; its repeat returns to lower preparation cost. No new paired-array output is observed in these F8 windows. This does **not** establish Sonic performance neutrality or explain the varying workload. Captures retain the known black-world/HUD state; the title menu, clouds and FMV are not certified.
- Main-output audio has no additional-byte shortages in the sampled F8/F9 covering bands across the six runs. Startup/intro shortages and incomplete post-writer tails are reported separately. No PCM, pacing, buffer ownership, audible-quality or audio-fix claim is made.

[Complete author verification, commands, identities and all six captures](https://github.com/mattias800/prosper/pull/3488#issuecomment-5595963042). Required Linux/general CI passes; the independently inspected Windows MinGW failure is the existing `capture_tunables` shutdown timeout tracked in #3470. Windows App and both macOS checks pass. Final independent [source/runtime](https://github.com/mattias800/prosper/pull/3488#pullrequestreview-5149871650) and [evidence](https://github.com/mattias800/prosper/pull/3488#pullrequestreview-5149879359) reviews approve this exact head.

Related to #3407 and #3441. Broader conversion, renderer residency, workload variability and performance work remain open.
