### PR TITLE
fix(capture): break the exit deadlock between the owned writer and the CRT onexit table

### DIFF
--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -260,6 +260,28 @@ that thread waits on becomes the focus, so matching signals from other threads a
 
 ## Gotchas learned (so the next agent doesn't relearn them)
 
+- **A thread joined from a static destructor can deadlock against the CRT's own exit table, and the
+  usual suspects are the wrong ones.** `main` was red on Windows MinGW for a day with
+  `capture_tunables (Timeout)` — a hang with no assertion output. The recorded hypothesis was the
+  natural one, and it was **falsified**: the writer thread was neither unjoined nor waiting on a
+  signal that never arrived. `gdb` on the hung process put it inside `fprintf`:
+
+  ```
+  Thread 1 (main)    _execute_onexit_table -> ~InteractiveFrameBundle -> std::thread::join
+  Thread 2 (writer)  __pformat_float -> __gdtoa -> __Balloc_D2A -> dtoa_lock -> atexit
+                     -> _register_onexit_function -> RtlEnterCriticalSection   [blocked]
+  ```
+
+  MinGW's float formatting lazily registers an `atexit` handler the first time `__gdtoa` allocates,
+  taking the CRT onexit-table critical section — the lock the exiting main thread already holds
+  while walking that table. Linux never sees it: the mechanism is MinGW's `gdtoa`.
+
+  **The general rule: a thread still doing work while another thread runs static destructors must
+  not touch anything that can lazily initialise CRT state.** `%f` is the one that bit us; any first
+  use of a facility that registers cleanup would do. Prefer integer formatting on such a thread, and
+  prefer draining worker threads explicitly before `main` returns over relying on a destructor to
+  join them. Fixed in #3470 / PR #3492.
+
 - Windows resets the user `%fs` base to 0 on every kernel transition; guest TLS survives only via the
   VEH `wrfsbase` re-apply (`hle_kernel_mem.cpp`/`guest_tls.cpp`). Native FSGSBASE (`rd/wrfsbase`,
   `WaitOnAddress`, `WakeByAddress*`) works and needs `-lsynchronization` (linked into `prosper_core`).

