### PR TITLE
libkernel: register the memory-pool and configured-flexible-memory calls — fixes NINJA GAIDEN 4's null deref (#3502)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -47,6 +47,23 @@ only difference.
 Alex Kidd's *world* is still wrong on this machine, and it is a different defect — the wave width
 makes no measurable difference to it either way.
 [#3479](https://github.com/mattias800/prosper/issues/3479).
+### Five new games, and three of them died the same way
+
+Five titles were added to the library and booted for the first time. *Syberia - The World Before*
+got furthest by a distance — its title screen and main menu render, and the audio is clean from the
+first second, over a splash that is still black. Three of the other four never presented a frame,
+and all three died of one thing: a kernel call prosper had never registered, answering "success"
+while writing nothing, so the guest read its own uninitialised stack as an address.
+
+### The argument that proved it was in the guest's own registers
+
+*NINJA GAIDEN 4* asks the kernel to reserve address space, and prosper's unregistered stub told it
+that worked without ever handing back an address. Rather than assume the call's shape from a
+published signature, we registered it as a probe that logs and does nothing — and the next call in
+the log asks to commit memory at address zero. That zero is the reservation that never came back,
+and a few instructions later it is the null the title crashes on. The crash is gone; the title now
+runs for two minutes without faulting and still draws nothing, which is a different and later
+problem. [#3502](https://github.com/mattias800/prosper/issues/3502)
 
 ## 2026-09-06
 

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -1684,7 +1684,136 @@ HLE(k_map_flexible_noname) { return k_map_flexible(a0, a1, a2, a3, 0, 0); }
 // (Unity/allocator sizing) -> either a wild over-commit or a refusal to allocate. We don't pool-account
 // flexible memory, so report the configured 512 MiB pool (shadPS4 parity); a later map that exceeds host
 // memory still fails cleanly with ENOMEM.
-HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0 = 512ull * 1024 * 1024; return 0; }
+// The one flexible-memory pool size. Both the Available and the Configured entry points answer
+// from it (#3502): two literals here would let the pair drift, and a guest that sizes an
+// allocator from Configured and then checks it against Available would see the drift, not us.
+constexpr uint64_t kFlexibleMemoryPoolBytes = 512ull * 1024 * 1024;   // shadPS4 parity
+HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0 = kFlexibleMemoryPoolBytes; return 0; }
+
+// ---- PS4/PS5 memory-pool API (#3502) -----------------------------------------------------------
+// An alternative to AllocateDirectMemory + MapDirectMemory: Expand takes physical memory into the
+// process's pool, Reserve claims virtual address space, Commit backs a reserved range. All three
+// were UNREGISTERED, so the dispatcher answered SCE_OK and wrote no out-parameter -- NINJA GAIDEN 4
+// (#3500) called Reserve during C-runtime init, never received an address, passed the untouched
+// value to Commit, and died dereferencing it. Same class as sceKernelAvailableFlexibleMemorySize
+// above, whose comment records the identical defect being fixed once already.
+//
+// The argument layout is LIVE-CAPTURED from the guest (PPSA25258, 2026-09-09), not assumed --
+// writing an out-parameter through a wrongly-positioned argument would be worse than the stub:
+//   Expand  a0=searchStart a1=searchEnd a2=len       a3=alignment a4=physAddrOut
+//   Reserve a0=addrIn      a1=len       a2=alignment a3=flags     a4=addrOut
+//   Commit  a0=addr        a1=len       a2=type      a3=prot      a4=flags
+// Observed: Expand(0, 0x400000000, 0xa6c00000, 0x10000, out) -> Reserve(0x1000000000, 0x400000,
+// 0x400000, 0, out) -> Commit(0, 0x400000, 0xc, 0x32, 0). Commit's addr=0 IS Reserve's unwritten
+// out-parameter, which is the null that faulted -- the chain is confirmed by the guest's own
+// arguments, not merely by call ordering.
+//
+// a5 is caller-indeterminate scratch on the 5-argument entry points and must never be read -- the
+// same trap sceKernelMapFlexibleMemory's a4 carries (see k_map_flexible_noname above). The probe
+// recorded a5 holding a stack address two bytes below a4, i.e. pure garbage.
+//
+// CONFIDENCE: HIGH on the argument layout (live-captured on the failing title).
+// CONFIDENCE: MED on pool accounting: prosper does not model a pool distinct from the direct-memory
+// arena, so Expand draws from that arena and Commit backs the reserved VA with ordinary anonymous
+// memory. The guest observes the contract it depends on -- a reservation address it can commit and
+// then use -- but a title that reads back pool-specific accounting would not be served by this.
+
+// sceKernelMemoryPoolExpand(off_t searchStart, off_t searchEnd, size_t len, size_t align,
+//                           off_t* physAddrOut)
+HLE(k_pool_expand) {
+    if (!a4) return 0x80020016ull;                                  // SCE_KERNEL_ERROR_EINVAL
+    if (!a2 || (a3 && (a3 & (a3 - 1)))) return 0x80020016ull;        // len 0, or non-power-of-two align
+    const uint64_t align = a3 ? a3 : 0x4000;
+    uint64_t off = 0;
+    if (!dmem_take(a2, align, 0, off, a0, a1 ? a1 : ~0ull)) {
+        MLOG("pool_expand len=0x%llx align=0x%llx in [0x%llx,0x%llx) -> ENOMEM\n",
+             (unsigned long long)a2, (unsigned long long)align,
+             (unsigned long long)a0, (unsigned long long)a1);
+        return 0x8002000cull;                                        // SCE_KERNEL_ERROR_ENOMEM
+    }
+    dmem_zero(off, a2);                       // fresh allocation -> zeroed pages (console semantics)
+    *(uint64_t*)(uintptr_t)a4 = off;
+    MLOG("pool_expand range=[0x%llx,0x%llx) len=0x%llx align=0x%llx -> phys=0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)align, (unsigned long long)off);
+    return 0;
+}
+
+// sceKernelMemoryPoolReserve(void* addrIn, size_t len, size_t align, int flags, void** addrOut)
+// Delegates to k_reserve_vrange rather than repeating it: that function carries the #312/#946
+// huge-reservation steering and the #115 idempotent re-reserve, both of which cost live
+// investigations to get right, and NINJA GAIDEN 4 reserves at 0x1000000000 -- the exact hint those
+// workarounds exist for. Only the calling convention differs (hint by value + separate out-pointer,
+// versus one in/out pointer), so adapt and forward.
+HLE(k_pool_reserve) {
+    if (!a4 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
+    uint64_t addr = a0;
+    const uint64_t rc = k_reserve_vrange((uint64_t)(uintptr_t)&addr, a1, a3, a2, 0, 0);
+    if (rc != 0) {
+        MLOG("pool_reserve hint=0x%llx len=0x%llx align=0x%llx flags=0x%llx -> 0x%llx\n",
+             (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+             (unsigned long long)a3, (unsigned long long)rc);
+        return rc;
+    }
+    *(uint64_t*)(uintptr_t)a4 = addr;
+    MLOG("pool_reserve hint=0x%llx len=0x%llx align=0x%llx -> 0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)addr);
+    return 0;
+}
+
+// sceKernelMemoryPoolCommit(void* addr, size_t len, int type, int prot, int flags)
+// Backs an address the guest has already reserved, so the mapping is FIXED regardless of the
+// caller's `flags` word -- that word carries pool flags, not the map flags k_map_flexible reads.
+// `type` (a2) is the direct-memory type; prosper does not model per-type pools, so it is logged and
+// otherwise unused. Passing a null name keeps track() from strncpy'ing a wild pointer.
+HLE(k_pool_commit) {
+    if (!a0 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
+    uint64_t addr = a0;
+    const uint64_t rc = k_map_flexible((uint64_t)(uintptr_t)&addr, a1, a3, 0x10 /*SCE_KERNEL_MAP_FIXED*/,
+                                       0, 0);
+    MLOG("pool_commit addr=0x%llx len=0x%llx type=0x%llx prot=0x%llx -> 0x%llx (mapped 0x%llx)\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)a3, (unsigned long long)rc, (unsigned long long)addr);
+    return rc;
+}
+
+// sceKernelConfiguredFlexibleMemorySize(size_t* sizeOut): the flexible budget this process was
+// CONFIGURED with, as distinct from what remains Available above. FF Tactics (#3498) reads it during
+// startup and raises sceKernelDebugRaiseExceptionOnReleaseMode two calls later when it comes back
+// unwritten. Both entry points answer from one constant so the pair can never drift -- the charter's
+// rule that a value reachable through two APIs is derived in one place.
+HLE(k_configured_flexible) {
+    if (!a0) return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
+    *(uint64_t*)(uintptr_t)a0 = kFlexibleMemoryPoolBytes;
+    return 0;
+}
+
+// sceKernelGetPageTableStats(int* out0, int* out1, int* out2, int* out3)
+// FOUR 32-bit out-parameters. Established from the guest (PPSA21783, 2026-09-09): the four
+// arguments were consecutive stack addresses four bytes apart and descending -- ...c94, ...c90,
+// ...c8c, ...c88 -- which is four adjacent `int`s passed in order, and a5 held an unrelated value.
+//
+// The FIELD SEMANTICS are NOT established. No published contract was consulted for the order or
+// meaning, and the guest's use of the values has not been disassembled. prosper does not account
+// page-table memory at all, so all four are answered 0: "nothing measured". That is a DEFINED
+// answer where the unregistered path left the guest reading its own uninitialised stack, which is
+// the whole defect class this change addresses -- but it is not a correct one, and it should not be
+// mistaken for one.
+//
+// CONFIDENCE: HIGH on the argument count and width (live-captured).
+// CONFIDENCE: LOW on the values. If a title divides by one of these, or treats a zero as "no
+// capacity", zero is wrong and the fix is to derive real figures from prosper's own mapping tables
+// -- not to substitute a plausible-looking constant, which would be fabrication.
+HLE(k_pagetable_stats) {
+    if (!a0 || !a1 || !a2 || !a3) return 0x80020016ull;              // SCE_KERNEL_ERROR_EINVAL
+    *(uint32_t*)(uintptr_t)a0 = 0;
+    *(uint32_t*)(uintptr_t)a1 = 0;
+    *(uint32_t*)(uintptr_t)a2 = 0;
+    *(uint32_t*)(uintptr_t)a3 = 0;
+    MLOG("pagetable_stats -> 0,0,0,0 (prosper does not account page-table memory)\n");
+    return 0;
+}
 
 // sceKernelAllocateDirectMemory(off_t start, off_t end, size_t len, size_t align, int memType, off_t* physOut)
 HLE(k_alloc_dmem) {   // (searchStart, searchEnd, len, alignment, memoryType, physAddrOut)
@@ -3467,6 +3596,14 @@ void register_kernel_mem_hle() {
     Hle::register_fn("4h6F1LLbTiw", (HleFn)k_map_flexible_noname,
                      "sceKernelMapFlexibleMemoryInternal");
     R("sceKernelAvailableFlexibleMemorySize", k_avail_flexible);   // was MISSING -> uninitialized budget
+    // #3502: registered by RAW NID exactly as the guest imports them. The name->NID hash is not
+    // re-derived here because these were resolved from the 3.20 reference against the live import
+    // list, and a hash mismatch would silently restore the return-0 stub this change exists to fix.
+    Hle::register_fn("qCSfqDILlns", (HleFn)k_pool_expand,        "sceKernelMemoryPoolExpand");
+    Hle::register_fn("pU-QydtGcGY", (HleFn)k_pool_reserve,       "sceKernelMemoryPoolReserve");
+    Hle::register_fn("Vzl66WmfLvk", (HleFn)k_pool_commit,        "sceKernelMemoryPoolCommit");
+    Hle::register_fn("n1-v6FgU7MQ", (HleFn)k_configured_flexible, "sceKernelConfiguredFlexibleMemorySize");
+    Hle::register_fn("tZ2yplY8MBY", (HleFn)k_pagetable_stats,    "sceKernelGetPageTableStats");
     R("sceKernelAllocateDirectMemory", k_alloc_dmem);
     R("sceKernelAllocateMainDirectMemory", k_alloc_main_dmem);  // 4-arg signature (physOut at arg3)
     R("sceKernelMapDirectMemory", k_map_dmem);
@@ -6423,7 +6560,136 @@ HLE(k_map_flexible) {
 HLE(k_map_flexible_noname) { return k_map_flexible(a0, a1, a2, a3, 0, 0); }
 
 // sceKernelAvailableFlexibleMemorySize(size_t* sizeOut) — 512 MiB budget (shadPS4 parity).
-HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0 = 512ull * 1024 * 1024; return 0; }
+// The one flexible-memory pool size. Both the Available and the Configured entry points answer
+// from it (#3502): two literals here would let the pair drift, and a guest that sizes an
+// allocator from Configured and then checks it against Available would see the drift, not us.
+constexpr uint64_t kFlexibleMemoryPoolBytes = 512ull * 1024 * 1024;   // shadPS4 parity
+HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0 = kFlexibleMemoryPoolBytes; return 0; }
+
+// ---- PS4/PS5 memory-pool API (#3502) -----------------------------------------------------------
+// An alternative to AllocateDirectMemory + MapDirectMemory: Expand takes physical memory into the
+// process's pool, Reserve claims virtual address space, Commit backs a reserved range. All three
+// were UNREGISTERED, so the dispatcher answered SCE_OK and wrote no out-parameter -- NINJA GAIDEN 4
+// (#3500) called Reserve during C-runtime init, never received an address, passed the untouched
+// value to Commit, and died dereferencing it. Same class as sceKernelAvailableFlexibleMemorySize
+// above, whose comment records the identical defect being fixed once already.
+//
+// The argument layout is LIVE-CAPTURED from the guest (PPSA25258, 2026-09-09), not assumed --
+// writing an out-parameter through a wrongly-positioned argument would be worse than the stub:
+//   Expand  a0=searchStart a1=searchEnd a2=len       a3=alignment a4=physAddrOut
+//   Reserve a0=addrIn      a1=len       a2=alignment a3=flags     a4=addrOut
+//   Commit  a0=addr        a1=len       a2=type      a3=prot      a4=flags
+// Observed: Expand(0, 0x400000000, 0xa6c00000, 0x10000, out) -> Reserve(0x1000000000, 0x400000,
+// 0x400000, 0, out) -> Commit(0, 0x400000, 0xc, 0x32, 0). Commit's addr=0 IS Reserve's unwritten
+// out-parameter, which is the null that faulted -- the chain is confirmed by the guest's own
+// arguments, not merely by call ordering.
+//
+// a5 is caller-indeterminate scratch on the 5-argument entry points and must never be read -- the
+// same trap sceKernelMapFlexibleMemory's a4 carries (see k_map_flexible_noname above). The probe
+// recorded a5 holding a stack address two bytes below a4, i.e. pure garbage.
+//
+// CONFIDENCE: HIGH on the argument layout (live-captured on the failing title).
+// CONFIDENCE: MED on pool accounting: prosper does not model a pool distinct from the direct-memory
+// arena, so Expand draws from that arena and Commit backs the reserved VA with ordinary anonymous
+// memory. The guest observes the contract it depends on -- a reservation address it can commit and
+// then use -- but a title that reads back pool-specific accounting would not be served by this.
+
+// sceKernelMemoryPoolExpand(off_t searchStart, off_t searchEnd, size_t len, size_t align,
+//                           off_t* physAddrOut)
+HLE(k_pool_expand) {
+    if (!a4) return 0x80020016ull;                                  // SCE_KERNEL_ERROR_EINVAL
+    if (!a2 || (a3 && (a3 & (a3 - 1)))) return 0x80020016ull;        // len 0, or non-power-of-two align
+    const uint64_t align = a3 ? a3 : 0x4000;
+    uint64_t off = 0;
+    if (!dmem_take(a2, align, 0, off, a0, a1 ? a1 : ~0ull)) {
+        MLOG("pool_expand len=0x%llx align=0x%llx in [0x%llx,0x%llx) -> ENOMEM\n",
+             (unsigned long long)a2, (unsigned long long)align,
+             (unsigned long long)a0, (unsigned long long)a1);
+        return 0x8002000cull;                                        // SCE_KERNEL_ERROR_ENOMEM
+    }
+    dmem_zero(off, a2);                       // fresh allocation -> zeroed pages (console semantics)
+    *(uint64_t*)(uintptr_t)a4 = off;
+    MLOG("pool_expand range=[0x%llx,0x%llx) len=0x%llx align=0x%llx -> phys=0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)align, (unsigned long long)off);
+    return 0;
+}
+
+// sceKernelMemoryPoolReserve(void* addrIn, size_t len, size_t align, int flags, void** addrOut)
+// Delegates to k_reserve_vrange rather than repeating it: that function carries the #312/#946
+// huge-reservation steering and the #115 idempotent re-reserve, both of which cost live
+// investigations to get right, and NINJA GAIDEN 4 reserves at 0x1000000000 -- the exact hint those
+// workarounds exist for. Only the calling convention differs (hint by value + separate out-pointer,
+// versus one in/out pointer), so adapt and forward.
+HLE(k_pool_reserve) {
+    if (!a4 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
+    uint64_t addr = a0;
+    const uint64_t rc = k_reserve_vrange((uint64_t)(uintptr_t)&addr, a1, a3, a2, 0, 0);
+    if (rc != 0) {
+        MLOG("pool_reserve hint=0x%llx len=0x%llx align=0x%llx flags=0x%llx -> 0x%llx\n",
+             (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+             (unsigned long long)a3, (unsigned long long)rc);
+        return rc;
+    }
+    *(uint64_t*)(uintptr_t)a4 = addr;
+    MLOG("pool_reserve hint=0x%llx len=0x%llx align=0x%llx -> 0x%llx\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)addr);
+    return 0;
+}
+
+// sceKernelMemoryPoolCommit(void* addr, size_t len, int type, int prot, int flags)
+// Backs an address the guest has already reserved, so the mapping is FIXED regardless of the
+// caller's `flags` word -- that word carries pool flags, not the map flags k_map_flexible reads.
+// `type` (a2) is the direct-memory type; prosper does not model per-type pools, so it is logged and
+// otherwise unused. Passing a null name keeps track() from strncpy'ing a wild pointer.
+HLE(k_pool_commit) {
+    if (!a0 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
+    uint64_t addr = a0;
+    const uint64_t rc = k_map_flexible((uint64_t)(uintptr_t)&addr, a1, a3, 0x10 /*SCE_KERNEL_MAP_FIXED*/,
+                                       0, 0);
+    MLOG("pool_commit addr=0x%llx len=0x%llx type=0x%llx prot=0x%llx -> 0x%llx (mapped 0x%llx)\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)a3, (unsigned long long)rc, (unsigned long long)addr);
+    return rc;
+}
+
+// sceKernelConfiguredFlexibleMemorySize(size_t* sizeOut): the flexible budget this process was
+// CONFIGURED with, as distinct from what remains Available above. FF Tactics (#3498) reads it during
+// startup and raises sceKernelDebugRaiseExceptionOnReleaseMode two calls later when it comes back
+// unwritten. Both entry points answer from one constant so the pair can never drift -- the charter's
+// rule that a value reachable through two APIs is derived in one place.
+HLE(k_configured_flexible) {
+    if (!a0) return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
+    *(uint64_t*)(uintptr_t)a0 = kFlexibleMemoryPoolBytes;
+    return 0;
+}
+
+// sceKernelGetPageTableStats(int* out0, int* out1, int* out2, int* out3)
+// FOUR 32-bit out-parameters. Established from the guest (PPSA21783, 2026-09-09): the four
+// arguments were consecutive stack addresses four bytes apart and descending -- ...c94, ...c90,
+// ...c8c, ...c88 -- which is four adjacent `int`s passed in order, and a5 held an unrelated value.
+//
+// The FIELD SEMANTICS are NOT established. No published contract was consulted for the order or
+// meaning, and the guest's use of the values has not been disassembled. prosper does not account
+// page-table memory at all, so all four are answered 0: "nothing measured". That is a DEFINED
+// answer where the unregistered path left the guest reading its own uninitialised stack, which is
+// the whole defect class this change addresses -- but it is not a correct one, and it should not be
+// mistaken for one.
+//
+// CONFIDENCE: HIGH on the argument count and width (live-captured).
+// CONFIDENCE: LOW on the values. If a title divides by one of these, or treats a zero as "no
+// capacity", zero is wrong and the fix is to derive real figures from prosper's own mapping tables
+// -- not to substitute a plausible-looking constant, which would be fabrication.
+HLE(k_pagetable_stats) {
+    if (!a0 || !a1 || !a2 || !a3) return 0x80020016ull;              // SCE_KERNEL_ERROR_EINVAL
+    *(uint32_t*)(uintptr_t)a0 = 0;
+    *(uint32_t*)(uintptr_t)a1 = 0;
+    *(uint32_t*)(uintptr_t)a2 = 0;
+    *(uint32_t*)(uintptr_t)a3 = 0;
+    MLOG("pagetable_stats -> 0,0,0,0 (prosper does not account page-table memory)\n");
+    return 0;
+}
 
 // sceKernelAllocateDirectMemory(start, end, len, align, memType, off_t* physOut)
 HLE(k_alloc_dmem) {
@@ -7275,6 +7541,14 @@ void register_kernel_mem_hle() {
     R("sceKernelMapFlexibleMemory", k_map_flexible_noname);
     Hle::register_fn("4h6F1LLbTiw", (HleFn)k_map_flexible_noname, "sceKernelMapFlexibleMemoryInternal");
     R("sceKernelAvailableFlexibleMemorySize", k_avail_flexible);
+    // #3502: registered by RAW NID exactly as the guest imports them. The name->NID hash is not
+    // re-derived here because these were resolved from the 3.20 reference against the live import
+    // list, and a hash mismatch would silently restore the return-0 stub this change exists to fix.
+    Hle::register_fn("qCSfqDILlns", (HleFn)k_pool_expand,        "sceKernelMemoryPoolExpand");
+    Hle::register_fn("pU-QydtGcGY", (HleFn)k_pool_reserve,       "sceKernelMemoryPoolReserve");
+    Hle::register_fn("Vzl66WmfLvk", (HleFn)k_pool_commit,        "sceKernelMemoryPoolCommit");
+    Hle::register_fn("n1-v6FgU7MQ", (HleFn)k_configured_flexible, "sceKernelConfiguredFlexibleMemorySize");
+    Hle::register_fn("tZ2yplY8MBY", (HleFn)k_pagetable_stats,    "sceKernelGetPageTableStats");
     R("sceKernelAllocateDirectMemory", k_alloc_dmem);
     R("sceKernelAllocateMainDirectMemory", k_alloc_main_dmem);
     R("sceKernelMapDirectMemory", k_map_dmem);

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -1721,8 +1721,17 @@ HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0
 // sceKernelMemoryPoolExpand(off_t searchStart, off_t searchEnd, size_t len, size_t align,
 //                           off_t* physAddrOut)
 HLE(k_pool_expand) {
-    if (!a4) return 0x80020016ull;                                  // SCE_KERNEL_ERROR_EINVAL
-    if (!a2 || (a3 && (a3 & (a3 - 1)))) return 0x80020016ull;        // len 0, or non-power-of-two align
+    // Every rejection below happens BEFORE dmem_take. Validating after it would consume arena on a
+    // call that then faults writing the result -- the allocation is unrecoverable because nothing
+    // has the offset yet. Raised in review of #3505.
+    if (a3 && (a3 & (a3 - 1))) return 0x80020016ull;   // non-power-of-two alignment breaks the
+                                                       // & ~(align-1) rounding below
+    // Length, 16 KiB granularity, and physAddrOut plausibility all come from the sibling
+    // allocator's own validator rather than being re-checked here. Its comment records why the
+    // pointer test belongs before the take: the old code allocated first and skipped the guarded
+    // write, giving false success plus leaked physical capacity. Answering the pool API more
+    // permissively than the arena underneath it is how the two drift apart.
+    if (!valid_dmem_allocation(a2, a3, 0, a4)) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
     const uint64_t align = a3 ? a3 : 0x4000;
     uint64_t off = 0;
     if (!dmem_take(a2, align, 0, off, a0, a1 ? a1 : ~0ull)) {
@@ -6597,8 +6606,17 @@ HLE(k_avail_flexible) { if (!a0) return 0x80020016ull; *(uint64_t*)(uintptr_t)a0
 // sceKernelMemoryPoolExpand(off_t searchStart, off_t searchEnd, size_t len, size_t align,
 //                           off_t* physAddrOut)
 HLE(k_pool_expand) {
-    if (!a4) return 0x80020016ull;                                  // SCE_KERNEL_ERROR_EINVAL
-    if (!a2 || (a3 && (a3 & (a3 - 1)))) return 0x80020016ull;        // len 0, or non-power-of-two align
+    // Every rejection below happens BEFORE dmem_take. Validating after it would consume arena on a
+    // call that then faults writing the result -- the allocation is unrecoverable because nothing
+    // has the offset yet. Raised in review of #3505.
+    if (a3 && (a3 & (a3 - 1))) return 0x80020016ull;   // non-power-of-two alignment breaks the
+                                                       // & ~(align-1) rounding below
+    // Length, 16 KiB granularity, and physAddrOut plausibility all come from the sibling
+    // allocator's own validator rather than being re-checked here. Its comment records why the
+    // pointer test belongs before the take: the old code allocated first and skipped the guarded
+    // write, giving false success plus leaked physical capacity. Answering the pool API more
+    // permissively than the arena underneath it is how the two drift apart.
+    if (!valid_dmem_allocation(a2, a3, 0, a4)) return 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
     const uint64_t align = a3 ? a3 : 0x4000;
     uint64_t off = 0;
     if (!dmem_take(a2, align, 0, off, a0, a1 ? a1 : ~0ull)) {

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -388,11 +388,24 @@ void test_kernel_memory_pool() {
             snprintf(msg, sizeof(msg), "GetPageTableStats leaves the upper 4 bytes of out%d alone", i);
             CHECK((uint32_t)(slot[i] >> 32) == 0x5A5A5A5Au, msg);
         }
-        // Kills: dropping the null guards on the second, third or fourth pointer -- a plausible
-        // edit, since only the first is obviously an out-parameter at a glance.
-        uint64_t one = 0;
-        CHECK(pts((uint64_t)(uintptr_t)&one, 0, 0, 0, 0, 0) != 0,
-              "GetPageTableStats rejects a null in ANY of its four slots");
+        // Kills: dropping the null guard on ANY ONE of the four pointers -- a plausible edit,
+        // since only the first is obviously an out-parameter at a glance.
+        //
+        // Each iteration nulls exactly ONE slot and leaves the other three valid, which is the
+        // whole point. The first version of this arm passed a single configuration -- one valid
+        // pointer and three nulls -- and asserted it covered "any" slot. It did not: deleting the
+        // `!a2` or `!a3` disjunct still left `!a1` to catch that call, so the arm stayed green
+        // against the very mutation it named. An arm that sits NEXT to the gap it claims reads
+        // exactly like one that covers it. Raised in review of #3505.
+        for (int null_slot = 0; null_slot < 4; ++null_slot) {
+            uint64_t sink[4] = {0, 0, 0, 0};
+            uint64_t arg[4];
+            for (int j = 0; j < 4; ++j) arg[j] = (uint64_t)(uintptr_t)&sink[j];
+            arg[null_slot] = 0;
+            char msg[160];
+            snprintf(msg, sizeof(msg), "GetPageTableStats rejects a null in slot %d ALONE", null_slot);
+            CHECK(pts(arg[0], arg[1], arg[2], arg[3], 0, 0) != 0, msg);
+        }
     }
 
     // ---- sceKernelMemoryPoolReserve: the call whose unwritten output crashed PPSA25258 ----

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -34,6 +34,15 @@ constexpr const char* kNpTrophy2GetTrophyInfoArray = "y3zHpdZO6ME"; // already r
 constexpr const char* kSaveDataTransferringMount    = "WAzWTZm1H+I";
 constexpr const char* kSaveDataTransferringMountPs4 = "RjMlsR8EXrw";
 constexpr const char* kSaveDataDirNameSearchPs4     = "X4MYzukPc3g";
+// #3502 -- the memory-pool family and the flexible-memory size pair. All five resolved against the
+// PS5 3.20 export tables and cross-checked against the live import list of the titles that call
+// them (PPSA25258, PPSA21783).
+constexpr const char* kMemoryPoolExpand            = "qCSfqDILlns";
+constexpr const char* kMemoryPoolReserve           = "pU-QydtGcGY";
+constexpr const char* kMemoryPoolCommit            = "Vzl66WmfLvk";
+constexpr const char* kConfiguredFlexibleMemorySize = "n1-v6FgU7MQ";
+constexpr const char* kAvailableFlexibleMemorySize  = "aNz11fnnzi4";
+constexpr const char* kGetPageTableStats            = "tZ2yplY8MBY";
 
 bool all_bytes_equal(const unsigned char* p, size_t n, unsigned char v) {
     for (size_t i = 0; i < n; ++i) if (p[i] != v) return false;
@@ -322,6 +331,95 @@ void test_http_ids() {
 
 } // namespace
 
+void test_kernel_memory_pool() {
+    printf("-- libkernel memory pool + flexible-memory sizes (#3502) --\n");
+    // Unregistered, these answered the dispatcher's 0 = SCE_OK and wrote no out-parameter, so the
+    // guest read its own uninitialised stack as an address or a size. NINJA GAIDEN 4 (PPSA25258)
+    // took Reserve's unwritten result straight into Commit and dereferenced null at +0x118.
+    //
+    // Boots cannot police this. The one title observed calling GetPageTableStats (PPSA21783) still
+    // aborts for an unrelated reason with or without a correct answer, so every assertion about it
+    // has to live here or nowhere.
+
+    // ---- the flexible-memory size pair ----
+    HleFn cfg   = Hle::lookup(kConfiguredFlexibleMemorySize);
+    HleFn avail = Hle::lookup(kAvailableFlexibleMemorySize);
+    CHECK(cfg != nullptr,   "sceKernelConfiguredFlexibleMemorySize is registered");
+    CHECK(avail != nullptr, "sceKernelAvailableFlexibleMemorySize is registered");
+    if (cfg && avail) {
+        uint64_t configured = 0x5A5A5A5A5A5A5A5Aull;
+        uint64_t available  = 0x5A5A5A5A5A5A5A5Aull;
+        CHECK(cfg((uint64_t)(uintptr_t)&configured, 0, 0, 0, 0, 0) == 0,
+              "Configured returns SCE_OK");
+        // Kills: registering it to a `return 0` no-op. That passes a ret==0 assertion while
+        // leaving the poison in place -- the exact stub this change removes.
+        CHECK(configured != 0x5A5A5A5A5A5A5A5Aull, "Configured writes its out-parameter");
+        CHECK(configured != 0, "Configured does not report a zero budget");
+        CHECK(avail((uint64_t)(uintptr_t)&available, 0, 0, 0, 0, 0) == 0,
+              "Available returns SCE_OK");
+        // Kills: re-introducing a second literal instead of the shared kFlexibleMemoryPoolBytes,
+        // which is how the pair silently drifts apart.
+        CHECK(configured == available,
+              "Configured and Available answer from ONE constant");
+        // Kills: dropping the null guard. Without it this call dereferences 0 instead of
+        // returning EINVAL, so the arm below is a crash test as much as a value test.
+        CHECK(cfg(0, 0, 0, 0, 0, 0) != 0, "Configured rejects a null out-parameter");
+    }
+
+    // ---- sceKernelGetPageTableStats: FOUR 32-bit out-parameters ----
+    HleFn pts = Hle::lookup(kGetPageTableStats);
+    CHECK(pts != nullptr, "sceKernelGetPageTableStats is registered");
+    if (pts) {
+        // Eight bytes of poison per slot; the contract writes only the low four. The width claim
+        // rests on live probe evidence (four consecutive stack addresses four bytes apart), and
+        // this is the only thing that holds it.
+        uint64_t slot[4];
+        memset(slot, 0x5A, sizeof(slot));
+        CHECK(pts((uint64_t)(uintptr_t)&slot[0], (uint64_t)(uintptr_t)&slot[1],
+                  (uint64_t)(uintptr_t)&slot[2], (uint64_t)(uintptr_t)&slot[3], 0, 0) == 0,
+              "GetPageTableStats returns SCE_OK");
+        for (int i = 0; i < 4; ++i) {
+            char msg[160];
+            snprintf(msg, sizeof(msg), "GetPageTableStats writes out%d", i);
+            CHECK((uint32_t)(slot[i] & 0xffffffffull) == 0u, msg);
+            // Kills: widening the store to uint64_t. That corrupts four bytes of guest stack
+            // beyond the contract at every slot -- sixteen bytes in total -- and NO boot can see
+            // it, because the only title observed calling this aborts either way.
+            snprintf(msg, sizeof(msg), "GetPageTableStats leaves the upper 4 bytes of out%d alone", i);
+            CHECK((uint32_t)(slot[i] >> 32) == 0x5A5A5A5Au, msg);
+        }
+        // Kills: dropping the null guards on the second, third or fourth pointer -- a plausible
+        // edit, since only the first is obviously an out-parameter at a glance.
+        uint64_t one = 0;
+        CHECK(pts((uint64_t)(uintptr_t)&one, 0, 0, 0, 0, 0) != 0,
+              "GetPageTableStats rejects a null in ANY of its four slots");
+    }
+
+    // ---- sceKernelMemoryPoolReserve: the call whose unwritten output crashed PPSA25258 ----
+    HleFn reserve = Hle::lookup(kMemoryPoolReserve);
+    CHECK(reserve != nullptr, "sceKernelMemoryPoolReserve is registered");
+    CHECK(Hle::lookup(kMemoryPoolExpand) != nullptr, "sceKernelMemoryPoolExpand is registered");
+    CHECK(Hle::lookup(kMemoryPoolCommit) != nullptr, "sceKernelMemoryPoolCommit is registered");
+    if (reserve) {
+        constexpr uint64_t kLen = 0x10000;   // small: this arm really does reserve address space
+        uint64_t out = 0x5A5A5A5A5A5A5A5Aull;
+        const uint64_t rc = reserve(0 /*no hint*/, kLen, kLen /*align*/, 0 /*flags*/,
+                                    (uint64_t)(uintptr_t)&out, 0);
+        CHECK(rc == 0, "Reserve succeeds for an unhinted 64 KiB range");
+        // Kills: the return-0-writes-nothing stub. This is NINJA GAIDEN 4's actual bug -- the
+        // guest passed this untouched value to Commit as an address.
+        CHECK(out != 0x5A5A5A5A5A5A5A5Aull, "Reserve writes its addrOut");
+        CHECK(out != 0, "Reserve does not hand back a null address");
+        CHECK((out & (kLen - 1)) == 0, "Reserve honours the requested alignment");
+        // Kills: dropping the addrOut null guard, which would fault rather than return EINVAL.
+        CHECK(reserve(0, kLen, kLen, 0, 0, 0) != 0, "Reserve rejects a null addrOut");
+    }
+    // Expand and Commit are deliberately exercised only for registration here: Expand consumes the
+    // direct-memory arena and Commit maps pages, and a unit test that quietly did either would be
+    // making the suite's later arms depend on how much arena it had left. Their behaviour is
+    // covered by the live-boot evidence on #3500.
+}
+
 int main() {
     printf("== test_false_success_nids ==\n");
     register_builtin_hle();
@@ -329,6 +427,7 @@ int main() {
     test_nptrophy2_info_queries();
     test_savedata_transferring_mount();
     test_http_ids();
+    test_kernel_memory_pool();
     if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #3502. Refs #3500, #3498.

## The defect

`sceKernelMemoryPool{Expand,Reserve,Commit}`, `sceKernelConfiguredFlexibleMemorySize` and
`sceKernelGetPageTableStats` were unregistered. The dispatcher's `return 0` answers `SCE_OK` **and
writes no out-parameter**, so the guest reads its own uninitialised stack as an address or a size.

`hle_kernel_mem.cpp:1682` already documents this exact defect being fixed once, for the sibling
`sceKernelAvailableFlexibleMemorySize`. These are the same family, unfixed.

## Failure scenario

NINJA GAIDEN 4 (`PPSA25258`) calls `Reserve` during C-runtime init, never receives an address, passes
the untouched value to `Commit`, and dereferences null at `+0x118` — `rdi=0x0`, below a `libc.prx`
frame. Zero frames presented, every run.

## The ABI was captured, not assumed

A wrongly-positioned out-parameter write is **worse** than the stub it replaces (the `libSceUlt`
lesson: a registered stub can be worse than none). So the first commit registered these as log-only
probes — returning 0 and writing nothing, i.e. behaviour byte-identical to the unregistered path —
purely to observe the guest:

```
[probe-3502] sceKernelMemoryPoolExpand  a0=0x0 a1=0x400000000 a2=0xa6c00000 a3=0x10000 a4=0x41436b750
[probe-3502] sceKernelMemoryPoolReserve a0=0x1000000000 a1=0x400000 a2=0x400000 a3=0x0 a4=0x7fff33b45e08
[probe-3502] sceKernelMemoryPoolCommit  a0=0x0 a1=0x400000 a2=0xc a3=0x32 a4=0x0
[probe-3502] sceKernelConfiguredFlexibleMemorySize a0=0x410f99960
[probe-3502] sceKernelGetPageTableStats a0=0x7f22fc1ffc94 a1=...c90 a2=...c8c a3=...c88
```

This settled three things a guessed SDK signature would have got wrong:

- **`Reserve` takes the hint by value in `a0` with the out-pointer in `a4`** — not the single in/out
  pointer `sceKernelReserveVirtualRange` uses.
- **`a5` is caller-indeterminate scratch** on the five-argument entry points; the probe caught it
  holding a stack address two bytes below `a4`. It is never read — the same trap
  `sceKernelMapFlexibleMemory`'s `a4` already carries.
- **`GetPageTableStats` takes four 32-bit out-parameters**, from four consecutive stack addresses
  four bytes apart and descending.

It also upgraded the diagnosis from suggestive to confirmed: **`Commit`'s `a0` is `0x0`** — Reserve's
never-written out-parameter handed straight back. The null is visible in the arguments, not inferred
from call ordering.

## Approach

Reserve delegates to `k_reserve_vrange` and Commit to `k_map_flexible` (with `MAP_FIXED`) rather than
repeating them. `k_reserve_vrange` carries the #312/#946 huge-reservation steering and the #115
idempotent re-reserve, and NINJA GAIDEN 4 reserves at `0x1000000000` — the exact hint those
workarounds exist for. Only the calling convention differs, so it is adapted and forwarded.

Available and Configured flexible memory now answer from one `kFlexibleMemoryPoolBytes` constant, so
the pair cannot drift — the charter's rule that a value reachable through two APIs is derived in one
place.

Registered by **raw NID**, exactly as the guest imports them, so a name/hash mismatch cannot silently
restore the stub.

Both `register_kernel_mem_hle()` arms are updated — the POSIX one at `:3455` and the Windows one at
`:7265`. That file documents its own trap here (two definitions ~3,200 lines apart, three one-arm
read errors in one session); #3503 proposes splitting it.

## Verification

Build: green, RelWithDebInfo, `-DPROSPER_APP=ON`, **fresh configure** into a clean build directory,
`-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0` so the three Messenger-specific cases execute rather than skip.

```
ctest --no-tests=error -j6
100% tests passed out of 459      rc=0      0 failed, 0 skipped
```

A first run in a reused build directory reported 127 failures and many `(Not Run)`. That result is
**withdrawn, not reconciled**: a full-tree build against that directory had been OOM-killed at
`-j16`, leaving test binaries missing, which is precisely the `(Not Run)` signature. The number above
is from a clean directory and is the only one quoted. (Instrument trap 243's advice — re-run from a
fresh configure before believing a surprising test failure — is what caught it.)

`PPSA25258`, `SDL_VIDEODRIVER=offscreen`, default launch, no environment variables:

| | before | after |
| --- | --- | --- |
| fault | `SIGSEGV addr=0x118 rdi=0x0` within seconds | **none in 120 s** |
| frames presented | 0 | 0 |

`PROSPER_MEMLOG=1` shows the API doing real work, including the second reserve being correctly
steered past the first:

```
pool_expand  range=[0x0,0x400000000) len=0xa6c00000 align=0x10000 -> phys=0x10000
pool_reserve hint=0x1000000000 len=0x400000   align=0x400000 -> 0x1000000000
pool_commit  addr=0x1000000000 len=0x400000 type=0xc prot=0x32 -> 0x0 (mapped 0x1000000000)
pool_reserve hint=0x1000000000 len=0xc0000000 align=0x400000 -> 0x1000400000
pool_commit  addr=0x1000400000 len=0x10000 ... -> 0x0   (and onward, 64 KiB at a time)
```

## What this does NOT do

- **It does not boot NINJA GAIDEN 4.** Still zero frames; the title now runs 120 s with no fault
  instead of dying early, i.e. it blocks somewhere later. **The rung does not move** — it stays at 0.
  A new gap surfaced behind it: `libkernel::LXo1tpFqJGs`, unregistered.
- **It does not fix FF Tactics.** `PPSA21783` still raises
  `sceKernelDebugRaiseExceptionOnReleaseMode(0xa0020001)` with **zero unimplemented NIDs remaining**.

  **What that rules out, precisely** (narrowed in review — the first draft of this bullet and of the
  #3498 comment said "the unregistered-NID hypothesis is falsified", which claims one step more than
  was measured): registering these two calls **and answering 512 MiB and four zeros** does not move
  the abort. It does **not** establish that the API family is uninvolved, because a wrong *value*
  produces the identical observation. `kFlexibleMemoryPoolBytes` is PS4/shadPS4 parity, now extended
  to a second API, for a PS5 title whose own log reports a **16,318 MiB** pool two lines above the
  abort.

  The discriminator that would separate them is cheap and has not been run: sweep the constant and
  see whether the abort is value-sensitive. Until then the honest status is "registration alone is
  not sufficient", not "the family is not involved".

  The contrast with NG4 still stands and is the useful part: there the guest's own arguments carried
  the null, so the chain was confirmed rather than inferred.
- **`sceKernelMemoryPoolDecommit` is deliberately not registered**, and the new gap this PR surfaces
  in NINJA GAIDEN 4 — `libkernel::LXo1tpFqJGs` — resolves to exactly that call. The title only
  reaches it *because* this change let it get further, so there was no captured ABI for it when this
  work started and guessing one is the thing this PR exists to avoid. It is the obvious next commit,
  and it needs its own probe.

  Worth flagging for whoever takes it: a family with Commit but no Decommit means the guest can
  claim pool memory and never release it, so this PR leaves NINJA GAIDEN 4 committing without a way
  to decommit. That is strictly better than the null deref it replaces and is not a resting place.
  Decommit also has **no out-parameter**, so the "worse than the stub" hazard does not apply to it —
  the risk there is unmapping the wrong range instead, which argues for validating against
  prosper's own tracked mappings before acting.

## Risk and confidence

- `CONFIDENCE: HIGH` on the argument layout — live-captured on the failing titles.
- `CONFIDENCE: MED` on pool accounting. prosper does not model a pool distinct from the direct-memory
  arena, so Expand draws from that arena and Commit backs the reserved VA with ordinary anonymous
  memory. The guest observes the contract it depends on; a title reading back pool-specific
  accounting would not be served.
- `CONFIDENCE: LOW` on `GetPageTableStats`' **values**. All four are answered 0 — "nothing measured".
  That is a *defined* answer where the guest previously read uninitialised stack, which is the defect
  class this PR addresses, but it is not a *correct* one and should not be mistaken for one. If a
  title divides by one of these or reads zero as "no capacity", the fix is to derive real figures
  from prosper's mapping tables, not to substitute a plausible-looking constant.

## Affected / unaffected

Only titles that call these NIDs change behaviour; every other title takes the identical path. The
one shared edit is `k_avail_flexible` now reading a named constant instead of an inline literal —
same value, no behavioural change.

## Review

Worth an independent read: this is reverse-engineered ABI semantics on a shared memory path, which
the charter names explicitly as review-warranted even when the diff is small.
