### PR TITLE
tools/refactor: survey which refactoring tool can act on each large file

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -170,9 +170,10 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME re_xref_decoder
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
   # survey_sizes.py's classifier decides which refactoring tool can act on a file, and it has been
-  # wrong four times: on the lambda boundary, by calling a file of many small functions "nothing to
-  # do", by measuring the lambda share over the enclosing namespace, and by inferring unparsed lines
-  # from region kinds (which cannot see a mid-file #if). The last two were in how the classifier's
+  # wrong five times: on the lambda boundary, by calling a file of many small functions "nothing to
+  # do", by measuring the lambda share over the enclosing namespace, by inferring unparsed lines
+  # from region kinds (which cannot see a mid-file #if), and by not mirroring regions_of's descent
+  # rule. The last three were in how the classifier's
   # INPUTS are measured, so no arithmetic case could have caught them; they are pinned by fixtures
   # under tools/refactor/testdata/ that the selftest scores ONLY where libclang is importable, and
   # it says loudly when it skips them. libclang resolves lazily, so the arithmetic half runs here
@@ -180,6 +181,14 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME refactor_survey_classifier
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/refactor/survey_sizes.py" --selftest)
+  # The measurement fixtures are a SEPARATE case so that a runner without libclang reports them as
+  # Skipped rather than folding them into a green Passed. A pass whose domain is smaller than the
+  # local one, with nothing in the report saying so, is the hazard this project records for its GPU
+  # tests under CI's software rasteriser.
+  add_test(NAME refactor_survey_measurement
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/refactor/survey_sizes.py" --selftest-parse)
+  set_tests_properties(refactor_survey_measurement PROPERTIES SKIP_RETURN_CODE 77)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_test(NAME profiling_access
              COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/profiling_access/test_access.py")

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -170,8 +170,12 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME re_xref_decoder
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
   # survey_sizes.py's classifier decides which refactoring tool can act on a file, and it has been
-  # wrong twice: once on the lambda boundary, once by calling a file of many small functions
-  # "nothing to do". Its selftest is pure arithmetic and resolves libclang lazily, so it runs here
+  # wrong four times: on the lambda boundary, by calling a file of many small functions "nothing to
+  # do", by measuring the lambda share over the enclosing namespace, and by inferring unparsed lines
+  # from region kinds (which cannot see a mid-file #if). The last two were in how the classifier's
+  # INPUTS are measured, so no arithmetic case could have caught them; they are pinned by fixtures
+  # under tools/refactor/testdata/ that the selftest scores ONLY where libclang is importable, and
+  # it says loudly when it skips them. libclang resolves lazily, so the arithmetic half runs here
   # even though the surveying itself needs a libclang the runner does not have.
   add_test(NAME refactor_survey_classifier
            COMMAND "${Python3_EXECUTABLE}"

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -169,6 +169,13 @@ if(Python3_Interpreter_FOUND)
                    "$<TARGET_FILE:self_dump>")
   add_test(NAME re_xref_decoder
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
+  # survey_sizes.py's classifier decides which refactoring tool can act on a file, and it has been
+  # wrong twice: once on the lambda boundary, once by calling a file of many small functions
+  # "nothing to do". Its selftest is pure arithmetic and resolves libclang lazily, so it runs here
+  # even though the surveying itself needs a libclang the runner does not have.
+  add_test(NAME refactor_survey_classifier
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/refactor/survey_sizes.py" --selftest)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_test(NAME profiling_access
              COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/profiling_access/test_access.py")

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -148,7 +148,7 @@ The measurement moved three specific beliefs:
 
 ### Three ways this survey measured the wrong thing, and all of them failed silently
 
-Neither produced an error or an odd-looking row. Each produced a confident verdict about a file
+None of them produced an error or an odd-looking row. Each produced a confident verdict about a file
 other than the one asked about, which is why they are recorded here rather than in a commit message.
 All three are now pinned by fixtures under `testdata/`, and each fixture is built so the defective
 measurement yields a **different verdict**, not merely a different number -- verified by re-running
@@ -262,10 +262,10 @@ python3 prosper/tools/refactor/survey_sizes.py --min-lines 2500     # needs libc
 python3 prosper/tools/refactor/survey_sizes.py --selftest           # no libclang needed
 ```
 
-`--selftest` runs the classifier's arithmetic cases always, and the two `testdata/` measurement
-fixtures **only where libclang is importable** -- saying so explicitly when it skips them, because
-those two are the checks that cover how the classifier's inputs are measured, and both shipped
-defects lived there rather than in the arithmetic. The registered ctest case
+`--selftest` runs the classifier's arithmetic cases always, and the four `testdata/` measurement
+checks **only where libclang is importable** -- saying so explicitly, and naming them, when it skips
+them. Those are the checks covering how the classifier's INPUTS are measured, and every defect this
+tool shipped lived there rather than in the arithmetic. The registered ctest case
 (`refactor_survey_classifier`) therefore gates the arithmetic everywhere and the measurement locally.
 
 **The invariant that makes incremental extraction safe is worth copying.** When a block was extracted

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -83,7 +83,7 @@ caveats found by trying it:
   functions.** From `clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp`, the tweak
   returns `nullptr` when a `LambdaExpr` is found — the comment is literally *"Don't extract from
   lambdas"*. `register_live_renderer` spans 8,221 lines of which **98.5%** is inside lambdas (8,101 of 8,221, from the AST — 89% is the
-  file-share figure in the table above, a different number) passed to registration calls, so every candidate worth extracting is in refused territory.
+  file-share figure in the table above, a different number) passed to registration calls, so every candidate worth extracting is in refused territory. (Those counts are from an earlier commit and the file has grown since; `survey_sizes.py` measures the same function at 10,244 lines and 98% lambda on 2026-09-10. The conclusion is unchanged, and the two figures are kept distinct rather than reconciled because they were taken at different heads.)
   `extract_function.py --probe` reports 0 of 10 accepted at its default bounds, and that is correct
   behaviour, not a bug. **That figure alone does not establish it**: a hand-built lambda-free
   25-line function also probes 0 of 1, while the same clangd session returns
@@ -124,13 +124,14 @@ lambda share of every dominant function in the tree, which is the datum that dec
 
 | verdict | files | meaning |
 | --- | --- | --- |
-| `SPLIT` | 12 | no dominant region -- `split_file.py` applies today |
 | `EXTRACT` | 13 | one dominant region, but lambda-light -- clangd's ExtractFunction can act |
-| `UNPARSED` | 1 | a large span the AST never saw -- see below; no AST tool can act until it is split |
+| `SPLIT` | 9 | no dominant region -- `split_file.py` applies today |
+| `UNPARSED` | 4 | a large span the AST never saw -- see below; no AST tool can act until it is split |
 | `HAND` | **1** | dominant AND mostly lambda -- clangd refuses, no tool can help |
+| `PARSE-FAIL` | 1 | not scored: `prosper-app/main.cpp` needs `-DPROSPER_APP=ON` to have a command |
 
 Exactly one file is in the untouchable state: `frontends/shared/live/live_renderer.cpp`, whose
-`register_live_renderer` is 10,244 lines at **99% lambda**. Everything else has a route.
+`register_live_renderer` is 10,244 lines at **98% lambda**. Everything else has a route.
 
 The measurement moved three specific beliefs:
 
@@ -138,26 +139,67 @@ The measurement moved three specific beliefs:
   work. So are the giant test `main`s -- `test_rdna2_to_spirv.cpp` at **3%**,
   `test_dynfetch_fold.cpp` at 6%, `test_recompile_coverage.cpp` at 2%. The per-block assertion-delta
   invariant recorded at the end of this file is exactly the tool for those.
-* **The two largest source files are plain `SPLIT` work** -- `gpu_executor.cpp` (12,058 lines,
-  biggest region 23%) and `hle_kernel_mem.cpp` (7,637 lines, biggest region **2%**, #3503).
+* **The largest source file is plain `SPLIT` work** -- `gpu_executor.cpp`, 12,058 lines, biggest
+  region 23%.
 * **A file of many small functions is the EASIEST split, and the first version of this tool called it
   `OK`.** It required two regions of >=200 lines before offering `SPLIT`, which ranked
   `hle_kernel_mem.cpp` as nothing-to-do. Region COUNT is what a seam needs; region SIZE is not.
   Fixed, and pinned by a selftest case carrying that file's real shape.
 
-### The AST cannot see the inactive side of an `#if`, and that is its own state
+### Two ways this survey measured the wrong thing, and both failed silently
 
-`hle_kernel_mem.cpp` is 7,637 lines of which the Windows arm is **3,909 -- 51% of the file** -- behind
-an `#if defined(__linux__) || defined(__APPLE__)`. Parsed on Linux, clang never sees it: the region
-map runs out at line 3720 and the whole Windows arm arrives as a single `TRAILER`.
+Neither produced an error or an odd-looking row. Each produced a confident verdict about a file
+other than the one asked about, which is why they are recorded here rather than in a commit message.
+Both are now pinned by fixtures under `testdata/`, and each fixture is built so the defective
+measurement yields a **different verdict**, not merely a different number -- verified by re-running
+the pre-fix code against them (`dominant_no_lambda` -> `HAND`; `midfile_inactive_arm` -> `EXTRACT`,
+0 unparsed).
 
-This is worth its own verdict rather than a footnote, because **every AST-driven statement about such
-a file is answering about the other half**. The first version of this tool scored the file `SPLIT`
-from the 49% it could see -- and worse, it discarded the trailer as scaffolding first, because
-`map_symbols` gives the outermost namespace's trailing text the `close` role and this tool filtered
-`open`/`close` out. 3,909 lines vanished from the accounting silently. Caught by cross-checking the
-survey's own numbers against `map_symbols.py` on the same file; nothing in the survey's output looked
-wrong on its own, which is the point.
+**The lambda share was measured over the enclosing namespace.** Nearly every file here is one
+`namespace prosper { ... }`, so a file's only *top-level* cursor is the namespace -- and a namespace
+answers `is_definition()` with True. Walking top-level cursors to find the dominant region's cursor
+therefore always found the namespace, and unioned every lambda in the whole file into the dominant
+function's share. Measured across the tree: **6 of 22 scored files carried an inflated share**, worst
+`rdna2_emit_cfg.cpp` at 0.428 against a true **0.258**. **No verdict actually changed** -- in a
+dominated file the namespace is nearly the dominant function, so the error stayed under the 0.50
+threshold everywhere. That is luck, not design: 0.428 is one small edit from flipping a file to
+"no tool can act on this". The fix descends to the region's own cursor (`region_cursor`).
+
+**Unparsed lines were inferred from region kinds, which cannot see a mid-file `#if`.** `map_symbols`
+tiles a file by cursor, so an inactive arm is never a region of its own -- it is folded into whichever
+region follows it and wears that region's kind. Keying on `TEXT`/`TRAILER` therefore saw an arm only
+when it ran to the END of the file. `src/host/memory/guest_write_watch.cpp` is the tree's own
+counter-instance: a 481-line `#ifdef _WIN32` arm at lines 71-551, 19% of the file, reported as **0**
+unparsed lines with a dominant "symbol" of `sched.h` -- the include directive whose region had
+absorbed the arm.
+
+The fix asks the preprocessor instead, through `clang_getSkippedRanges` (reached by ctypes; the
+Python bindings do not wrap it), and **sums every skipped arm** rather than counting only ones
+individually above the threshold. That matters twice over: it found three more files than the
+trailing-span heuristic did, taking `UNPARSED` from 1 to 4 --
+
+| file | lines | unparsed | was |
+| --- | --- | --- | --- |
+| `src/hle/memory/hle_kernel_mem.cpp` | 7,637 | **52%** (7 spans) | UNPARSED, at 51% from one span |
+| `src/hle/kernel/hle_kernel.cpp` | 5,395 | **30%** | SPLIT |
+| `src/hle/fs/hle_file.cpp` | 4,560 | **21%** | SPLIT |
+| `src/host/memory/guest_write_watch.cpp` | 2,513 | **20%** | SPLIT |
+
+-- and it fails **closed**: if `clang_getSkippedRanges` is missing the tool exits rather than
+reporting zero, because reporting "no unparsed lines" when the question cannot be asked is exactly
+the silent under-report above.
+
+`UNPARSED_SHARE` (0.15) is a **convention, not a measurement**. The tree has four files above it, the
+lowest at 20%, and nothing here pins where in the gap below that the line belongs.
+
+### Why `UNPARSED` is its own verdict rather than a footnote
+
+**Every AST-driven statement about such a file is answering about the other part.** The first version
+of this tool scored `hle_kernel_mem.cpp` as `SPLIT` from the 48% it could see -- and worse, discarded
+the trailing arm as scaffolding first, because `map_symbols` gives the outermost namespace's trailing
+text the `close` role and this tool filtered `open`/`close` out. 3,909 lines left the accounting
+silently. Caught by cross-checking the survey's own numbers against `map_symbols.py` on the same
+file; nothing in the survey's output looked wrong on its own, which is the point.
 
 The practical consequence for #3503: **that split cannot be driven by `split_file.py`**, because the
 tool is blind to the arm being moved. A platform-arm split is a textual line-range move at the
@@ -169,6 +211,20 @@ like a small, uninteresting file. In a survey that is the worst place for it to 
 would be ranked as needing no work. One file is currently in that state:
 `frontends/prosper-app/main.cpp`, which has no compile command unless the app is configured
 (`-DPROSPER_APP=ON`); configure with it to bring that file into the survey.
+
+### Running it
+
+```bash
+python3 prosper/tools/refactor/survey_sizes.py --min-lines 2500     # needs libclang + a build dir
+python3 prosper/tools/refactor/survey_sizes.py --selftest           # no libclang needed
+```
+
+`--selftest` runs the classifier's arithmetic cases always, and the two `testdata/` measurement
+fixtures **only where libclang is importable** -- saying so explicitly when it skips them, because
+those two are the checks that cover how the classifier's inputs are measured, and both shipped
+defects lived there rather than in the arithmetic. The registered ctest case
+(`refactor_survey_classifier`) therefore gates the arithmetic everywhere and the measurement locally.
+
 **The invariant that makes incremental extraction safe is worth copying.** When a block was extracted
 out of `test_rdna2_to_spirv.cpp`'s `main`, the thing that made it checkable was a count of assertions
 *executed*, asserted as a per-block delta:

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -146,24 +146,41 @@ The measurement moved three specific beliefs:
   `hle_kernel_mem.cpp` as nothing-to-do. Region COUNT is what a seam needs; region SIZE is not.
   Fixed, and pinned by a selftest case carrying that file's real shape.
 
-### Two ways this survey measured the wrong thing, and both failed silently
+### Three ways this survey measured the wrong thing, and all of them failed silently
 
 Neither produced an error or an odd-looking row. Each produced a confident verdict about a file
 other than the one asked about, which is why they are recorded here rather than in a commit message.
-Both are now pinned by fixtures under `testdata/`, and each fixture is built so the defective
+All three are now pinned by fixtures under `testdata/`, and each fixture is built so the defective
 measurement yields a **different verdict**, not merely a different number -- verified by re-running
-the pre-fix code against them (`dominant_no_lambda` -> `HAND`; `midfile_inactive_arm` -> `EXTRACT`,
-0 unparsed).
+each pre-fix version against all of them, where every mutation reddens its own fixture and leaves
+the others green (`dominant_no_lambda` -> `HAND` at a 0.729 share for a function with no lambda;
+`midfile_inactive_arm` -> `EXTRACT` with 0 unparsed, naming the include directive that swallowed the
+arm; `namespace_without_children` -> `NO-CURSOR`).
 
 **The lambda share was measured over the enclosing namespace.** Nearly every file here is one
 `namespace prosper { ... }`, so a file's only *top-level* cursor is the namespace -- and a namespace
 answers `is_definition()` with True. Walking top-level cursors to find the dominant region's cursor
 therefore always found the namespace, and unioned every lambda in the whole file into the dominant
-function's share. Measured across the tree: **6 of 22 scored files carried an inflated share**, worst
-`rdna2_emit_cfg.cpp` at 0.428 against a true **0.258**. **No verdict actually changed** -- in a
+function's share. Measured across the tree: **6 of the 14 files that have a lambda share at all carried an inflated
+one**, worst `rdna2_emit_cfg.cpp` at 0.428 against a true **0.258**. Fourteen is the honest
+denominator, and it is not the number of scored files: the share is computed only for a file a single
+region dominates, so the 9 `SPLIT` files could never have been inflated, and `live_renderer.cpp` --
+which was -- is neither `SPLIT` nor `EXTRACT`. So the error rate among files where the question is
+asked is 43%, not the 27% a count against all scored files suggests. **No verdict actually changed** -- in a
 dominated file the namespace is nearly the dominant function, so the error stayed under the 0.50
 threshold everywhere. That is luck, not design: 0.428 is one small edit from flipping a file to
 "no tool can act on this". The fix descends to the region's own cursor (`region_cursor`).
+
+**`region_cursor` did not mirror `regions_of`'s descent rule.** `emit()` descends into a namespace
+only when it HAS in-target children (`map_symbols.py:174`); the first version of `region_cursor`
+descended on `depth < max_depth` alone. A namespace with no in-target children is emitted as a plain
+`body` region by the kids-empty fallthrough, so it can BE a file's dominant region -- and the lookup
+walked straight past it and reported `NO-CURSOR`, refusing to score a file whose answer was not in
+doubt. Reachable with nothing exotic: a namespace whose body is all comments
+(`testdata/namespace_without_children.cpp`, 98.9% of its file). No file in the tree currently hits
+it, so this cost nothing -- it was found by constructing the case rather than by observing one, and
+it is recorded because `NO-CURSOR` firing on a false alarm would have read as a tool limitation
+rather than a tool bug.
 
 **Unparsed lines were inferred from region kinds, which cannot see a mid-file `#if`.** `map_symbols`
 tiles a file by cursor, so an inactive arm is never a region of its own -- it is folded into whichever
@@ -185,9 +202,22 @@ trailing-span heuristic did, taking `UNPARSED` from 1 to 4 --
 | `src/hle/fs/hle_file.cpp` | 4,560 | **21%** | SPLIT |
 | `src/host/memory/guest_write_watch.cpp` | 2,513 | **20%** | SPLIT |
 
--- and it fails **closed**: if `clang_getSkippedRanges` is missing the tool exits rather than
-reporting zero, because reporting "no unparsed lines" when the question cannot be asked is exactly
-the silent under-report above.
+-- and it fails **closed** everywhere the question cannot be answered, because "no unparsed lines"
+and "I could not ask" must never be the same output. A missing `clang_getSkippedRanges` exits; a file
+absent from its own TU, or a NULL range list, scores `NO-PREPROC` rather than 0.
+
+The subtlest of those was a path comparison. The clip that keeps other files' skipped include guards
+out of the count originally compared `resolve()`d paths -- and this repository is reachable under two
+spellings that resolve **differently** and name one file, the container's `/home/<user>/...` bind
+mount and the host's `/var/home/<user>/...`. Under the alias spelling every span was discarded and
+`hle_file.cpp` reported **0** skipped lines instead of 963, which would have scored it `SPLIT`. The
+comparison is by **inode** now (`os.path.samefile`), and where even that errors it counts the span
+rather than dropping it: an over-count raises `UNPARSED`, which someone sees, and an under-count is
+the silent wrong answer. Measured both spellings: 963 and 963.
+
+Span line numbers include the `#if` and `#endif` directives themselves, because that is what libclang
+reports and they are lines the AST produced nothing for. Anyone reconstructing these figures as
+"lines of skipped CODE" will get about two fewer per span.
 
 `UNPARSED_SHARE` (0.15) is a **convention, not a measurement**. The tree has four files above it, the
 lowest at 20%, and nothing here pins where in the gap below that the line belongs.

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -154,8 +154,11 @@ All three are now pinned by fixtures under `testdata/`, and each fixture is buil
 measurement yields a **different verdict**, not merely a different number -- verified by re-running
 each pre-fix version against all of them, where every mutation reddens its own fixture and leaves
 the others green (`dominant_no_lambda` -> `HAND` at a 0.729 share for a function with no lambda;
-`midfile_inactive_arm` -> `EXTRACT` with 0 unparsed, naming the include directive that swallowed the
-arm; `namespace_without_children` -> `NO-CURSOR`).
+`midfile_inactive_arm` -> `EXTRACT` with 0 unparsed, naming `posix_only_1` -- the first declaration
+after the skipped arm, whose region had absorbed it; `namespace_without_children` -> `NO-CURSOR`).
+The same absorption in the tree names an `#include` rather than a function (`guest_write_watch.cpp`'s
+`sched.h`); which declaration a swallowed arm ends up attributed to is simply whichever cursor
+follows it.
 
 **The lambda share was measured over the enclosing namespace.** Nearly every file here is one
 `namespace prosper { ... }`, so a file's only *top-level* cursor is the namespace -- and a namespace
@@ -177,7 +180,7 @@ descended on `depth < max_depth` alone. A namespace with no in-target children i
 `body` region by the kids-empty fallthrough, so it can BE a file's dominant region -- and the lookup
 walked straight past it and reported `NO-CURSOR`, refusing to score a file whose answer was not in
 doubt. Reachable with nothing exotic: a namespace whose body is all comments
-(`testdata/namespace_without_children.cpp`, 98.9% of its file). No file in the tree currently hits
+(`testdata/namespace_without_children.cpp`, whose `commentary` region is 93 of 110 lines, 84.5%). No file in the tree currently hits
 it, so this cost nothing -- it was found by constructing the case rather than by observing one, and
 it is recorded because `NO-CURSOR` firing on a false alarm would have read as a tool limitation
 rather than a tool bug.
@@ -204,7 +207,17 @@ trailing-span heuristic did, taking `UNPARSED` from 1 to 4 --
 
 -- and it fails **closed** everywhere the question cannot be answered, because "no unparsed lines"
 and "I could not ask" must never be the same output. A missing `clang_getSkippedRanges` exits; a file
-absent from its own TU, or a NULL range list, scores `NO-PREPROC` rather than 0.
+the translation unit never read, or a NULL range list, scores `NO-PREPROC` rather than 0.
+
+That second guard was itself dead when first written, which is worth recording because it is this
+PR's own defect class appearing inside the fix for it. The check was `if File.from_name(...) is
+None` -- and it never is. `clang_getFile` resolves through the file manager, so it answers for any
+file that exists on disk whether or not the TU read it, and cindex asserts the handle is non-NULL
+besides. A foreign file therefore came back with a valid handle, an empty skipped-range list, and a
+confident **0**, behind a guard that could not fire. Membership is tested against the TU's own
+inclusion record now (`_file_in_tu`), which also turns an existing assumption into a check: a header
+has no compile command, so `flags_for` parses the first TU whose *text* mentions it, without
+confirming the include sits on an active branch.
 
 The subtlest of those was a path comparison. The clip that keeps other files' skipped include guards
 out of the count originally compared `resolve()`d paths -- and this repository is reachable under two

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -124,8 +124,9 @@ lambda share of every dominant function in the tree, which is the datum that dec
 
 | verdict | files | meaning |
 | --- | --- | --- |
-| `SPLIT` | 13 | no dominant region -- `split_file.py` applies today |
+| `SPLIT` | 12 | no dominant region -- `split_file.py` applies today |
 | `EXTRACT` | 13 | one dominant region, but lambda-light -- clangd's ExtractFunction can act |
+| `UNPARSED` | 1 | a large span the AST never saw -- see below; no AST tool can act until it is split |
 | `HAND` | **1** | dominant AND mostly lambda -- clangd refuses, no tool can help |
 
 Exactly one file is in the untouchable state: `frontends/shared/live/live_renderer.cpp`, whose
@@ -143,6 +144,24 @@ The measurement moved three specific beliefs:
   `OK`.** It required two regions of >=200 lines before offering `SPLIT`, which ranked
   `hle_kernel_mem.cpp` as nothing-to-do. Region COUNT is what a seam needs; region SIZE is not.
   Fixed, and pinned by a selftest case carrying that file's real shape.
+
+### The AST cannot see the inactive side of an `#if`, and that is its own state
+
+`hle_kernel_mem.cpp` is 7,637 lines of which the Windows arm is **3,909 -- 51% of the file** -- behind
+an `#if defined(__linux__) || defined(__APPLE__)`. Parsed on Linux, clang never sees it: the region
+map runs out at line 3720 and the whole Windows arm arrives as a single `TRAILER`.
+
+This is worth its own verdict rather than a footnote, because **every AST-driven statement about such
+a file is answering about the other half**. The first version of this tool scored the file `SPLIT`
+from the 49% it could see -- and worse, it discarded the trailer as scaffolding first, because
+`map_symbols` gives the outermost namespace's trailing text the `close` role and this tool filtered
+`open`/`close` out. 3,909 lines vanished from the accounting silently. Caught by cross-checking the
+survey's own numbers against `map_symbols.py` on the same file; nothing in the survey's output looked
+wrong on its own, which is the point.
+
+The practical consequence for #3503: **that split cannot be driven by `split_file.py`**, because the
+tool is blind to the arm being moved. A platform-arm split is a textual line-range move at the
+`#if`/`#else`/`#endif` boundaries -- provable by concatenation, and needing no AST at all.
 
 `survey_sizes.py` reports a file whose parse emitted errors as `PARSE-FAIL` and gives it **no
 verdict**, because a libclang parse driven from a g++ database fails softly -- a partial AST looks

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -12,6 +12,7 @@ each one does a transformation whose correctness can be *checked*, not merely re
 | `split_file.py` | splits one translation unit into several along a region partition |
 | `classify_tests.py` | proposes a folder for each test from its own includes |
 | `check_include_paths.py` | finds targets that reach a project include they cannot resolve |
+| `survey_sizes.py` | ranks every large file by WHICH of these tools can act on it |
 
 Run every tool's `--selftest` first; `split_file.py` and `promote_internal.py` run theirs
 automatically before doing anything.
@@ -113,6 +114,42 @@ caveats found by trying it:
 
 It stays incremental work regardless: a few extractions at a time, verified, by whoever is already
 changing that code.
+
+## Which files are in which state -- measured, 2026-09-10
+
+The table above was written from a handful of files looked at by hand, and it left the impression
+that the giant functions are mostly beyond tooling. **They are not.** `survey_sizes.py` measures the
+lambda share of every dominant function in the tree, which is the datum that decides it, and across
+28 files at or above 2,500 lines the split is:
+
+| verdict | files | meaning |
+| --- | --- | --- |
+| `SPLIT` | 13 | no dominant region -- `split_file.py` applies today |
+| `EXTRACT` | 13 | one dominant region, but lambda-light -- clangd's ExtractFunction can act |
+| `HAND` | **1** | dominant AND mostly lambda -- clangd refuses, no tool can help |
+
+Exactly one file is in the untouchable state: `frontends/shared/live/live_renderer.cpp`, whose
+`register_live_renderer` is 10,244 lines at **99% lambda**. Everything else has a route.
+
+The measurement moved three specific beliefs:
+
+* **`rdna2_emit_alu.cpp`'s 8,186-line `emit_alu` is only 11% lambda**, so it is `EXTRACT`, not hand
+  work. So are the giant test `main`s -- `test_rdna2_to_spirv.cpp` at **3%**,
+  `test_dynfetch_fold.cpp` at 6%, `test_recompile_coverage.cpp` at 2%. The per-block assertion-delta
+  invariant recorded at the end of this file is exactly the tool for those.
+* **The two largest source files are plain `SPLIT` work** -- `gpu_executor.cpp` (12,058 lines,
+  biggest region 23%) and `hle_kernel_mem.cpp` (7,637 lines, biggest region **2%**, #3503).
+* **A file of many small functions is the EASIEST split, and the first version of this tool called it
+  `OK`.** It required two regions of >=200 lines before offering `SPLIT`, which ranked
+  `hle_kernel_mem.cpp` as nothing-to-do. Region COUNT is what a seam needs; region SIZE is not.
+  Fixed, and pinned by a selftest case carrying that file's real shape.
+
+`survey_sizes.py` reports a file whose parse emitted errors as `PARSE-FAIL` and gives it **no
+verdict**, because a libclang parse driven from a g++ database fails softly -- a partial AST looks
+like a small, uninteresting file. In a survey that is the worst place for it to hide, since the file
+would be ranked as needing no work. One file is currently in that state:
+`frontends/prosper-app/main.cpp`, which has no compile command unless the app is configured
+(`-DPROSPER_APP=ON`); configure with it to bring that file into the survey.
 **The invariant that makes incremental extraction safe is worth copying.** When a block was extracted
 out of `test_rdna2_to_spirv.cpp`'s `main`, the thing that made it checkable was a count of assertions
 *executed*, asserted as a per-block delta:

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -149,6 +149,25 @@ class SkippedRangesUnavailable(RuntimeError):
     """The skipped-arm question could not be asked. Never answered as zero -- see skipped_lines."""
 
 
+def _file_in_tu(tu, path: pathlib.Path) -> bool:
+    """Did this translation unit actually READ this file?
+
+    Either it is the TU's main file, or it appears in the TU's inclusion record. Both matter: a
+    header has no compile command of its own, so `flags_for` parses the first TU whose text mentions
+    it -- a match that does not check the include is on an ACTIVE preprocessor branch. This turns
+    that assumption into a check.
+    """
+    try:
+        if _same_file(tu.spelling, path):
+            return True
+    except (OSError, TypeError):
+        pass
+    for inc in tu.get_includes():
+        if inc.include is not None and _same_file(inc.include.name, path):
+            return True
+    return False
+
+
 def _same_file(a: str, b: pathlib.Path) -> bool:
     """Same file on disk, compared by INODE rather than by spelling.
 
@@ -185,11 +204,20 @@ def skipped_lines(tu, path: pathlib.Path) -> int:   # requires _need_clang()
     Summed over every arm, and clipped to this file: a TU pulls in hundreds of headers whose own
     include guards skip, and those say nothing about the file being surveyed.
     """
-    f = ci.File.from_name(tu, str(path))
-    if f is None:
-        # Never 0. "The file is not in its own translation unit" is not "this file skips nothing";
-        # answering 0 here is the same silent under-report this function exists to end.
-        raise SkippedRangesUnavailable(f"{path} is not a file of its own translation unit")
+    # Membership is tested against the TU's own inclusion record, NOT by asking whether
+    # `File.from_name` came back empty. It never does: `clang_getFile` resolves through the file
+    # manager, so it answers for any file that exists on disk whether or not this TU ever read it,
+    # and cindex asserts the handle is non-NULL besides (cindex.py's ClangObject). A file outside
+    # the TU therefore yields a valid handle, an empty skipped-range list, and a confident 0 --
+    # exactly the silent zero this function exists to end, wearing a guard that cannot fire.
+    if not _file_in_tu(tu, path):
+        raise SkippedRangesUnavailable(
+            f"{path.name} is not part of the translation unit that was parsed "
+            f"({pathlib.Path(tu.spelling).name}); its skipped arms cannot be measured from it")
+    try:
+        f = ci.File.from_name(tu, str(path))
+    except Exception as exc:                      # noqa: BLE001 - cindex asserts on a bad handle
+        raise SkippedRangesUnavailable(f"no file handle for {path.name}: {exc!r}") from exc
     rl = _SKIPPED_RANGES(tu, f)
     if not rl:
         raise SkippedRangesUnavailable(f"clang_getSkippedRanges returned NULL for {path}")
@@ -315,8 +343,12 @@ def measure(path: pathlib.Path, flags: list[str], parse_target: pathlib.Path) ->
     except SkippedRangesUnavailable as exc:
         return {"file": rel, "lines": total, "verdict": "NO-PREPROC", "why": str(exc)}
     regions = MS.regions_of(tu, path, total)
-    # Movable regions only. An `open`/`close` is replicated into every output part, so it is not a
-    # place a split can cut and must not count toward the file having a seam.
+    # Drop the regions a split replicates rather than relocates: an `open`/`close` is copied into
+    # every output part, so it is not a place a split can cut and must not count toward the file
+    # having a seam. Note this is REPLICATED, which is `open`/`close` only -- `preamble` regions stay
+    # in, even though map_symbols' own docstring describes the preamble as replicated too. Left as
+    # it is deliberately: changing it would move a published count, and the two tools disagreeing
+    # about whether a preamble is movable is map_symbols' question to settle, not this survey's.
     sized = [(r["end"] - r["start"] + 1, r) for r in regions if r.get("role") not in MS.REPLICATED]
     if unparsed / max(total, 1) >= UNPARSED_SHARE:
         return {"file": rel, "lines": total, "regions": len(sized),
@@ -459,6 +491,27 @@ def _parse_selftest() -> int:
         print(f"        full row: {r}")
     bad += not ok
 
+    # The inode comparison had no arm at all until review pointed it out: every fixture uses one
+    # spelling, so reverting `_same_file` to a `resolve()` comparison left them all green. A HARD
+    # LINK reproduces the property the bind-mount alias has and nothing else here does -- two paths
+    # that name one file and that `resolve()` reports as different, since neither is a symlink.
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        one = pathlib.Path(td) / "one.cpp"
+        one.write_text("int x;\n")
+        two = pathlib.Path(td) / "two.cpp"
+        try:
+            os.link(one, two)
+            distinct = one.resolve() != two.resolve()
+            ok = distinct and _same_file(str(two), one)
+            print(f"  [{'ok' if ok else 'FAIL'}] hard-linked paths: resolve() differs={distinct}, "
+                  f"_same_file={_same_file(str(two), one)} "
+                  f"(want both True -- a resolve() comparison drops every span under an alias)")
+            bad += not ok
+        except OSError as exc:
+            print(f"  [FAIL] could not hard-link to test the alias case: {exc}")
+            bad += 1
+
     b = _TESTDATA / "midfile_inactive_arm.cpp"
     r = measure(b, flags, b)
     share = r.get("unparsed_share", 0.0)
@@ -505,8 +558,9 @@ def selftest() -> int:
     else:
         # Say so rather than reporting a quieter PASS. These two checks are the ones that cover how
         # the classifier's INPUTS are measured, and both shipped defects lived there.
-        print("  -- parse fixtures SKIPPED: no libclang here, so the two measurement checks")
-        print("     (dominant-cursor, mid-file inactive arm) did NOT run. Arithmetic only.")
+        print("  -- parse fixtures SKIPPED: no libclang here, so the four measurement checks")
+        print("     (dominant-cursor, namespace descent, mid-file inactive arm, inode alias)")
+        print("     did NOT run. Arithmetic only.")
     print("== PASS ==" if not bad else f"== FAIL: {bad} ==")
     return 1 if bad else 0
 

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""survey_sizes.py -- rank the tree's large files by WHICH refactoring tool can act on each.
+
+`map_symbols.py` answers "how is this one file shaped". That is the right question once a file has
+been chosen, and the wrong one for choosing: it needs an invocation, a compile command and a reading
+per file, and this tree has ninety candidates. Picking targets by `wc -l` is worse -- it ranks by
+symptom. A 12,000-line file that is two hundred functions is an afternoon with `split_file.py`; a
+12,000-line file that is ONE function is not, and no amount of splitting will make it one.
+
+So this reports, for every file over a threshold, which of three states it is in:
+
+  SPLIT    no single top-level region dominates -> `split_file.py` applies today.
+  EXTRACT  one region dominates, but it is not mostly lambdas -> clangd's ExtractFunction can act on
+           it (see README's Ruled out: clangd does the capture analysis correctly).
+  HAND     one region dominates AND it is mostly lambda bodies -> clangd REFUSES to extract from a
+           lambda ("Don't extract from lambdas", ExtractFunction.cpp), so no tool in this repo or in
+           clang can shrink it. Hand restructuring, or leave it alone.
+
+The lambda share is the whole point of the third column. It is the datum that decides between "a tool
+can do this" and "a tool cannot", and it was previously measured by hand for a single function.
+
+PARSE FAILURES ARE REPORTED, NEVER SCORED. A libclang parse driven from a g++ compile_commands.json
+fails SOFTLY -- it returns a partial AST rather than an error -- so a file that did not really parse
+comes back with few regions and looks merely uninteresting. That is this project's instrument-not-the
+-subject shape exactly, and a survey is where it would do the most damage, because the file would be
+silently ranked as "nothing to do here". Any file whose parse emits an error is printed as PARSE-FAIL
+with the first diagnostic and given no verdict.
+
+Usage:
+  python3 prosper/tools/refactor/survey_sizes.py                       # the default roots
+  ... --min-lines 800 --roots src frontends                            # widen or narrow
+  ... --json survey.json                                               # machine-readable
+  ... --selftest                                                       # prove the classifier
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import importlib.util
+import json
+import pathlib
+import sys
+
+_HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _load_map_symbols():
+    """Import map_symbols.py as a module so its parser is shared rather than re-implemented."""
+    spec = importlib.util.spec_from_file_location("map_symbols", _HERE / "map_symbols.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["map_symbols"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# libclang is resolved LAZILY, on the first parse. `--selftest` exercises only classify(), which is
+# pure arithmetic, so it must run on a machine that has no libclang at all -- that is what lets the
+# classifier be a registered ctest case rather than a thing somebody remembers to run. Importing
+# map_symbols at module scope would defeat it: that module imports clang.cindex on load.
+MS = None
+ci = None
+
+
+def _need_clang() -> None:
+    global MS, ci
+    if MS is not None:
+        return
+    MS = _load_map_symbols()
+    import clang.cindex as _ci
+    ci = _ci
+
+
+# A region must reach this share of the file before the file counts as dominated by it. Below it,
+# splitting has somewhere to cut; at or above it, splitting only renames the problem.
+DOMINANT_SHARE = 0.40
+# ... and a dominant region must be at least this much of a lambda nest before clangd's refusal is
+# what actually blocks extraction, rather than an incidental detail.
+LAMBDA_SHARE = 0.50
+# A file needs this many top-level regions before a split has anywhere to cut. Deliberately small,
+# and the first draft got this wrong in a way the tree caught: it demanded two regions of >=200 lines
+# each, which classified `hle_kernel_mem.cpp` -- 7,637 lines whose biggest region is 180 (2%) -- as
+# "nothing to do". A file of a hundred small functions is the EASIEST split there is, not the
+# hardest; the thing that blocks splitting is one region dominating, which DOMINANT_SHARE already
+# measures. Region COUNT is what a seam needs, not region size.
+SPLITTABLE_REGIONS = 4
+# Still reported, because a file whose regions are all tiny may want grouping by role rather than a
+# straight cut -- but it no longer gates the verdict.
+SPLITTABLE_REGION_LINES = 200
+
+
+def lambda_lines(cursor) -> int:   # requires _need_clang()
+    """Number of DISTINCT lines inside lambda bodies under CURSOR.
+
+    Union, not sum: lambdas nest here (a registration lambda containing a per-draw lambda), and
+    adding their extents would count the inner one twice and can exceed the function's own length.
+    """
+    spans: list[tuple[int, int]] = []
+
+    def walk(c) -> None:
+        if c.kind == ci.CursorKind.LAMBDA_EXPR:
+            e = c.extent
+            if e.start.file is not None:
+                spans.append((e.start.line, e.end.line))
+            return                      # inner lambdas are already inside this span
+        for k in c.get_children():
+            walk(k)
+
+    walk(cursor)
+    if not spans:
+        return 0
+    spans.sort()
+    merged = [list(spans[0])]
+    for s, e in spans[1:]:
+        if s <= merged[-1][1] + 1:
+            merged[-1][1] = max(merged[-1][1], e)
+        else:
+            merged.append([s, e])
+    return sum(e - s + 1 for s, e in merged)
+
+
+def classify(total: int, biggest: int, lam: int, regions: int) -> str:
+    """The verdict, kept pure so --selftest can pin it without parsing anything.
+
+    REGIONS is the file's top-level region count, not a count of large ones -- see SPLITTABLE_REGIONS.
+    """
+    if total <= 0:
+        return "OK"
+    share = biggest / total
+    if share >= DOMINANT_SHARE:
+        return "HAND" if biggest > 0 and lam / biggest >= LAMBDA_SHARE else "EXTRACT"
+    return "SPLIT" if regions >= SPLITTABLE_REGIONS else "OK"
+
+
+def survey_one(path: pathlib.Path, db: pathlib.Path) -> dict:
+    _need_clang()
+    rel = str(path)
+    total = len(path.read_text(errors="replace").splitlines())
+    try:
+        flags, parse_target = MS.flags_for(path, db)
+    except SystemExit as exc:
+        return {"file": rel, "lines": total, "verdict": "PARSE-FAIL", "why": str(exc)}
+    index = ci.Index.create()
+    try:
+        tu = index.parse(str(parse_target), args=flags + MS.builtin_includes(),
+                         options=ci.TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD)
+    except Exception as exc:                      # noqa: BLE001 - report, never score
+        return {"file": rel, "lines": total, "verdict": "PARSE-FAIL", "why": repr(exc)}
+
+    errs = [d for d in tu.diagnostics if d.severity >= ci.Diagnostic.Error]
+    if errs:
+        return {"file": rel, "lines": total, "verdict": "PARSE-FAIL",
+                "why": f"{len(errs)} parse error(s); first: {errs[0].spelling}"}
+
+    regions = MS.regions_of(tu, path, total)
+    sized = [(r["end"] - r["start"] + 1, r) for r in regions if r.get("role") not in MS.REPLICATED]
+    if not sized:
+        return {"file": rel, "lines": total, "verdict": "OK", "regions": 0}
+    sized.sort(key=lambda t: -t[0])
+    big_len, big = sized[0]
+
+    # Lambda share is only meaningful for the dominant region, and finding its cursor means walking
+    # the TU once more; skip it when the file is not dominated anyway.
+    lam = 0
+    if big_len / total >= DOMINANT_SHARE:
+        for c in tu.cursor.get_children():
+            if (c.location.file and pathlib.Path(c.location.file.name).resolve() == path.resolve()
+                    and c.extent.start.line <= big["decl_line"] <= c.extent.end.line
+                    and c.is_definition()):
+                lam = lambda_lines(c)
+                break
+
+    big_regions = sum(1 for n, _ in sized if n >= SPLITTABLE_REGION_LINES)
+    return {
+        "file": rel, "lines": total, "regions": len(regions),
+        "biggest": big["name"], "biggest_lines": big_len,
+        "biggest_share": round(big_len / total, 3),
+        "lambda_lines": lam,
+        "lambda_share_of_biggest": round(lam / big_len, 3) if big_len else 0.0,
+        "regions_over_%d" % SPLITTABLE_REGION_LINES: big_regions,
+        "verdict": classify(total, big_len, lam, len(regions)),
+    }
+
+
+def selftest() -> int:
+    """Pin the classifier on constructed cases -- no parsing, so it cannot pass for a parse reason."""
+    cases = [
+        # (total, biggest, lambda, big_regions, expected)
+        (10000, 9000, 8900, 1, "HAND"),      # live_renderer shape: one function, nearly all lambda
+        (10000, 9000,   10, 1, "EXTRACT"),   # one function, lambda-free -> clangd can act
+        (10000, 1000,    0, 8, "SPLIT"),     # many mid-sized regions -> split_file.py
+        ( 7637,  180,    0, 96, "SPLIT"),    # hle_kernel_mem shape: huge, all small regions.
+                                             # The first classifier called this OK, which was wrong:
+                                             # many small functions is the EASIEST split.
+        (10000,  300,    0, 2, "OK"),        # large-ish but only two regions -- no real seam
+        (10000, 4000, 1999, 3, "EXTRACT"),   # just BELOW the lambda boundary
+        (10000, 4000, 2000, 3, "HAND"),      # exactly AT it -- `>=` puts the boundary in HAND
+        (   0,    0,    0, 0, "OK"),         # empty file must not divide by zero
+    ]
+    bad = 0
+    for total, big, lam, nreg, want in cases:
+        got = classify(total, big, lam, nreg)
+        ok = got == want
+        print(f"  [{'ok' if ok else 'FAIL'}] classify({total},{big},{lam},{nreg}) = {got}"
+              f"{'' if ok else f' (want {want})'}")
+        bad += not ok
+    # The boundary pair above is the point, and the first draft of this selftest got it wrong in a
+    # useful way: it asserted EXTRACT for 2000/4000 while the docstring said 0.50 is HAND. The
+    # classifier was right and the expectation was not. Pin the direction explicitly so the next
+    # reader cannot re-introduce that disagreement between comment and behaviour.
+    if classify(10000, 4000, 2000, 3) != "HAND":
+        print("  [FAIL] a lambda share exactly AT the threshold must be HAND")
+        bad += 1
+    if classify(10000, 4000, 1999, 3) != "EXTRACT":
+        print("  [FAIL] a lambda share just BELOW the threshold must stay EXTRACT")
+        bad += 1
+    print("== PASS ==" if not bad else f"== FAIL: {bad} ==")
+    return 1 if bad else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--roots", nargs="*", default=["src", "frontends", "tools", "tests"])
+    ap.add_argument("--min-lines", type=int, default=1500)
+    ap.add_argument("--build", default="prosper/build-linux")
+    ap.add_argument("--json", type=pathlib.Path)
+    ap.add_argument("--jobs", type=int, default=6)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+
+    _need_clang()
+    root = MS.repo_root()
+    db = root / args.build / "compile_commands.json"
+    if not db.exists():
+        db = root / "prosper" / args.build.replace("prosper/", "") / "compile_commands.json"
+    if not db.exists():
+        sys.exit(f"no compile_commands.json under {args.build}; configure cmake first")
+
+    cands: list[pathlib.Path] = []
+    for r in args.roots:
+        base = root / "prosper" / r
+        if not base.exists():
+            continue
+        for p in base.rglob("*"):
+            if p.suffix in (".cpp", ".hpp", ".h", ".cc") and p.is_file():
+                if len(p.read_text(errors="replace").splitlines()) >= args.min_lines:
+                    cands.append(p)
+    cands.sort()
+    print(f"[survey] {len(cands)} file(s) at or above {args.min_lines} lines; parsing with {args.jobs} job(s)\n")
+
+    rows: list[dict] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for res in ex.map(lambda p: survey_one(p, db), cands):
+            rows.append(res)
+
+    rows.sort(key=lambda r: -r.get("lines", 0))
+    order = {"SPLIT": 0, "EXTRACT": 1, "HAND": 2, "PARSE-FAIL": 3, "OK": 4}
+    print(f"{'verdict':<11}{'lines':>7}{'big':>7}{'share':>7}{'lam%':>6}  file / dominant symbol")
+    print("-" * 100)
+    for r in sorted(rows, key=lambda r: (order.get(r["verdict"], 9), -r.get("lines", 0))):
+        if r["verdict"] == "PARSE-FAIL":
+            print(f"{'PARSE-FAIL':<11}{r['lines']:>7}{'':>7}{'':>7}{'':>6}  {r['file']}\n"
+                  f"{'':>38}  {r['why'][:90]}")
+            continue
+        rel = r["file"].split("prosper/", 1)[-1]
+        print(f"{r['verdict']:<11}{r['lines']:>7}{r.get('biggest_lines', 0):>7}"
+              f"{r.get('biggest_share', 0):>7.0%}{r.get('lambda_share_of_biggest', 0):>6.0%}  "
+              f"{rel}\n{'':>38}  {r.get('biggest', '')}")
+
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    print("\n[survey] " + ", ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+    if args.json:
+        args.json.write_text(json.dumps(rows, indent=2))
+        print(f"[survey] wrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -7,17 +7,41 @@ per file, and this tree has ninety candidates. Picking targets by `wc -l` is wor
 symptom. A 12,000-line file that is two hundred functions is an afternoon with `split_file.py`; a
 12,000-line file that is ONE function is not, and no amount of splitting will make it one.
 
-So this reports, for every file over a threshold, which of three states it is in:
+So this reports, for every file over a threshold, which of four states it is in:
 
-  SPLIT    no single top-level region dominates -> `split_file.py` applies today.
-  EXTRACT  one region dominates, but it is not mostly lambdas -> clangd's ExtractFunction can act on
-           it (see README's Ruled out: clangd does the capture analysis correctly).
-  HAND     one region dominates AND it is mostly lambda bodies -> clangd REFUSES to extract from a
-           lambda ("Don't extract from lambdas", ExtractFunction.cpp), so no tool in this repo or in
-           clang can shrink it. Hand restructuring, or leave it alone.
+  SPLIT     no single region dominates -> `split_file.py` applies today.
+  EXTRACT   one region dominates, but it is not mostly lambdas -> clangd's ExtractFunction can act
+            on it (see README's Ruled out: clangd does the capture analysis correctly).
+  HAND      one region dominates AND it is mostly lambda bodies -> clangd REFUSES to extract from a
+            lambda ("Don't extract from lambdas", ExtractFunction.cpp), so no tool in this repo or
+            in clang can shrink it. Hand restructuring, or leave it alone.
+  UNPARSED  a large part of the file is behind an inactive `#if` -> every AST-driven verdict about
+            the file is answering about the other part only, so no AST-driven verdict is given.
 
-The lambda share is the whole point of the third column. It is the datum that decides between "a tool
-can do this" and "a tool cannot", and it was previously measured by hand for a single function.
+The lambda share is the whole point of the third column. It is the datum that decides between "a
+tool can do this" and "a tool cannot", and it was previously measured by hand for a single function.
+
+TWO THINGS THIS TOOL MUST NOT DO, both of which it did do, and both of which failed SILENTLY --
+producing a confident verdict about a different file rather than an error. They are the reason the
+measurements below are taken the way they are rather than the obvious way:
+
+  * MEASURE THE LAMBDA SHARE OVER THE WRONG CURSOR. Nearly every file here is one
+    `namespace prosper { ... }`, so a file's only top-level cursor is the namespace -- and a
+    namespace answers `is_definition()` with True. Walking top-level cursors to find the dominant
+    region's cursor therefore always found the NAMESPACE, and unioned every lambda in the whole file
+    into the dominant function's share. `testdata/dominant_no_lambda.cpp` is the hand-built instance:
+    a dominant function containing no lambda at all, beside a small all-lambda sibling, which the
+    old code reported at a 0.63 lambda share -- HAND, "no tool can act", for a function clangd
+    extracts from happily. Descend to the region's OWN cursor (`region_cursor`).
+
+  * INFER UNPARSED LINES FROM REGION KINDS. `map_symbols` tiles a file by cursor, so an inactive
+    `#if` arm is not a region of its own: it is folded into whichever region follows it and wears
+    that region's kind. Keying on TEXT/TRAILER therefore sees an arm only when it runs to the END of
+    the file. `src/host/memory/guest_write_watch.cpp` is the tree's own counter-instance -- a
+    481-line `#ifdef _WIN32` arm at lines 71-551, 19% of the file, reported as 0 unparsed lines with
+    a dominant "symbol" of `sched.h`. Ask the PREPROCESSOR instead (`clang_getSkippedRanges`), which
+    records every skipped arm wherever it sits, and sum them: hle_kernel_mem.cpp is 52.1% across
+    seven spans, not the 51% its single trailing span showed.
 
 PARSE FAILURES ARE REPORTED, NEVER SCORED. A libclang parse driven from a g++ compile_commands.json
 fails SOFTLY -- it returns a partial AST rather than an error -- so a file that did not really parse
@@ -36,12 +60,14 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import ctypes
 import importlib.util
 import json
 import pathlib
 import sys
 
 _HERE = pathlib.Path(__file__).resolve().parent
+_TESTDATA = _HERE / "testdata"
 
 
 def _load_map_symbols():
@@ -53,21 +79,41 @@ def _load_map_symbols():
     return mod
 
 
-# libclang is resolved LAZILY, on the first parse. `--selftest` exercises only classify(), which is
-# pure arithmetic, so it must run on a machine that has no libclang at all -- that is what lets the
-# classifier be a registered ctest case rather than a thing somebody remembers to run. Importing
-# map_symbols at module scope would defeat it: that module imports clang.cindex on load.
+# libclang is resolved LAZILY, on the first parse. `--selftest`'s arithmetic cases exercise only
+# classify(), which is pure, so they must run on a machine that has no libclang at all -- that is
+# what lets the classifier be a registered ctest case rather than a thing somebody remembers to run.
+# Importing map_symbols at module scope would defeat it: that module imports clang.cindex on load.
 MS = None
 ci = None
+_SKIPPED_RANGES = None
 
 
 def _need_clang() -> None:
-    global MS, ci
+    global MS, ci, _SKIPPED_RANGES
     if MS is not None:
         return
     MS = _load_map_symbols()
     import clang.cindex as _ci
     ci = _ci
+    # Built here, not at module scope: the `ranges` member is an array of cindex's own SourceRange,
+    # so the struct cannot be declared until clang.cindex has been imported, and a ctypes
+    # `_fields_` cannot be reassigned after the class exists.
+    class _CXSourceRangeList(ctypes.Structure):
+        _fields_ = [("count", ctypes.c_uint), ("ranges", ctypes.POINTER(ci.SourceRange))]
+
+    lib = ci.conf.lib
+    # The python bindings do not wrap clang_getSkippedRanges (checked on clang 21's cindex.py), so
+    # reach the C entry point directly. argtypes are deliberately left unset: cindex's TranslationUnit
+    # and File carry `_as_parameter_`, which ctypes uses for an unprototyped call, and declaring
+    # them as c_void_p instead would bypass that. Only restype needs stating.
+    try:
+        lib.clang_getSkippedRanges.restype = ctypes.POINTER(_CXSourceRangeList)
+    except AttributeError:
+        # Fail CLOSED. Reporting 0 unparsed lines when the question cannot be asked is precisely the
+        # silent-under-report this tool exists to avoid, and it would land as a confident verdict.
+        sys.exit("libclang here has no clang_getSkippedRanges; cannot measure unparsed spans "
+                 "and will not guess. Upgrade libclang (present since clang 3.7).")
+    _SKIPPED_RANGES = lib.clang_getSkippedRanges
 
 
 # A region must reach this share of the file before the file counts as dominated by it. Below it,
@@ -76,12 +122,12 @@ DOMINANT_SHARE = 0.40
 # ... and a dominant region must be at least this much of a lambda nest before clangd's refusal is
 # what actually blocks extraction, rather than an incidental detail.
 LAMBDA_SHARE = 0.50
-# A text region this large means the parser never saw that code -- almost always the inactive side of
-# an `#if defined(_WIN32)` platform arm. Below this it is ordinary scaffolding (includes, a namespace
-# close); at or above it, the AST is blind to a substantial part of the file and every AST-driven
-# verdict about that file is answering about the other part only.
+# Skipped-arm lines this share of a file mean the AST is blind to a substantial part of it, and every
+# AST-driven verdict is then answering about the other part only. A CONVENTION, not a measurement:
+# the tree has two files above it (guest_write_watch.cpp at 19.7%, hle_kernel_mem.cpp at 52.1%) and
+# the next is far below, so the band is wide and nothing here pins where in it the line belongs.
 UNPARSED_SHARE = 0.15
-# A file needs this many top-level regions before a split has anywhere to cut. Deliberately small,
+# A file needs this many movable regions before a split has anywhere to cut. Deliberately small,
 # and the first draft got this wrong in a way the tree caught: it demanded two regions of >=200 lines
 # each, which classified `hle_kernel_mem.cpp` -- 7,637 lines whose biggest region is 180 (2%) -- as
 # "nothing to do". A file of a hundred small functions is the EASIEST split there is, not the
@@ -91,6 +137,42 @@ SPLITTABLE_REGIONS = 4
 # Still reported, because a file whose regions are all tiny may want grouping by role rather than a
 # straight cut -- but it no longer gates the verdict.
 SPLITTABLE_REGION_LINES = 200
+
+
+def merge_spans(spans: list[tuple[int, int]]) -> int:
+    """Number of DISTINCT lines covered by SPANS. Union, never sum -- see lambda_lines."""
+    if not spans:
+        return 0
+    spans = sorted(spans)
+    merged = [list(spans[0])]
+    for s, e in spans[1:]:
+        if s <= merged[-1][1] + 1:
+            merged[-1][1] = max(merged[-1][1], e)
+        else:
+            merged.append([s, e])
+    return sum(e - s + 1 for s, e in merged)
+
+
+def skipped_lines(tu, path: pathlib.Path) -> int:   # requires _need_clang()
+    """Lines of PATH the PREPROCESSOR skipped -- the inactive arms of #if/#ifdef/#ifndef.
+
+    Summed over every arm, and clipped to this file: a TU pulls in hundreds of headers whose own
+    include guards skip, and those say nothing about the file being surveyed.
+    """
+    f = ci.File.from_name(tu, str(path))
+    if f is None:
+        return 0
+    rl = _SKIPPED_RANGES(tu, f)
+    if not rl:
+        return 0
+    spans: list[tuple[int, int]] = []
+    for i in range(rl.contents.count):
+        r = rl.contents.ranges[i]
+        s, e = r.start, r.end
+        if s.file is None or pathlib.Path(s.file.name).resolve() != path.resolve():
+            continue
+        spans.append((s.line, e.line))
+    return merge_spans(spans)
 
 
 def lambda_lines(cursor) -> int:   # requires _need_clang()
@@ -111,24 +193,48 @@ def lambda_lines(cursor) -> int:   # requires _need_clang()
             walk(k)
 
     walk(cursor)
-    if not spans:
-        return 0
-    spans.sort()
-    merged = [list(spans[0])]
-    for s, e in spans[1:]:
-        if s <= merged[-1][1] + 1:
-            merged[-1][1] = max(merged[-1][1], e)
-        else:
-            merged.append([s, e])
-    return sum(e - s + 1 for s, e in merged)
+    return merge_spans(spans)
+
+
+def region_cursor(tu, path: pathlib.Path, region: dict, max_depth: int = 3):
+    """The cursor that PRODUCED this region, found by descending exactly as regions_of tiles.
+
+    Not a top-level scan. `regions_of` descends through namespaces, so a region's cursor is usually
+    a namespace MEMBER -- and the file's only top-level cursor is the namespace itself, which
+    answers is_definition() with True and would match every region in the file. See the module
+    docstring; `testdata/dominant_no_lambda.cpp` reddens if this goes back to a top-level scan.
+    """
+    want_start, want_end = region["decl_line"], region["end"]
+    found = None
+
+    def walk(c, depth: int) -> None:
+        nonlocal found
+        for k in c.get_children():
+            if found is not None:
+                return
+            if k.location.file is None:
+                continue
+            if pathlib.Path(k.location.file.name).resolve() != path.resolve():
+                continue
+            if k.kind == ci.CursorKind.NAMESPACE and depth < max_depth:
+                walk(k, depth + 1)
+                continue
+            if k.extent.start.line == want_start and k.extent.end.line == want_end:
+                found = k
+                return
+
+    walk(tu.cursor, 0)
+    return found
 
 
 def classify(total: int, biggest: int, lam: int, regions: int, unparsed: int = 0) -> str:
     """The verdict, kept pure so --selftest can pin it without parsing anything.
 
-    REGIONS is the file's top-level region count, not a count of large ones -- see SPLITTABLE_REGIONS.
-    UNPARSED is lines the AST never saw, and it is checked FIRST: a verdict computed from half a file
-    is not a weaker verdict, it is a statement about a different file.
+    REGIONS is the file's MOVABLE region count -- regions a split could actually relocate, so the
+    namespace open/close that every output part gets a copy of are not counted. See
+    SPLITTABLE_REGIONS. UNPARSED is lines the preprocessor skipped, and it is checked FIRST: a
+    verdict computed from half a file is not a weaker verdict, it is a statement about a different
+    file.
     """
     if total <= 0:
         return "OK"
@@ -136,18 +242,16 @@ def classify(total: int, biggest: int, lam: int, regions: int, unparsed: int = 0
         return "UNPARSED"
     share = biggest / total
     if share >= DOMINANT_SHARE:
-        return "HAND" if biggest > 0 and lam / biggest >= LAMBDA_SHARE else "EXTRACT"
+        return "HAND" if lam / biggest >= LAMBDA_SHARE else "EXTRACT"
     return "SPLIT" if regions >= SPLITTABLE_REGIONS else "OK"
 
 
-def survey_one(path: pathlib.Path, db: pathlib.Path) -> dict:
+def measure(path: pathlib.Path, flags: list[str], parse_target: pathlib.Path) -> dict:
+    """Parse and score one file. Split out from survey_one so fixtures can be scored with fixed
+    flags, without a compile_commands.json."""
     _need_clang()
     rel = str(path)
     total = len(path.read_text(errors="replace").splitlines())
-    try:
-        flags, parse_target = MS.flags_for(path, db)
-    except SystemExit as exc:
-        return {"file": rel, "lines": total, "verdict": "PARSE-FAIL", "why": str(exc)}
     index = ci.Index.create()
     try:
         tu = index.parse(str(parse_target), args=flags + MS.builtin_includes(),
@@ -160,56 +264,70 @@ def survey_one(path: pathlib.Path, db: pathlib.Path) -> dict:
         return {"file": rel, "lines": total, "verdict": "PARSE-FAIL",
                 "why": f"{len(errs)} parse error(s); first: {errs[0].spelling}"}
 
+    unparsed = skipped_lines(tu, path)
     regions = MS.regions_of(tu, path, total)
-    # Regions the parser contributed no declaration to. `map_symbols` gives the outermost namespace's
-    # trailing text the `close` role, so on a file whose second half sits behind an inactive `#if`
-    # the ENTIRE unparsed arm arrives as one `close`/TRAILER region -- and this filter used to drop
-    # it as scaffolding. On hle_kernel_mem.cpp that silently hid 3,909 lines, 51% of the file, and
-    # scored what remained as though it were the whole thing.
-    unparsed = sum(r["end"] - r["start"] + 1 for r in regions
-                   if r.get("kind") in ("TEXT", "TRAILER")
-                   and (r["end"] - r["start"] + 1) / max(total, 1) >= UNPARSED_SHARE)
+    # Movable regions only. An `open`/`close` is replicated into every output part, so it is not a
+    # place a split can cut and must not count toward the file having a seam.
     sized = [(r["end"] - r["start"] + 1, r) for r in regions if r.get("role") not in MS.REPLICATED]
-    if not sized:
-        return {"file": rel, "lines": total, "verdict": "OK", "regions": 0}
     if unparsed / max(total, 1) >= UNPARSED_SHARE:
-        return {"file": rel, "lines": total, "regions": len(regions),
+        return {"file": rel, "lines": total, "regions": len(sized),
                 "unparsed_lines": unparsed, "unparsed_share": round(unparsed / total, 3),
-                "biggest": "<unparsed span>", "biggest_lines": unparsed,
-                "biggest_share": round(unparsed / total, 3),
+                "biggest": "<%d line(s) behind an inactive #if>" % unparsed,
+                "biggest_lines": unparsed, "biggest_share": round(unparsed / total, 3),
                 "lambda_lines": 0, "lambda_share_of_biggest": 0.0,
                 "verdict": "UNPARSED"}
+    if not sized:
+        return {"file": rel, "lines": total, "verdict": "OK", "regions": 0,
+                "unparsed_lines": unparsed}
     sized.sort(key=lambda t: -t[0])
     big_len, big = sized[0]
 
     # Lambda share is only meaningful for the dominant region, and finding its cursor means walking
-    # the TU once more; skip it when the file is not dominated anyway.
-    lam = 0
+    # the TU again; skip it when the file is not dominated anyway.
+    lam, cursor_found = 0, True
     if big_len / total >= DOMINANT_SHARE:
-        for c in tu.cursor.get_children():
-            if (c.location.file and pathlib.Path(c.location.file.name).resolve() == path.resolve()
-                    and c.extent.start.line <= big["decl_line"] <= c.extent.end.line
-                    and c.is_definition()):
-                lam = lambda_lines(c)
-                break
+        c = region_cursor(tu, path, big)
+        if c is None:
+            cursor_found = False
+        else:
+            lam = lambda_lines(c)
+    if not cursor_found:
+        # Never fall through to lam=0, which would read as EXTRACT -- the optimistic verdict -- on
+        # no evidence at all.
+        return {"file": rel, "lines": total, "regions": len(sized),
+                "biggest": big["name"], "biggest_lines": big_len,
+                "biggest_share": round(big_len / total, 3),
+                "unparsed_lines": unparsed, "verdict": "NO-CURSOR",
+                "why": "dominant region %d-%d matched no cursor" % (big["decl_line"], big["end"])}
 
-    big_regions = sum(1 for n, _ in sized if n >= SPLITTABLE_REGION_LINES)
     return {
-        "file": rel, "lines": total, "regions": len(regions),
+        "file": rel, "lines": total, "regions": len(sized),
         "biggest": big["name"], "biggest_lines": big_len,
         "biggest_share": round(big_len / total, 3),
         "lambda_lines": lam,
         "lambda_share_of_biggest": round(lam / big_len, 3) if big_len else 0.0,
-        "regions_over_%d" % SPLITTABLE_REGION_LINES: big_regions,
+        "regions_over_%d" % SPLITTABLE_REGION_LINES:
+            sum(1 for n, _ in sized if n >= SPLITTABLE_REGION_LINES),
         "unparsed_lines": unparsed,
-        "verdict": classify(total, big_len, lam, len(regions), unparsed),
+        "verdict": classify(total, big_len, lam, len(sized), unparsed),
     }
 
 
-def selftest() -> int:
+def survey_one(path: pathlib.Path, db: pathlib.Path) -> dict:
+    _need_clang()
+    try:
+        flags, parse_target = MS.flags_for(path, db)
+    except SystemExit as exc:
+        return {"file": str(path),
+                "lines": len(path.read_text(errors="replace").splitlines()),
+                "verdict": "PARSE-FAIL", "why": str(exc)}
+    return measure(path, flags, parse_target)
+
+
+def _arithmetic_selftest() -> int:
     """Pin the classifier on constructed cases -- no parsing, so it cannot pass for a parse reason."""
     cases = [
-        # (total, biggest, lambda, big_regions, expected)
+        # (total, biggest, lambda, movable_regions, expected)
         (10000, 9000, 8900, 1, "HAND"),      # live_renderer shape: one function, nearly all lambda
         (10000, 9000,   10, 1, "EXTRACT"),   # one function, lambda-free -> clangd can act
         (10000, 1000,    0, 8, "SPLIT"),     # many mid-sized regions -> split_file.py
@@ -220,12 +338,15 @@ def selftest() -> int:
         (10000, 4000, 2000, 3, "HAND"),      # exactly AT it -- `>=` puts the boundary in HAND
         (   0,    0,    0, 0, "OK"),         # empty file must not divide by zero
     ]
-    # UNPARSED cases carry the fifth argument, so they are listed separately.
     unparsed_cases = [
         # (total, biggest, lambda, regions, unparsed, expected)
-        (7637,  180, 0, 246, 3909, "UNPARSED"),   # hle_kernel_mem's REAL shape: 51% behind an #if.
-                                                  # Scored SPLIT before the unparsed span was
-                                                  # counted, from the 49% the parser could see.
+        (7637,  180, 0, 246, 3978, "UNPARSED"),   # hle_kernel_mem's REAL shape: 52% behind #ifs,
+                                                  # across SEVEN spans. Scored SPLIT before the
+                                                  # skipped arms were counted, from the 48% the
+                                                  # parser could see.
+        (2513,  200, 0,  60,  495, "UNPARSED"),   # guest_write_watch: 19.7%, and every line of it
+                                                  # MID-FILE. Reported 0 unparsed while the verdict
+                                                  # keyed on region kinds.
         (10000, 1000, 0,  96, 1499, "SPLIT"),     # just below 15% -- ordinary scaffolding
         (10000, 1000, 0,  96, 1500, "UNPARSED"),  # exactly at it
         (10000, 9000, 8900, 1, 1600, "UNPARSED"), # unparsed WINS over HAND: a verdict from half a
@@ -251,9 +372,62 @@ def selftest() -> int:
     for total, big, lam, nreg, unp, want in unparsed_cases:
         got = classify(total, big, lam, nreg, unp)
         ok = got == want
-        print(f"  [{'ok' if ok else 'FAIL'}] classify({total},{big},{lam},{nreg},unparsed={unp}) = {got}"
-              f"{'' if ok else f' (want {want})'}")
+        print(f"  [{'ok' if ok else 'FAIL'}] classify({total},{big},{lam},{nreg},unparsed={unp})"
+              f" = {got}{'' if ok else f' (want {want})'}")
         bad += not ok
+    return bad
+
+
+def _parse_selftest() -> int:
+    """Score the two fixtures, whose answers are known by construction.
+
+    These are the cases the arithmetic above CANNOT reach: both past defects were in how the inputs
+    to classify() were measured, not in classify() itself, so every arithmetic case passed happily
+    while the tool reported the opposite verdict for a real file. Each fixture is built so that the
+    defective measurement produces a DIFFERENT verdict, not merely a different number.
+    """
+    bad = 0
+    flags = ["-std=c++20", "-xc++"]
+
+    a = _TESTDATA / "dominant_no_lambda.cpp"
+    r = measure(a, flags, a)
+    lam_share = r.get("lambda_share_of_biggest")
+    ok = r["verdict"] == "EXTRACT" and lam_share == 0.0
+    print(f"  [{'ok' if ok else 'FAIL'}] {a.name}: verdict={r['verdict']} "
+          f"biggest={r.get('biggest')!r} lambda_share={lam_share} "
+          f"(want EXTRACT / 0.0 -- measuring over the namespace gives HAND)")
+    if not ok:
+        print(f"        full row: {r}")
+    bad += not ok
+
+    b = _TESTDATA / "midfile_inactive_arm.cpp"
+    r = measure(b, flags, b)
+    share = r.get("unparsed_share", 0.0)
+    ok = r["verdict"] == "UNPARSED" and share >= UNPARSED_SHARE
+    print(f"  [{'ok' if ok else 'FAIL'}] {b.name}: verdict={r['verdict']} "
+          f"unparsed={r.get('unparsed_lines')} share={share} "
+          f"(want UNPARSED -- inferring from region kinds gives 0 unparsed)")
+    if not ok:
+        print(f"        full row: {r}")
+    bad += not ok
+    return bad
+
+
+def selftest() -> int:
+    bad = _arithmetic_selftest()
+    try:
+        import clang.cindex  # noqa: F401
+        have_clang = True
+    except ImportError:
+        have_clang = False
+    if have_clang:
+        print("  -- parse fixtures (libclang present) --")
+        bad += _parse_selftest()
+    else:
+        # Say so rather than reporting a quieter PASS. These two checks are the ones that cover how
+        # the classifier's INPUTS are measured, and both shipped defects lived there.
+        print("  -- parse fixtures SKIPPED: no libclang here, so the two measurement checks")
+        print("     (dominant-cursor, mid-file inactive arm) did NOT run. Arithmetic only.")
     print("== PASS ==" if not bad else f"== FAIL: {bad} ==")
     return 1 if bad else 0
 
@@ -285,29 +459,34 @@ def main() -> int:
             continue
         for p in base.rglob("*"):
             if p.suffix in (".cpp", ".hpp", ".h", ".cc") and p.is_file():
+                if _TESTDATA in p.parents:
+                    continue                      # fixtures are deliberately misshapen
                 if len(p.read_text(errors="replace").splitlines()) >= args.min_lines:
                     cands.append(p)
     cands.sort()
-    print(f"[survey] {len(cands)} file(s) at or above {args.min_lines} lines; parsing with {args.jobs} job(s)\n")
+    print(f"[survey] {len(cands)} file(s) at or above {args.min_lines} lines; "
+          f"parsing with {args.jobs} job(s)\n")
 
     rows: list[dict] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
         for res in ex.map(lambda p: survey_one(p, db), cands):
             rows.append(res)
 
-    rows.sort(key=lambda r: -r.get("lines", 0))
-    order = {"SPLIT": 0, "EXTRACT": 1, "UNPARSED": 2, "HAND": 3, "PARSE-FAIL": 4, "OK": 5}
-    print(f"{'verdict':<11}{'lines':>7}{'big':>7}{'share':>7}{'lam%':>6}  file / dominant symbol")
-    print("-" * 100)
+    order = {"SPLIT": 0, "EXTRACT": 1, "UNPARSED": 2, "HAND": 3,
+             "NO-CURSOR": 4, "PARSE-FAIL": 5, "OK": 6}
+    print(f"{'verdict':<11}{'lines':>7}{'big':>7}{'share':>7}{'lam%':>6}{'unp%':>6}"
+          f"  file / dominant symbol")
+    print("-" * 104)
     for r in sorted(rows, key=lambda r: (order.get(r["verdict"], 9), -r.get("lines", 0))):
-        if r["verdict"] == "PARSE-FAIL":
-            print(f"{'PARSE-FAIL':<11}{r['lines']:>7}{'':>7}{'':>7}{'':>6}  {r['file']}\n"
-                  f"{'':>38}  {r['why'][:90]}")
+        if r["verdict"] in ("PARSE-FAIL", "NO-CURSOR"):
+            print(f"{r['verdict']:<11}{r['lines']:>7}{'':>7}{'':>7}{'':>6}{'':>6}  {r['file']}\n"
+                  f"{'':>44}  {r['why'][:90]}")
             continue
         rel = r["file"].split("prosper/", 1)[-1]
+        unp = r.get("unparsed_lines", 0) / max(r.get("lines", 1), 1)
         print(f"{r['verdict']:<11}{r['lines']:>7}{r.get('biggest_lines', 0):>7}"
-              f"{r.get('biggest_share', 0):>7.0%}{r.get('lambda_share_of_biggest', 0):>6.0%}  "
-              f"{rel}\n{'':>38}  {r.get('biggest', '')}")
+              f"{r.get('biggest_share', 0):>7.0%}{r.get('lambda_share_of_biggest', 0):>6.0%}"
+              f"{unp:>6.0%}  {rel}\n{'':>44}  {r.get('biggest', '')}")
 
     counts: dict[str, int] = {}
     for r in rows:

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -76,6 +76,11 @@ DOMINANT_SHARE = 0.40
 # ... and a dominant region must be at least this much of a lambda nest before clangd's refusal is
 # what actually blocks extraction, rather than an incidental detail.
 LAMBDA_SHARE = 0.50
+# A text region this large means the parser never saw that code -- almost always the inactive side of
+# an `#if defined(_WIN32)` platform arm. Below this it is ordinary scaffolding (includes, a namespace
+# close); at or above it, the AST is blind to a substantial part of the file and every AST-driven
+# verdict about that file is answering about the other part only.
+UNPARSED_SHARE = 0.15
 # A file needs this many top-level regions before a split has anywhere to cut. Deliberately small,
 # and the first draft got this wrong in a way the tree caught: it demanded two regions of >=200 lines
 # each, which classified `hle_kernel_mem.cpp` -- 7,637 lines whose biggest region is 180 (2%) -- as
@@ -118,13 +123,17 @@ def lambda_lines(cursor) -> int:   # requires _need_clang()
     return sum(e - s + 1 for s, e in merged)
 
 
-def classify(total: int, biggest: int, lam: int, regions: int) -> str:
+def classify(total: int, biggest: int, lam: int, regions: int, unparsed: int = 0) -> str:
     """The verdict, kept pure so --selftest can pin it without parsing anything.
 
     REGIONS is the file's top-level region count, not a count of large ones -- see SPLITTABLE_REGIONS.
+    UNPARSED is lines the AST never saw, and it is checked FIRST: a verdict computed from half a file
+    is not a weaker verdict, it is a statement about a different file.
     """
     if total <= 0:
         return "OK"
+    if unparsed / total >= UNPARSED_SHARE:
+        return "UNPARSED"
     share = biggest / total
     if share >= DOMINANT_SHARE:
         return "HAND" if biggest > 0 and lam / biggest >= LAMBDA_SHARE else "EXTRACT"
@@ -152,9 +161,24 @@ def survey_one(path: pathlib.Path, db: pathlib.Path) -> dict:
                 "why": f"{len(errs)} parse error(s); first: {errs[0].spelling}"}
 
     regions = MS.regions_of(tu, path, total)
+    # Regions the parser contributed no declaration to. `map_symbols` gives the outermost namespace's
+    # trailing text the `close` role, so on a file whose second half sits behind an inactive `#if`
+    # the ENTIRE unparsed arm arrives as one `close`/TRAILER region -- and this filter used to drop
+    # it as scaffolding. On hle_kernel_mem.cpp that silently hid 3,909 lines, 51% of the file, and
+    # scored what remained as though it were the whole thing.
+    unparsed = sum(r["end"] - r["start"] + 1 for r in regions
+                   if r.get("kind") in ("TEXT", "TRAILER")
+                   and (r["end"] - r["start"] + 1) / max(total, 1) >= UNPARSED_SHARE)
     sized = [(r["end"] - r["start"] + 1, r) for r in regions if r.get("role") not in MS.REPLICATED]
     if not sized:
         return {"file": rel, "lines": total, "verdict": "OK", "regions": 0}
+    if unparsed / max(total, 1) >= UNPARSED_SHARE:
+        return {"file": rel, "lines": total, "regions": len(regions),
+                "unparsed_lines": unparsed, "unparsed_share": round(unparsed / total, 3),
+                "biggest": "<unparsed span>", "biggest_lines": unparsed,
+                "biggest_share": round(unparsed / total, 3),
+                "lambda_lines": 0, "lambda_share_of_biggest": 0.0,
+                "verdict": "UNPARSED"}
     sized.sort(key=lambda t: -t[0])
     big_len, big = sized[0]
 
@@ -177,7 +201,8 @@ def survey_one(path: pathlib.Path, db: pathlib.Path) -> dict:
         "lambda_lines": lam,
         "lambda_share_of_biggest": round(lam / big_len, 3) if big_len else 0.0,
         "regions_over_%d" % SPLITTABLE_REGION_LINES: big_regions,
-        "verdict": classify(total, big_len, lam, len(regions)),
+        "unparsed_lines": unparsed,
+        "verdict": classify(total, big_len, lam, len(regions), unparsed),
     }
 
 
@@ -188,13 +213,23 @@ def selftest() -> int:
         (10000, 9000, 8900, 1, "HAND"),      # live_renderer shape: one function, nearly all lambda
         (10000, 9000,   10, 1, "EXTRACT"),   # one function, lambda-free -> clangd can act
         (10000, 1000,    0, 8, "SPLIT"),     # many mid-sized regions -> split_file.py
-        ( 7637,  180,    0, 96, "SPLIT"),    # hle_kernel_mem shape: huge, all small regions.
-                                             # The first classifier called this OK, which was wrong:
-                                             # many small functions is the EASIEST split.
+        (10000, 1000,    0, 96, "SPLIT"),   # huge, all small regions -- the EASIEST split there is.
+                                            # An earlier classifier called this OK, which was wrong.
         (10000,  300,    0, 2, "OK"),        # large-ish but only two regions -- no real seam
         (10000, 4000, 1999, 3, "EXTRACT"),   # just BELOW the lambda boundary
         (10000, 4000, 2000, 3, "HAND"),      # exactly AT it -- `>=` puts the boundary in HAND
         (   0,    0,    0, 0, "OK"),         # empty file must not divide by zero
+    ]
+    # UNPARSED cases carry the fifth argument, so they are listed separately.
+    unparsed_cases = [
+        # (total, biggest, lambda, regions, unparsed, expected)
+        (7637,  180, 0, 246, 3909, "UNPARSED"),   # hle_kernel_mem's REAL shape: 51% behind an #if.
+                                                  # Scored SPLIT before the unparsed span was
+                                                  # counted, from the 49% the parser could see.
+        (10000, 1000, 0,  96, 1499, "SPLIT"),     # just below 15% -- ordinary scaffolding
+        (10000, 1000, 0,  96, 1500, "UNPARSED"),  # exactly at it
+        (10000, 9000, 8900, 1, 1600, "UNPARSED"), # unparsed WINS over HAND: a verdict from half a
+                                                  # file is about a different file
     ]
     bad = 0
     for total, big, lam, nreg, want in cases:
@@ -213,6 +248,12 @@ def selftest() -> int:
     if classify(10000, 4000, 1999, 3) != "EXTRACT":
         print("  [FAIL] a lambda share just BELOW the threshold must stay EXTRACT")
         bad += 1
+    for total, big, lam, nreg, unp, want in unparsed_cases:
+        got = classify(total, big, lam, nreg, unp)
+        ok = got == want
+        print(f"  [{'ok' if ok else 'FAIL'}] classify({total},{big},{lam},{nreg},unparsed={unp}) = {got}"
+              f"{'' if ok else f' (want {want})'}")
+        bad += not ok
     print("== PASS ==" if not bad else f"== FAIL: {bad} ==")
     return 1 if bad else 0
 
@@ -255,7 +296,7 @@ def main() -> int:
             rows.append(res)
 
     rows.sort(key=lambda r: -r.get("lines", 0))
-    order = {"SPLIT": 0, "EXTRACT": 1, "HAND": 2, "PARSE-FAIL": 3, "OK": 4}
+    order = {"SPLIT": 0, "EXTRACT": 1, "UNPARSED": 2, "HAND": 3, "PARSE-FAIL": 4, "OK": 5}
     print(f"{'verdict':<11}{'lines':>7}{'big':>7}{'share':>7}{'lam%':>6}  file / dominant symbol")
     print("-" * 100)
     for r in sorted(rows, key=lambda r: (order.get(r["verdict"], 9), -r.get("lines", 0))):

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -31,8 +31,8 @@ measurements below are taken the way they are rather than the obvious way:
     region's cursor therefore always found the NAMESPACE, and unioned every lambda in the whole file
     into the dominant function's share. `testdata/dominant_no_lambda.cpp` is the hand-built instance:
     a dominant function containing no lambda at all, beside a small all-lambda sibling, which the
-    old code reported at a 0.63 lambda share -- HAND, "no tool can act", for a function clangd
-    extracts from happily. Descend to the region's OWN cursor (`region_cursor`).
+    old code reports at a 0.729 lambda share (43 lambda lines against the 59-line region) -- HAND,
+    "no tool can act", for a function clangd extracts from happily. Descend to the region's OWN cursor (`region_cursor`).
 
   * INFER UNPARSED LINES FROM REGION KINDS. `map_symbols` tiles a file by cursor, so an inactive
     `#if` arm is not a region of its own: it is folded into whichever region follows it and wears
@@ -63,6 +63,7 @@ import concurrent.futures
 import ctypes
 import importlib.util
 import json
+import os
 import pathlib
 import sys
 
@@ -86,10 +87,11 @@ def _load_map_symbols():
 MS = None
 ci = None
 _SKIPPED_RANGES = None
+_DISPOSE_RANGES = None
 
 
 def _need_clang() -> None:
-    global MS, ci, _SKIPPED_RANGES
+    global MS, ci, _SKIPPED_RANGES, _DISPOSE_RANGES
     if MS is not None:
         return
     MS = _load_map_symbols()
@@ -108,12 +110,14 @@ def _need_clang() -> None:
     # them as c_void_p instead would bypass that. Only restype needs stating.
     try:
         lib.clang_getSkippedRanges.restype = ctypes.POINTER(_CXSourceRangeList)
+        lib.clang_disposeSourceRangeList.argtypes = [ctypes.POINTER(_CXSourceRangeList)]
     except AttributeError:
         # Fail CLOSED. Reporting 0 unparsed lines when the question cannot be asked is precisely the
         # silent-under-report this tool exists to avoid, and it would land as a confident verdict.
         sys.exit("libclang here has no clang_getSkippedRanges; cannot measure unparsed spans "
                  "and will not guess. Upgrade libclang (present since clang 3.7).")
     _SKIPPED_RANGES = lib.clang_getSkippedRanges
+    _DISPOSE_RANGES = lib.clang_disposeSourceRangeList
 
 
 # A region must reach this share of the file before the file counts as dominated by it. Below it,
@@ -123,9 +127,11 @@ DOMINANT_SHARE = 0.40
 # what actually blocks extraction, rather than an incidental detail.
 LAMBDA_SHARE = 0.50
 # Skipped-arm lines this share of a file mean the AST is blind to a substantial part of it, and every
-# AST-driven verdict is then answering about the other part only. A CONVENTION, not a measurement:
-# the tree has two files above it (guest_write_watch.cpp at 19.7%, hle_kernel_mem.cpp at 52.1%) and
-# the next is far below, so the band is wide and nothing here pins where in it the line belongs.
+# AST-driven verdict is then answering about the other part only. The VALUE is a convention, but the
+# PARTITION it produces is not sensitive to it: measured over the tree, the highest share among files
+# it does not catch is 4.34% (exec_image_linux.cpp) and the lowest among the four it does is 19.70%
+# (guest_write_watch.cpp). Any threshold in (4.34%, 19.70%] yields exactly the same four files, so
+# 0.15 is a point in a wide empty band rather than a line drawn through the data.
 UNPARSED_SHARE = 0.15
 # A file needs this many movable regions before a split has anywhere to cut. Deliberately small,
 # and the first draft got this wrong in a way the tree caught: it demanded two regions of >=200 lines
@@ -137,6 +143,26 @@ SPLITTABLE_REGIONS = 4
 # Still reported, because a file whose regions are all tiny may want grouping by role rather than a
 # straight cut -- but it no longer gates the verdict.
 SPLITTABLE_REGION_LINES = 200
+
+
+class SkippedRangesUnavailable(RuntimeError):
+    """The skipped-arm question could not be asked. Never answered as zero -- see skipped_lines."""
+
+
+def _same_file(a: str, b: pathlib.Path) -> bool:
+    """Same file on disk, compared by INODE rather than by spelling.
+
+    `resolve()` is not enough here. This repository is reached under two spellings that resolve
+    differently and name one file -- the container's `/home/<user>/...` bind mount and the host's
+    `/var/home/<user>/...` -- and a mismatch made the old clip discard every span and report a file
+    with 963 skipped lines as having none. Falling back to True on an OS error keeps that failure in
+    the loud direction: an over-count raises UNPARSED, which is visible, where an under-count is the
+    silent wrong answer.
+    """
+    try:
+        return os.path.samefile(a, b)
+    except OSError:
+        return True
 
 
 def merge_spans(spans: list[tuple[int, int]]) -> int:
@@ -161,18 +187,27 @@ def skipped_lines(tu, path: pathlib.Path) -> int:   # requires _need_clang()
     """
     f = ci.File.from_name(tu, str(path))
     if f is None:
-        return 0
+        # Never 0. "The file is not in its own translation unit" is not "this file skips nothing";
+        # answering 0 here is the same silent under-report this function exists to end.
+        raise SkippedRangesUnavailable(f"{path} is not a file of its own translation unit")
     rl = _SKIPPED_RANGES(tu, f)
     if not rl:
-        return 0
-    spans: list[tuple[int, int]] = []
-    for i in range(rl.contents.count):
-        r = rl.contents.ranges[i]
-        s, e = r.start, r.end
-        if s.file is None or pathlib.Path(s.file.name).resolve() != path.resolve():
-            continue
-        spans.append((s.line, e.line))
-    return merge_spans(spans)
+        raise SkippedRangesUnavailable(f"clang_getSkippedRanges returned NULL for {path}")
+    try:
+        spans: list[tuple[int, int]] = []
+        for i in range(rl.contents.count):
+            r = rl.contents.ranges[i]
+            s, e = r.start, r.end
+            if s.file is not None and not _same_file(s.file.name, path):
+                continue
+            # A span's line numbers include the `#if` and `#endif` directives themselves, because
+            # that is what libclang reports. Counted as given: they are lines of the file the AST
+            # produced nothing for, which is the quantity here. Worth two lines per span if anyone
+            # reconstructs this figure as "lines of skipped CODE" and finds it slightly smaller.
+            spans.append((s.line, e.line))
+        return merge_spans(spans)
+    finally:
+        _DISPOSE_RANGES(rl)
 
 
 def lambda_lines(cursor) -> int:   # requires _need_clang()
@@ -216,7 +251,18 @@ def region_cursor(tu, path: pathlib.Path, region: dict, max_depth: int = 3):
                 continue
             if pathlib.Path(k.location.file.name).resolve() != path.resolve():
                 continue
-            if k.kind == ci.CursorKind.NAMESPACE and depth < max_depth:
+            # Mirror emit()'s descent condition EXACTLY, kids-check included. Descending on
+            # `depth < max_depth` alone is not the same rule: a namespace with no in-target children
+            # is emitted by regions_of as a plain `body` region (the kids-empty fallthrough at
+            # map_symbols.py:174), so it can BE the dominant region -- and descending past it
+            # without testing it reports NO-CURSOR for a file that has a perfectly good answer.
+            # `testdata/namespace_without_children.cpp` is that case, reachable with nothing more
+            # exotic than a namespace whose body is all comments.
+            kids = [k2 for k2 in k.get_children()
+                    if k2.location.file is not None
+                    and pathlib.Path(k2.location.file.name).resolve() == path.resolve()] \
+                if k.kind == ci.CursorKind.NAMESPACE else []
+            if kids and depth < max_depth:
                 walk(k, depth + 1)
                 continue
             if k.extent.start.line == want_start and k.extent.end.line == want_end:
@@ -264,7 +310,10 @@ def measure(path: pathlib.Path, flags: list[str], parse_target: pathlib.Path) ->
         return {"file": rel, "lines": total, "verdict": "PARSE-FAIL",
                 "why": f"{len(errs)} parse error(s); first: {errs[0].spelling}"}
 
-    unparsed = skipped_lines(tu, path)
+    try:
+        unparsed = skipped_lines(tu, path)
+    except SkippedRangesUnavailable as exc:
+        return {"file": rel, "lines": total, "verdict": "NO-PREPROC", "why": str(exc)}
     regions = MS.regions_of(tu, path, total)
     # Movable regions only. An `open`/`close` is replicated into every output part, so it is not a
     # place a split can cut and must not count toward the file having a seam.
@@ -400,6 +449,16 @@ def _parse_selftest() -> int:
         print(f"        full row: {r}")
     bad += not ok
 
+    c = _TESTDATA / "namespace_without_children.cpp"
+    r = measure(c, flags, c)
+    ok = r["verdict"] == "EXTRACT" and r.get("biggest") == "commentary"
+    print(f"  [{'ok' if ok else 'FAIL'}] {c.name}: verdict={r['verdict']} "
+          f"biggest={r.get('biggest')!r} "
+          f"(want EXTRACT/'commentary' -- descending on depth alone gives NO-CURSOR)")
+    if not ok:
+        print(f"        full row: {r}")
+    bad += not ok
+
     b = _TESTDATA / "midfile_inactive_arm.cpp"
     r = measure(b, flags, b)
     share = r.get("unparsed_share", 0.0)
@@ -411,6 +470,26 @@ def _parse_selftest() -> int:
         print(f"        full row: {r}")
     bad += not ok
     return bad
+
+
+def selftest_parse_only() -> int:
+    """The measurement fixtures alone, reporting SKIP (77) where libclang is absent.
+
+    Registered as its own ctest case so the smaller domain is VISIBLE. Folded into `--selftest` the
+    parse checks simply do not run on a runner without libclang, and ctest prints `Passed` -- a green
+    result whose domain is strictly smaller than the local one, with nothing in the report saying so.
+    This project has that exact hazard recorded for its GPU tests on CI's software rasteriser; a
+    `Skipped` row is the honest form of the same situation.
+    """
+    try:
+        import clang.cindex  # noqa: F401
+    except ImportError:
+        print("SKIP: no libclang here, so the measurement fixtures cannot run.")
+        print("      The arithmetic classifier is covered by refactor_survey_classifier.")
+        return 77
+    bad = _parse_selftest()
+    print("== PASS ==" if not bad else f"== FAIL: {bad} ==")
+    return 1 if bad else 0
 
 
 def selftest() -> int:
@@ -440,7 +519,11 @@ def main() -> int:
     ap.add_argument("--json", type=pathlib.Path)
     ap.add_argument("--jobs", type=int, default=6)
     ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--selftest-parse", action="store_true",
+                    help="only the measurement fixtures; exit 77 (ctest SKIP) without libclang")
     args = ap.parse_args()
+    if args.selftest_parse:
+        return selftest_parse_only()
     if args.selftest:
         return selftest()
 
@@ -473,16 +556,20 @@ def main() -> int:
             rows.append(res)
 
     order = {"SPLIT": 0, "EXTRACT": 1, "UNPARSED": 2, "HAND": 3,
-             "NO-CURSOR": 4, "PARSE-FAIL": 5, "OK": 6}
+             "NO-CURSOR": 4, "NO-PREPROC": 5, "PARSE-FAIL": 6, "OK": 7}
     print(f"{'verdict':<11}{'lines':>7}{'big':>7}{'share':>7}{'lam%':>6}{'unp%':>6}"
           f"  file / dominant symbol")
     print("-" * 104)
     for r in sorted(rows, key=lambda r: (order.get(r["verdict"], 9), -r.get("lines", 0))):
-        if r["verdict"] in ("PARSE-FAIL", "NO-CURSOR"):
-            print(f"{r['verdict']:<11}{r['lines']:>7}{'':>7}{'':>7}{'':>6}{'':>6}  {r['file']}\n"
-                  f"{'':>44}  {r['why'][:90]}")
-            continue
+        # Strip to a repo-relative path on EVERY branch. This repository is public and an absolute
+        # path publishes the developer's account name and directory layout; the strip used to be on
+        # the scored branch only, so exactly the rows that name a problem leaked one.
         rel = r["file"].split("prosper/", 1)[-1]
+        if r["verdict"] in ("PARSE-FAIL", "NO-CURSOR", "NO-PREPROC"):
+            why = r["why"].replace(str(root) + "/", "").replace(str(root), "")
+            print(f"{r['verdict']:<11}{r['lines']:>7}{'':>7}{'':>7}{'':>6}{'':>6}  {rel}\n"
+                  f"{'':>44}  {why[:90]}")
+            continue
         unp = r.get("unparsed_lines", 0) / max(r.get("lines", 1), 1)
         print(f"{r['verdict']:<11}{r['lines']:>7}{r.get('biggest_lines', 0):>7}"
               f"{r.get('biggest_share', 0):>7.0%}{r.get('lambda_share_of_biggest', 0):>6.0%}"

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -158,30 +158,36 @@ def _file_in_tu(tu, path: pathlib.Path) -> bool:
     that assumption into a check.
     """
     try:
-        if _same_file(tu.spelling, path):
+        if _same_file(tu.spelling, path, on_error=False):
             return True
-    except (OSError, TypeError):
+    except TypeError:                             # no tu.spelling; the include scan still runs
         pass
     for inc in tu.get_includes():
-        if inc.include is not None and _same_file(inc.include.name, path):
+        if inc.include is not None and _same_file(inc.include.name, path, on_error=False):
             return True
     return False
 
 
-def _same_file(a: str, b: pathlib.Path) -> bool:
+def _same_file(a: str, b: pathlib.Path, on_error: bool = True) -> bool:
     """Same file on disk, compared by INODE rather than by spelling.
 
     `resolve()` is not enough here. This repository is reached under two spellings that resolve
     differently and name one file -- the container's `/home/<user>/...` bind mount and the host's
     `/var/home/<user>/...` -- and a mismatch made the old clip discard every span and report a file
-    with 963 skipped lines as having none. Falling back to True on an OS error keeps that failure in
-    the loud direction: an over-count raises UNPARSED, which is visible, where an under-count is the
-    silent wrong answer.
+    with 963 skipped lines as having none.
+
+    ON_ERROR is which way to fail when the stat itself fails, and the two callers want OPPOSITE
+    directions -- so it is a parameter rather than a fixed policy. For the span clip, True: an
+    over-count raises UNPARSED, which someone sees, where an under-count is the silent wrong
+    answer. For the membership test in `_file_in_tu`, False: a failed stat is not evidence the
+    translation unit read the file, and answering True would assert membership on no information
+    and hand the caller a confident 0. The same "fail toward the visible outcome" rule lands on
+    different booleans because the visible outcome differs.
     """
     try:
         return os.path.samefile(a, b)
     except OSError:
-        return True
+        return on_error
 
 
 def merge_spans(spans: list[tuple[int, int]]) -> int:
@@ -460,7 +466,7 @@ def _arithmetic_selftest() -> int:
 
 
 def _parse_selftest() -> int:
-    """Score the two fixtures, whose answers are known by construction.
+    """Score the measurement fixtures, whose answers are known by construction.
 
     These are the cases the arithmetic above CANNOT reach: both past defects were in how the inputs
     to classify() were measured, not in classify() itself, so every arithmetic case passed happily

--- a/prosper/tools/refactor/testdata/dominant_no_lambda.cpp
+++ b/prosper/tools/refactor/testdata/dominant_no_lambda.cpp
@@ -1,0 +1,117 @@
+// Fixture for survey_sizes.py --selftest. NOT built: nothing globs tools/refactor/testdata.
+//
+// The discriminator for "which cursor is the lambda share measured over". `dominant` is the
+// biggest region and contains ZERO lambdas, so the honest verdict is EXTRACT -- clangd can act on
+// it. `sibling` is small and almost entirely one lambda body. A survey that measures the lambda
+// share over the enclosing NAMESPACE instead of over the dominant region attributes sibling's
+// lambda to dominant and reports HAND, which is the opposite answer: "no tool can act on it".
+namespace prosper {
+
+int dominant(int x) {
+  int acc = 0;
+  acc += x * 1; if (acc > 1000) acc -= 7;
+  acc += x * 2; if (acc > 1000) acc -= 7;
+  acc += x * 3; if (acc > 1000) acc -= 7;
+  acc += x * 4; if (acc > 1000) acc -= 7;
+  acc += x * 5; if (acc > 1000) acc -= 7;
+  acc += x * 6; if (acc > 1000) acc -= 7;
+  acc += x * 7; if (acc > 1000) acc -= 7;
+  acc += x * 8; if (acc > 1000) acc -= 7;
+  acc += x * 9; if (acc > 1000) acc -= 7;
+  acc += x * 10; if (acc > 1000) acc -= 7;
+  acc += x * 11; if (acc > 1000) acc -= 7;
+  acc += x * 12; if (acc > 1000) acc -= 7;
+  acc += x * 13; if (acc > 1000) acc -= 7;
+  acc += x * 14; if (acc > 1000) acc -= 7;
+  acc += x * 15; if (acc > 1000) acc -= 7;
+  acc += x * 16; if (acc > 1000) acc -= 7;
+  acc += x * 17; if (acc > 1000) acc -= 7;
+  acc += x * 18; if (acc > 1000) acc -= 7;
+  acc += x * 19; if (acc > 1000) acc -= 7;
+  acc += x * 20; if (acc > 1000) acc -= 7;
+  acc += x * 21; if (acc > 1000) acc -= 7;
+  acc += x * 22; if (acc > 1000) acc -= 7;
+  acc += x * 23; if (acc > 1000) acc -= 7;
+  acc += x * 24; if (acc > 1000) acc -= 7;
+  acc += x * 25; if (acc > 1000) acc -= 7;
+  acc += x * 26; if (acc > 1000) acc -= 7;
+  acc += x * 27; if (acc > 1000) acc -= 7;
+  acc += x * 28; if (acc > 1000) acc -= 7;
+  acc += x * 29; if (acc > 1000) acc -= 7;
+  acc += x * 30; if (acc > 1000) acc -= 7;
+  acc += x * 31; if (acc > 1000) acc -= 7;
+  acc += x * 32; if (acc > 1000) acc -= 7;
+  acc += x * 33; if (acc > 1000) acc -= 7;
+  acc += x * 34; if (acc > 1000) acc -= 7;
+  acc += x * 35; if (acc > 1000) acc -= 7;
+  acc += x * 36; if (acc > 1000) acc -= 7;
+  acc += x * 37; if (acc > 1000) acc -= 7;
+  acc += x * 38; if (acc > 1000) acc -= 7;
+  acc += x * 39; if (acc > 1000) acc -= 7;
+  acc += x * 40; if (acc > 1000) acc -= 7;
+  acc += x * 41; if (acc > 1000) acc -= 7;
+  acc += x * 42; if (acc > 1000) acc -= 7;
+  acc += x * 43; if (acc > 1000) acc -= 7;
+  acc += x * 44; if (acc > 1000) acc -= 7;
+  acc += x * 45; if (acc > 1000) acc -= 7;
+  acc += x * 46; if (acc > 1000) acc -= 7;
+  acc += x * 47; if (acc > 1000) acc -= 7;
+  acc += x * 48; if (acc > 1000) acc -= 7;
+  acc += x * 49; if (acc > 1000) acc -= 7;
+  acc += x * 50; if (acc > 1000) acc -= 7;
+  acc += x * 51; if (acc > 1000) acc -= 7;
+  acc += x * 52; if (acc > 1000) acc -= 7;
+  acc += x * 53; if (acc > 1000) acc -= 7;
+  acc += x * 54; if (acc > 1000) acc -= 7;
+  acc += x * 55; if (acc > 1000) acc -= 7;
+  return acc;
+}
+
+int sibling(int v) {
+  auto step = [](int a) {
+    a += 1;
+    a += 2;
+    a += 3;
+    a += 4;
+    a += 5;
+    a += 6;
+    a += 7;
+    a += 8;
+    a += 9;
+    a += 10;
+    a += 11;
+    a += 12;
+    a += 13;
+    a += 14;
+    a += 15;
+    a += 16;
+    a += 17;
+    a += 18;
+    a += 19;
+    a += 20;
+    a += 21;
+    a += 22;
+    a += 23;
+    a += 24;
+    a += 25;
+    a += 26;
+    a += 27;
+    a += 28;
+    a += 29;
+    a += 30;
+    a += 31;
+    a += 32;
+    a += 33;
+    a += 34;
+    a += 35;
+    a += 36;
+    a += 37;
+    a += 38;
+    a += 39;
+    a += 40;
+    return a;
+  };
+  return step(v);
+}
+
+}  // namespace prosper

--- a/prosper/tools/refactor/testdata/midfile_inactive_arm.cpp
+++ b/prosper/tools/refactor/testdata/midfile_inactive_arm.cpp
@@ -1,0 +1,91 @@
+// Fixture for survey_sizes.py --selftest. NOT built: nothing globs tools/refactor/testdata.
+//
+// The discriminator for "can the survey see an unparsed span that is not at the end of the file".
+// The _WIN32 arm below sits in the MIDDLE, with real code after it, so it is folded into the
+// following cursor's region and carries that cursor's kind. A survey that infers unparsed lines
+// from region kinds cannot see it; the preprocessor's own skipped-range record can.
+namespace prosper {
+
+int before() { return 1; }
+
+#ifdef _WIN32
+static int win_only_1() { return 1; }
+static int win_only_2() { return 2; }
+static int win_only_3() { return 3; }
+static int win_only_4() { return 4; }
+static int win_only_5() { return 5; }
+static int win_only_6() { return 6; }
+static int win_only_7() { return 7; }
+static int win_only_8() { return 8; }
+static int win_only_9() { return 9; }
+static int win_only_10() { return 10; }
+static int win_only_11() { return 11; }
+static int win_only_12() { return 12; }
+static int win_only_13() { return 13; }
+static int win_only_14() { return 14; }
+static int win_only_15() { return 15; }
+static int win_only_16() { return 16; }
+static int win_only_17() { return 17; }
+static int win_only_18() { return 18; }
+static int win_only_19() { return 19; }
+static int win_only_20() { return 20; }
+static int win_only_21() { return 21; }
+static int win_only_22() { return 22; }
+static int win_only_23() { return 23; }
+static int win_only_24() { return 24; }
+static int win_only_25() { return 25; }
+static int win_only_26() { return 26; }
+static int win_only_27() { return 27; }
+static int win_only_28() { return 28; }
+static int win_only_29() { return 29; }
+static int win_only_30() { return 30; }
+static int win_only_31() { return 31; }
+static int win_only_32() { return 32; }
+static int win_only_33() { return 33; }
+static int win_only_34() { return 34; }
+static int win_only_35() { return 35; }
+static int win_only_36() { return 36; }
+static int win_only_37() { return 37; }
+static int win_only_38() { return 38; }
+static int win_only_39() { return 39; }
+static int win_only_40() { return 40; }
+static int win_only_41() { return 41; }
+static int win_only_42() { return 42; }
+static int win_only_43() { return 43; }
+static int win_only_44() { return 44; }
+static int win_only_45() { return 45; }
+static int win_only_46() { return 46; }
+static int win_only_47() { return 47; }
+static int win_only_48() { return 48; }
+static int win_only_49() { return 49; }
+static int win_only_50() { return 50; }
+static int win_only_51() { return 51; }
+static int win_only_52() { return 52; }
+static int win_only_53() { return 53; }
+static int win_only_54() { return 54; }
+static int win_only_55() { return 55; }
+static int win_only_56() { return 56; }
+static int win_only_57() { return 57; }
+static int win_only_58() { return 58; }
+static int win_only_59() { return 59; }
+static int win_only_60() { return 60; }
+#else
+static int posix_only_1() { return 1; }
+static int posix_only_2() { return 2; }
+static int posix_only_3() { return 3; }
+static int posix_only_4() { return 4; }
+static int posix_only_5() { return 5; }
+static int posix_only_6() { return 6; }
+static int posix_only_7() { return 7; }
+static int posix_only_8() { return 8; }
+static int posix_only_9() { return 9; }
+static int posix_only_10() { return 10; }
+static int posix_only_11() { return 11; }
+static int posix_only_12() { return 12; }
+#endif
+
+int after_a() { return 2; }
+int after_b() { return 3; }
+int after_c() { return 4; }
+
+}  // namespace prosper

--- a/prosper/tools/refactor/testdata/namespace_without_children.cpp
+++ b/prosper/tools/refactor/testdata/namespace_without_children.cpp
@@ -1,11 +1,21 @@
 // Fixture for survey_sizes.py --selftest. NOT built: nothing globs tools/refactor/testdata.
 //
-// The discriminator for "does region_cursor mirror regions_of's descent rule". This
-// namespace holds no declarations, only comments, so it has no in-target children -- and
-// regions_of therefore emits it as a plain `body` region rather than an open/close pair,
-// which lets it be the file's dominant region. A region_cursor that descends into every
-// namespace on depth alone walks straight past it and reports NO-CURSOR, refusing to score a
-// file whose answer is not in doubt.
+// The discriminator for "does region_cursor mirror regions_of's descent rule". The
+// `commentary` namespace below holds no declarations, only comments, so it has no in-target
+// children -- and regions_of therefore emits it as a plain `body` region rather than an
+// open/close pair, which lets it be the file's dominant region. A region_cursor that descends
+// into every namespace on depth alone walks straight past it and reports NO-CURSOR, refusing
+// to score a file whose answer is not in doubt.
+//
+// `prosper` is deliberately FIRST. Put it last and the commentary namespace lands before the
+// first namespace opener, which regions_of relabels as `preamble` -- and this fixture would
+// then be pinning a preamble region by accident, so a later change to how preambles are
+// counted would redden it for a reason that has nothing to do with namespace descent.
+namespace prosper {
+int a() { return 1; }
+int b() { return 2; }
+}  // namespace prosper
+
 namespace commentary {
 // note line 1: no declaration here, so this namespace has no in-target children
 // note line 2: no declaration here, so this namespace has no in-target children
@@ -98,8 +108,3 @@ namespace commentary {
 // note line 89: no declaration here, so this namespace has no in-target children
 // note line 90: no declaration here, so this namespace has no in-target children
 }  // namespace commentary
-
-namespace prosper {
-int a() { return 1; }
-int b() { return 2; }
-}  // namespace prosper

--- a/prosper/tools/refactor/testdata/namespace_without_children.cpp
+++ b/prosper/tools/refactor/testdata/namespace_without_children.cpp
@@ -1,0 +1,105 @@
+// Fixture for survey_sizes.py --selftest. NOT built: nothing globs tools/refactor/testdata.
+//
+// The discriminator for "does region_cursor mirror regions_of's descent rule". This
+// namespace holds no declarations, only comments, so it has no in-target children -- and
+// regions_of therefore emits it as a plain `body` region rather than an open/close pair,
+// which lets it be the file's dominant region. A region_cursor that descends into every
+// namespace on depth alone walks straight past it and reports NO-CURSOR, refusing to score a
+// file whose answer is not in doubt.
+namespace commentary {
+// note line 1: no declaration here, so this namespace has no in-target children
+// note line 2: no declaration here, so this namespace has no in-target children
+// note line 3: no declaration here, so this namespace has no in-target children
+// note line 4: no declaration here, so this namespace has no in-target children
+// note line 5: no declaration here, so this namespace has no in-target children
+// note line 6: no declaration here, so this namespace has no in-target children
+// note line 7: no declaration here, so this namespace has no in-target children
+// note line 8: no declaration here, so this namespace has no in-target children
+// note line 9: no declaration here, so this namespace has no in-target children
+// note line 10: no declaration here, so this namespace has no in-target children
+// note line 11: no declaration here, so this namespace has no in-target children
+// note line 12: no declaration here, so this namespace has no in-target children
+// note line 13: no declaration here, so this namespace has no in-target children
+// note line 14: no declaration here, so this namespace has no in-target children
+// note line 15: no declaration here, so this namespace has no in-target children
+// note line 16: no declaration here, so this namespace has no in-target children
+// note line 17: no declaration here, so this namespace has no in-target children
+// note line 18: no declaration here, so this namespace has no in-target children
+// note line 19: no declaration here, so this namespace has no in-target children
+// note line 20: no declaration here, so this namespace has no in-target children
+// note line 21: no declaration here, so this namespace has no in-target children
+// note line 22: no declaration here, so this namespace has no in-target children
+// note line 23: no declaration here, so this namespace has no in-target children
+// note line 24: no declaration here, so this namespace has no in-target children
+// note line 25: no declaration here, so this namespace has no in-target children
+// note line 26: no declaration here, so this namespace has no in-target children
+// note line 27: no declaration here, so this namespace has no in-target children
+// note line 28: no declaration here, so this namespace has no in-target children
+// note line 29: no declaration here, so this namespace has no in-target children
+// note line 30: no declaration here, so this namespace has no in-target children
+// note line 31: no declaration here, so this namespace has no in-target children
+// note line 32: no declaration here, so this namespace has no in-target children
+// note line 33: no declaration here, so this namespace has no in-target children
+// note line 34: no declaration here, so this namespace has no in-target children
+// note line 35: no declaration here, so this namespace has no in-target children
+// note line 36: no declaration here, so this namespace has no in-target children
+// note line 37: no declaration here, so this namespace has no in-target children
+// note line 38: no declaration here, so this namespace has no in-target children
+// note line 39: no declaration here, so this namespace has no in-target children
+// note line 40: no declaration here, so this namespace has no in-target children
+// note line 41: no declaration here, so this namespace has no in-target children
+// note line 42: no declaration here, so this namespace has no in-target children
+// note line 43: no declaration here, so this namespace has no in-target children
+// note line 44: no declaration here, so this namespace has no in-target children
+// note line 45: no declaration here, so this namespace has no in-target children
+// note line 46: no declaration here, so this namespace has no in-target children
+// note line 47: no declaration here, so this namespace has no in-target children
+// note line 48: no declaration here, so this namespace has no in-target children
+// note line 49: no declaration here, so this namespace has no in-target children
+// note line 50: no declaration here, so this namespace has no in-target children
+// note line 51: no declaration here, so this namespace has no in-target children
+// note line 52: no declaration here, so this namespace has no in-target children
+// note line 53: no declaration here, so this namespace has no in-target children
+// note line 54: no declaration here, so this namespace has no in-target children
+// note line 55: no declaration here, so this namespace has no in-target children
+// note line 56: no declaration here, so this namespace has no in-target children
+// note line 57: no declaration here, so this namespace has no in-target children
+// note line 58: no declaration here, so this namespace has no in-target children
+// note line 59: no declaration here, so this namespace has no in-target children
+// note line 60: no declaration here, so this namespace has no in-target children
+// note line 61: no declaration here, so this namespace has no in-target children
+// note line 62: no declaration here, so this namespace has no in-target children
+// note line 63: no declaration here, so this namespace has no in-target children
+// note line 64: no declaration here, so this namespace has no in-target children
+// note line 65: no declaration here, so this namespace has no in-target children
+// note line 66: no declaration here, so this namespace has no in-target children
+// note line 67: no declaration here, so this namespace has no in-target children
+// note line 68: no declaration here, so this namespace has no in-target children
+// note line 69: no declaration here, so this namespace has no in-target children
+// note line 70: no declaration here, so this namespace has no in-target children
+// note line 71: no declaration here, so this namespace has no in-target children
+// note line 72: no declaration here, so this namespace has no in-target children
+// note line 73: no declaration here, so this namespace has no in-target children
+// note line 74: no declaration here, so this namespace has no in-target children
+// note line 75: no declaration here, so this namespace has no in-target children
+// note line 76: no declaration here, so this namespace has no in-target children
+// note line 77: no declaration here, so this namespace has no in-target children
+// note line 78: no declaration here, so this namespace has no in-target children
+// note line 79: no declaration here, so this namespace has no in-target children
+// note line 80: no declaration here, so this namespace has no in-target children
+// note line 81: no declaration here, so this namespace has no in-target children
+// note line 82: no declaration here, so this namespace has no in-target children
+// note line 83: no declaration here, so this namespace has no in-target children
+// note line 84: no declaration here, so this namespace has no in-target children
+// note line 85: no declaration here, so this namespace has no in-target children
+// note line 86: no declaration here, so this namespace has no in-target children
+// note line 87: no declaration here, so this namespace has no in-target children
+// note line 88: no declaration here, so this namespace has no in-target children
+// note line 89: no declaration here, so this namespace has no in-target children
+// note line 90: no declaration here, so this namespace has no in-target children
+}  // namespace commentary
+
+namespace prosper {
+int a() { return 1; }
+int b() { return 2; }
+}  // namespace prosper


### PR DESCRIPTION
## What this adds

`prosper/tools/refactor/survey_sizes.py` — a repo-wide survey that answers **which refactoring tool can act on each large file**, so targets are chosen by shape rather than by `wc -l`. A 12,000-line file that is two hundred functions is an afternoon with `split_file.py`; a 12,000-line file that is one function is not, and no amount of splitting makes it one.

Four verdicts, plus three that decline to score:

| verdict | meaning |
| --- | --- |
| `SPLIT` | no region dominates — `split_file.py` applies today |
| `EXTRACT` | one region dominates but is lambda-light — clangd's ExtractFunction can act |
| `HAND` | dominant **and** mostly lambda bodies — clangd refuses ("Don't extract from lambdas"), no tool helps |
| `UNPARSED` | a large span sits behind an inactive `#if`, so every AST verdict would describe a different part of the file |
| `PARSE-FAIL` / `NO-CURSOR` / `NO-PREPROC` | reported, never scored |

## Result over the tree — 28 files at or above 2,500 lines

`EXTRACT=13, SPLIT=9, UNPARSED=4, HAND=1, PARSE-FAIL=1`

**22 of 28 have a route.** Exactly one file is untouchable: `frontends/shared/live/live_renderer.cpp`, whose `register_live_renderer` is 10,244 lines at **98% lambda**.

This corrects the impression the README previously left, that the giant functions are mostly beyond tooling:

- **`rdna2_emit_alu.cpp`'s 8,186-line `emit_alu` is 11% lambda**, so clangd can extract from it. So can it from the giant test `main`s — `test_rdna2_to_spirv.cpp` at 3%, `test_recompile_coverage.cpp` at 2%.
- **`hle_kernel_mem.cpp` is `UNPARSED` at 52%, not a plain split.** 3,978 lines across seven skipped spans, the largest of them 3,908 lines, sit behind inactive `#if`s -- and that largest arm alone is the 51% the superseded single-span heuristic reported, which is why the two figures should not be confused. So `split_file.py` cannot drive #3503 — the tool is blind to the very arm that issue wants to move. That needs a textual line-range move at the directive boundaries. Recorded on #3503; three more files share the shape (`hle_kernel.cpp` 30%, `hle_file.cpp` 21%, `guest_write_watch.cpp` 20%).

## The interesting part is how often this tool was wrong

The classifier has been wrong **five times**, and `CMakeLists.txt` records all five next to the test that pins them. Two were arithmetic. **Three were in how the classifier's INPUTS are measured**, so every arithmetic case passed happily while the tool reported the opposite verdict for a real file — and none produced an error or an odd-looking row:

1. **The lambda share was measured over the enclosing namespace.** Nearly every file here is one `namespace prosper { ... }`, and a namespace answers `is_definition()` True, so the scan for the dominant region's cursor always found it. 6 of the 14 files that have a share at all were inflated, worst `rdna2_emit_cfg.cpp` at 0.428 against a true 0.258. **No verdict changed** — luck, since 0.50 is the threshold.
2. **Unparsed lines were inferred from region kinds**, which structurally cannot see an inactive `#if` that is not at the end of the file. `guest_write_watch.cpp` — a 481-line `#ifdef _WIN32` arm mid-file — reported **0** unparsed with a dominant "symbol" of `sched.h`, the include whose region had absorbed it. Now asks the preprocessor (`clang_getSkippedRanges`) and sums every arm.
3. **`region_cursor` did not mirror `regions_of`'s descent rule**, so a namespace that is itself a body region was walked past and scored `NO-CURSOR`.

And once in the *fix* for (2): a fail-closed guard that could not fire. `File.from_name(...) is None` never is — `clang_getFile` resolves through the file manager and answers for any file on disk, read by the TU or not — so a foreign file returned a valid handle, an empty range list and a confident **0**, under a README paragraph promising the opposite. Membership is tested against the TU's inclusion record now.

## Verification

Each of the three input defects is pinned by a fixture under `tools/refactor/testdata/`, built so the **defective measurement yields a different verdict**, not merely a different number. Verified by re-running each pre-fix version against all of them: every mutation reddens its own fixture and leaves the others green.

| mutation | reddens |
| --- | --- |
| pre-fix top-level cursor scan | `dominant_no_lambda` → `HAND` at 0.729 for a function with no lambda |
| pre-fix region-kind inference | `midfile_inactive_arm` → `EXTRACT`, 0 unparsed, naming `posix_only_1` |
| descend on depth alone | `namespace_without_children` → `NO-CURSOR` |
| `resolve()` path comparison | the hard-link arm |

That last arm exists because the inode comparison had none: every fixture uses one spelling, so reverting it left them all green. A **hard link** reproduces the property the bind-mount alias has and nothing else here does — two paths naming one file that `resolve()` reports as different. Under the alias spelling the old comparison discarded every span and reported `hle_file.cpp` as having **0** skipped lines instead of 963.

- `ctest --no-tests=error` — **455** tests; two registered cases here, `refactor_survey_classifier` (13 arithmetic cases, runs everywhere) and `refactor_survey_measurement` (4 measurement checks, `SKIP_RETURN_CODE 77`).
- The measurement checks are a **separate** case deliberately: folded into one, they simply do not run on a runner without libclang and ctest prints `Passed` — a green result on a strictly smaller domain with nothing saying so. `Skipped` is the honest form, and this project already records that hazard for its GPU tests under CI's software rasteriser.
- Docs numbered-table gate clean; `diff --check` clean; 0 `Claude-Session:` trailers.

## Risk

Tooling only — no emulator code, nothing linked into any target. The fixtures live under `tools/refactor/testdata/`, which nothing globs (`CMakeLists.txt:88` globs `src/*.cpp` only).

Follow-ups filed: #3515 (`map_symbols.py` documents a `--clusters` flag that does not exist) and #3516 (`gpu_executor.cpp`, the largest `SPLIT` file, with its seam measured from the reference matrix).