--- a/prosper/src/gpu/timeline/gpu_timeline.cpp
+++ b/prosper/src/gpu/timeline/gpu_timeline.cpp
@@ -2260,6 +2260,7 @@ void InteractiveFrameBundle::run_writer() {
 void InteractiveFrameBundle::shutdown() {
     // Serializes joiners without holding the state mutex while the writer publishes its result.
     std::lock_guard shutdown_lock(shutdown_mx);
+    GpuCaptureBundle abandoned;                // released after `mx` is dropped; see below
     {
         std::lock_guard lock(mx);
         stopping = true;
@@ -2269,7 +2270,11 @@ void InteractiveFrameBundle::shutdown() {
         // writer while this thread waits inside a static destructor is half of the exit deadlock
         // in #3470. Reporting it inline leaves the writer with nothing to do but return.
         if (capturing || !armed_path.empty()) {
-            bundle = {};                       // free the payload; nobody will write it
+            // Detached under the lock, released outside it. This can be gigabytes, and on the
+            // destructor path the thread running it is inside the CRT's exit lock -- the old code
+            // freed the payload on the WRITER, outside `mx`, and that property is worth keeping.
+            abandoned = std::move(bundle);
+            bundle = {};
             InteractiveGrabOutcome cancelled;
             cancelled.bundle_path = capturing ? current_path : armed_path;
             cancelled.max_unique_bytes = max_unique_bytes;
@@ -2277,13 +2282,20 @@ void InteractiveFrameBundle::shutdown() {
             std::fprintf(stderr, "[grab] frame-bundle write failed: %s\n", cancelled.error.c_str());
             outcome = std::move(cancelled);
             outcome_pending = true;
-            writing = false;
+            // `writing` is deliberately NOT touched. This block is reachable only with it already
+            // false -- a request is refused while writing (see request_interactive_capture_bundle),
+            // and the present handler sets it only while clearing `capturing` and `armed_path`, so
+            // a genuinely mid-write window takes neither branch and is joined below exactly as
+            // before. Clearing it here would be dead on every real path and would release the busy
+            // flag mid-write on any path that ever reached it, letting a new capture race the
+            // outcome slot.
             capturing = false;
             armed_path.clear(); current_path.clear();
         }
         g_interactive_frame_active.store(false, std::memory_order_release);
         wake.notify_one();
     }
+    abandoned = {};                            // outside `mx`, before the join
     if (writer.joinable()) writer.join();
 }
 

--- a/prosper/src/gpu/timeline/gpu_timeline.cpp
+++ b/prosper/src/gpu/timeline/gpu_timeline.cpp
@@ -2240,8 +2240,13 @@ void InteractiveFrameBundle::run_writer() {
         else
             std::fprintf(stderr, "[grab] frame-bundle write failed: %s\n",
                          work.outcome.error.c_str());
-        std::fprintf(stderr, "[grab] frame-bundle owned writer finished in %.3f ms\n",
-                     std::chrono::duration<double, std::milli>(
+        // Microseconds as an INTEGER, deliberately. A "%.3f" here deadlocked the process at
+        // exit on Windows: MinGW's float formatting lazily registers an atexit handler the first
+        // time __gdtoa allocates, which takes the CRT's onexit-table critical section -- and the
+        // thread joining this one holds exactly that lock while walking the same table from a
+        // static destructor. Integer conversion never reaches __gdtoa (#3470).
+        std::fprintf(stderr, "[grab] frame-bundle owned writer finished in %lld us\n",
+                     (long long)std::chrono::duration_cast<std::chrono::microseconds>(
                          std::chrono::steady_clock::now() - start).count());
         {
             std::lock_guard lock(mx);
@@ -2258,14 +2263,21 @@ void InteractiveFrameBundle::shutdown() {
     {
         std::lock_guard lock(mx);
         stopping = true;
+        // A cancelled window is reported HERE rather than handed to the writer as a job. Nothing
+        // is written for it -- the error is preset, so write_gpu_capture_bundle was never reached
+        // -- so the only thing the writer did with it was log and publish, and doing that on the
+        // writer while this thread waits inside a static destructor is half of the exit deadlock
+        // in #3470. Reporting it inline leaves the writer with nothing to do but return.
         if (capturing || !armed_path.empty()) {
-            WriteJob cancelled;
-            cancelled.bundle = std::move(bundle);
-            cancelled.outcome.bundle_path = capturing ? current_path : armed_path;
-            cancelled.outcome.max_unique_bytes = max_unique_bytes;
-            cancelled.outcome.error = "capture window cancelled at shutdown";
-            job = std::move(cancelled);
-            writing = true;
+            bundle = {};                       // free the payload; nobody will write it
+            InteractiveGrabOutcome cancelled;
+            cancelled.bundle_path = capturing ? current_path : armed_path;
+            cancelled.max_unique_bytes = max_unique_bytes;
+            cancelled.error = "capture window cancelled at shutdown";
+            std::fprintf(stderr, "[grab] frame-bundle write failed: %s\n", cancelled.error.c_str());
+            outcome = std::move(cancelled);
+            outcome_pending = true;
+            writing = false;
             capturing = false;
             armed_path.clear(); current_path.clear();
         }

--- a/prosper/tests/gpu/timeline/test_capture_tunables.cpp
+++ b/prosper/tests/gpu/timeline/test_capture_tunables.cpp
@@ -24,6 +24,7 @@
 #include <filesystem>
 #include <string>
 #include <system_error>
+#include <thread>
 #include "fixtures/test_scratch.h"
 #ifdef _WIN32
 #include <io.h>
@@ -171,6 +172,40 @@ int main(int argc, char** argv) {
             begin_gpu_timeline_submit(n);
             record_gpu_timeline_submit(GpuState{}, n);
         }
+        return 0;
+    }
+    // Arms a real capture -- which starts the owned writer thread -- and then merely returns from
+    // main, leaving the whole teardown to static destruction. That is the shape #3470 deadlocked on:
+    // the destructor joins the writer while holding the CRT's onexit-table lock, and the writer
+    // needed that same lock to finish formatting its own completion log.
+    //
+    // The child bounds ITSELF rather than letting the parent wait. A hung exit would otherwise
+    // surface only as a ctest timeout, which produces no assertion output, says nothing about which
+    // case hung, and leaves a stuck process behind. _Exit is deliberate: it must not run the atexit
+    // table it is reporting on.
+    if (argc > 2 && std::strcmp(argv[1], "--child-arm-and-return") == 0) {
+        std::printf("  [child] started (arm and return)\n");
+        std::fflush(stdout);
+        const auto accepted = request_interactive_capture_bundle(argv[2], 64).accepted;
+        std::fprintf(stderr, "[child] armed=%d\n", accepted ? 1 : 0);
+        std::fflush(stderr);
+        std::thread([] {
+            std::this_thread::sleep_for(std::chrono::seconds(20));
+            // A RAW write, not stdio. The thread this is watching is stuck holding CRT locks, and a
+            // std::fprintf here queues behind the very deadlock the watchdog exists to report --
+            // measured: with the defect restored the watchdog never fired at all and the child had
+            // to be killed by the harness. write() takes no CRT lock and allocates nothing, and
+            // _Exit skips the atexit table under discussion.
+            static const char msg[] =
+                "[child] STILL RUNNING 20s after main returned: exit is stuck, which is #3470\n";
+#ifdef _WIN32
+            _write(2, msg, (unsigned)(sizeof msg - 1));
+#else
+            ssize_t ignored = write(2, msg, sizeof msg - 1);
+            (void)ignored;
+#endif
+            std::_Exit(3);
+        }).detach();
         return 0;
     }
     if (argc > 2 && std::strcmp(argv[1], "--child-bundle") == 0) {
@@ -545,6 +580,27 @@ int main(int argc, char** argv) {
               "the refusal reaches stderr of a process that never reached main");
         CHECK(!contains(child.stderr_text, "[child] reached main"),
               "the refusal happens at LOAD: the child never ran a line of its own");
+    }
+
+    {
+        // The exit path itself, as an ASSERTION rather than as a ctest wall clock (#3470). Before
+        // the fix this child never exited at all; its watchdog now reports status 3 in that case,
+        // so a regression costs 20 s and names itself instead of costing the job's whole timeout.
+        const std::filesystem::path armed = scratch / ("prosper-capture-tunables-armed-" +
+                                                       std::to_string(nonce) + ".prgbundle");
+        const ChildRun child =
+            run_child(argv[0], "--child-arm-and-return " + quoted(armed), child_err);
+        if (child.rc != 0)
+            std::printf("  [note] child rc=%d, stderr was: %s\n", child.rc,
+                        child.stderr_text.c_str());
+        CHECK(contains(child.stderr_text, "[child] armed=1"),
+              "the child really armed a capture, so the writer thread existed to be joined");
+        CHECK(child.rc == 0,
+              "a process that arms a capture and merely returns from main still EXITS");
+        CHECK(!contains(child.stderr_text, "STILL RUNNING"),
+              "...and exits without its watchdog having to kill it");
+        std::error_code armed_ec;
+        std::filesystem::remove(armed, armed_ec);
     }
 
     std::error_code ec;


### PR DESCRIPTION
Fixes #3470. `main`'s **Windows MinGW** job has failed on every run since #3460 â€” always the same
single test, always a 600 s ctest timeout rather than an assertion.

## The cause, from a stack rather than a hypothesis

`gdb` attached to the hung `capture_tunables` process:

```
Thread 1 (main)    _execute_onexit_table -> ~InteractiveFrameBundle -> shutdown
                   -> std::thread::join -> WaitForSingleObject
Thread 2 (writer)  __pformat_float -> __gdtoa -> __Balloc_D2A -> dtoa_lock -> atexit
                   -> _register_onexit_function -> RtlEnterCriticalSection   [blocked]
```

The writer is inside `fprintf`, formatting the `%.3f` of its own completion log. MinGW's float
conversion **lazily registers an atexit handler** the first time `__gdtoa` allocates, and that takes
the CRT's onexit-table critical section â€” the lock the exiting main thread already holds while
walking that same table from a static destructor. Main waits for the writer; the writer waits for
main's lock.

Linux never sees it: the mechanism is MinGW's `gdtoa`. It needs the writer thread #3460 introduced,
which is why the bisect landed there.

The issue recorded a plausible and different hypothesis â€” a thread not joined, or waiting on
something that never arrives. It was wrong. The writer is neither unjoined nor unwoken; it is
blocked inside `printf`.

## The fix

Two changes, each removing one half of the meeting:

1. **`shutdown()` no longer hands the writer a job.** A cancelled window writes nothing â€” the error
   is preset, so `write_gpu_capture_bundle` was never reached â€” so the job's only effect was to log
   and publish, and the caller can do both. The writer's remaining act is to see `stopping` and
   return.
2. **The writer's duration log formats an integer of microseconds.** Nothing about the message needs
   a float, and `%.3f` was the only call on that thread that could reach the lazy-atexit path.

**Measured separately, either change alone is sufficient** â€” each arm passes with the other reverted.
That is what the stack predicts: the deadlock needs the writer to be doing work during exit *and*
that work to take the CRT lock. Keeping both is defence in depth, not two necessary fixes, and I would
rather say so than imply a second cause I did not observe.

## The regression is bounded and names itself

A 600 s ctest timeout is a poor signal: no assertion output, no indication of which case hung, ten
minutes of every CI run to observe. The new arm makes the child police its own exit â€” it arms a real
capture, returns from `main`, and a watchdog thread hard-exits with a distinctive status if static
destruction has not completed in 20 s. The parent asserts a status.

Verified in both directions. With the defect restored:

```
  [note] child rc=143, stderr was: [child] armed=1
[grab] frame-bundle owned writer finished in [child] STILL RUNNING 20s after main returned: ...
  [FAIL] a process that arms a capture and merely returns from main still EXITS
  [FAIL] ...and exits without its watchdog having to kill it
```

Note the truncated `owned writer finished in ` â€” the writer caught mid-`fprintf`, exactly where gdb
found it.

The watchdog writes with `write(2, ...)` rather than `fprintf`, and that is not incidental: with
stdio it **never fired at all**, because it queued behind the very deadlock it exists to report and
the child had to be killed by the harness. A watchdog that shares a lock with its subject is not a
watchdog.

**One claim withdrawn, on review.** What the negative-control transcript demonstrates is that the arm
*detects* the regression — two failures, and the watchdog's `STILL RUNNING` line reaches the child's
stderr, so the thread ran. It does **not** demonstrate that `_Exit(3)` completed: the parent hangs at
its own exit in that build, so the harness timeout killed the whole process group and `system()`
returned 143 rather than 3. "A regression is detected and names itself" is proven; "a regression
costs 20 s" is not.

## Verification

`test_capture_tunables` on Windows/MinGW, this branch: **3 of 3 runs exit 0 and PASS**. Before:
hangs every time, killed at the harness timeout.

Every assertion in that test passed even before this change â€” the test's logic was never at fault,
only its ability to exit. (An earlier reading of mine reported five assertion failures; that was my
own error, running the binary from the wrong working directory so its child spawns could not resolve
the executable. Withdrawn.)

## Risk

The cancelled-window outcome is now published by the thread calling `shutdown()` rather than by the
writer. Both did so under `mx`, and the observable result â€” `outcome`, `outcome_pending`, and the
`[grab] frame-bundle write failed: capture window cancelled at shutdown` line â€” is unchanged;
`test_interactive_capture_writer` asserts exactly that sequence and still passes. A window genuinely
mid-*write* when shutdown is called is unaffected: that job is already in flight and is joined as
before.
