### PR TITLE
docs: reframe the README around the experiment; move build steps to BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,173 @@
+# Building and running prosper
+
+Everything here is the mechanical part: dependencies, configure/build/test commands per platform,
+and how to launch a dump. For what prosper is, see the [README](README.md); for the rules a change
+is held to, [`CLAUDE.md`](CLAUDE.md) and [`docs/VERIFICATION.md`](prosper/docs/VERIFICATION.md).
+
+CI builds and tests Linux, Windows/MinGW and macOS on every push and pull request, and runs host
+ASan/UBSan and TSan jobs. Those are the supported configurations.
+
+The live graphics backend, the standalone compute backend and the app require **Vulkan 1.4** headers
+and a 1.4 device; older loaders and devices are rejected with a diagnostic. Ubuntu 24.04's system
+headers and loader are 1.3, so Linux CI installs pinned Khronos 1.4.341 headers and loader through
+`.github/actions/setup-vulkan`. Capability policy and the measurements behind the floor are in
+[`docs/VULKAN_RUNTIME.md`](prosper/docs/VULKAN_RUNTIME.md).
+
+## Linux (primary)
+
+Requires a C++20 compiler, CMake and Ninja. A Vulkan loader is needed for the graphics tests (the
+headless path uses the `llvmpipe` software ICD). `spirv-tools` provides `spirv-val`, which the
+`spv_validate` test requires. The AvPlayer backend uses FFmpeg for demux and VA-API for hardware
+video decode.
+
+```sh
+sudo apt install ninja-build pkg-config libvulkan-dev mesa-vulkan-drivers \
+  vulkan-validationlayers spirv-tools libavformat-dev libavcodec-dev libavutil-dev \
+  libswresample-dev libswscale-dev libva-dev
+```
+
+That gives the distribution's 1.3 headers, which build and run the test suite. For the live
+backends and the app, supply 1.4 headers and loader as the CI action above does.
+
+```sh
+cmake -S prosper -B prosper/build-linux -G Ninja
+cmake --build prosper/build-linux
+ctest --test-dir prosper/build-linux --no-tests=error   # unit + boot + Vulkan-execution tests
+```
+
+Add `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON` for the windowed frontend with
+audio and controllers; CMake fetches SDL3 when it is not installed. Video source-open requires a
+working VA-API render device by default; select a non-default node with
+`PROSPER_AVP_VAAPI_DEVICE=/dev/dri/renderD129`. `PROSPER_AVP_ALLOW_SOFTWARE=1` is an explicit
+diagnostic fallback, not normal playback.
+
+## Windows
+
+The supported toolchain is 64-bit MinGW-w64 UCRT. In an MSYS2 UCRT64 shell, the headless core —
+no SDL, no Vulkan, and the configuration CI runs on every push:
+
+```sh
+pacman -S --needed git mingw-w64-ucrt-x86_64-{gcc,cmake,ninja,spirv-tools}
+cmake -S prosper -B prosper/build-windows-core -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
+cmake --build prosper/build-windows-core
+ctest --test-dir prosper/build-windows-core --output-on-failure --no-tests=error
+```
+
+For the windowed app, add the Vulkan packages and enable the SDL3 backends:
+
+```sh
+pacman -S --needed mingw-w64-ucrt-x86_64-{vulkan-headers,vulkan-loader}
+cmake -S prosper -B prosper/build-windows-app -G Ninja \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPROSPER_APP=ON \
+  -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON
+cmake --build prosper/build-windows-app --target prosper-app
+./prosper/build-windows-app/prosper-app.exe --test-pattern --frames 120
+```
+
+From native PowerShell, the repository launcher does configure, build and launch in one command
+against WinLibs or MSYS2 MinGW plus an installed Vulkan SDK:
+
+```powershell
+.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
+```
+
+The full native build, screenshot and diagnostic recipe is in
+[`WINDOWS_PORT_HANDOFF.md`](prosper/docs/WINDOWS_PORT_HANDOFF.md).
+
+On a Windows host, drive **git** from PowerShell and use WSL only for cmake and running: a worktree
+created from Windows stores a Windows-path gitdir link that WSL's git cannot resolve.
+
+## macOS
+
+Built as x86_64 and tested under Rosetta 2 — the guest's code is x86-64, so there is no ARM path.
+This exercises the Darwin guest-execution substrate, not just a compile.
+
+```sh
+brew install ninja spirv-tools
+softwareupdate --install-rosetta --agree-to-license
+cmake -S prosper -B prosper/build-macos -G Ninja \
+  -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
+cmake --build prosper/build-macos
+ctest --test-dir prosper/build-macos --output-on-failure --no-tests=error
+```
+
+The SDL3 + MoltenVK app needs a universal driver (Homebrew's is arm64-only);
+`prosper/scripts/fetch-macos-vulkan.sh` fetches one, and `-DPROSPER_MACOS_MOLTENVK=<path>` points the
+build at it. The app's Vulkan 1.4 floor applies here too: a MoltenVK device exposing less than 1.4 is
+rejected. The CI job disables Vulkan and runs the headless core and substrate tests only. Details and
+current limits: [`docs/PORTING.md`](prosper/docs/PORTING.md).
+
+## Testing notes
+
+- **`--no-tests=error` is not optional when you quote a result.** Plain `ctest` exits 0 on a build
+  directory with nothing registered, so "no tests ran" and "everything passed" are otherwise the
+  same exit code. Quote the discovered test *count* alongside the exit code — a count is
+  falsifiable, an exit code alone is not.
+- **`spv_validate` fails rather than skips when `spirv-val` is missing.** It is the strict SPIR-V
+  gate, and silently skipping is how a real defect once shipped.
+- **A dump other than `PPSA24651` skips three cases rather than failing them.** Configuring
+  `-DGAME_DUMP=<DUMP_ROOT>/<TITLE_ID>-app0` at another title skips the cases that assert against
+  *The Messenger's* own bytes, so read the skip count and not only the exit code.
+- **Snapshot guards are a release-time regression inventory, not a per-commit gate.** See
+  [`tools/snapshot/AGENTS.md`](prosper/tools/snapshot/AGENTS.md).
+
+A single tool can be built without configuring the project:
+
+```sh
+g++ -O2 -std=c++20 prosper/tools/self_dump/self_dump.cpp -o self_dump
+./self_dump <DUMP_ROOT>/PPSA24651-app0/eboot.bin [--symbols]
+```
+
+## Editor / LSP
+
+CMake exports `compile_commands.json` into the build directory; a symlink at the repository root
+points clangd at it. Each worktree is its own source tree and needs its own configure, or its files
+resolve no includes.
+
+```sh
+cmake -S prosper -B prosper/build-linux
+ln -sf prosper/build-linux/compile_commands.json compile_commands.json
+clangd --check=<file> --compile-commands-dir=.     # exit 0 = parsed
+```
+
+## Running a dump
+
+You supply your own legally-obtained dump; nothing in this repository or its releases contains
+games, firmware or keys.
+
+A `v*` tag publishes desktop archives on the
+[releases page](https://github.com/mattias800/prosper/releases) —
+`prosper-linux-x86_64.AppImage`, `prosper-linux-x86_64.tar.gz` and `prosper-windows-x64.zip`, each
+with a `.sha256`. Take the AppImage for normal Linux desktop use and the tarball when the AppImage
+runtime cannot start (it needs FUSE). Each archive ships a launcher that supplies the guest
+environment, creates local save data and enables the window, audio and controller:
+
+```bash
+tar -xzf prosper-linux-x86_64.tar.gz && cd prosper-linux-x86_64
+./start-prosper.sh ~/ps5/PPSA24651-app0
+```
+
+```powershell
+./start-prosper.ps1 'D:/PS5/PPSA24651-app0'
+```
+
+The Linux archives carry FFmpeg, libva and the Vulkan loader because their sonames differ per
+distribution, and link SDL3 statically. What you must supply is **glibc 2.39 or newer** and your
+GPU's Vulkan driver. `--list-games --games-dir ~/ps5` prints the titles it can see and exits without
+opening a window, which is the quickest way to confirm a download runs.
+
+There is no game picker or settings UI. Requirements, keyboard mapping, save-data selection,
+recordings and troubleshooting: [`LINUX_RELEASE.md`](prosper/docs/LINUX_RELEASE.md),
+[`WINDOWS_RELEASE.md`](prosper/docs/WINDOWS_RELEASE.md), and
+[`packaging/linux/`](prosper/packaging/linux/README.md) for how the archives are built.
+
+Expect the milestone recorded in [`COMPATIBILITY.md`](COMPATIBILITY.md) for a given title and
+nothing beyond it.
+
+## Building from a source checkout, in a worktree
+
+Several agents and the maintainer run this repository concurrently, so the main checkout and its
+build directory are contended. Work in your own worktree with its own build directory, and remove
+it when your branch merges — `prosper/tools/worktree_reclaim.py` reports what is reclaimable.
+See `CLAUDE.md` for the full protocol, including why run artifacts must not go in `/tmp`.

--- a/README.md
+++ b/README.md
@@ -1,293 +1,63 @@
 <p align="center">
-  <img src="assets/prosper-logo.png" alt="prosper" width="256">
+  <img src="assets/prosper-logo.png" alt="prosper" width="200">
 </p>
 
 # prosper
 
-**A user-space PlayStation 5 → PC compatibility layer.** Think *Proton/Wine, but for PS5*: prosper
-runs PS5 (Prospero) game binaries on Linux (primary) and Windows (secondary) by reimplementing the
-console's OS, ABI, and GPU stack on the host — **not** by emulating a CPU.
+prosper is a user-space PS5 (Prospero) → PC compatibility layer for Linux and Windows. The PS5 is
+x86-64, so guest code runs natively and there is no CPU emulation. The work is loading Sony's
+SELF/ELF modules and linking them into one address space, reimplementing the PS5 system libraries
+on top of host facilities, translating the ABI where the guest's conventions differ, and translating
+AGC GPU command streams to Vulkan, which includes an RDNA2 → SPIR-V shader recompiler.
 
-> ⚠️ **Experimental research project.** It is not a general-purpose game runner yet. Tested retail
-> titles currently reach different milestones and still expose substantial compatibility gaps. See
-> [Game compatibility](COMPATIBILITY.md) for title-by-title results and known blockers.
-Progress blog, newest first: [`BLOG.md`](BLOG.md).
+It exists to test a method: whether a repository can be structured — charter, tooling, tests,
+evidence rules — so that AI agents do reverse-engineering work of this kind over months, with a
+human who sets direction and reviews results but does not write code. Preservation work has this
+shape, and there is more of it than there are people doing it.
 
-## Screenshots
+This is not a product. There is no support, no release schedule, and no claim that any title works
+beyond the specific route documented for it.
 
-Real retail PS5 titles running under prosper on Linux — direct, unmodified captures from the frontend
-(no post-processing), retained at each title's native output resolution. Each reaches the milestone noted
-in [Game compatibility](COMPATIBILITY.md).
+## How the work is organised
 
-<p align="center">
-  <img src="assets/screenshots/messenger.webp" alt="The Messenger — first level gameplay"><br>
-  <em><strong>The Messenger</strong> — first level, native 1920×1080</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/dead-cells.webp" alt="Dead Cells — Prisoners' Quarters gameplay"><br>
-  <em><strong>Dead Cells</strong> — controllable Prisoners' Quarters</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/blasphemous2.webp" alt="Blasphemous 2 — first playable room"><br>
-  <em><strong>Blasphemous 2</strong> — first playable room</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/evergate.webp" alt="Evergate — first tutorial room gameplay"><br>
-  <em><strong>Evergate</strong> — first tutorial room</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/gris.webp" alt="GRIS — opening gameplay"><br>
-  <em><strong>GRIS</strong> — opening gameplay, native 1920×1080</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/syberia-profile.webp" alt="Syberia: Remastered — profile menu with its full-width 3D scene restored; exposure remains incorrect"><br>
-  <em><strong>Syberia: Remastered</strong> — profile menu and restored 3D scene, still overexposed, native 1920×1080</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/space-adventure-cobra.webp" alt="Space Adventure Cobra — tutorial combat"><br>
-  <em><strong>Space Adventure Cobra — The Awakening</strong> — tutorial combat, native 1920×1080</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/blue-prince-hall.webp" alt="Blue Prince — Day One entrance hall"><br>
-  <em><strong>Blue Prince</strong> — Day One entrance hall, native 1920×1080</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/terminator.webp" alt="Terminator 2D: NO FATE — attract-mode gameplay"><br>
-  <em><strong>Terminator 2D: NO FATE</strong> — attract-mode gameplay</em>
-</p>
-<p align="center">
-  <img src="assets/screenshots/dragon-quest-vii-onboarding.webp" alt="Dragon Quest VII Reimagined — first-run System Settings 1/4 onboarding"><br>
-  <em><strong>Dragon Quest VII Reimagined</strong> — first-run System Settings 1/4 onboarding, native 3840×2160</em>
-</p>
+- [`CLAUDE.md`](CLAUDE.md) is the project charter: scope, build and run recipes, evidence rules, and
+  the recorded mistakes that have cost the most time. It is read before starting work and assumes no
+  memory of previous sessions.
+- Progress is defined by a six-rung ladder per title. A game loop running over a black screen is not
+  gameplay, and a build that compiles is not progress.
+- Verification is programmatic ([`docs/VERIFICATION.md`](prosper/docs/VERIFICATION.md)): Vulkan
+  tests that assert numeric and pixel results, a `spirv-val` gate on every SPIR-V emitter, and
+  golden-image guards over real boots.
+- Falsified hypotheses are recorded in a `## Ruled out` section in the relevant status document.
+  Measurements that turned out to come from the apparatus rather than the subject are recorded as
+  numbered instrument traps.
+- Questions that existing tools cannot answer are answered by writing a tool, under
+  [`tools/`](prosper/tools/AGENTS.md).
+- GitHub issues hold work that spans sessions. Concurrent agents claim an issue before starting and
+  work in separate git worktrees. Non-obvious changes get an independent review before merge.
 
-> These illustrative screenshots are captures of prosper's own rendered output; the games' artwork remains
-> the property of its respective owners. No game files, assets, keys, or data are redistributed in this
-> repository — you must supply your own legally-obtained dump.
+Most of the costly failures so far have not been in generated code, but in bookkeeping and
+inference. A retracted figure left standing in the charter kept being used for a day after it was
+withdrawn. A review finding with a plausible `file:line` citation was repeated across many sessions
+without anyone opening the file. A positive control passed on a case it could not have detected.
+Each of those is now a rule in `CLAUDE.md`.
 
-## Why no CPU emulation?
+## Scope
 
-The PS5 is an x86-64 (AMD Zen 2) machine, so guest game code runs **natively** on any modern PC.
-prosper is therefore shaped like Wine, not like an emulator. The engineering is:
+No game files, keys or Sony code are in this repository. You supply your own legally obtained dump.
+prosper holds no console keys, performs no decryption, and operates only on module segments that are
+already unencrypted. It also refuses to link the third-party replacements for Sony libraries that
+some dumps carry, since loading one would perform the circumvention by proxy. Entitlement and
+add-content queries are answered from the content present on disk rather than approved
+unconditionally. Sony's library interfaces are reimplemented from published symbol and NID data,
+clean-room. The project is independent and not affiliated with Sony Interactive Entertainment.
 
-- **Loading** Sony's `SELF`/`ELF` module format and linking multiple modules into one address space,
-- **HLE** (high-level emulation) of the PS5 system libraries (`libkernel`, `libc`, `libSceAgc`,
-  `libScePad`, `libSceSaveData`, `libSceNp`, the dialog/IME libraries, …) by thunking to the host's
-  real facilities (libc, pthreads, `mmap`, `futex`, Vulkan, …),
-- **ABI translation** where the guest's FreeBSD/SysV conventions differ from the host, and
-- **Graphics translation:** PS5 **AGC** command streams → Vulkan, including a from-scratch
-  **RDNA2 → SPIR-V shader recompiler** and the RDNA2 texture-tiling / block-compression decoders.
+## Where things are
 
-Because the PS5 and Steam Deck / AMD Linux machines share the same RDNA2 GPU family, Linux is the
-natural primary target and the long-term dream is running on that hardware.
+- [`BUILDING.md`](BUILDING.md) — dependencies, build and test commands, launching a dump.
+- [`prosper/README.md`](prosper/README.md) — the source tree and its architecture documents.
+- [`CLAUDE.md`](CLAUDE.md) — the charter.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — what makes an external contribution reviewable.
+- [`COMPATIBILITY.md`](COMPATIBILITY.md) — per-title results.
 
-## Status
-
-prosper boots **multiple real retail titles** from user-supplied, **unencrypted-segment** dumps. The
-tested set spans multiple engines and exercises the loader, host-side OS/ABI layer, services, input,
-audio, and graphics stack. See [Game compatibility](COMPATIBILITY.md) for exact per-title progress.
-
-**Boot & runtime (host-side OS / ABI / HLE):**
-- ✅ Parses `SELF`/`ELF`, builds a relocatable image, resolves Sony **NID**-hashed imports, links the
-  game's modules with a global export table + per-import HLE stubs, and runs the Sony CRT + C++ global
-  constructors.
-- ✅ Enough `libkernel`/`libc` for real memory management (virtual + direct + flexible memory, guard
-  pages), threads (pthreads, TLS, mutexes/conds, event flags, semaphores, `sync_on_address` futex),
-  scheduling, time, AIO + positioned file I/O (with `/app0` path translation), and locale/ctype.
-- ✅ Boots several engine families into their running frame loop and real GPU submission — **Unity /
-  IL2CPP** (loads the C# metadata, spins up the full IL2CPP GC + worker thread pool, drives Unity's
-  `GfxDevice` bring-up), **Unreal Engine**, and Rockstar's **RAGE** — with several titles reaching
-  interactive menus or gameplay.
-- ✅ System services the game gates on: user/pad service, SaveData (real per-slot memory blocks),
-  AvPlayer / AJM lifecycle, common dialogs + IME (with an optional real SDL3 dialog frontend), NP /
-  online (honest signed-out), system-parameter (language) — implemented as faithful behaviors, not
-  success-returning stubs.
-
-**Graphics (AGC → Vulkan):**
-- ✅ **AGC command frontend:** `sceAgcCreateShader` (relocates the embedded RDNA2 shader ELFs) and the
-  submit path; a real submitted `Dcb` is decoded (→ PM4 packets) and folded into a GPU register-state,
-  with GPU-completion (EOP) events and DMA/fence writes delivered on the guest's own timeline
-  (regression-locked by tests).
-- ✅ **RDNA2 → SPIR-V shader recompiler** (we recompile the GPU ISA, not emulate it): full scalar/
-  vector ALU (float/int/bitwise/convert/compare/select/bitfield/pack), `SCC`, **divergent control
-  flow** (EXEC-mask predication, `saveexec`/restore, `execz` if-then and loop exits), `SMEM`
-  constant/descriptor loads, `MUBUF` vertex-fetch + load/store, `MIMG` `image_sample`/`_l`/`_lz`/
-  `image_load`, `LDS` + barriers, `EXP` render-target/position/param exports, and `VINTRP`
-  interpolation. Descriptors that spill into the **Extended User Data (EUD)** area are resolved. Every
-  SPIR-V-emitting entry point declared in the graphics headers — the recompiler stages and the
-  hand-assembled compute modules alike — is `spirv-val`-gated in CI by `tools/spv_validate`, which
-  fails both when a module is invalid and when a new emitter is added without one. (The pre-baked
-  glslang modules in `tests/` are fixtures, not emitters, and are covered by the Vulkan validation
-  layer instead.)
-- ✅ **Texture decode:** GFX10 `SW_4KB_S` / `SW_64KB_S` de-swizzle for all element sizes (1/2/4/8/16 B,
-  derived from the authoritative addrlib table) plus BC1–BC7 and BC6H block decompression, honoring
-  the T# format, `DST_SEL` channel swizzle, and the paired S# sampler (filter / wrap / anisotropy /
-  LOD / border).
-- ✅ **Frame spine → live renderer:** decoded register-state → `render_state` / `vk_translate` →
-  `resolve_pipeline_state` → real `VkGraphicsPipeline`s, with topology, blend (incl. separate-alpha),
-  depth, stencil, per-MRT color-write-mask, the game's real fast-clear color, and a render-to-texture
-  cache for multi-pass composites — all driven from the decoded registers and pixel-verified.
-
-**Frontend:** `prosper-app` is a windowed player (SDL3 window + Vulkan present + audio sink +
-evdev/SDL3 controllers + real message/error/IME dialogs), sharing the same boot + render core as the
-headless `boot_trace`.
-
-Development is **agentic-first**: correctness is verified programmatically — a broad suite of
-**self-checking tests** under `ctest` (including a headless Vulkan/llvmpipe harness that runs recompiled shaders and asserts
-numeric/pixel results, and per-opcode round-trip disassembly checks), a **golden-image snapshot guard**
-that boots a real title and pixel/content-asserts an exact frame, cross-platform CI (Linux +
-Windows/MinGW), structured logs, and purpose-built tracing tooling — never by hand.
-
-## Legal / ethical
-
-- **No game files, keys, or copyrighted Sony code are included** in this repository, and none ever
-  will be. You must supply your own legally-obtained dump.
-- prosper only works with **unencrypted** module segments; it contains **no** console decryption
-  keys and performs no circumvention of Sony's cryptography.
-- Sony's library interfaces are reimplemented from published symbol/NID information, clean-room style,
-  the way Wine reimplements Win32.
-- This is an independent interoperability / preservation research project, not affiliated with or
-  endorsed by Sony Interactive Entertainment.
-
-## Building
-
-### Linux
-
-Requires a C++20 compiler, CMake, and Ninja. A Vulkan loader is needed for the graphics tests
-(the CI/headless path uses the `llvmpipe` software ICD). `spirv-tools` provides `spirv-val`, which
-the `spv_validate` test requires — it is the strict SPIR-V validation gate and fails rather than
-skipping when the validator is missing. The native AvPlayer backend uses FFmpeg for MP4
-demux/audio conversion and VA-API for hardware video decode. On Ubuntu/Debian:
-
-```sh
-sudo apt install ninja-build pkg-config libvulkan-dev libavformat-dev libavcodec-dev \
-  libavutil-dev libswresample-dev libswscale-dev libva-dev spirv-tools
-```
-
-```sh
-cd prosper
-cmake -G Ninja -B build-linux
-cmake --build build-linux
-ctest --test-dir build-linux --no-tests=error  # unit + boot + Vulkan-execution tests
-```
-
-Add `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON` to build the windowed frontend
-with audio and controller support. CMake fetches SDL3 when it is not installed. Video source-open
-requires a working VA-API render device by default; select a non-default node with
-`PROSPER_AVP_VAAPI_DEVICE=/dev/dri/renderD129`. `PROSPER_AVP_ALLOW_SOFTWARE=1` is an explicit
-diagnostic fallback, not normal playback behavior.
-
-### Windows core
-
-The supported Windows toolchain is 64-bit MinGW-w64 UCRT. In an MSYS2 UCRT64 shell:
-
-```sh
-pacman -S --needed git mingw-w64-ucrt-x86_64-gcc \
-  mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja \
-  mingw-w64-ucrt-x86_64-spirv-tools
-cmake -S prosper -B prosper/build-windows-core -G Ninja \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
-cmake --build prosper/build-windows-core
-ctest --test-dir prosper/build-windows-core --output-on-failure --no-tests=error
-```
-
-This builds and tests the headless core without SDL or Vulkan. GitHub Actions runs the same UCRT64
-path on every push and pull request.
-
-### Windows app
-
-Install the Vulkan development packages in the same UCRT64 shell, then enable the app and its SDL3
-backends:
-
-```sh
-pacman -S --needed mingw-w64-ucrt-x86_64-vulkan-headers \
-  mingw-w64-ucrt-x86_64-vulkan-loader
-cmake -S prosper -B prosper/build-windows-app -G Ninja \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPROSPER_APP=ON \
-  -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON
-cmake --build prosper/build-windows-app --target prosper-app
-./prosper/build-windows-app/prosper-app.exe --test-pattern --frames 120
-```
-
-From native PowerShell, the repository launcher supports WinLibs or MSYS2 MinGW plus an installed
-Vulkan SDK and performs configure, build, and launch in one command:
-
-```powershell
-.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
-```
-
-The detailed native build, screenshot, and diagnostic recipe is in
-[`WINDOWS_PORT_HANDOFF.md`](prosper/docs/WINDOWS_PORT_HANDOFF.md).
-
-## Windows download and use
-
-A `v*` tag publishes `prosper-windows-x64.zip` and its `.sha256` on the repository's
-[GitHub Releases page](https://github.com/mattias800/prosper/releases). The archive contains
-`prosper-app.exe`, a one-command PowerShell launcher, and its usage guide; it never contains games,
-firmware, or keys.
-
-After extracting the archive, launch an unpacked `app0` directory:
-
-```powershell
-./start-prosper.ps1 'D:/PS5/PPSA24651-app0'
-```
-
-There is no game-picker or settings UI yet. The launcher supplies the required guest environment,
-creates local save data, and enables the Vulkan window, audio, physical controller, and keyboard
-overlay. Use `./start-prosper.ps1 -TestPattern -Frames 120` to test the frontend without a game.
-See [`WINDOWS_RELEASE.md`](prosper/docs/WINDOWS_RELEASE.md) for requirements, direct-executable use,
-save-data selection, the complete keyboard mapping, recordings, and troubleshooting.
-
-## Linux download and use
-
-A `v*` tag publishes `prosper-linux-x86_64.AppImage` and `prosper-linux-x86_64.tar.gz`, each with a
-`.sha256`, on the same [GitHub Releases page](https://github.com/mattias800/prosper/releases). Take the
-AppImage for normal desktop use and the tarball when the AppImage runtime cannot start (it needs
-FUSE). Like the Windows archive, neither contains games, firmware, or keys.
-
-```bash
-chmod +x prosper-linux-x86_64.AppImage
-PROSPER_GUEST_ARGS=-force-gfx-direct \
-  ./prosper-linux-x86_64.AppImage --dump ~/ps5/PPSA24651-app0
-```
-
-The tarball ships `start-prosper.sh`, the counterpart of the Windows launcher, which supplies that
-environment for you:
-
-```bash
-tar -xzf prosper-linux-x86_64.tar.gz && cd prosper-linux-x86_64
-./start-prosper.sh ~/ps5/PPSA24651-app0
-```
-
-FFmpeg, libva and the Vulkan loader travel inside the archive because their sonames differ on every
-distribution; SDL3 is statically linked. What you must supply is **glibc 2.39 or newer** and your
-GPU's Vulkan driver — no archive can carry either. `./prosper-linux-x86_64.AppImage --list-games --games-dir ~/ps5` prints
-the titles it can see and exits without opening a window, which is the quickest way to confirm a
-download runs. See [`LINUX_RELEASE.md`](prosper/docs/LINUX_RELEASE.md) for the full requirements,
-keyboard mapping, recordings, and troubleshooting, and
-[`prosper/packaging/linux/`](prosper/packaging/linux/README.md) for how the archives are built.
-
-## Repository layout
-
-```
-prosper/
-  src/self/       SELF/ELF parsing → relocatable module image
-  src/loader/     multi-module linker + global export table
-  src/hle/        HLE of Sony libraries (libc, libkernel, AGC/graphics, services), NID hashing
-  src/host/       host execution: per-platform image mapping, ABI stubs, fault handling
-  src/gpu/        AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
-                  texture tiling + BC decode, and the RDNA2→SPIR-V shader recompiler
-  frontends/      shared boot+render core, the windowed prosper-app, SDL3 audio/dialog, controllers
-  tools/          boot_trace, self_dump, shader_histo, snapshot (golden-image guard), spv_validate, …
-  tests/          unit + boot + Vulkan-execution tests (run under ctest)
-  docs/           ARCHITECTURE, ROADMAP, GRAPHICS, RENDER_LOOP, VERIFICATION, and per-frontier logs
-```
-
-The July 2026 renderer profiling results, correctness constraints, rejected experiments, and next
-architecture step are recorded in
-[`RENDERER_PERFORMANCE_2026_07.md`](prosper/docs/RENDERER_PERFORMANCE_2026_07.md).
-
-## License
-
-See [LICENSE](LICENSE) if present. Game files, assets, keys, and Sony SDK symbols are the property of
-their respective owners and are not redistributed here; the documentation screenshots are captures of
-prosper's own rendered output, shown for illustration.
+No `LICENSE` file exists yet, so no license is granted by default. Open an issue to ask.

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -1,111 +1,49 @@
-# prosper
+# prosper — source tree
 
-A PS5 (Prospero) → **Linux/Windows** user-space compatibility layer — *Proton for PS5*.
+This directory is the project itself: the compatibility layer, its tools, its tests and its
+documentation. Start from the [repository README](../README.md) for what prosper is and why it
+exists, [`../BUILDING.md`](../BUILDING.md) to build it, and [`../CLAUDE.md`](../CLAUDE.md) — the
+project charter — before changing anything here.
 
-Not a CPU emulator: the PS5 is x86-64, so guest code runs **natively**. `prosper` reimplements the
-operating system (FreeBSD-derived), the library ABI (Sony NID-linked modules), and the GPU
-(AGC → Vulkan) underneath the unmodified game binary.
+A PS5 (Prospero) → **Linux/Windows** user-space compatibility layer, shaped like Proton rather than
+like an emulator. Not a CPU emulator: the PS5 is x86-64, so guest code runs **natively**. prosper
+reimplements the operating system (FreeBSD-derived), the library ABI (Sony NID-linked modules) and
+the GPU (AGC → Vulkan) underneath an unmodified game binary. It operates only on dumps whose SELF
+segments are already unencrypted, which is what makes the project possible without console keys.
+Dumps are user-supplied and gitignored.
 
-**Primary title:** `PPSA24651` — *The Messenger* (Unity 2022 / IL2CPP). The compatibility corpus now
-tracks 39 titles across Unity/IL2CPP, Unreal Engine, RAGE, Hedgehog Engine and custom engines; see
-[`../COMPATIBILITY.md`](../COMPATIBILITY.md) for the current user-visible milestones. Their SELF
-segments are unencrypted, which is what makes the project possible without console keys. Dumps are
-user-supplied and gitignored.
+## Orientation
 
-For development, start with [Debugging and profiling workflows](docs/DEBUGGING_WORKFLOWS.md):
-question-to-tool recipes, capability controls, host sanitizer checks and GPU capture analysis.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — how the layers fit together.
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) — what is planned.
+- [`docs/GRAPHICS.md`](docs/GRAPHICS.md), [`docs/RESOURCE_BINDING.md`](docs/RESOURCE_BINDING.md),
+  [`docs/RECOMPILER_REMAINING.md`](docs/RECOMPILER_REMAINING.md) — the AGC → Vulkan pipeline, its
+  descriptor model, and the shader recompiler's remaining gaps.
+- [`docs/VERIFICATION.md`](docs/VERIFICATION.md) — the programmatic, no-manual-eyeballing
+  verification strategy every change is held to.
+- [`docs/PORTING.md`](docs/PORTING.md) — per-platform substrate notes (Linux, Windows, macOS/Rosetta).
+- [`tools/AGENTS.md`](tools/AGENTS.md) — what each tool is for and which question it answers.
+- [`docs/DEBUGGING_WORKFLOWS.md`](docs/DEBUGGING_WORKFLOWS.md) — question-to-tool recipes,
+  capability controls, host sanitizer checks and GPU capture analysis. Start here for development.
+- [`docs/VULKAN_RUNTIME.md`](docs/VULKAN_RUNTIME.md) — the Vulkan 1.4 runtime floor the live
+  graphics and compute backends require, and the capability policy behind it.
+- [`docs/GAME_COMPAT_ORCHESTRATION.md`](docs/GAME_COMPAT_ORCHESTRATION.md) — concurrent title work,
+  and the numbered list of instrument traps: measurements that turned out to come from the
+  apparatus rather than the subject.
+- `docs/<TITLE>_STATUS.md` — the investigation record for one title. Read its `## Ruled out`
+  section before forming a hypothesis; it lists the hypotheses already falsified and the evidence
+  that settled them. Closed investigations keep theirs too, including
+  [`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current per-title state lives
+  in the `tracker:game` issues, not in this tree.
 
-## Status
-- ✅ **M0–M1 — Recon, tooling & loader.** Format cracked; SELF/ELF → relocatable image → multi-module
-  link → NID import binding.
-- ✅ **M2–M3 — HLE + boot.** libkernel/libc (virtual/direct/flexible memory + guard pages, threads,
-  futex, AIO + file I/O, time, locale); IL2CPP GC + thread pool; system services the games gate on
-  (user/pad, SaveData, AvPlayer/AJM, common dialogs + IME, NP/online, system language). Boots
-  **through** IL2CPP and Unity's GfxDevice into the running frame loop.
-- ✅ **M4 — Graphics (AGC → Vulkan).** AGC frontend (CreateShader + submit; PM4 decode → command
-  processor → register-state fold; EOP/DMA/fence writes on the guest timeline). **RDNA2→SPIR-V
-  recompiler:** broad scalar/vector ALU coverage + `SCC`; divergent control flow (EXEC predication,
-  saveexec/restore, `execz` if-then + loop exits); `SMEM`, `MUBUF` vertex-fetch/load/store, `MIMG`
-  sample/load, `LDS` + fail-closed barrier lowering,
-  `EXP`/`VINTRP`; EUD-resident descriptor resolution; every SPIR-V emitter `spirv-val`-gated in CI
-  (`tools/spv_validate`). Texture decode:
-  GFX10 `SW_4KB_S`/`SW_64KB_S` de-swizzle for all element sizes + BC1–7/BC6H, T# format + `DST_SEL`
-  swizzle + paired S# sampler. Frame spine → `resolve_pipeline_state` → real `VkGraphicsPipeline`s
-  with blend (incl. separate-alpha)/depth/stencil/write-mask/fast-clear + a render-to-texture cache.
-- ✅ **The Messenger renders through gameplay:** intro, title, menus, save list, and the complete first
-  level render at native 1920×1080 with working scripted gamepad progression. The LUT producer,
-  foreground culling, and cross-call depth/stencil lifecycle fixes are regression-covered by Vulkan
-  tests and the real-game snapshot guard.
-- ✅ **Graphics investigation tooling:** versioned live GPU capture/replay (`.prgcap`), per-draw/resource
-  inspection and isolation, strict reflected SPIR-V/runtime descriptor validation, render-target producer
-  provenance, normal screenshot capture, and a local content-metric snapshot guard. Native-speed `.prgtl`
-  submit/present indexes can select an exact submit or semantic route checkpoint before renderer sampling and
-  materialize immutable, content-deduplicated graphics/compute state plus mixed operation order for offline
-  replay (#594).
-  Offline dependency graphs resolve in-submit resource versions and identify deduplicated prior-submit
-  leaves, including temporal read-before-write surfaces, without invoking Vulkan (#595). Capture v7 retains
-  bounded, content-addressed raw RDNA2 and exact opcode/PC/state diagnostics for unrealized draws/dispatches;
-  `gpu_replay` can inspect and extract the failed stage without rerunning the title (#618).
-- ✅ **Dead Cells reaches gameplay reproducibly:** deterministic native-Windows routes pass the splash and menus
-  into the first playable scene with rendering disabled or with every retained GPU submit fully executed and
-  published (#766). The persistent-depth rejection is fixed: timeline-v5 backing hashes and
-  compute writer provenance identify Unity's 32 KiB HTILE fill as the per-frame fast clear, and overlapping
-  guest GPU writes now invalidate the detached Vulkan depth cache (#611). A routed live A/B restores the
-  foreground/platform/HUD layers that remained black without invalidation.
-  Four repeated fragment failures were uniform VCCZ-exit light-accumulation loops. The stage-specific
-  structurizer now accepts that shape only when each compare operand has a proved wave-uniform reaching
-  definition; varying bounds and the compute wave-mask form still reject. Current routed gameplay submits
-  realize every semantic draw (#615).
-  Version-8 GPU captures seed temporal render targets, retain complete depth-surface programming, preserve
-  exact persistent Vulkan depth/stencil checkpoint planes, and keep content-addressed resource versions for
-  faithful offline isolation (#568/#594/#569). Dispatch thread counts and derived workgroup dimensions,
-  compute program binding, direct type-1 buffers, and mixed graphics/compute PM4 order now execute correctly
-  (#580/#576/#584).
-  The later giant translucent Dead Cells gameplay surface was a native-format loss: a 642x362 RGBA16F lighting
-  target was rendered and sampled as RGBA8, clamping HDR values before composition. Renderer-owned targets now
-  preserve RGBA16F through render, readback, seeding, sampling, and persistent Vulkan caches. Capture v13 records
-  the RTT format and remains backward-compatible with v1..v12 artifacts (#773). A compute reset of that lighting
-  backing also invalidates the overlapping CPU RTT copy; retaining it had re-seeded the previous frame and driven
-  the temporal effect toward white/yellow (#780). Residual window-light banding is tracked separately in #781.
-- ✅ **Blasphemous 2 reaches first gameplay:** prelinking the title's optional FMOD core/studio
-  plugins lets IL2CPP P/Invoke complete `FMODAudioBanksManager` initialization (#638/#640). The later AGC
-  fault was prosper corrupting live DCB state: `+kSrjIVxKFE` is `sceAgcDcbPushMarker`, not the context
-  constructor modeled by the old workaround (#641). A dedicated two-pass `sceHttpUriParse` implementation
-  replaces the success-with-stale-output stub that crashed the title's telemetry worker (#642). The routed
-  run continues through its Http2 calls and loads gameplay scenes, UI, enemies, bosses, audio banks, and
-  cutscene assets. Normal-return guest pthreads now leave host `%fs` active before glibc performs its own
-  thread cleanup (#644), removing the next host crash. Poll-safe scripted presses and observed-state logging
-  (#646) reliably traverse the long opening. PS5 primitive type 7 is the title's procedural RectList clear;
-  mapping it to a four-corner Vulkan triangle strip clears stale UI alpha instead of rasterizing three points
-  over an otherwise valid world (#654). A 420-frame sampled-render native capture confirms the complete first
-  playable room, and screenshot manifests distinguish new publications from actual pixel progress (#648).
-  The route and capture recipe are in `scripts/blasphemous2/README.md`.
-- 🚧 **Active frontiers (2026-08-11):** GTA V reaches its title/menu and routed gameplay entry, where
-  the HUD, radar and tutorial text render over an absent 3D world. The six-stage runtime-selected
-  descriptor-array lift is complete. Program-tagged live evidence proved that the earlier "about 57 CFG
-  sites" count mixed consequent structurizer messages with independent terminal failures; reviewed work
-  now advances the exact failing programs one instruction or resource contract at a time. The current
-  routed sample has 29 recompile-empty programs plus 6 invalid-descriptor programs, a 35-program union
-  with no new failures versus the preceding sample (#2412/#2481). Subgroup-contract limits are tracked
-  separately in #2429. Dragon Quest VII now boots and submits
-  continuously on Windows (#2447), but routed
-  progression can hit a fixed `sceKernelBatchMap` ENOMEM whose high-volume memory logger suppresses the
-  repro (#2448/#2450). Sonic Racing: CrossWorlds has advanced to rung 2: pulsed input reaches its full
-  4K title screen, while the later profile panel and terminal white state remain open (#2358/#2360).
-
-The completed Messenger black-render investigation and reusable evidence boundary are recorded in
-[`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub
-issues; title failures should produce a reproducible route/capture and a narrowly scoped issue rather
-than a moving-revision hypothesis log.
-
-See [`docs/ROADMAP.md`](docs/ROADMAP.md), [`docs/GRAPHICS.md`](docs/GRAPHICS.md),
-[`docs/RENDER_LOOP.md`](docs/RENDER_LOOP.md), and [`docs/VERIFICATION.md`](docs/VERIFICATION.md)
-(the agentic-first, programmatic, no-manual-eyeballing verification strategy).
+Folders that hold real content carry an `AGENTS.md` describing what belongs in them. It is a map,
+not documentation of the code.
 
 ## Layout
+
 ```
 prosper/
-  docs/            architecture, roadmap, graphics, verification, per-frontier logs
+  docs/            architecture, roadmap, graphics, verification, per-title and per-frontier logs
   src/self/        SELF/ELF parsing → relocatable module image
   src/loader/      multi-module linker + global export table
   src/hle/         HLE of Sony libraries (libc, libkernel, AGC/graphics, services), NID hashing
@@ -113,42 +51,32 @@ prosper/
   src/gpu/         AGC→Vulkan: PM4 decode, command processor, render state, vk_translate,
                    texture tiling + BC decode, RDNA2→SPIR-V recompiler
   frontends/       shared boot+render core, windowed prosper-app, SDL3 audio/dialog, controllers
-  tools/           self_dump, boot_trace, shader_histo, screenshot, snapshot, gpu_timeline, gpu_replay,
-                   spv_validate
+  tools/           self_dump, boot_trace, screenshot, snapshot, gpu_timeline, gpu_replay,
+                   spv_validate, shader_histo, re/, il2cpp/, refactor/, …
   tests/           unit + boot + Vulkan-execution tests (ctest)
+  scripts/         per-title launch and input routes
   CMakeLists.txt
 ```
 
+`CMakeLists.txt` globs `src/*.cpp` recursively, so a new subfolder under `src/` needs no
+source-list edit. Every new file belongs under `prosper/` for that reason — CI enforces it, because
+a file added at the repository root compiles nowhere while every job still reports success.
+
 ## Build
 
-The live Vulkan renderer, compute backend, and windowed frontend require Vulkan 1.4 headers,
-loader, and a Vulkan 1.4 device. Optional features are checked individually; no experimental driver
-flags are required. Older MoltenVK devices no longer satisfy the runtime requirement. See
-[Vulkan runtime](docs/VULKAN_RUNTIME.md) for capability policy and modernization measurements.
+Commands, dependencies and the testing gotchas are in [`../BUILDING.md`](../BUILDING.md). The live
+renderer, compute backend and windowed frontend need Vulkan 1.4 headers, loader and device. The short
+version, from the repository root:
 
 ```
-cmake -S . -B build -G Ninja
-cmake --build build
-ctest --test-dir build --no-tests=error  # report the discovered count; it varies by platform
-```
-`ctest` needs `spirv-val` on `PATH` — `spirv-tools` on Fedora/Ubuntu,
-`mingw-w64-ucrt-x86_64-spirv-tools` in MSYS2, `brew install spirv-tools` on macOS. The
-`spv_validate` test is the strict SPIR-V validation gate and **fails** rather than skipping when
-the validator is absent, because silently skipping is how #1711 shipped.
-Add `-DPROSPER_APP=ON` for the windowed `prosper-app` frontend (fetches SDL3). Or a tool directly:
-```
-g++ -O2 -std=c++20 tools/self_dump/self_dump.cpp -o self_dump
-./self_dump ../PPSA24651-app0/eboot.bin [--symbols]
-```
-
-From the parent repository root, native Windows builds and runs the full graphics + WASAPI audio +
-controller/keyboard frontend with:
-
-```powershell
-.\prosper\scripts\run-windows.ps1 .\PPSA24651-app0
+cmake -S prosper -B prosper/build-linux -G Ninja
+cmake --build prosper/build-linux
+ctest --test-dir prosper/build-linux --no-tests=error
 ```
 
 ## Legal / scope
-Interoperability & preservation research on legally-owned titles. `prosper` ships **no** Sony code,
-firmware, or keys — it reimplements published library interfaces clean-room style. It only operates on
-**already-unencrypted** dumps; it does not defeat DRM/encryption.
+
+Interoperability and preservation research on legally-owned titles. prosper ships **no** Sony code,
+firmware or keys — it reimplements published library interfaces clean-room style. It operates only
+on **already-unencrypted** dumps, performs no decryption, and refuses to link the third-party
+Sony-library replacements that some dumps carry. See the repository README for the full statement.


### PR DESCRIPTION
## Goal

The README was drawing the wrong readers. It opened with a logo, eleven screenshots and a
per-title status inventory, which reads as a product page for a PS5 game runner rather than as
what this repository is: a test of whether a project can be structured so that AI agents do
long-running reverse-engineering work without a human writing code. Requested by the project
owner, who asked for the screenshots removed, the framing led by the experiment, a much shorter
page, and a factual register with no selling.

## Approach

**`README.md` — 293 → 63 lines.** Now: what prosper is and what the work consists of; why it
exists (the method under test, and that preservation work has this shape and more of it than
people doing it); a flat "not a product" statement; six statements of how the work is organised
(the charter, the six-rung ladder, programmatic verification, `## Ruled out` plus numbered
instrument traps, tooling over grinding, issues/worktrees/review); a paragraph recording that the
costly failures have been in bookkeeping and inference rather than in generated code; scope and
legality; pointers.

Removed: all screenshots, the ✅ subsystem walls, the per-title status prose, the layout block,
and both "download and use" sections. Per-title results are now one neutral pointer to
`COMPATIBILITY.md`, kept so the project's own record stays discoverable.

**`BUILDING.md` — new, 161 lines.** Everything mechanical: Linux/Windows/macOS dependencies and
commands, the testing facts worth keeping (`--no-tests=error`, the `spirv-val` gate, the three
cases that skip on a non-`PPSA24651` dump), clangd setup, and launching a dump from the release
archives.

**`prosper/README.md` — 145 → 75 lines.** Its status wall was stale and duplicated the root: it
claimed 39 tracked titles, carried an August frontier log, and linked `RENDER_LOOP.md`, which
`CLAUDE.md` marks superseded. Now orientation, layout and a pointer to `BUILDING.md`.

## Rebased onto `main`

This branch was first built on the local checkout's `master` (f68e971f), which is a diverged
lineage: `origin/master` no longer exists, and `origin/main` has 3,381 commits that base does not.
Both READMEs had changed there, so the work was rebuilt on `origin/main` and three things main had
were carried forward rather than reverted: the `docs/DEBUGGING_WORKFLOWS.md` pointer, the Vulkan 1.4
runtime floor (now in `BUILDING.md` with the Ubuntu 24.04 1.3 caveat and the `setup-vulkan` action,
plus a line in `prosper/README.md`), and the `docs/MESSENGER_BLACK_RENDER.md` pointer, which is
named where `## Ruled out` sections are described because it is a closed investigation carrying one
and is not a `*_STATUS.md` file. The only reference deliberately dropped is `docs/RENDER_LOOP.md`,
which `CLAUDE.md` marks superseded.

## Two content decisions worth review

- **The License section.** It said "See [LICENSE](LICENSE) if present" and no `LICENSE` file
  exists. It now states that no license is granted by default and to open an issue to ask. This
  is a statement about the project's licensing, so it is the line most worth a second opinion.
- **The logo stayed.** Only screenshots were asked for; a centred hero image is still arguably
  product-shaped, and it is a one-line removal if wanted.

## Deliberately unaffected

`COMPATIBILITY.md`, `PROGRESS_TRACKER.md`, `BLOG.md` and every status doc are untouched — the
screenshots and the per-title record still live where they belong. No code, build, test or
packaging file changes.

## Risk

Documentation-only, so nothing can regress at runtime. The real risk is a wrong factual claim in
prose, which no CI job can see; every relative link was resolved against the filesystem and every
technical statement checked against its source (the CI workflow for the platform matrix,
`CONTRIBUTING.md` for the new-file rule, `module_path_policy.hpp` for the refusal-to-link claim,
`docs/PORTING.md` for the macOS/Rosetta configuration).

## Verification

Run on the exact head:

```
git diff --name-only origin/main...HEAD | grep -v '\.md$'   # empty: .md-only diff
git diff --check                                              # clean
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py
python3 prosper/tools/docs/check_numbered_table.py --ordered \
    --table-header Instrument --baseline <origin/main copy> \
    prosper/docs/GAME_COMPAT_ORCHESTRATION.md
```

Results: the diff is `.md`-only, `diff --check` is clean, the numbered-table gate passes over
every tracked `.md` (rc=0), and the ordered Instrument baseline reports 274 rows, unique and
ascending, with none of the base's rows deleted. No numbered table is touched by this diff, so
`check_merge_result.py` has nothing to arbitrate. No build or ctest run is applicable.

No screenshots are added, so there is no `BLOG.md` entry.

Merged without waiting for CI under the documentation-only exception in `CLAUDE.md`, with the
docs gate run locally first.
