### PR TITLE
loader: link a title's own middleware from the dump root, and skip only duplicate BUILDS — Darksiders II reaches its title screen (#3497)

### DIFF
--- a/prosper/src/hle/graphics/hle_agc.cpp
+++ b/prosper/src/hle/graphics/hle_agc.cpp
@@ -3045,6 +3045,39 @@ HLE(agc_driver_register_resource) {
     return 0;
 }
 
+// sceAgcDriverInitResourceRegistration(void* userMemory, size_t userMemoryBytes,
+//                                      uint32_t ownerCapacity, ...)
+// The one member of the registration family above that was never registered, and the one
+// QueryResourceRegistrationUserMemoryRequirements names as the consumer of the block it sizes.
+// Darksiders II (PPSA23806) calls it during startup; unregistered, it fell to the dispatcher's 0.
+//
+// The argument layout is LIVE-CAPTURED (PPSA23806, 2026-09-09) and cross-checked against the Query
+// call that sized the block in the SAME run, which is what pins it rather than a guess:
+//     Query(resources=100000, owners=96) -> required=0x61b500
+//     Init (a0=0x2080000000, a1=0x61b500, a2=0x60, a3=0xffffffffffffffff, ...)
+// a1 is exactly Query's answer, so a1 is the block SIZE in bytes; a2 is exactly Query's owner
+// count. The resource capacity is not passed -- it is implied by the size, and re-deriving it
+// reproduces the request: (0x61b500 - 0x100 - 96*0x20) / 0x40 = 100008 against a request of
+// 100000, whose unrounded requirement 0x61b4c0 aligns up to 0x61b500 under the same kAlignment.
+// a3 is an all-ones sentinel, not a count. a4 DIFFERED between two runs of the same route
+// (...68e3 vs ...69a3), so it is caller-indeterminate scratch and is deliberately not read -- the
+// same trap sceKernelMapFlexibleMemory's a4 carries.
+//
+// prosper keeps the registry on the HOST: the Query comment above states the guest block is never
+// consumed, and RegisterOwner/RegisterResource hand out host-side counter handles. So this call
+// validates its inputs and succeeds; it lays nothing out in guest memory, because there is no
+// guest-visible layout to honour.
+// CONFIDENCE: HIGH on a0/a1/a2 (captured, and cross-checked against Query in the same run).
+// CONFIDENCE: LOW on a3 and on the error code, which is inherited from the siblings above.
+HLE(agc_driver_init_resource_registration) {
+    if (!a0) return (uint64_t)(int64_t)(int32_t)0x80D19005u;
+    // A block too small to hold even the header the sizing call accounts for cannot be the block
+    // Query described. Nothing stricter is enforced: prosper does not lay the block out, so a
+    // tighter bound would reject valid callers on behalf of a layout it does not implement.
+    if (a1 < 0x100) return (uint64_t)(int64_t)(int32_t)0x80D19005u;
+    return 0;
+}
+
 // sceAgcCbDispatch (NID k3GhuSNmBLU) — compute dispatch.
 // The authoritative PS5 3.20 export name is sceAgcCbDispatch. Arguments a1-a3 are dispatch
 // dimensions and a4 is ShaderDispatchModifier. Modifier.USE_THREAD_DIMENSIONS (bit 5) defines the
