### PR TITLE
diag: a guest-state dump that cannot run must say so, not print success (#3509)

### DIFF
--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -4680,8 +4680,23 @@ void dump_guest_thread_trace(const char* path, uint64_t pthread_filter) {
     }
     if (close_output) CloseHandle(output);
 #else
-    (void)path;
+    // NOT a silent no-op (#3509). See the sibling note in sync_futex.cpp: the caller announces the
+    // dump, so silence here reads as success plus a caller error.
+    //
+    // Nothing to report on POSIX. This function's Windows body walks `g_win_guest_threads`, a
+    // registry populated only by the Win32 guest-thread trampoline, and `interruptible_cond_wait`'s
+    // POSIX arm is `(void)kind;` -- no guest wait is ever registered here. Reporting requires that
+    // registration to exist first, which is its own piece of work rather than a port of this
+    // function.
+    FILE* out = stderr;
+    FILE* opened = nullptr;
+    if (path && *path) { opened = std::fopen(path, "a"); if (opened) out = opened; }
+    std::fprintf(out,
+                 "[thread-trace] UNAVAILABLE on this platform: guest threads and their waits are "
+                 "registered only on Windows (hle_kernel.cpp g_win_guest_threads, sync_futex.cpp "
+                 "interruptible_cond_wait), so there is nothing to walk. See #3509.\n");
     (void)pthread_filter;
+    if (opened) std::fclose(opened);
 #endif
 }
 

--- a/prosper/src/hle/sync/sync_futex.cpp
+++ b/prosper/src/hle/sync/sync_futex.cpp
@@ -782,7 +782,23 @@ void dump_guest_sync_trace(const char* path) {
     }
     if (opened) std::fclose(opened);
 #else
-    (void)path;
+    // NOT a silent no-op (#3509). The caller prints "timed guest-state dump #N" before calling this,
+    // so returning quietly makes the announcement read as success and the absence of a file read as
+    // the caller's mistake -- which is exactly how this cost a run before being diagnosed.
+    //
+    // There is genuinely nothing to report here: the sync ring, its recorder and the wait
+    // registration it draws from are all inside this file's `#ifdef _WIN32` (opens :33, closes
+    // :262), so on POSIX no event is ever recorded. Porting the DUMPER alone would print an empty
+    // ring, which is a different lie. What that needs is guest-wait registration on POSIX, which is
+    // its own piece of work.
+    FILE* out = stderr;
+    FILE* opened = nullptr;
+    if (path && *path) { opened = std::fopen(path, "a"); if (opened) out = opened; }
+    std::fprintf(out,
+                 "[sync-trace] UNAVAILABLE on this platform: the sync event ring is Windows-only "
+                 "(sync_futex.cpp #ifdef _WIN32), so no events are recorded here and there is "
+                 "nothing to dump. See #3509.\n");
+    if (opened) std::fclose(opened);
 #endif
 }
 


### PR DESCRIPTION
Fixes #3509.

## The defect

`PROSPER_APP_GUEST_DUMP_MS` prints that it dumped, and writes nothing:

```
[app] timed guest-state dump #1 after 12000 ms at frame 3995
```

…with no file at `PROSPER_APP_GUEST_DUMP_PATH`, nothing on stderr, nothing anywhere. Both functions the timed dump calls had `(void)path;` as their entire non-Windows arm — `dump_guest_thread_trace` (`hle_kernel.cpp`) and `dump_guest_sync_trace` (`sync_futex.cpp`).

**The announcement is the defect, not the absence.** A missing feature is discovered in seconds; one that reports success and produces nothing costs a run and then makes you doubt your own invocation. That is what happened: I hit it while investigating BlazBlue's logo hold (#3496) and spent a run before diagnosing the tool rather than the title.

It also lands on the wrong platform — Linux is the primary development target, and "what is this title waiting on" is exactly what this tool exists to answer.

## The fix

Both functions now write to the requested path and name the reason, citing the file and guard rather than the symptom:

```
$ PROSPER_APP_GUEST_DUMP_MS=8000 PROSPER_APP_GUEST_DUMP_PATH=<path> \
    prosper-app --dump <DUMP_ROOT>/PPSA29714-app0 --volume 0
[app] timed guest-state dump #1 after 8000 ms at frame 2722

$ cat <path>
[thread-trace] UNAVAILABLE on this platform: guest threads and their waits are registered only on
  Windows (hle_kernel.cpp g_win_guest_threads, sync_futex.cpp interruptible_cond_wait), so there is
  nothing to walk. See #3509.
[sync-trace] UNAVAILABLE on this platform: the sync event ring is Windows-only (sync_futex.cpp
  #ifdef _WIN32), so no events are recorded here and there is nothing to dump. See #3509.
```

The value is that the announcement and the outcome now agree.

## This is NOT a port, and the issue's suggestion that one was easy is corrected on it

I wrote in #3509 that the sync ring was "already platform-neutral… a straightforward lift", having read the dumper's body, seen no Win32 calls in it, and **not checked the scope of the guard around everything it reads**. Measured properly:

| | |
| --- | --- |
| `sync_futex.cpp`'s `#ifdef _WIN32` | opens `:33`, closes `:262` |
| the ring `g_sync_trace` | `:102-107` — **inside** it |
| its recorder `sync_trace` | `:109` — **inside** it |
| `snapshot_guest_wait_registry` | `:695` — portable *signature*, Windows-only **body**, returns 0/0 |
| `interruptible_cond_wait` | `:304` — POSIX arm is `(void)kind;`, so **no guest wait is registered on Linux at all** |

Porting the dumper alone would print an empty ring — a different lie than the silent one. Real POSIX support requires guest-wait *registration* first, which is separate work. The note on #3509 suggests reading Linux's own state (`/proc/self/task`, `wchan`, futex addresses) rather than mirroring the Win32 `WaitSlot` registry, since that may be both simpler and more truthful.

## Verification

```
BUILD_RC=0   CTEST_RC=0   100% tests passed out of 460
```

Behaviour verified by running it on `PPSA29714`: the message reaches `PROSPER_APP_GUEST_DUMP_PATH` where the file was previously never created.

## Risk

Diagnostic-only. No guest-visible behaviour changes: both edits are to a previously-empty `#else` arm that ran only when a developer set `PROSPER_APP_GUEST_DUMP_MS`, and the Windows arms are untouched. `CONFIDENCE: HIGH`.

## Not done here

No test arm. Nothing currently exercises either function on any platform, and asserting "this switch produces output" needs a harness that can run the app with an env var and read a file — worth having (it is what would have caught this) but a larger change than the fix. Flagging rather than quietly omitting.
