### PR TITLE
fix(capture): retry a bundle install past Windows' transient replace window

### DIFF
--- a/prosper/src/gpu/capture/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/capture/gpu_capture_bundle.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <thread>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -139,8 +140,29 @@ struct TemporaryBundleFile {
         file.close();
         if (!flushed || !file) { error = "cannot finish bundle temporary file"; return false; }
 #ifdef _WIN32
-        if (!MoveFileExW(payload.c_str(), target.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-            error = "cannot install bundle: Windows error " + std::to_string(GetLastError());
+        // Replacing a file on Windows leaves the old destination briefly in a delete-pending state,
+        // and a second MoveFileEx onto it during that window is refused with ERROR_ACCESS_DENIED
+        // even though nothing is wrong with either writer. Two captures installing to one path is
+        // not hypothetical -- it is what the concurrent-writer contract in
+        // test_gpu_capture_bundle_streaming asserts, and it failed 5 runs in 20 without this (#3494).
+        //
+        // Bounded, and only for the codes that are transient by construction. A destination another
+        // process holds open for the whole call still fails after the budget, which is what the
+        // "OS sharing restriction refuses replacement" arm in that same test requires: a retry loop
+        // that never gave up would turn that refusal into a hang.
+        DWORD install_error = 0;
+        for (unsigned attempt = 0; attempt < 50; ++attempt) {
+            if (MoveFileExW(payload.c_str(), target.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+                install_error = 0;
+                break;
+            }
+            install_error = GetLastError();
+            if (install_error != ERROR_ACCESS_DENIED && install_error != ERROR_SHARING_VIOLATION)
+                break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        }
+        if (install_error) {
+            error = "cannot install bundle: Windows error " + std::to_string(install_error);
             return false;
         }
 #else

--- a/prosper/src/gpu/capture/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/capture/gpu_capture_bundle.cpp
@@ -150,10 +150,15 @@ struct TemporaryBundleFile {
         // process holds open for the whole call still fails after the budget, which is what the
         // "OS sharing restriction refuses replacement" arm in that same test requires: a retry loop
         // that never gave up would turn that refusal into a hang.
+        // Success is the CALL's return value, never the error code. Deciding from GetLastError()
+        // would report success for a failing call that happened to leave it at zero -- a silent
+        // success the unretried version could not reach, and the destructor would then delete the
+        // temporary that was never installed.
+        bool installed = false;
         DWORD install_error = 0;
-        for (unsigned attempt = 0; attempt < 50; ++attempt) {
+        for (unsigned attempt = 0; attempt < 50 && !installed; ++attempt) {
             if (MoveFileExW(payload.c_str(), target.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-                install_error = 0;
+                installed = true;
                 break;
             }
             install_error = GetLastError();
@@ -161,7 +166,7 @@ struct TemporaryBundleFile {
                 break;
             std::this_thread::sleep_for(std::chrono::milliseconds(2));
         }
-        if (install_error) {
+        if (!installed) {
             error = "cannot install bundle: Windows error " + std::to_string(install_error);
             return false;
         }


### PR DESCRIPTION
Fixes #3494.

## The failure

`gpu_capture_bundle_streaming` fails intermittently on Windows/MinGW:

```
FAIL: both concurrent independent writes complete (line 264)
```

Measured on Windows 11 / MinGW: **5 failures in 20 runs**, and separately 2 in 12 — order 5–25%, so
roughly one CI run in five for any PR that gets far enough to run it.

## The cause

The test starts two threads calling `write_gpu_capture_bundle` on the **same destination** and
asserts both succeed — each reserves its own temporary and the last to install wins. Installation is
a single unretried `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`.

Windows leaves a replaced file briefly in a delete-pending state, and a second replace onto it during
that window is refused. Patching the test to print the failure gives the same answer every time:

```
[why] writer 0 failed: cannot install bundle: Windows error 5
```

`5` is `ERROR_ACCESS_DENIED`. Nothing is wrong with either writer; they collided.

## Not caused by #3492

That PR's CI run is where this surfaced, so it was worth ruling out with one variable on the same
build tree:

| build | runs | pass | fail |
| --- | --- | --- | --- |
| #3492's branch | 12 | 10 | 2 |
| the same branch, its change reverted | 12 | 10 | 2 |

Identical. #3492 touches `gpu_timeline.cpp`'s shutdown path, which this test never calls. The race is
pre-existing and was invisible while `capture_tunables` failed first and the job read as "the known
one".

## The fix

A bounded retry — 50 attempts, 2 ms apart — covering only `ERROR_ACCESS_DENIED` and
`ERROR_SHARING_VIOLATION`, the two codes that are transient by construction. Any other code fails
immediately, as before.

The bound is not arbitrary caution. The same test has an arm that holds the destination open for the
whole call and requires the install to be **refused**; a retry loop that never gave up would turn
that refusal into a hang. That arm passes in all runs below, so the budget is short enough to still
give up.

POSIX `rename` is atomic and has no such window, so this stays inside the `_WIN32` branch.

## Verification

`test_gpu_capture_bundle_streaming` on Windows/MinGW, this branch: **40 runs, 40 passes.** Before:
5 failures in 20, and 2 in 12.

No new test. The existing one already asserts exactly the contract that was breaking — it was
failing one run in five — so the honest change here is to make it pass rather than to add a second
test beside it. What a new test could add is determinism, and I could not find a way to force the
delete-pending window open on demand without reaching past the API into filesystem internals.

## Risk

A genuinely blocked destination now takes up to 100 ms longer to report failure, on a path that
writes multi-megabyte capture bundles. Success is unaffected: the first attempt succeeds and the loop
exits.