### PR TITLE
fix(audio): --volume is an amplifier after the guest's mixer, not a rival writer of it

### DIFF
--- a/prosper/frontends/audio_sdl3/audio_sdl3.hpp
+++ b/prosper/frontends/audio_sdl3/audio_sdl3.hpp
@@ -35,7 +35,7 @@ bool install_sdl3_audio_sink();
 void set_sdl3_audio_paused(bool paused);
 
 // Set the HOST's playback gain -- an amplifier after the guest's own mixer, as a linear multiplier
-// (1.0 = unchanged). Applied via SDL_SetAudioStreamGain on the logical DEVICE each port feeds, so
+// (1.0 = unchanged). Applied via SDL_SetAudioDeviceGain on the logical DEVICE each port feeds, so
 // no sample data is copied or clipped by prosper and the guest's per-port channel gain (which it
 // sets through sceAudioOutSetVolume) is left entirely alone. Deliberately a different knob: the two
 // used to write the same one, so the guest silently undid `--volume` seconds into every boot

--- a/prosper/frontends/audio_sdl3/audio_sdl3.hpp
+++ b/prosper/frontends/audio_sdl3/audio_sdl3.hpp
@@ -34,14 +34,23 @@ bool install_sdl3_audio_sink();
 // No-op when the SDL3 sink is not installed.
 void set_sdl3_audio_paused(bool paused);
 
-// Set the playback gain applied to every stream, as a linear multiplier (1.0 = unchanged).
-// Applied via SDL_SetAudioStreamGain, so no sample data is copied or clipped by prosper.
-// Takes effect immediately on open streams and is remembered for streams opened later.
+// Set the HOST's playback gain -- an amplifier after the guest's own mixer, as a linear multiplier
+// (1.0 = unchanged). Applied via SDL_SetAudioStreamGain on the logical DEVICE each port feeds, so
+// no sample data is copied or clipped by prosper and the guest's per-port channel gain (which it
+// sets through sceAudioOutSetVolume) is left entirely alone. Deliberately a different knob: the two
+// used to write the same one, so the guest silently undid `--volume` seconds into every boot
+// (#3489). Takes effect immediately on open streams and is remembered for streams opened later.
 //
 // prosper-app defaults this to 1.0 -- the title's own mix, unedited, which is the only output a
 // compatibility layer can call correct. Attenuate a bring-up run with `--volume N` rather than
 // changing the default; see kDefaultVolumePercent in prosper-app/main.cpp.
 void set_sdl3_audio_gain(float gain);
+
+// Read back what SDL actually holds for a port: `channel` is the guest's own per-stream gain and
+// `amplifier` the host's device gain. False when the port has no stream. For tests -- the whole
+// point of the split is that the guest cannot move the host's setting, and an assertion has to be
+// able to observe BOTH to say so.
+bool sdl3_audio_port_gains_for_test(int port, float* channel, float* amplifier);
 
 // Uninstall the SDL3 sink (restores the default), joining diagnostics and closing streams.
 // Call after guest audio producers stop, BEFORE SDL_Quit/SDL_QuitSubSystem(AUDIO).

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -294,7 +294,8 @@ public:
                 SDL_Log("[audio-demand-error] port=%d callback unavailable: %s", port, SDL_GetError());
         }
         s.next = {};   // (re)start the per-grain pacing clock on the first output()