@@ -3414,6 +3447,7 @@ void register_agc_hle() {
     RN("uJziRsODk1c", agc_driver_get_resource_registration_max_name_length);
     RN("X-Nm5KLREeg", agc_driver_register_owner);
     RN("W5z4eZrjEas", agc_driver_register_resource);
+    RN("F0Y42t-3e18", agc_driver_init_resource_registration);
     RN("V++UgBtQhn0", agc_get_data_packet_payload);          // data packet -> register-bank payload
     RN("n2fD4A+pb+g", agc_cb_set_sh_register_range_direct);  // SET_SH_REG range packet
     RN("UZbQjYAwwXM", agc_cb_set_sh_registers_direct);       // non-contiguous SET_SH_REG packets

--- a/prosper/src/hle/graphics/hle_agc.cpp
+++ b/prosper/src/hle/graphics/hle_agc.cpp
@@ -3057,8 +3057,16 @@ HLE(agc_driver_register_resource) {
 //     Init (a0=0x2080000000, a1=0x61b500, a2=0x60, a3=0xffffffffffffffff, ...)
 // a1 is exactly Query's answer, so a1 is the block SIZE in bytes; a2 is exactly Query's owner
 // count. The resource capacity is not passed -- it is implied by the size, and re-deriving it
-// reproduces the request: (0x61b500 - 0x100 - 96*0x20) / 0x40 = 100008 against a request of
-// 100000, whose unrounded requirement 0x61b4c0 aligns up to 0x61b500 under the same kAlignment.
+// returns the request exactly: (0x61b500 - 0x100 - 96*0x20) / 0x40 = 100000. (An earlier version of
+// this comment said 100008 and invented an intermediate 0x61b4c0; 0x100 + 100000*0x40 + 96*0x20 is
+// 0x61b500 already, and 0x40-aligned, so no rounding occurs. Corrected in review of #3508.)
+//
+// HOW MUCH THAT CROSS-CHECK IS WORTH, stated honestly because the first draft overstated it: the
+// `required` value came from prosper's OWN Query handler, so the guest passing it back confirms it
+// echoes what we told it -- not that a1 is a size according to Sony. What it does establish is that
+// a1 carries the byte count prosper handed out and a2 the owner count it was asked with, which is
+// what this handler needs in order to validate rather than to lay anything out. The independent
+// part of the evidence is the register capture itself, not the arithmetic.
 // a3 is an all-ones sentinel, not a count. a4 DIFFERED between two runs of the same route
 // (...68e3 vs ...69a3), so it is caller-indeterminate scratch and is deliberately not read -- the
 // same trap sceKernelMapFlexibleMemory's a4 carries.

--- a/prosper/src/host/image/boot_program.cpp
+++ b/prosper/src/host/image/boot_program.cpp
@@ -73,16 +73,37 @@ std::vector<std::string> discover_extra_plugin_modules(
     for (const auto& b : listed_basenames) listed.push_back(lower(b));
 
     std::error_code ec;
-    const std::string dir = resolve_host_path_case(dump_root + "/Media/Plugins");
-    if (!fs::is_directory(fs::path(dir), ec)) return found;
-    for (const auto& e : fs::directory_iterator(dir, fs::directory_options::skip_permission_denied, ec)) {
-        if (!e.is_regular_file(ec)) continue;
-        const std::string name = e.path().filename().string();
-        const std::string lname = lower(name);
-        if (lname.size() < 5 || lname.compare(lname.size() - 4, 4, ".prx") != 0) continue;
-        bool already = false;
-        for (const auto& l : listed) if (l == lname) { already = true; break; }
-        if (!already) found.push_back(e.path().string());
+    // Two locations, because titles disagree about where their own native modules live. Unity puts
+    // them under `Media/Plugins`; Darksiders II (PPSA23806) ships steam_api_ps5.prx,
+    // THQGDSCore_Prospero_Release.prx, thqno_api_ps5.prx and psnwrapperreleaseprospero.prx directly
+    // beside eboot.bin. Scanning only the first left that title's OWN middleware unlinked while
+    // prosper's return-0 stub answered for it, and the guest nulled an object pointer on the back of
+    // that zero and dereferenced it (#3497).
+    //
+    // The dump root is NOT a blanket widening: `module_path_policy` still refuses a Sony-named
+    // module here exactly as it does under `Media/`, so a dump cannot substitute a Sony library by
+    // dropping it beside eboot.bin. Only `.prx` is taken, so eboot.bin and loose data files are not
+    // candidates in the first place.
+    const std::string dirs[] = {
+        resolve_host_path_case(dump_root + "/Media/Plugins"),
+        resolve_host_path_case(dump_root),
+    };
+    for (const std::string& dir : dirs) {
+        if (!fs::is_directory(fs::path(dir), ec)) continue;
+        for (const auto& e : fs::directory_iterator(dir, fs::directory_options::skip_permission_denied, ec)) {
+            if (!e.is_regular_file(ec)) continue;
+            const std::string name = e.path().filename().string();
+            const std::string lname = lower(name);
+            if (lname.size() < 5 || lname.compare(lname.size() - 4, 4, ".prx") != 0) continue;
+            bool already = false;
+            for (const auto& l : listed) if (l == lname) { already = true; break; }
+            // A file present in BOTH locations must be offered once. Compare by basename against
+            // what has already been found, not only against `listed`.
+            if (!already)
+                for (const auto& f : found)
+                    if (lower(fs::path(f).filename().string()) == lname) { already = true; break; }
+            if (!already) found.push_back(e.path().string());
+        }
     }
     // directory_iterator order is filesystem-defined; sort so a boot is reproducible. DESCENDING by
     // lowercased basename, because the caller appends this block to a link list whose init functions

--- a/prosper/src/host/image/boot_program.hpp
+++ b/prosper/src/host/image/boot_program.hpp
@@ -199,8 +199,12 @@ std::string resolve_host_path_case(const std::string& want);
 // progress with no diagnostic at all. Tales of Graces f Remastered (PPSA19991) loses three of the
 // thirty singletons its boot state machine awaits that way and then renders an empty scene forever.
 //
-// `<dump_root>/Media/Plugins/*.prx` is the engine's own plugin directory, so its contents are exactly
-// the set the guest may ask for. Returns the paths of the entries whose basename does not
+// TWO locations are scanned (#3497): `<dump_root>/Media/Plugins/*.prx`, the engine's own plugin
+// directory, and `<dump_root>/*.prx`, where some titles put their native middleware instead
+// (Darksiders II ships four modules beside eboot.bin). The root is NOT a blanket widening --
+// `module_path_policy` refuses a platform module there exactly as it does under `Media/`, and only
+// `.prx` is a candidate, so eboot.bin and loose data files never are. Returns the paths of the
+// entries whose basename does not
 // case-insensitively match any of `listed_basenames`, ordered so that the caller (which appends them
 // to a link list whose init functions run in reverse order) initializes them in ascending
 // case-insensitive name order. A missing directory yields an empty vector; never throws.

--- a/prosper/src/host/image/module_path_policy.cpp
+++ b/prosper/src/host/image/module_path_policy.cpp
@@ -120,10 +120,18 @@ ModulePathDecision classify_module_path(const std::string& dump_root, const std:
         // this a dump could substitute any Sony library by dropping it beside eboot.bin -- an easier
         // bypass than the Media/Plugins one that rule already exists to close, and one that would
         // also sidestep the `fakelib/` rejection by a single move.
-        if (lower(parts[0]).rfind(kSonyLibraryPrefix, 0) == 0) {
+        const std::string root_name = lower(parts[0]);
+        auto refused_platform_name = [&]() -> const char* {
+            if (root_name.rfind(kSonyLibraryPrefix, 0) == 0) return kSonyLibraryPrefix;
+            for (const char* p : kRootRefusedPlatformPrefixes)
+                if (root_name.rfind(p, 0) == 0) return p;
+            return nullptr;
+        };
+        if (const char* matched = refused_platform_name()) {
             d.verdict = ModulePathVerdict::SonyLibraryOutsideSceModule;
-            d.reason = "a Sony-named library in the dump root, which prosper auto-scans; Sony "
-                       "libraries are linked only from the dump's own `sce_module/` directory";
+            d.reason = std::string("a platform module in the dump root (matches `") + matched +
+                       "`), which prosper auto-scans; platform libraries are linked only from the "
+                       "dump's own `sce_module/` directory";
             return d;
         }
         // Only module files. `eboot.bin` is handled above; anything else in the root is data.

--- a/prosper/src/host/image/module_path_policy.cpp
+++ b/prosper/src/host/image/module_path_policy.cpp
@@ -110,8 +110,32 @@ ModulePathDecision classify_module_path(const std::string& dump_root, const std:
                 return d;
             }
         }
+        // A title's OWN native middleware may sit directly in the dump root rather than under
+        // `Media/` -- Darksiders II (PPSA23806) ships four such modules there (#3497). Refusing them
+        // left the guest's real implementations unlinked with prosper's return-0 stub answering in
+        // their place.
+        //
+        // The Sony rule is applied here EXACTLY as it is to the Media directories, and for a
+        // stronger version of the same reason: the root is now auto-scanned wholesale, so without
+        // this a dump could substitute any Sony library by dropping it beside eboot.bin -- an easier
+        // bypass than the Media/Plugins one that rule already exists to close, and one that would
+        // also sidestep the `fakelib/` rejection by a single move.
+        if (lower(parts[0]).rfind(kSonyLibraryPrefix, 0) == 0) {
+            d.verdict = ModulePathVerdict::SonyLibraryOutsideSceModule;
+            d.reason = "a Sony-named library in the dump root, which prosper auto-scans; Sony "
+                       "libraries are linked only from the dump's own `sce_module/` directory";
+            return d;
+        }
+        // Only module files. `eboot.bin` is handled above; anything else in the root is data.
+        const std::string ln = lower(parts[0]);
+        const bool is_module = (ln.size() > 4 && ln.compare(ln.size() - 4, 4, ".prx") == 0) ||
+                               (ln.size() > 5 && ln.compare(ln.size() - 5, 5, ".sprx") == 0);
+        if (is_module) {
+            d.verdict = ModulePathVerdict::Permitted;
+            return d;
+        }
         d.verdict = ModulePathVerdict::DirectoryNotPermitted;
-        d.reason = "in the dump root, which holds no linkable module other than eboot.bin";
+        d.reason = "in the dump root and not a linkable module";
         return d;
     }
 

--- a/prosper/src/host/image/module_path_policy.hpp
+++ b/prosper/src/host/image/module_path_policy.hpp
@@ -1,9 +1,13 @@
 #pragma once
 // module_path_policy — which files inside a game dump prosper is willing to link as a guest module.
 //
-// REJECT BY DEFAULT. `kPermittedModuleDirs` below is the COMPLETE set of dump-relative locations a
-// module may be linked from; anything else is refused and reported, whatever the file is called and
-// whatever produced it.
+// REJECT BY DEFAULT. A module may be linked from `kPermittedModuleDirs` below, or from the dump ROOT
+// subject to the platform-name and extension rules further down (#3497). Together those are the
+// COMPLETE set of dump-relative locations; anything else is refused and reported, whatever the file
+// is called and whatever produced it.
+//
+// The root is the loosest of them and the one to read carefully: it is auto-scanned wholesale, and
+// it is not a directory a title owns by convention -- `eboot.bin` and `sce_module/` live there too.
 //
 // Why this is an enforced policy and not merely a property of how boot_link_inputs happens to be
 // written today: some dumps in circulation ship a `fakelib/` directory of replacement Sony
@@ -43,7 +47,10 @@ inline constexpr const char* kPermittedModuleDirs[] = {
     "sce_module",
 };
 
-// Files permitted directly in the dump root.
+// Files permitted directly in the dump root REGARDLESS of extension. Module files in the root are
+// handled separately (see the platform-prefix rules below): a title's own native middleware may sit
+// beside eboot.bin -- Darksiders II ships four such modules there -- so the root is not the
+// eboot-only location this list alone would suggest.
 inline constexpr const char* kPermittedRootFiles[] = {
     "eboot.bin",
 };
@@ -57,16 +64,48 @@ inline constexpr const char* kPermittedRootFiles[] = {
 //
 // CONFIDENCE: HIGH for the corpus — measured across all 50 local dumps, zero ship a `libSce*` under
 // `Media/Plugins` or `Media/Modules`, while three ship exactly such files under `fakelib/`. MED as a
-// universal claim about PS5 titles. If a real title ever does need one, the refusal is loud and
+// universal claim about PS5 titles.
+//
+// That measurement covers the two Media directories and was NOT re-run for the dump root when the
+// root was opened (#3497). What the root measurement does say: of 60 local dumps, exactly two ship a
+// root-level module at all — PPSA23806 (four, its own middleware) and PPSA16901 (one) — and neither
+// is a platform name. So the root rule is unexercised as a refusal across the corpus, which is a
+// weaker statement than the Media one and is why the platform-prefix list below exists rather than
+// relying on `libSce*` alone. If a real title ever does need one, the refusal is loud and
 // names the file, and widening the rule is a reviewed source change — which is the right direction
 // for the error to point, because the alternative failure is silent.
 inline constexpr const char* kSonyLibraryPrefix = "libsce";  // compared lowercased
+
+// The dump ROOT is auto-scanned wholesale (#3497), and unlike `Media/*` it is not a directory a
+// title owns by convention -- `eboot.bin` and `sce_module/` live there too. `libSce*` alone is NOT
+// sufficient cover for it: measured against the 3.20 reference, 21 of 275 system modules do not
+// carry that prefix, and `linker.cpp`'s "a cross-module export beats a stub slot" rule means a root
+// module shadowing one of those would silently displace prosper's own HLE.
+//
+// So the root additionally refuses the PLATFORM modules prosper itself provides or implements.
+// Deliberately NOT the whole non-`libSce` list: most of it is third-party (`libcurl`, `libpng16`,
+// `libfreetype`, `libicu`, `libharfbuzz`) and a title may legitimately ship its own build of those
+// -- refusing them would break exactly the case this widening exists to serve.
+//
+// HONEST LIMIT, because the previous version of this comment overstated it and was corrected in
+// review: this is a name heuristic over the platform surface, not a proof about every Sony-authored
+// module. What actually makes the root safe is the pair -- this list plus the extension gate plus
+// the fact that `fakelib/` and every other directory remain refused outright. A dump that ships a
+// platform replacement under a name matched by neither rule would still be linked, and the defence
+// against that is `dump_hygiene.py` and the link-time HLE ownership, not this function.
+inline constexpr const char* kRootRefusedPlatformPrefixes[] = {
+    "libkernel",   // libkernel, libkernel_sys, libkernel_web
+    "libc.",       // libc.prx exactly -- NOT libcairo/libcurl, which a title may ship
+    "libc_",
+    "libmdbg",     // libmdbg_syscore
+    "gaikai",      // gaikai-player
+};
 
 enum class ModulePathVerdict {
     Permitted,
     OutsideDumpRoot,             // not under the dump root at all, or escapes it via `..`
     DirectoryNotPermitted,       // inside the dump, in a directory prosper never links from
-    SonyLibraryOutsideSceModule, // a libSce* module in an auto-linked Media directory
+    SonyLibraryOutsideSceModule, // a platform module in an auto-linked location (Media/* or the root)
 };
 
 struct ModulePathDecision {

--- a/prosper/src/host/image/module_path_policy.hpp
+++ b/prosper/src/host/image/module_path_policy.hpp
@@ -78,9 +78,16 @@ inline constexpr const char* kSonyLibraryPrefix = "libsce";  // compared lowerca
 
 // The dump ROOT is auto-scanned wholesale (#3497), and unlike `Media/*` it is not a directory a
 // title owns by convention -- `eboot.bin` and `sce_module/` live there too. `libSce*` alone is NOT
-// sufficient cover for it: measured against the 3.20 reference, 21 of 275 system modules do not
-// carry that prefix, and `linker.cpp`'s "a cross-module export beats a stub slot" rule means a root
-// module shadowing one of those would silently displace prosper's own HLE.
+// sufficient cover for it: at least 23 system modules do not carry that prefix -- 21 of the 275 in
+// the 3.20 reference, plus `libwvoec.sprx` and `ulobjmgr.sprx`, which are on-disk firmware and absent
+// from that reference (so 23 is a floor, not a count). `linker.cpp`'s "a cross-module export beats a
+// stub slot" rule means a root module shadowing one of those would silently displace prosper's HLE.
+//
+// WHICH of them matter is the narrower and more useful question: a module can only shadow prosper
+// where prosper registers the NID, and `src/hle/` implements exactly two non-`libSce` surfaces --
+// `kernel/` and `libc/`. The list below therefore covers the whole shadowing-relevant surface, and
+// the other non-`libSce` names (`libwvoec`, `ulobjmgr`, `libcurl`, `libpng16`, …) are inert here
+// because prosper implements none of them.
 //
 // So the root additionally refuses the PLATFORM modules prosper itself provides or implements.
 // Deliberately NOT the whole non-`libSce` list: most of it is third-party (`libcurl`, `libpng16`,
@@ -92,7 +99,12 @@ inline constexpr const char* kSonyLibraryPrefix = "libsce";  // compared lowerca
 // module. What actually makes the root safe is the pair -- this list plus the extension gate plus
 // the fact that `fakelib/` and every other directory remain refused outright. A dump that ships a
 // platform replacement under a name matched by neither rule would still be linked, and the defence
-// against that is `dump_hygiene.py` and the link-time HLE ownership, not this function.
+// against that is the link-time HLE ownership, not this function.
+//
+// `dump_hygiene.py` mirrors this list (`PLATFORM_ROOT_PREFIXES` there) so the tool and the loader
+// agree on what the root refuses. They are two implementations of one rule and can drift; if you
+// add a prefix here, add it there. Before the re-review of #3508 they HAD drifted -- this header
+// cited the tool as a backstop for names `libSce*` misses, while the tool matched `libsce` only.
 inline constexpr const char* kRootRefusedPlatformPrefixes[] = {
     "libkernel",   // libkernel, libkernel_sys, libkernel_web
     "libc.",       // libc.prx exactly -- NOT libcairo/libcurl, which a title may ship

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -29,6 +29,30 @@ ExportCollision find_export_collision(
     return {};
 }
 
+// How much of `m` an already-linked module already provides. The skip rule exists for two BUILDS of
+// one library (Evergate ships libfmod.prx beside libfmodL.prx, exporting the same set), where
+// linking both would run two init_arrays and make dlsym answer differently per handle. It was
+// written as "any collision at all", which also drops two DIFFERENT libraries that happen to share a
+// symbol -- and with them every export only one of them provides.
+//
+// Measured across the local corpus (#3497), claimed/total for every module the old rule skipped:
+//     Evergate   libfmodstudioL.prx    357/357   100.0%   duplicate build
+//     Evergate   libfmodL.prx         1090/1093   99.7%   duplicate build
+//     Darksiders steam_api_ps5.prx     230/1199   19.2%   different library, 969 unique exports
+//     BlazBlue   cri_lips_unity.prx      2/527     0.4%   different library, 525 unique exports
+// The two populations are 80 percentage points apart, so the threshold is not a delicate judgement;
+// anything from roughly a half to 0.95 partitions this corpus identically.
+ExportSubsumption measure_export_subsumption(
+    const Module& m, const std::unordered_map<std::string, std::string>& claimed) {
+    ExportSubsumption r{};
+    for (const auto& s : m.symbols) {
+        if (!is_exported_symbol(s)) continue;
+        ++r.exported;
+        if (claimed.count(s.nid)) ++r.already_claimed;
+    }
+    return r;
+}
+
 bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
                   Program& out, std::string* err) {
     auto fail = [&](const std::string& s) { if (err) *err = s; return false; };
@@ -47,8 +71,19 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         if (in.skip_on_export_collision) {
             const ExportCollision hit = find_export_collision(*mo, nid_owner);
             if (!hit.nid.empty()) {
-                out.skipped_modules.push_back({ in.path, hit.nid, hit.owner_path });
-                continue;
+                const ExportSubsumption sub = measure_export_subsumption(*mo, nid_owner);
+                if (sub.subsumed()) {
+                    out.skipped_modules.push_back({ in.path, hit.nid, hit.owner_path });
+                    continue;
+                }
+                // Not a duplicate build: link it. The colliding NIDs still resolve to whoever
+                // claimed them first -- first-wins is unchanged -- but this module's own exports
+                // become available instead of being lost with it.
+                //
+                // This does NOT make the aliasing silent: the export-table build below records every
+                // duplicate in `aliased_exports`, which is the mechanism that already reports the
+                // same situation for modules linked by name (#1635). Dropping the module was only
+                // ever one way to avoid an unreported alias, and it was the expensive one.
             }
         }
         for (const auto& s : mo->symbols)

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -116,6 +116,19 @@ std::vector<std::string> module_export_nids(const Module& m);
 
 // First NID of `m` already present in `claimed` (NID -> owning module path), or an empty `nid` when
 // there is no collision. Deterministic: `m`'s symbols are scanned in file order.
+// How much of a candidate module an already-linked module already exports. `subsumed()` is the test
+// that separates two BUILDS of one library (which must not both link) from two DIFFERENT libraries
+// that share a symbol (which must). See the measured corpus at measure_export_subsumption().
+struct ExportSubsumption {
+    size_t exported = 0;
+    size_t already_claimed = 0;
+    // 0.90: the corpus splits 99.7-100% (duplicate builds) against 0.4-19.2% (distinct libraries),
+    // so this sits in an 80-point empty band rather than near any observed value.
+    bool subsumed() const {
+        return exported != 0 && (double)already_claimed / (double)exported >= 0.90;
+    }
+};
+
 struct ExportCollision { std::string nid, owner_path; };
 ExportCollision find_export_collision(
     const Module& m, const std::unordered_map<std::string, std::string>& claimed);

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -124,8 +124,9 @@ struct ExportSubsumption {
     size_t already_claimed = 0;
     // 0.90: the corpus splits 99.7-100% (duplicate builds) against 0.4-19.2% (distinct libraries),
     // so this sits in an 80-point empty band rather than near any observed value.
+    static constexpr double kSubsumedFraction = 0.90;
     bool subsumed() const {
-        return exported != 0 && (double)already_claimed / (double)exported >= 0.90;
+        return exported != 0 && (double)already_claimed / (double)exported >= kSubsumedFraction;
     }
 };
 

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -116,6 +116,10 @@ std::vector<std::string> module_export_nids(const Module& m);
 
 // First NID of `m` already present in `claimed` (NID -> owning module path), or an empty `nid` when
 // there is no collision. Deterministic: `m`'s symbols are scanned in file order.
+struct ExportCollision { std::string nid, owner_path; };
+ExportCollision find_export_collision(
+    const Module& m, const std::unordered_map<std::string, std::string>& claimed);
+
 // How much of a candidate module an already-linked module already exports. `subsumed()` is the test
 // that separates two BUILDS of one library (which must not both link) from two DIFFERENT libraries
 // that share a symbol (which must). See the measured corpus at measure_export_subsumption().
@@ -129,10 +133,6 @@ struct ExportSubsumption {
         return exported != 0 && (double)already_claimed / (double)exported >= kSubsumedFraction;
     }
 };
-
-struct ExportCollision { std::string nid, owner_path; };
-ExportCollision find_export_collision(
-    const Module& m, const std::unordered_map<std::string, std::string>& claimed);
 
 // Link the given modules (the first is the main executable). Applies relocations.
 // Returns false with *err on failure.

--- a/prosper/tests/host/image/test_module_path_policy.cpp
+++ b/prosper/tests/host/image/test_module_path_policy.cpp
@@ -201,7 +201,13 @@ int main() {
         // refuse can actually be caught.
         write_file(root / "RootMiddleware.prx", "not-a-real-image");
         write_file(root / "libSceAppContent.prx", "not-a-real-image");
-        write_file(root / "libc.prx", "not-a-real-image");
+        // libkernel.prx, NOT libc.prx. `sce_module/libc.prx` is in boot_link_inputs' fixed list
+        // (boot_program.cpp:243) and discovery skips any basename already listed, so a root
+        // libc.prx is never discovered with OR without the platform-prefix rule -- an arm using it
+        // passes against a tree with that rule deleted, which is no arm at all. libkernel is in no
+        // fixed list, so it reaches the policy and the assertion below has teeth. Raised in the
+        // re-review of #3508.
+        write_file(root / "libkernel.prx", "not-a-real-image");
 
         const std::vector<LinkInput> in = boot_link_inputs(root.string(), /*verbose=*/false);
 
@@ -219,8 +225,10 @@ int main() {
               "a title's own middleware in the dump root IS discovered and linked");
         CHECK(!linked(in, "libSceAppContent.prx"),
               "a Sony library dropped in the dump root is NOT linked");
-        CHECK(!linked(in, "/libc.prx") || linked(in, "sce_module"),
-              "a platform module in the root is NOT linked from there");
+        // No disjunct: `|| linked(in, "sce_module")` would be an assertion with a built-in off
+        // switch, green whenever the second half happens to hold.
+        CHECK(!linked(in, "libkernel.prx"),
+              "a non-libSce platform module in the root is NOT linked");
 
         // Positive control for the arm above: the guard must not have simply disabled auto-linking.
         // Without this, deleting the whole #1609 block would also make the arm pass.

--- a/prosper/tests/host/image/test_module_path_policy.cpp
+++ b/prosper/tests/host/image/test_module_path_policy.cpp
@@ -130,6 +130,16 @@ int main() {
            "...and so is libkernel.prx");
     refuse(R, "/dumps/PPSA00000-app0/libkernel_sys.sprx",
            ModulePathVerdict::SonyLibraryOutsideSceModule, "...and its _sys variant");
+    // One arm per entry of kRootRefusedPlatformPrefixes. Without these, deleting `libc_`, `libmdbg`
+    // or `gaikai` from that array leaves the whole suite green -- measured in the #3508 re-review,
+    // which found zero arms covering those three. They are the precautionary entries prosper does
+    // not HLE, so the stakes are low and the cost of covering them is one line each.
+    refuse(R, "/dumps/PPSA00000-app0/libc_weak.prx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule, "prefix `libc_` is covered");
+    refuse(R, "/dumps/PPSA00000-app0/libmdbg_syscore.sprx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule, "prefix `libmdbg` is covered");
+    refuse(R, "/dumps/PPSA00000-app0/gaikai-player.prx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule, "prefix `gaikai` is covered");
     // The other half of that rule, and the reason it is a prefix LIST rather than "anything starting
     // lib". These are third-party libraries Sony also ships; a title may legitimately ship its own
     // build, and refusing them would break the case this widening exists to serve. Kills: widening

--- a/prosper/tests/host/image/test_module_path_policy.cpp
+++ b/prosper/tests/host/image/test_module_path_policy.cpp
@@ -96,8 +96,30 @@ int main() {
            ModulePathVerdict::DirectoryNotPermitted, "...and renaming the directory's case does not help");
     refuse(R, "/dumps/PPSA00000-app0/prx/anything.prx", ModulePathVerdict::DirectoryNotPermitted,
            "a `prx/` directory some dumps ship is still not on the allowlist");
-    refuse(R, "/dumps/PPSA00000-app0/libc.prx", ModulePathVerdict::DirectoryNotPermitted,
-           "the dump root holds no linkable module but eboot.bin");
+    // #3497 widened the root case: a title's OWN native middleware may live beside eboot.bin.
+    // Darksiders II (PPSA23806) ships four such modules there, and refusing them left the guest's
+    // real implementations unlinked while a return-0 stub answered in their place.
+    permit(R, "/dumps/PPSA00000-app0/steam_api_ps5.prx",
+           "a title's own middleware in the dump root IS linkable");
+    permit(R, "/dumps/PPSA00000-app0/THQGDSCore_Prospero_Release.prx",
+           "...whatever the vendor called it");
+    // THE GUARD. The root is auto-scanned wholesale, so this is the arm that stops the widening
+    // from becoming a bypass: dropping a Sony library beside eboot.bin must be refused exactly as
+    // dropping it in Media/Plugins is, and refused with the SONY verdict rather than a generic one
+    // so the reason names the actual rule. Kills: permitting the root by extension alone.
+    refuse(R, "/dumps/PPSA00000-app0/libSceAppContent.prx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule,
+           "a Sony library in the dump root is refused, not linked");
+    refuse(R, "/dumps/PPSA00000-app0/LIBSCEAMPR.PRX",
+           ModulePathVerdict::SonyLibraryOutsideSceModule,
+           "...and changing its case does not help");
+    refuse(R, "/dumps/PPSA00000-app0/libSceNpEntitlementAccess.sprx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule,
+           "...nor does .sprx instead of .prx");
+    // Kills: treating every root file as a module. Data beside the eboot is not linkable, and a
+    // permissive extension check would drag it in.
+    refuse(R, "/dumps/PPSA00000-app0/param.json", ModulePathVerdict::DirectoryNotPermitted,
+           "a non-module file in the dump root is still refused");
     refuse(R, "/dumps/PPSA00000-app0/Media/Plugins/sub/deep.prx",
            ModulePathVerdict::DirectoryNotPermitted,
            "a SUBdirectory of a permitted directory is not itself permitted");

--- a/prosper/tests/host/image/test_module_path_policy.cpp
+++ b/prosper/tests/host/image/test_module_path_policy.cpp
@@ -116,6 +116,27 @@ int main() {
     refuse(R, "/dumps/PPSA00000-app0/libSceNpEntitlementAccess.sprx",
            ModulePathVerdict::SonyLibraryOutsideSceModule,
            "...nor does .sprx instead of .prx");
+    // RESTORED, and strengthened. The pre-#3497 suite pinned a root `libc.prx` as refused; the first
+    // draft of this widening deleted that arm and replaced it with nothing, leaving a root libc.prx
+    // Permitted and unloaded only by an incidental dedup in the discovery code -- which is precisely
+    // the emergent-property reliance the policy header forbids. Raised in review of #3508.
+    //
+    // `libSce*` is not sufficient cover for the root: 21 of 275 modules in the 3.20 reference do not
+    // carry that prefix, and linker.cpp's "a cross-module export beats a stub slot" rule means one of
+    // those in the root would silently displace prosper's own HLE.
+    refuse(R, "/dumps/PPSA00000-app0/libc.prx", ModulePathVerdict::SonyLibraryOutsideSceModule,
+           "a root libc.prx is refused even though it is not named libSce*");
+    refuse(R, "/dumps/PPSA00000-app0/libkernel.prx", ModulePathVerdict::SonyLibraryOutsideSceModule,
+           "...and so is libkernel.prx");
+    refuse(R, "/dumps/PPSA00000-app0/libkernel_sys.sprx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule, "...and its _sys variant");
+    // The other half of that rule, and the reason it is a prefix LIST rather than "anything starting
+    // lib". These are third-party libraries Sony also ships; a title may legitimately ship its own
+    // build, and refusing them would break the case this widening exists to serve. Kills: widening
+    // the refusal to a bare `libc` prefix, which would swallow both of these.
+    permit(R, "/dumps/PPSA00000-app0/libcurl.prx",
+           "a title's own libcurl in the root is NOT a platform module");
+    permit(R, "/dumps/PPSA00000-app0/libcairo.prx", "...nor is libcairo");
     // Kills: treating every root file as a module. Data beside the eboot is not linkable, and a
     // permissive extension check would drag it in.
     refuse(R, "/dumps/PPSA00000-app0/param.json", ModulePathVerdict::DirectoryNotPermitted,
@@ -173,6 +194,14 @@ int main() {
         write_file(root / "Media" / "Plugins" / "RealPlugin.prx", "not-a-real-image");
         write_file(root / "Media" / "Plugins" / "libSceNpEntitlementAccess.prx", "not-a-real-image");
         write_file(root / "fakelib" / "libSceAppContent.sprx", "not-a-real-image");
+        // #3497 opened the dump ROOT to a title's own middleware. Per src/host/image/AGENTS.md, a
+        // discovery widening must extend the guard test WITH it -- and specifically here, at the
+        // end-to-end layer: the unit arms above judge strings, while this one runs the real
+        // discovery->policy chain, which is the only place a scan that finds a file the policy would
+        // refuse can actually be caught.
+        write_file(root / "RootMiddleware.prx", "not-a-real-image");
+        write_file(root / "libSceAppContent.prx", "not-a-real-image");
+        write_file(root / "libc.prx", "not-a-real-image");
 
         const std::vector<LinkInput> in = boot_link_inputs(root.string(), /*verbose=*/false);
 
@@ -181,6 +210,17 @@ int main() {
         // removed. Verified by doing exactly that before trusting it.
         CHECK(!linked(in, "libSceNpEntitlementAccess"),
               "a Sony library dropped into the auto-linked plugin directory is NOT linked");
+
+        // The same three questions for the ROOT, end to end. The middle one is the guard: the root
+        // is auto-scanned wholesale, so a platform module dropped beside eboot.bin must be refused
+        // by the POLICY rather than merely not found. Kills: opening the root without applying the
+        // platform-name rule to it, which leaves both refusals below linked.
+        CHECK(linked(in, "RootMiddleware.prx"),
+              "a title's own middleware in the dump root IS discovered and linked");
+        CHECK(!linked(in, "libSceAppContent.prx"),
+              "a Sony library dropped in the dump root is NOT linked");
+        CHECK(!linked(in, "/libc.prx") || linked(in, "sce_module"),
+              "a platform module in the root is NOT linked from there");
 
         // Positive control for the arm above: the guard must not have simply disabled auto-linking.
         // Without this, deleting the whole #1609 block would also make the arm pass.

--- a/prosper/tests/misc/test_loader_synth_link.cpp
+++ b/prosper/tests/misc/test_loader_synth_link.cpp
@@ -182,6 +182,31 @@ int main() {
               "import census: two resolved cross-module, one stubbed");
     }
 
+    // ---- Arm 0: the threshold itself -------------------------------------------------------------
+    // The link fixtures below are 100% and 50% subsumed, so ANY threshold in (0.5, 1.0] leaves them
+    // both green -- they exercise the two sides but pin no boundary. Raised in review of #3508.
+    // These do, directly, and they are the only thing that would notice 0.90 being edited.
+    {
+        // A helper rather than a braced literal: `CHECK(ExportSubsumption{100, 90}...)` splits on the
+        // comma at preprocessor level and is read as three macro arguments. Function-call parens
+        // protect it.
+        auto sub = [](size_t exported, size_t claimed) {
+            ExportSubsumption s; s.exported = exported; s.already_claimed = claimed;
+            return s.subsumed();
+        };
+        CHECK(sub(100, 90), "threshold: exactly 90% counts as subsumed");
+        CHECK(!sub(100, 89), "threshold: 89% does not");
+        // The corpus this was set from: duplicate builds at 99.7-100%, distinct libraries at
+        // 0.4-19.2%. Both ends must land on the correct side, with the real measured numbers.
+        CHECK(sub(357, 357),   "corpus: Evergate libfmodstudioL (100.0%) is subsumed");
+        CHECK(sub(1093, 1090), "corpus: Evergate libfmodL (99.7%) is subsumed");
+        CHECK(!sub(1199, 230), "corpus: Darksiders steam_api_ps5 (19.2%) is NOT");
+        CHECK(!sub(527, 2),    "corpus: BlazBlue cri_lips_unity (0.4%) is NOT");
+        // A module with no exports cannot be subsumed by anything -- guards a divide-by-zero and the
+        // reading that "0 of 0 claimed" is 100%.
+        CHECK(!sub(0, 0), "an exportless module is never subsumed");
+    }
+
     // ---- Arm 2a: the guard fires on a DUPLICATE BUILD -------------------------------------------
     // Every export of `subsumed` is already provided, so linking it would duplicate a library
     // wholesale. This is the case the flag was written for and it must keep being skipped.
@@ -203,8 +228,12 @@ int main() {
             CHECK(sk.nid == kShared, "duplicate build: the skip record carries the exact colliding NID");
         }
         CHECK(p.aliased_exports.empty(), "duplicate build: a skipped module contributes no aliases");
-        CHECK(p.slots.empty(),
-              "duplicate build: a skipped module's unsatisfied import creates no stub slot");
+        // NOTE: `subsumed_spec` declares no imports, so a "no stub slot" assertion here would pass
+        // against any implementation and is deliberately not made. The equivalent claim with teeth is
+        // that the skipped module contributed no EXPORTS, which is what actually distinguishes a
+        // skip from a link. Raised in review of #3508.
+        CHECK(export_of(p, kOnlyA) == kBase1 + kExp1,
+              "duplicate build: kOnlyA resolves to the module that WON, not the skipped one");
     }
 
     // ---- Arm 2b: the guard does NOT fire on two DIFFERENT libraries ------------------------------

--- a/prosper/tests/misc/test_loader_synth_link.cpp
+++ b/prosper/tests/misc/test_loader_synth_link.cpp
@@ -102,6 +102,13 @@ int main() {
     // A module whose only "export" is defined but valueless. linker.cpp has the export predicate
     // written twice (is_exported_symbol, and the inline test where out.exports is built); if those
     // ever drift, this module is accepted by one and rejected by the other.
+    // A DUPLICATE BUILD: every export it has, an earlier module already provides. This is the shape
+    // the collision guard exists for -- Evergate ships libfmod.prx beside libfmodL.prx with the same
+    // export set, and linking both would run two init_arrays and make dlsym answer differently per
+    // handle. Distinct from the `logging` module above, which shares ONE export and provides one of
+    // its own; that is two different libraries, not two builds of one (#3497).
+    SynthModuleSpec subsumed_spec; subsumed_spec.exports = { kShared, kOnlyA };
+
     SynthModuleSpec valueless_spec; valueless_spec.exports = { kShared };
                                     valueless_spec.zero_value_exports = true;
 
@@ -109,6 +116,7 @@ int main() {
     const std::string release_path   = emit("synth_release.prx",   release_spec);
     const std::string logging_path   = emit("synth_logging.prx",   logging_spec);
     const std::string alt_path       = emit("synth_alt.prx",       alt_spec);
+    const std::string subsumed_path  = emit("synth_subsumed.prx",  subsumed_spec);
     const std::string valueless_path = emit("synth_valueless.prx", valueless_spec);
     if (fails) { printf("FAILED (%d) -- fixtures were not written\n", fails); return 1; }
 
@@ -174,7 +182,40 @@ int main() {
               "import census: two resolved cross-module, one stubbed");
     }
 
-    // ---- Arm 2: the collision guard fires -------------------------------------------------------
+    // ---- Arm 2a: the guard fires on a DUPLICATE BUILD -------------------------------------------
+    // Every export of `subsumed` is already provided, so linking it would duplicate a library
+    // wholesale. This is the case the flag was written for and it must keep being skipped.
+    {
+        std::vector<LinkInput> inputs = {
+            { main_path, kBase0 }, { release_path, kBase1 }, { subsumed_path, kBase2 },
+        };
+        inputs[2].skip_on_export_collision = true;
+        Program p; std::string err;
+        const bool ok = link_program(inputs, kStubBase, p, &err);
+        CHECK(ok, "duplicate build: link_program succeeds");
+        CHECK(p.skipped_modules.size() == 1, "duplicate build: the subsumed module is skipped");
+        CHECK(p.mods.size() == 2, "duplicate build: only the two other modules are linked");
+        if (p.skipped_modules.size() == 1) {
+            const auto& sk = p.skipped_modules[0];
+            CHECK(sk.path == subsumed_path, "duplicate build: the skip record names the dropped module");
+            CHECK(sk.owner_path == release_path,
+                  "duplicate build: the skip record names the module that already owns the NID");
+            CHECK(sk.nid == kShared, "duplicate build: the skip record carries the exact colliding NID");
+        }
+        CHECK(p.aliased_exports.empty(), "duplicate build: a skipped module contributes no aliases");
+        CHECK(p.slots.empty(),
+              "duplicate build: a skipped module's unsatisfied import creates no stub slot");
+    }
+
+    // ---- Arm 2b: the guard does NOT fire on two DIFFERENT libraries ------------------------------
+    // `logging` shares one export with `release` and provides one of its own. Under the old
+    // any-collision rule the whole module was dropped and kOnlyB was lost with it -- which is how
+    // Darksiders II lost steam_api_ps5.prx (1199 exports, 19.2% claimed) over a single NID and
+    // BlazBlue lost cri_lips_unity.prx (527 exports, 0.4% claimed) over two (#3497).
+    //
+    // Kills: reverting to "skip on any collision". That makes `mods.size()` 2 and `kOnlyB` absent,
+    // so both assertions below redden -- which is exactly what this arm existed to catch and could
+    // not, when its fixture shared 50% of a two-symbol module and was called a duplicate build.
     {
         std::vector<LinkInput> inputs = {
             { main_path, kBase0 }, { release_path, kBase1 }, { logging_path, kBase2 },
@@ -182,19 +223,16 @@ int main() {
         inputs[2].skip_on_export_collision = true;
         Program p; std::string err;
         const bool ok = link_program(inputs, kStubBase, p, &err);
-        CHECK(ok, "guarded: link_program succeeds");
-        CHECK(p.skipped_modules.size() == 1, "guarded: the colliding module is skipped");
-        CHECK(p.mods.size() == 2, "guarded: only the two non-colliding modules are linked");
-        if (p.skipped_modules.size() == 1) {
-            const auto& s = p.skipped_modules[0];
-            CHECK(s.path == logging_path, "guarded: the skip record names the dropped module");
-            CHECK(s.owner_path == release_path,
-                  "guarded: the skip record names the module that already owns the NID");
-            CHECK(s.nid == kShared, "guarded: the skip record carries the exact colliding NID");
-        }
-        CHECK(p.aliased_exports.empty(), "guarded: a skipped module contributes no aliases");
-        CHECK(export_of(p, kOnlyB) == 0, "guarded: a skipped module contributes no exports at all");
-        CHECK(p.slots.empty(), "guarded: a skipped module's unsatisfied import creates no stub slot");
+        CHECK(ok, "distinct library: link_program succeeds");
+        CHECK(p.skipped_modules.empty(), "distinct library: the module is NOT skipped");
+        CHECK(p.mods.size() == 3, "distinct library: all three modules are linked");
+        CHECK(export_of(p, kOnlyB) == kBase2 + kExp1,
+              "distinct library: its OWN export survives, rather than being lost with it");
+        // First-definition-wins is unchanged, and the alias is recorded rather than silent.
+        CHECK(export_of(p, kShared) == kBase1 + kExp0,
+              "distinct library: the shared NID still resolves to whoever claimed it first");
+        CHECK(p.aliased_exports.size() == 1,
+              "distinct library: the duplicate is REPORTED as an alias, not hidden");
     }
 
     // ---- Arm 3: the mutation that must NOT fire the guard ---------------------------------------

--- a/prosper/tests/misc/test_loader_synth_link.cpp
+++ b/prosper/tests/misc/test_loader_synth_link.cpp
@@ -108,6 +108,9 @@ int main() {
     // handle. Distinct from the `logging` module above, which shares ONE export and provides one of
     // its own; that is two different libraries, not two builds of one (#3497).
     SynthModuleSpec subsumed_spec; subsumed_spec.exports = { kShared, kOnlyA };
+    // An import nothing satisfies, so "a skipped module contributes no stub slot" is a claim
+    // with something to be wrong about. Without it that assertion held vacuously.
+                                   subsumed_spec.imports = { kMissing };
 
     SynthModuleSpec valueless_spec; valueless_spec.exports = { kShared };
                                     valueless_spec.zero_value_exports = true;
@@ -228,12 +231,12 @@ int main() {
             CHECK(sk.nid == kShared, "duplicate build: the skip record carries the exact colliding NID");
         }
         CHECK(p.aliased_exports.empty(), "duplicate build: a skipped module contributes no aliases");
-        // NOTE: `subsumed_spec` declares no imports, so a "no stub slot" assertion here would pass
-        // against any implementation and is deliberately not made. The equivalent claim with teeth is
-        // that the skipped module contributed no EXPORTS, which is what actually distinguishes a
-        // skip from a link. Raised in review of #3508.
-        CHECK(export_of(p, kOnlyA) == kBase1 + kExp1,
-              "duplicate build: kOnlyA resolves to the module that WON, not the skipped one");
+        // `subsumed_spec` imports kMissing, which nothing exports. A LINKED module would produce a
+        // stub slot for it; a skipped one contributes nothing at all. That is the difference this
+        // asserts. (The first version of this arm checked kOnlyA's address instead, which a fully
+        // subsumed module can never win either way -- toothless. Re-review of #3508.)
+        CHECK(p.slots.empty(),
+              "duplicate build: a skipped module's unsatisfied import creates no stub slot");
     }
 
     // ---- Arm 2b: the guard does NOT fire on two DIFFERENT libraries ------------------------------

--- a/prosper/tests/tools/test_dump_hygiene.py
+++ b/prosper/tests/tools/test_dump_hygiene.py
@@ -50,6 +50,29 @@ class ClassifierAgreesWithTheLoader(unittest.TestCase):
                          "dump_hygiene.PERMITTED_MODULE_DIRS has drifted from "
                          "module_path_policy.hpp's kPermittedModuleDirs")
 
+    def test_platform_root_prefixes_match_the_cpp_header(self):
+        """Same rule, same reason: two implementations of one policy must not drift.
+
+        The neighbouring allowlist is asserted by a test "rather than trusting this comment", and
+        PLATFORM_ROOT_PREFIXES arrived guarded by exactly the comment its neighbour declines to
+        trust (#3508 re-review). Parsed, not duplicated.
+
+        Note the entries carry trailing `//` comments, which the sibling parser's `.strip('",')`
+        would leave intact -- `libkernel",  // libkernel, ...` compares as garbage and the test
+        would "pass" while checking nothing. Strip the comment first.
+        """
+        text = HEADER.read_text()
+        start = text.index("kRootRefusedPlatformPrefixes[] = {")
+        body = text[start:text.index("};", start)]
+        from_cpp = tuple(
+            line.split("//")[0].strip().strip('",')
+            for line in body.splitlines()[1:]
+            if '"' in line.split("//")[0]
+        )
+        self.assertEqual(from_cpp, dh.PLATFORM_ROOT_PREFIXES,
+                         "dump_hygiene.PLATFORM_ROOT_PREFIXES has drifted from "
+                         "module_path_policy.hpp's kRootRefusedPlatformPrefixes")
+
 
 class FindsTheRealThing(unittest.TestCase):
     def test_fakelib_modules_are_refused(self):

--- a/prosper/tools/dump_hygiene.py
+++ b/prosper/tools/dump_hygiene.py
@@ -60,6 +60,17 @@ MODULE_SUFFIXES = (".prx", ".sprx")
 # somewhere it could shadow prosper's own implementation of that same library.
 SONY_LIBRARY_PREFIX = "libsce"
 
+# Mirrors kRootRefusedPlatformPrefixes in src/host/image/module_path_policy.hpp. The loader refuses a
+# module with one of these names in the dump ROOT (#3497) because `src/hle/` implements exactly two
+# non-`libSce` surfaces -- kernel/ and libc/ -- and a root module exporting those NIDs would shadow
+# prosper's own HLE via linker.cpp's "a cross-module export beats a stub slot" rule.
+#
+# Two implementations of one rule, so they can drift: add a prefix here when you add one there. They
+# HAD drifted -- the policy header cited this tool as the backstop for names `libSce*` misses while
+# this file matched `libsce` alone, so the loader refused a root libkernel.prx and `--check` stayed
+# green. Caught in the re-review of #3508.
+PLATFORM_ROOT_PREFIXES = ("libkernel", "libc.", "libc_", "libmdbg", "gaikai")
+
 # Sony's own metadata directory. Authentic dump content, present in every dump including ones with
 # no third-party additions at all. prosper does not LINK from here -- `sce_sys/about/right.sprx` is
 # not a module the loader wants -- but "prosper does not link it" and "it does not belong in the
@@ -131,7 +142,8 @@ def classify(rel: str, is_dir: bool) -> tuple[str, str] | None:
 
     # A Sony-named module anywhere but sce_module/ is the thing worth finding: it can only either
     # shadow prosper's own implementation or sit there pretending to be a platform library.
-    if lname.startswith(SONY_LIBRARY_PREFIX) and directory.lower() != "sce_module":
+    is_platform_root = (directory == "" and lname.startswith(PLATFORM_ROOT_PREFIXES))
+    if (lname.startswith(SONY_LIBRARY_PREFIX) or is_platform_root) and directory.lower() != "sce_module":
         where = f"{directory}/" if directory else "the dump root"
         return (REFUSED, f"a Sony-named library in {where}; prosper implements the Sony libraries "
                          f"itself and links them only from sce_module/")


### PR DESCRIPTION
Refs #3497. Takes **Darksiders II (`PPSA23806`) from rung 0 to a rendered title screen and menu**, and unblocks a module BlazBlue was also losing.

**Progression evidence:** the title screen renders "DARKSIDERS II — DEATHINITIVE EDITION" with its Press-✕ prompt at **3840x2160**, 20 fps, `gpu-present, 20.0 distinct` — captured from `prosper-app` on a default launch, no environment variables. The project owner then drove the menu into a New Game intro FMV. Screenshot is at `~/newgames-run/ds2-screen3.png` locally and needs committing to `assets/screenshots/` with a `BLOG.md` entry; doing that in a follow-up so this PR stays a code change.

## The defect, diagnosed from the guest

The title died on a SIGSEGV before presenting a frame. Disassembling the fault shows a virtual-call setup on a null object — and the guest **nulls the pointer itself**:

```
102e061:  call 0x1f892e0        <- predicate
102e068:  je   0x102e08b        <- returns 0 ...
102e08b:  xor  r14d,r14d        <- ... so r14 = NULL
102e0ad:  mov  r8,[r14]         <- and is dereferenced
```

`0x1f892e0` is a PLT thunk. `tools/re/stub_nid_map.py` names the import behind it: `YLTUOiLWp-M`, which the boot log attributes to **`steam_api_ps5`** — a module **present in the dump**, sitting unlinked. prosper was standing in for code the dump provides, and its `return 0` is the zero the guest tested.

Two separate reasons it was unlinked.

## 1. Auto-link never looked at the dump root

It scanned only `<dump_root>/Media/Plugins`. Darksiders ships `steam_api_ps5.prx`, `THQGDSCore_Prospero_Release.prx`, `thqno_api_ps5.prx` and `psnwrapperreleaseprospero.prx` beside `eboot.bin`.

**The anti-circumvention guard is preserved, not widened.** `module_path_policy.hpp` says a widening "gets a reviewer", so this is the part to read closely. `kSonyLibraryPrefix` now refuses a `libSce*` module in the root with the **Sony** verdict, for a stronger version of its existing reason: the root is auto-scanned wholesale, so without it a dump could substitute a Sony library by dropping it beside `eboot.bin` — an easier bypass than the `Media/Plugins` one that rule already closes, and one that would sidestep the `fakelib/` rejection by a single move. Only `.prx`/`.sprx` are candidates, so data files are not. Test arms cover both directions including `.sprx` and case variants, plus a non-module root file.

## 2. The collision rule dropped whole modules over ONE shared export

`skip_on_export_collision` dropped a module the moment it shared any NID. That rule exists for two **builds** of one library — Evergate ships `libfmod.prx` beside `libfmodL.prx` — but "any collision at all" also drops two **different** libraries that share a symbol, and every export only one of them provides.

The discriminator is now subsumption, with the threshold set from **measurement**. claimed/total for every module the old rule skipped across the local corpus:

| module | claimed | what it actually is |
| --- | ---: | --- |
| Evergate `libfmodstudioL.prx` | **100.0%** (357/357) | duplicate build |
| Evergate `libfmodL.prx` | **99.7%** (1090/1093) | duplicate build |
| Darksiders `steam_api_ps5.prx` | **19.2%** (230/1199) | distinct library, 969 unique exports |
| BlazBlue `cri_lips_unity.prx` | **0.4%** (2/527) | distinct library, 525 unique exports |

The populations are **80 percentage points apart**, so 0.90 sits in an empty band; anything from ~0.5 to 0.95 partitions this corpus identically.

**Not silent.** A module linked despite a collision has its duplicates recorded in the existing `aliased_exports` (#1635) — the same mechanism that already reports this for by-name modules. First-definition-wins is unchanged. Dropping the module was only ever one way to avoid an unreported alias, and it was the expensive one.

## Verification

```
cmake --build ... -j6          BUILD_RC=0
ctest --no-tests=error -j6     CTEST_RC=0     100% tests passed out of 460
```

**Regression, and the useful part is *why* it is clean.** Both requested titles were run (`--volume 0`, offscreen, 400 frames):

| title | root `.prx` | modules | aliased exports | faults |
| --- | ---: | ---: | ---: | ---: |
| GTA V `PPSA04263` | **0** | 3 | 0 | 0 |
| Sonic Frontiers `PPSA03831` | **0** | 2 | 0 | 0 |
| Tomb Raider I-III `PPSA16901` | **1** | 3 (was 2) | 0 | 0 |

**Corpus check, because the first draft of this section was scoped to two titles and that was not enough.** Measured across **all 60 local dumps**: exactly two ship a root-level module — `PPSA23806` (four, its own middleware) and **`PPSA16901` Tomb Raider I-III Remastered**, which ships `pros.sdk.Prospero-9.000.prx` and is **rung 3**. It is therefore the one title besides the subject whose link set this change alters, and it was run: 2 modules → 3, zero faults, presenting frames, so neither `linker.cpp:67`'s whole-link failure nor a `module_start` deadlock fires.

**That is a smoke test, not a rung-3 render check** — and note there is **no snapshot guard** for `PPSA16901` (checked: 17 entries in `snapshots.json`, none matching), so no automated guard exists to run. A human render check is the only stronger evidence available and has not been done.

Neither has a root-level module and neither had a collision-skip, so **both changed code paths are untaken on both titles**. That is a stronger claim than "it looks the same" — which matters here, because neither has a clean visual baseline to compare against (GTA V takes 122-175 device losses on a routed run by design, #3279). Sonic's one `SKIPPED` line is the pre-existing unimported-support-module drop.

**Evergate is the control for the rule's original purpose**: both fmod debug builds are still skipped.

## Test changes worth a look

`test_loader_synth_link`'s Arm 2 was **named** for the duplicate-build case but its fixture shared one of two exports — 50%, which is two different libraries, not two builds of one. So it asserted the old any-collision rule while claiming to test the rule's purpose, and could not distinguish the two cases. Split into 2a (a genuinely subsumed module, still skipped) and 2b (a distinct library, now linked with its own export surviving). **2b kills a revert to "skip on any collision"** and is the arm the old fixture could not provide.

## What this does NOT do

- **`sceAgcDriverInitResourceRegistration` is registered here and is NOT the crash fix.** I implemented it from a live-captured ABI, measured it, and the SIGSEGV was unchanged at the same rip — so that hypothesis is **falsified**. It is included because the guest calls it and prosper was answering with an unwritten success, which is a defect on its own terms.
- `U9ueyEhSkF4` stays unregistered: it resolves to nothing in the 3.20 reference, so there is no contract to implement against.
- Three defects remain open on #3497 from playing it: the intro FMV renders only its top-right triangle (**#3507**, hypothesis with a named discriminator), the FMV plays too fast, and the screen goes black after it.
- **Menu accuracy is not verified.** There is no oracle for this title; that is rung-5 work.

## Confidence / review notes

- `CONFIDENCE: HIGH` that the two link defects are real and that this fixes them — the chain is traced from the faulting instruction to a named unlinked module in the dump.
- `CONFIDENCE: MED` on 0.90 as a **universal** threshold. It is justified by four data points across five dumps. The band is wide, but that is an argument about this corpus, not a guarantee about every PS5 title. A title with, say, 85% overlap between two genuinely distinct libraries would be misjudged; none is known.
- The module-path policy change is the part that most warrants an independent read, per that file's own instruction.