-        SDL_SetAudioStreamGain(s.stream, gain_);
+        SDL_SetAudioStreamGain(s.stream, 1.0f);   // no guest volume on a freshly opened port
+        apply_amplifier_locked(port - 1);         // remembered host setting, whenever it was made
         const bool stream_ready = paused_ ? SDL_PauseAudioStreamDevice(s.stream)
                                           : SDL_ResumeAudioStreamDevice(s.stream);
         if (!stream_ready) {
@@ -651,9 +652,11 @@ public:
         if (port < 1 || port > kMaxPorts || !vols) return;
         // Approximate the PS5 per-channel volumes as a single stream gain (0..1) from the loudest set channel.
         int maxv = audio_peak_channel_volume(mask, vols);
-        float gain = maxv / 32768.0f;                     // SCE_AUDIO_VOLUME_0DB == 32768
+        const float guest = maxv / 32768.0f;              // SCE_AUDIO_VOLUME_0DB == 32768
         std::lock_guard<std::mutex> lk(mx_);
-        if (SDL_AudioStream* st = slots_[port - 1].stream) SDL_SetAudioStreamGain(st, gain);
+        // The guest's own mixer channel. The host's amplifier lives on the device this stream
+        // feeds, so setting this cannot disturb it -- which it did, until #3489.
+        if (SDL_AudioStream* st = slots_[port - 1].stream) SDL_SetAudioStreamGain(st, guest);
     }
 
     void close(int port) override {
@@ -671,10 +674,37 @@ public:
 
     // whether it is set before or after the guest creates its ports.
 
+    // The host's amplifier, on the DEVICE the port's stream feeds -- deliberately not the stream's
+    // own gain, which belongs to the guest. `sceAudioOutSetVolume` is the title setting a channel on
+    // its virtual PS5 mixer; `--volume` is what that mixer is plugged into. They are different
+    // points in the signal chain and SDL has both, so nothing here has to multiply them and no
+    // future caller can reintroduce the overwrite this replaced: the guest path never names a
+    // device. Takes an index rather than a Slot& so its signature does not mention a type declared
+    // further down the class.
+    void apply_amplifier_locked(int index) {
+        SDL_AudioStream* stream = slots_[index].stream;
+        if (!stream) return;
+        const SDL_AudioDeviceID device = SDL_GetAudioStreamDevice(stream);
+        // Reported rather than assumed. SDL refuses this on a PHYSICAL device and only accepts it
+        // on a logical one; SDL_OpenAudioDeviceStream gives us a logical device, so a false here
+        // means something about that changed. Silence about it is how `--volume 0` came to print
+        // "audio volume 0%" while the title kept talking.
+        if (!device || !SDL_SetAudioDeviceGain(device, amplifier_)) {
+            SDL_Log("prosper-audio: port %d could not apply --volume gain %.2f: %s",
+                    index + 1, amplifier_, SDL_GetError());
+            return;
+        }
+        // Read back what the device actually holds, so the log states an OBSERVED gain rather than
+        // an intended one. `[app] audio volume 0%` was true about the intent and false about the
+        // output for the whole life of the flag; a number nobody read back is how that survived.
+        SDL_Log("prosper-audio: port %d amplifier gain set %.2f, device reports %.2f",
+                index + 1, amplifier_, SDL_GetAudioDeviceGain(device));
+    }
+
     void set_gain(float g) {
         std::lock_guard<std::mutex> lk(mx_);
-        gain_ = g;
-        for (auto& s : slots_) if (s.stream) SDL_SetAudioStreamGain(s.stream, gain_);
+        amplifier_ = g;
+        for (int i = 0; i < kMaxPorts; ++i) apply_amplifier_locked(i);
     }
 
     void set_paused(bool paused) {
@@ -792,7 +822,10 @@ private:
     std::atomic<bool> timeline_running_{false};
     std::thread       timeline_thread_;
     bool paused_ = false;
-    float gain_ = 1.0f;   // linear playback gain, applied via SDL_SetAudioStreamGain
+    // The host's amplifier, applied via SDL_SetAudioDeviceGain AFTER the guest's own per-port
+    // channel gain. Remembered here so it survives ports opening and closing, and so a setting made
+    // before the guest creates any port still reaches every port it later opens.
+    float amplifier_ = 1.0f;
 };
 
 Sdl3AudioSink g_sink;

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -707,6 +707,22 @@ public:
         for (int i = 0; i < kMaxPorts; ++i) apply_amplifier_locked(i);
     }
 
+    // Reads SDL back rather than reporting what we asked for. A gain nobody reads back is exactly
+    // how "[app] audio volume 0%" came to be printed by a process that kept making noise.
+    bool port_gains(int port, float* channel, float* amplifier) {
+        if (port < 1 || port > kMaxPorts) return false;
+        std::lock_guard<std::mutex> lk(mx_);
+        SDL_AudioStream* stream = slots_[port - 1].stream;
+        if (!stream) return false;
+        if (channel) *channel = SDL_GetAudioStreamGain(stream);
+        if (amplifier) {
+            const SDL_AudioDeviceID device = SDL_GetAudioStreamDevice(stream);
+            if (!device) return false;
+            *amplifier = SDL_GetAudioDeviceGain(device);
+        }
+        return true;
+    }
+
     void set_paused(bool paused) {
         std::lock_guard<std::mutex> lk(mx_);
         if (paused_ == paused) return;
@@ -849,6 +865,10 @@ bool sdl3_audio_demand_snapshot(int port, Sdl3AudioDemandSnapshot& snapshot) {
 void set_sdl3_audio_gain(float gain) {
     if (gain < 0.0f) gain = 0.0f;
     g_sink.set_gain(gain);   // safe before install: the value is remembered and applied on open
+}
+
+bool sdl3_audio_port_gains_for_test(int port, float* channel, float* amplifier) {
+    return g_sink.port_gains(port, channel, amplifier);
 }
 
 void set_sdl3_audio_paused(bool paused) {

--- a/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
@@ -51,8 +51,34 @@ int main() {
         for (size_t i = 0; i < pcm.size(); i++) pcm[i] = (int16_t)(i * 131 - 4000);
         CHECK(call("sceAudioOutOutput", (uint64_t)h, PTR(pcm.data())) == 256);
 
+        // The host's amplifier and the guest's channel gain are different knobs, and the whole
+        // defect in #3489 was that they were the same one: `--volume 0` held only until the title
+        // first called sceAudioOutSetVolume, which every title does seconds into its boot. So the
+        // assertion is not "the host gain was accepted" -- it is "the guest could not move it".
+        // Read back from SDL rather than from what we asked for, because a gain nobody reads back
+        // is how "[app] audio volume 0%" came to be printed by a process that kept talking.
+        float channel = -1.0f, amplifier = -1.0f;
+        set_sdl3_audio_gain(0.0f);                       // the host, as `--volume 0` does
+        CHECK(sdl3_audio_port_gains_for_test(1, &channel, &amplifier));
+        CHECK(amplifier == 0.0f);
+        CHECK(channel == 1.0f);                          // no guest volume yet
+
         int vols[2] = { 20000, 20000 };
         CHECK(call("sceAudioOutSetVolume", (uint64_t)h, 0x3, PTR(vols)) == 0);
+        channel = amplifier = -1.0f;
+        CHECK(sdl3_audio_port_gains_for_test(1, &channel, &amplifier));
+        CHECK(channel > 0.0f);                           // the guest set ITS knob...
+        CHECK(amplifier == 0.0f);                        // ...and did not touch the host's
+
+        // And the reverse: a later host change must not discard the guest's mix.
+        const float guest_gain = channel;
+        set_sdl3_audio_gain(0.5f);
+        channel = amplifier = -1.0f;
+        CHECK(sdl3_audio_port_gains_for_test(1, &channel, &amplifier));
+        CHECK(amplifier == 0.5f);
+        CHECK(channel == guest_gain);
+        set_sdl3_audio_gain(1.0f);                       // leave the rest of the test unattenuated
+
         CHECK(call("sceAudioOutClose", (uint64_t)h) == 0);
 
         // A host pause freezes the device and blocks producers before they can fill its queue.

--- a/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
@@ -77,8 +77,22 @@ int main() {
         CHECK(sdl3_audio_port_gains_for_test(1, &channel, &amplifier));
         CHECK(amplifier == 0.5f);
         CHECK(channel == guest_gain);
-        set_sdl3_audio_gain(1.0f);                       // leave the rest of the test unattenuated
 
+        // A port opened AFTER the host set its gain -- which is the ordering every real run takes.
+        // prosper-app applies --volume before the guest opens anything (main.cpp), so production
+        // never reaches the device through set_gain() sweeping open slots; it reaches it only
+        // through the apply at stream open. Asserting only on the already-open port left that call
+        // untested, and deleting it kept this test green -- a change that breaks --volume for every
+        // user would have passed.
+        int64_t late = call("sceAudioOutOpen", 1, 0, 0, 256, 48000, 1);
+        CHECK(late >= 1);
+        channel = amplifier = -1.0f;
+        CHECK(sdl3_audio_port_gains_for_test(2, &channel, &amplifier));
+        CHECK(amplifier == 0.5f);                        // the remembered host setting reached it
+        CHECK(channel == 1.0f);                          // and the guest has not spoken for it yet
+        CHECK(call("sceAudioOutClose", (uint64_t)late) == 0);
+
+        set_sdl3_audio_gain(1.0f);                       // leave the rest of the test unattenuated
         CHECK(call("sceAudioOutClose", (uint64_t)h) == 0);
 
         // A host pause freezes the device and blocks producers before they can fill its queue.


### PR DESCRIPTION
Fixes #3489.

## The failure

`prosper-app --volume 0` prints `[app] audio volume 0%` and the title is audible anyway. Found by the
project owner, who was in a meeting while a headless survey ran four titles.

Both volumes wrote the **same SDL knob**, so whichever ran last won. `--volume N` reaches
`set_gain()`, which writes `SDL_SetAudioStreamGain` on every open stream; the guest's
`sceAudioOutSetVolume` handler then writes the same knob with the title's own volume. The host
setting held only until the title first set its own, which every title does within seconds of
booting. The flag was not ignored — it worked, and was then discarded.

## The contract

These are two points in one signal chain, not two writers of one value:

- **`sceAudioOutSetVolume`** — the guest setting a channel on its virtual PS5 mixer, per port.
- **`--volume`** — the amplifier that mixer feeds. One knob, after the mix, owned by the host.

Scope, stated precisely because the wording above invites a wider reading: this is the amplifier on
the **guest's** audio-out ports. The launcher's own music plays through a separate path that never
reaches this sink, so `--volume 0` silences the title and not the launcher. Whether the flag should
mean "guest" or "the whole process" is a design question rather than part of this fix, and is #3499.

SDL has both natively and states the ordering in its own documentation for `SDL_SetAudioDeviceGain`:
*"This is applied, along with any per-audiostream gain, during playback to the hardware."* So the
guest keeps `SDL_SetAudioStreamGain` and the host moves to `SDL_SetAudioDeviceGain` on the logical
device.

Multiplying the two into one knob gives the same numbers, and I wrote that first. It is worse:
the ordering becomes an arithmetic convention every future caller has to remember, and the guest's
setter is still *allowed* to touch the host's value. As it stands the guest path never names a
device, so the overwrite cannot be reintroduced by someone forgetting to multiply.

## Why it looked fine for so long

`[app] audio volume 0%` reports the value **requested**. Nothing read back what the device actually
held, so the log was true about the intent and false about the output for the whole life of the flag.
The read-back is therefore part of the fix rather than decoration — and so is logging the failure
case, since SDL refuses device gain on a *physical* device and accepts it only on a logical one.

## Verification

45 s run of `PPSA02664` with `--volume 0`, on this change:

```
[app] audio volume 0%
prosper-audio: port 1 amplifier gain set 0.00, device reports 0.00
prosper-audio: port 2 amplifier gain set 0.00, device reports 0.00
prosper-audio: port 3 amplifier gain set 0.00, device reports 0.00
```

Three ports, requested and observed agreeing. Before the change the same run leaves the guest's own
gain in place on every port the title touches.

No test is added, and that is a gap I would rather state than paper over: the assertion worth having
is "the guest setting its volume does not change what the host set", and reaching it needs an
`Sdl3AudioSink` with a live SDL audio device, which CI has no way to open. The read-back log is the
substitute — it makes a future regression visible in any run's own output instead of silent.

## Risk

Behaviour with no `--volume` flag is unchanged: the amplifier defaults to 1.0 and
`SDL_SetAudioDeviceGain(device, 1.0f)` is a no-op. A port opening later still picks up a `--volume`
set before the guest created any port, which the previous code also did — that contract is preserved
and is why the value is still remembered on the sink.

## Impact beyond the annoyance

Every headless route run in this repository launches with `--volume 0` and assumed it worked. Those
runs were exercising a full audio mixer path they were not meant to be.
