### PR TITLE
tools/refactor: promote_internal wrote headers that cannot compile, three ways

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -178,6 +178,13 @@ if(Python3_Interpreter_FOUND)
   # under tools/refactor/testdata/ that the selftest scores ONLY where libclang is importable, and
   # it says loudly when it skips them. libclang resolves lazily, so the arithmetic half runs here
   # even though the surveying itself needs a libclang the runner does not have.
+  # map_symbols' clustering decides where a split cuts, and its failure mode is a confident wrong
+  # proposal rather than a crash -- one draft collapsed a 6,515-line file into a single 6,374-line
+  # "part" and reported a 0% cut. Pure arithmetic over the reference matrix, and libclang resolves
+  # lazily there now, so this runs on a runner that has none.
+  add_test(NAME refactor_map_symbols_clusters
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/refactor/map_symbols.py" --selftest)
   add_test(NAME refactor_survey_classifier
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/refactor/survey_sizes.py" --selftest)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -182,6 +182,12 @@ if(Python3_Interpreter_FOUND)
   # proposal rather than a crash -- one draft collapsed a 6,515-line file into a single 6,374-line
   # "part" and reported a 0% cut. Pure arithmetic over the reference matrix, and libclang resolves
   # lazily there now, so this runs on a runner that has none.
+  # split_file.py was in NO ctest case at all, so a "3/3 refactor tests pass" said nothing about
+  # the splitter -- including a cross-reference check whose arms could not fail. Both gaps found in
+  # the same review.
+  add_test(NAME refactor_split_file
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/refactor/split_file.py" --selftest)
   add_test(NAME refactor_map_symbols_clusters
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/refactor/map_symbols.py" --selftest)

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -287,20 +287,25 @@ the defect changes the group COUNT rather than merely a number.
 ### The three tools are a chain, and each one checks the step before it
 
 `map_symbols` proposes a seam, `promote_internal` makes the shared vocabulary visible, `split_file`
-cuts. The order is forced, and the reason is worth stating because skipping a step produces a result
-that passes every check and does not compile:
+cuts. The middle step is not always needed -- 42 of `gpu_capture.cpp`'s 155 body regions are already
+external, and a seam that only crosses those needs no promotion at all. What the order buys is that
+**whether you need it is now decidable before the cut** rather than at build time:
 
 ```bash
-map_symbols.py  --file <f> --clusters 3 --json /tmp/f.json   # where to cut, and what it costs
-promote_internal.py --map /tmp/f.json --regions <closure> --header <f>_internal.hpp
-map_symbols.py  --file <f> --json /tmp/f2.json               # promotion changes every index
-split_file.py   --map /tmp/f2.json --plan <plan> --dry-run
+map_symbols.py  --file <f> --clusters 3 --json ~/work/f.json   # where to cut, and what it costs
+split_file.py   --map ~/work/f.json --plan <plan> --dry-run    # refuses, naming what to promote
+promote_internal.py --map ~/work/f.json --regions <closure> --header <f>_internal.hpp
+map_symbols.py  --file <f> --json ~/work/f2.json               # promotion changes every index
+split_file.py   --map ~/work/f2.json --plan <plan> --dry-run
 ```
 
+(Maps go under `$HOME`, not `/tmp`: that is a RAM-backed tmpfs here with a quota shared by every
+concurrent agent.)
+
 **Both closure checks exist because their absence was measured, not imagined.** Splitting
-`gpu_capture.cpp`'s serialize/deserialize into their own file satisfied every check `split_file` had
--- exact tiling, a clean partition, byte-for-byte reconstruction -- and then failed to compile with
-**25 undeclared names**, because `Writer`, `Reader`, `kMagic`, `read_table` and twenty others have
+`gpu_capture.cpp`'s serialize/deserialize into their own file satisfied every check `split_file`
+*then had* -- exact tiling, a clean partition, byte-for-byte reconstruction -- and failed to compile
+with **25 undeclared names**, because `Writer`, `Reader`, `kMagic`, `read_table` and twenty others have
 internal linkage and stayed in the other part. Every one of those checks is byte accounting: they
 establish that no LINE was lost, never that a line can still be used where it ended up.
 

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -255,6 +255,35 @@ would be ranked as needing no work. One file is currently in that state:
 `frontends/prosper-app/main.cpp`, which has no compile command unless the app is configured
 (`-DPROSPER_APP=ON`); configure with it to bring that file into the survey.
 
+### Choosing where to cut
+
+`map_symbols.py --clusters [N]` groups the file's regions by what they actually reference, and
+reports the cost of the seam it proposes:
+
+```
+== proposed seams: 9 group(s), target ~2149 lines each == -- you asked for 3, and the reference
+   structure plus that size cap do not permit fewer
+   252 of 2927 references cross a boundary (9%) -- that is the promote-to-header list
+   83 merge(s) the references wanted were refused by the size cap; a group AT the cap is the cap
+   talking, not a seam
+```
+
+The cross-boundary count is the number that matters, because those are the internal-linkage edges
+the REFERENCES section warns about -- a split that separates a `static` helper from its callers
+*"does not fail at review, it fails at link"*. Having the list up front turns `promote_internal.py`
+into a decision instead of a compile-error hunt.
+
+**Two things it says about itself, and both are load-bearing.** A group sitting exactly AT the size
+cap is the cap talking, not a structural seam -- it stopped there because it was told to. And the
+part count is what the references and the cap allow, not what you asked for; the tool says so rather
+than forcing the number. Grouping by NAME finds none of this: on `gpu_executor.cpp` a name-prefix
+pass put 183 of 273 regions in "other".
+
+**A 0% cut is a tell, not a success.** An early draft let attachment ignore the cap, which funnelled
+every group into the largest connected component -- one 6,374-line "part" out of 6,515 lines,
+reported as a perfect zero-cut split. That is pinned by a selftest arm now, with the fixture built so
+the defect changes the group COUNT rather than merely a number.
+
 ### Running it
 
 ```bash

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -313,7 +313,13 @@ The reference matrix that answers it was already in the map. `split_file` reads 
 naming the definitions and printing the `promote_internal` command that fixes them. Measured against
 the compiler on that split: **23 names flagged, 25 reported by g++, and the two it did not name are
 `r` and `w`** -- local variables in cascading errors from `Reader r;` and `Writer w;`. No false
-positives.
+positives on that file.
+
+**The check cannot see inactive `#if` arms**, and that limit is not small: libclang parses one arm,
+so a map made on Linux carries no references from the 52% of `hle_kernel_mem.cpp` or the 30% of
+`hle_kernel.cpp` that sit behind a platform conditional. A split validated here can still strand a
+definition the other platform's arm uses. `survey_sizes.py` reports that share per file as
+`UNPARSED`; treat a clean result on such a file as a statement about the active arm only.
 
 `promote_internal` has the mirror of the same check, for the same reason.
 

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -262,10 +262,13 @@ python3 prosper/tools/refactor/survey_sizes.py --min-lines 2500     # needs libc
 python3 prosper/tools/refactor/survey_sizes.py --selftest           # no libclang needed
 ```
 
-`--selftest` runs the classifier's arithmetic cases always, and the four `testdata/` measurement
-checks **only where libclang is importable** -- saying so explicitly, and naming them, when it skips
-them. Those are the checks covering how the classifier's INPUTS are measured, and every defect this
-tool shipped lived there rather than in the arithmetic. The registered ctest case
+`--selftest` runs the classifier's arithmetic cases always, and the four measurement checks **only
+where libclang is importable** -- three of them score committed fixtures under `testdata/`, while the
+fourth builds a hard link in a temporary directory, because the property it needs (two paths naming
+one file that `resolve()` reports as different) cannot be committed as a fixture. `--selftest` says
+so explicitly, and names them, when it skips them. Those are the checks covering how the
+classifier's INPUTS are measured, and every defect this tool shipped lived there rather than in the
+arithmetic. The registered ctest case
 (`refactor_survey_classifier`) therefore gates the arithmetic everywhere and the measurement locally.
 
 **The invariant that makes incremental extraction safe is worth copying.** When a block was extracted

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -284,6 +284,34 @@ every group into the largest connected component -- one 6,374-line "part" out of
 reported as a perfect zero-cut split. That is pinned by a selftest arm now, with the fixture built so
 the defect changes the group COUNT rather than merely a number.
 
+### The three tools are a chain, and each one checks the step before it
+
+`map_symbols` proposes a seam, `promote_internal` makes the shared vocabulary visible, `split_file`
+cuts. The order is forced, and the reason is worth stating because skipping a step produces a result
+that passes every check and does not compile:
+
+```bash
+map_symbols.py  --file <f> --clusters 3 --json /tmp/f.json   # where to cut, and what it costs
+promote_internal.py --map /tmp/f.json --regions <closure> --header <f>_internal.hpp
+map_symbols.py  --file <f> --json /tmp/f2.json               # promotion changes every index
+split_file.py   --map /tmp/f2.json --plan <plan> --dry-run
+```
+
+**Both closure checks exist because their absence was measured, not imagined.** Splitting
+`gpu_capture.cpp`'s serialize/deserialize into their own file satisfied every check `split_file` had
+-- exact tiling, a clean partition, byte-for-byte reconstruction -- and then failed to compile with
+**25 undeclared names**, because `Writer`, `Reader`, `kMagic`, `read_table` and twenty others have
+internal linkage and stayed in the other part. Every one of those checks is byte accounting: they
+establish that no LINE was lost, never that a line can still be used where it ended up.
+
+The reference matrix that answers it was already in the map. `split_file` reads it now and refuses,
+naming the definitions and printing the `promote_internal` command that fixes them. Measured against
+the compiler on that split: **23 names flagged, 25 reported by g++, and the two it did not name are
+`r` and `w`** -- local variables in cascading errors from `Reader r;` and `Writer w;`. No false
+positives.
+
+`promote_internal` has the mirror of the same check, for the same reason.
+
 ### Running it
 
 ```bash

--- a/prosper/tools/refactor/map_symbols.py
+++ b/prosper/tools/refactor/map_symbols.py
@@ -274,6 +274,15 @@ def cross_refs(tu, target: pathlib.Path, regions: list[dict]) -> dict[int, dict[
             ref = ch.referenced
             if ref is None:
                 continue
+            # A NAMESPACE cursor is not a reference to anything a split has to keep together. Every
+            # re-opening `namespace {` and `namespace prosper {` resolves `.referenced` to the
+            # namespace declaration, so the brace itself became an edge -- attributed to whichever
+            # body region happened to hold the first cursor carrying that USR. Measured on
+            # hle_kernel.cpp: 19 of 19 edges whose source is a replicated region were this, 13 of
+            # them pointing at `fbsd_errno`, and acting on them refused every legal two-part plan
+            # for the file. They are noise in every consumer, not only the splitter.
+            if ch.kind == ci.CursorKind.NAMESPACE or ref.kind == ci.CursorKind.NAMESPACE:
+                continue
             usr = ref.get_usr()
             if usr not in owner:
                 continue

--- a/prosper/tools/refactor/map_symbols.py
+++ b/prosper/tools/refactor/map_symbols.py
@@ -24,7 +24,8 @@ This reports two things about a file, both from clang's own AST:
 
 Usage:
   python3 prosper/tools/refactor/map_symbols.py --file prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
-  ... --clusters      # suggest seams: greedily group regions that reference each other
+  ... --clusters [N]  # suggest seams: greedily group regions that reference each other
+                      #   into N parts (default 6), reporting the cut cost
   ... --json out.json # machine-readable, for split_file.py
 
 Flags come from the build's compile_commands.json, so the parse sees exactly what the compiler sees.
@@ -40,14 +41,27 @@ import subprocess
 import sys
 from collections import defaultdict
 
-import clang.cindex as ci
+# libclang is imported LAZILY. Everything that parses needs it, and `propose_clusters` -- which
+# decides where a split should cut -- does not: it is arithmetic over the reference matrix. Keeping
+# the import out of module scope is what lets `--selftest` pin that arithmetic on a machine with no
+# libclang, which is the shape of this project's CI. `survey_sizes.py` resolves it the same way and
+# for the same reason.
+ci = None
 
-# The bindings look for a bare `libclang.so`, which the runtime package does not ship; the versioned
-# soname is what is actually installed. Fail loudly rather than letting a later call die obscurely.
-for cand in ("/usr/lib64/libclang.so.22.1", "/usr/lib64/libclang.so"):
-    if pathlib.Path(cand).exists():
-        ci.Config.set_library_file(cand)
-        break
+
+def _need_clang() -> None:
+    global ci
+    if ci is not None:
+        return
+    import clang.cindex as _ci
+    # The bindings look for a bare `libclang.so`, which the runtime package does not ship; the
+    # versioned soname is what is actually installed. Fail loudly rather than letting a later call
+    # die obscurely.
+    for cand in ("/usr/lib64/libclang.so.22.1", "/usr/lib64/libclang.so"):
+        if pathlib.Path(cand).exists():
+            _ci.Config.set_library_file(cand)
+            break
+    ci = _ci                              # last: this is the guard the early return above tests
 
 
 def repo_root() -> pathlib.Path:
@@ -292,16 +306,207 @@ def cross_refs(tu, target: pathlib.Path, regions: list[dict]) -> dict[int, dict[
     return {k: dict(v) for k, v in edges.items()}
 
 
+def propose_clusters(regions, edges, parts: int) -> tuple[list[list[int]], dict]:
+    """Group body regions into PARTS candidate output files, cutting where the references are thin.
+
+    Greedy agglomeration over the reference matrix, heaviest edge first, which is what the file's
+    REFERENCES section is for: an internal-linkage helper separated from its callers does not fail
+    at review, it fails at link. Grouping on that matrix puts them on the same side by construction.
+
+    The size cap is reported rather than hidden, because it is the part that lies. Two groups landing
+    on the same line count means the CAP stopped the merge, not that a seam is there -- so the
+    summary marks which boundaries are structural and which are the cap talking. Grouping by NAME
+    does not find these: on gpu_executor.cpp a name-prefix pass put 183 of 273 regions in "other".
+    """
+    body = {r["index"]: r for r in regions if r["role"] == "body"}
+    size = {i: r["end"] - r["start"] + 1 for i, r in body.items()}
+    total = sum(size.values())
+    cap = max(1, total // max(1, parts))
+
+    w: dict[tuple[int, int], int] = {}
+    for a, ds in edges.items():
+        for b, n in ds.items():
+            if a in body and b in body and a != b:
+                key = (min(a, b), max(a, b))
+                w[key] = w.get(key, 0) + n
+
+    parent = {i: i for i in body}
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+    csize = dict(size)
+    capped = 0
+    for (a, b), _ in sorted(w.items(), key=lambda kv: -kv[1]):
+        ra, rb = find(a), find(b)
+        if ra == rb:
+            continue
+        if csize[ra] + csize[rb] > cap:
+            capped += 1               # a merge the references wanted and the cap refused
+            continue
+        parent[rb] = ra
+        csize[ra] += csize[rb]
+
+    groups: dict[int, list[int]] = {}
+    for i in body:
+        groups.setdefault(find(i), []).append(i)
+
+    # SECOND PASS: attach the tail. A cap-driven greedy leaves a long run of singletons -- 30 of 41
+    # on gpu_capture.cpp -- and a proposal the caller then has to place by hand is not a proposal.
+    # Merge the smallest group into whichever group it references most, ignoring the cap, until the
+    # requested part count is reached. A region with no cross-references at all has nothing to
+    # attach to and stays where it is; that is information, not a failure.
+    def edge_between(g1, g2):
+        return sum(w.get((min(a, b), max(a, b)), 0) for a in g1 for b in g2)
+
+    # The cap binds here too, and that is the whole difference between a proposal and a lie. Without
+    # it, "attach the smallest to whatever it references most" funnels every group into the largest
+    # connected component: on this file it produced ONE 6,374-line group out of 6,515 and reported a
+    # 0% cut -- a split that is not a split, wearing a perfect score. A 0% cut is a tell.
+    # So attachment stops at the cap, the part count is whatever the structure and the cap allow,
+    # and the caller is told when that is more than they asked for.
+    while True:
+        keys = sorted(groups, key=lambda k: sum(size[i] for i in groups[k]))
+        if len(keys) <= parts:
+            break
+        moved = False
+        for k in keys:
+            ksz = sum(size[i] for i in groups[k])
+            best, best_w = None, 0
+            for other in keys:
+                if other == k or sum(size[i] for i in groups[other]) + ksz > cap:
+                    continue
+                ww = edge_between(groups[k], groups[other])
+                if ww > best_w:
+                    best, best_w = other, ww
+            if best is not None:
+                groups[best] += groups[k]
+                del groups[k]
+                moved = True
+                break
+        if not moved:
+            break            # nothing can grow without breaching the cap; report what there is
+
+    out = sorted(groups.values(), key=lambda g: -sum(size[i] for i in g))
+    gid = {i: n for n, g in enumerate(out) for i in g}
+    cut = sum(n for (a, b), n in w.items() if gid[a] != gid[b])
+    stats = {"cut": cut, "total_refs": sum(w.values()), "cap": cap, "capped_merges": capped,
+             "singletons": sum(1 for g in out if len(g) == 1), "asked": parts}
+    return out, stats
+
+
+def print_clusters(regions, edges, parts: int) -> None:
+    body = {r["index"]: r for r in regions if r["role"] == "body"}
+    size = {i: r["end"] - r["start"] + 1 for i, r in body.items()}
+    groups, st = propose_clusters(regions, edges, parts)
+    share = st["cut"] / st["total_refs"] if st["total_refs"] else 0.0
+    over = (f" -- you asked for {st['asked']}, and the reference structure plus that size cap do "
+            f"not permit fewer" if len(groups) > st["asked"] else "")
+    print(f"\n== proposed seams: {len(groups)} group(s), target ~{st['cap']} lines each =={over}")
+    print(f"   {st['cut']} of {st['total_refs']} references cross a boundary ({share:.0%}) -- that "
+          f"is the promote-to-header list")
+    print(f"   {st['capped_merges']} merge(s) the references wanted were refused by the size cap; "
+          f"a group AT the cap is the cap talking, not a seam")
+    print(f"   {st['singletons']} group(s) of one region\n")
+    for n, g in enumerate(groups):
+        lines = sum(size[i] for i in g)
+        at_cap = " <- at the cap" if lines >= st["cap"] else ""
+        tops = sorted(g, key=lambda i: -size[i])[:3]
+        names = ", ".join(f"{body[i]['name']}({size[i]})" for i in tops)
+        print(f"  [{n}] {len(g):>4} region(s) {lines:>6}L{at_cap}")
+        print(f"       {names[:96]}")
+        print(f"       plan: {' '.join(str(i) for i in sorted(g))}"[:300])
+
+
+def selftest() -> int:
+    """Pin propose_clusters. Pure arithmetic over the reference matrix, so it runs without libclang.
+
+    The clustering is the part that decides where a split cuts, and its failure mode is not a crash:
+    it is a confident proposal that is wrong. Both arms below were live defects during development.
+    """
+    bad = 0
+
+    def check(cond, label):
+        nonlocal bad
+        if not cond:
+            print(f"  [FAIL] {label}")
+            bad += 1
+
+    # Two tight clusters, 100 lines each, joined by ONE weak edge. The seam is obvious by
+    # construction, which is what makes it a usable oracle.
+    regions = [{"index": 0, "start": 1, "end": 1, "role": "open", "name": "ns"}]
+    line = 2
+    for i in range(1, 5):
+        regions.append({"index": i, "start": line, "end": line + 24, "role": "body",
+                        "name": f"a{i}"})
+        line += 25
+    for i in range(5, 9):
+        regions.append({"index": i, "start": line, "end": line + 24, "role": "body",
+                        "name": f"b{i}"})
+        line += 25
+    edges = {1: {2: 50, 3: 50, 4: 50}, 2: {3: 50, 4: 50}, 3: {4: 50},
+             5: {6: 50, 7: 50, 8: 50}, 6: {7: 50, 8: 50}, 7: {8: 50},
+             4: {5: 1}}
+    groups, st = propose_clusters(regions, edges, 2)
+    check(len(groups) == 2, f"two clusters joined by one weak edge split in two (got {len(groups)})")
+    check(all(len(g) == 4 for g in groups), f"and evenly (got {[len(g) for g in groups]})")
+    check(st["cut"] == 1, f"cutting exactly the weak edge (got {st['cut']})")
+
+    # THE CAP MUST BIND DURING ATTACHMENT. Without it, "attach the smallest group to whatever it
+    # references most" funnels everything into the largest connected component: measured on
+    # gpu_capture.cpp it produced ONE 6,374-line group out of 6,515 and reported a 0% cut -- a
+    # split that is not a split, wearing a perfect score. A 0% cut over a non-trivial graph is a
+    # tell, not a success, so it is asserted against directly.
+    cap = st["cap"]
+    check(all(sum(regions[i]["end"] - regions[i]["start"] + 1 for i in g) <= cap * 1.5
+              for g in groups),
+          "no group runs away past the size cap")
+    # The fixture has to make the FIRST pass leave more groups than asked for, or the attachment
+    # loop never runs and the arm certifies nothing -- checked by mutation, not assumed. Six regions
+    # of 100 lines with parts=4 gives a cap of 150, so no two can merge (200 > 150): the greedy
+    # leaves six, attachment is entered, and the cap is the only thing standing between six groups
+    # and one.
+    big = [{"index": 0, "start": 1, "end": 1, "role": "open", "name": "ns"}]
+    ln = 2
+    for i in range(1, 7):
+        big.append({"index": i, "start": ln, "end": ln + 99, "role": "body", "name": f"c{i}"})
+        ln += 100
+    dense = {i: {j: 10 for j in range(1, 7) if j != i} for i in range(1, 7)}
+    dgroups, dst = propose_clusters(big, dense, 4)
+    check(len(dgroups) == 6,
+          f"the size cap holds during attachment; without it everything funnels into the largest "
+          f"connected component (got {len(dgroups)} group(s))")
+    check(dst["cut"] > 0, "and a 0% cut is not manufactured by merging everything")
+
+    # A region nothing references has nothing to attach to; it must survive rather than vanish.
+    lone, _ = propose_clusters(regions, {1: {2: 5}}, 2)
+    check(sum(len(g) for g in lone) == 8, "every body region appears in exactly one group")
+
+    print("== PASS ==" if not bad else f"== FAIL: {bad} ==")
+    return 1 if bad else 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--file", required=True, type=pathlib.Path)
+    ap.add_argument("--file", type=pathlib.Path)
+    ap.add_argument("--selftest", action="store_true",
+                    help="pin the clustering arithmetic; needs no libclang and no build")
     ap.add_argument("--build", default="prosper/build-linux")
     ap.add_argument("--json", type=pathlib.Path)
+    ap.add_argument("--clusters", nargs="?", type=int, const=6, default=None,
+                    metavar="PARTS",
+                    help="suggest seams: group regions that reference each other (default 6 parts)")
     ap.add_argument("--min-lines", type=int, default=0,
                     help="only print regions at least this many lines long")
     args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+    if not args.file:
+        sys.exit("--file is required")
 
+    _need_clang()
     root = repo_root()
     target = (root / args.file) if not args.file.is_absolute() else args.file
     if not target.exists():
@@ -339,6 +544,9 @@ def main() -> int:
         inn = sum(v for s, d in edges.items() for t, v in d.items() if t == r["index"])
         print(f"  [{r['index']:4d}] {r['start']:6d}-{r['end']:<6d} {span:6d}L  "
               f"out={out:<4d} in={inn:<4d} {r['role']:<9s} {r['kind']:<22s} {r['name'][:52]}")
+
+    if args.clusters is not None:
+        print_clusters(regions, edges, args.clusters)
 
     if args.json:
         # The digest is what lets split_file.py prove the map still describes the file. Without it

--- a/prosper/tools/refactor/map_symbols.py
+++ b/prosper/tools/refactor/map_symbols.py
@@ -563,9 +563,14 @@ def main() -> int:
         # fail if the file GREW -- an assertion that cannot fail on an edit is not a check.
         import hashlib
         digest = hashlib.sha256(target.read_bytes()).hexdigest()
+        # RECORD THE PARSE ERRORS IN THE MAP. The warning above goes to a terminal nobody keeps,
+        # and the map outlives it -- so a consumer reading this file has no way to tell a complete
+        # map from one built on a partial AST, and prints its own reassuring [ok] either way. A
+        # libclang parse driven from a g++ database fails softly, so this is not a rare case.
         args.json.write_text(json.dumps({"file": str(target.relative_to(root)),
                                          "sha256": digest,
                                          "total_lines": total_lines,
+                                         "parse_errors": len(fatal),
                                          "regions": regions,
                                          "edges": {str(k): v for k, v in edges.items()}}, indent=1))
         print(f"  wrote {args.json}")

--- a/prosper/tools/refactor/map_symbols.py
+++ b/prosper/tools/refactor/map_symbols.py
@@ -416,7 +416,12 @@ def print_clusters(regions, edges, parts: int) -> None:
         names = ", ".join(f"{body[i]['name']}({size[i]})" for i in tops)
         print(f"  [{n}] {len(g):>4} region(s) {lines:>6}L{at_cap}")
         print(f"       {names[:96]}")
-        print(f"       plan: {' '.join(str(i) for i in sorted(g))}"[:300])
+        plan = " ".join(str(i) for i in sorted(g))
+        # NOT truncated. This line exists to be copy-pasted into split_file.py; a silent cut at 300
+        # characters drops every region past about the hundredth and yields a plan that is a valid
+        # prefix of the right answer, which is the worst failure available here. split_file.py
+        # catches an incomplete partition, but only after the caller has run it.
+        print(f"       plan: {plan}")
 
 
 def selftest() -> int:
@@ -481,7 +486,11 @@ def selftest() -> int:
 
     # A region nothing references has nothing to attach to; it must survive rather than vanish.
     lone, _ = propose_clusters(regions, {1: {2: 5}}, 2)
-    check(sum(len(g) for g in lone) == 8, "every body region appears in exactly one group")
+    seen = [i for g in lone for i in g]
+    # The SET and the COUNT, not just the count: a total of 8 is equally consistent with one region
+    # duplicated and another dropped, which is precisely what a bad merge produces.
+    check(sorted(seen) == list(range(1, 9)) and len(seen) == 8,
+          f"every body region appears in exactly one group (got {sorted(seen)})")
 
     print("== PASS ==" if not bad else f"== FAIL: {bad} ==")
     return 1 if bad else 0

--- a/prosper/tools/refactor/promote_internal.py
+++ b/prosper/tools/refactor/promote_internal.py
@@ -203,6 +203,34 @@ def canonical_include(source_rel: str, header_name: str) -> str:
     return header_name
 
 
+def preprocessor_depth_after(text: str) -> int:
+    """Net `#if` nesting left open by TEXT. Zero means the text is balanced on its own."""
+    depth = 0
+    for raw in text.splitlines():
+        d = raw.strip()
+        if d.startswith("#if"):
+            depth += 1
+        elif d.startswith("#endif"):
+            depth = max(0, depth - 1)
+    return depth
+
+
+def declarations_needed(promote, edges, regions) -> list[int]:
+    """Regions the PROMOTED code calls that are staying behind, so the header must declare them.
+
+    Every such destination, not merely the ones referenced from outside the file. That narrower
+    rule is what this replaced, and it is a different set: an ordinary internal helper called only
+    from within this file was never "public", so no declaration was emitted for it, the header used
+    it above its definition, and the build failed with `not declared in this scope` -- for
+    `checked_mul`, `resource_footprint_impl`, `blob_max_bytes_from_env` and two others in one run.
+    The `[warn] no declaration could be derived` branch could not fire for them either, because
+    they never reached it.
+    """
+    kept = set(promote)
+    return sorted({d for i in promote for d in edges.get(i, set())
+                   if d not in kept and d in regions and regions[d].get("role") == "body"})
+
+
 def build(map_data: dict, original: str, promote: list[int], header_rel: str,
           namespace: str, guard_note: str, include_spelling: str = "",
           forward_decls: list[str] | None = None) -> tuple[str, str, list[str]]:
@@ -216,7 +244,21 @@ def build(map_data: dict, original: str, promote: list[int], header_rel: str,
 
     preamble = [r for r in map_data["regions"] if r.get("role") == "preamble"]
     head = ["#pragma once\n", "\n", guard_note, "\n"]
-    head += ["".join(lines[r["start"] - 1:r["end"]]) for r in preamble]
+    pre_text = "".join("".join(lines[r["start"] - 1:r["end"]]) for r in preamble)
+    head.append(pre_text)
+    # The preamble is COPIED, and a copy can end inside a conditional the original closes later.
+    # gpu_capture.cpp opens `#if defined(__linux__) || defined(__APPLE__)` among its includes and
+    # closes it far below, outside any preamble region -- so the verbatim copy shipped 3 `#if`
+    # against 2 `#endif` and the header failed with "unterminated #if". The tool already models
+    # preprocessor depth for the regions it PROMOTES; this applies the same care to the part it
+    # replicates. Closing here is safe in a way that dropping would not be: every directive copied
+    # is an include-guard-style condition around includes, and leaving its body active in the
+    # header would change which declarations the header sees.
+    open_depth = preprocessor_depth_after(pre_text)
+    if open_depth > 0:
+        head.append(f"\n// Closing {open_depth} conditional(s) the copied preamble left open; the\n"
+                    "// original closes them further down, outside any preamble region.\n")
+        head += ["#endif\n"] * open_depth
     head += ["\n", f"namespace {namespace} {{\n", "\n"]
     if forward_decls:
         head.append("// Declared here, DEFINED in the .cpp this header was lifted out of: other\n"
@@ -391,6 +433,35 @@ def selftest() -> int:
     check("void user()" in src, "unpromoted code stays put")
     check(not verify(SELF_SRC, SELF_MAP, [3, 4], hdr, src, "s_internal.hpp"),
           "verification passes on a correct promotion")
+
+    # DECLARATIONS THE HEADER OWES. Extracted out of main() specifically so it is reachable here:
+    # the rule it implements was wrong for as long as it was unreachable, and the comment above it
+    # already stated the correct rule while the code did something narrower.
+    # `helper` (region 4) is called by `user` (6) and is NOT referenced outside the file, so it is
+    # not "public" -- the exact shape that produced an uncompilable header. Promote `user` and the
+    # header must be told about `helper`.
+    edges_fix = {6: {3, 4}}
+    regs_fix = {r["index"]: r for r in SELF_MAP["regions"]}
+    check(declarations_needed([6], edges_fix, regs_fix) == [3, 4],
+          "a promoted region's callees that stay behind are ALL declared, public or not")
+    check(declarations_needed([3, 4, 6], edges_fix, regs_fix) == [],
+          "nothing is owed when the callees were promoted too")
+    check(declarations_needed([6], {6: {1, 5}}, regs_fix) == [],
+          "namespace open/close regions are never declarations")
+
+    # PREAMBLE BALANCE. A copied preamble can end inside a conditional the original closes later,
+    # which shipped an unterminated `#if` in a real run. Both arms matter: the second is what
+    # separates "closes what it opened" from "always appends an #endif".
+    check(preprocessor_depth_after("#include <a>\n#if defined(X)\n#include <b>\n") == 1,
+          "an unclosed `#if` in the copied preamble is detected")
+    check(preprocessor_depth_after("#if defined(X)\n#include <b>\n#endif\n") == 0,
+          "a balanced preamble is left alone")
+    unbal_map = {**SELF_MAP, "regions": [dict(r) for r in SELF_MAP["regions"]]}
+    unbal_src = "#include <a>\n#if defined(X)\n" + SELF_SRC.split("\n", 2)[2]
+    h_unbal, _, _ = build(unbal_map, unbal_src, [3, 4], "s_internal.hpp", "ns", "// n\n",
+                          "s_internal.hpp")
+    check(preprocessor_depth_after(h_unbal) == 0,
+          "the emitted header is preprocessor-balanced even when the preamble is not")
 
     # prototype_of is pure and therefore reachable from here, unlike the fixes that live in main().
     # The fixture's default argument CONTAINS PARENTHESES, which is the shape that breaks the
@@ -641,7 +712,42 @@ def main() -> int:
 
     # Anything promoted code CALLS but that stayed behind needs a declaration in the header.
     edges_all = {int(k): {int(t) for t in v} for k, v in map_data.get("edges", {}).items()}
-    wanted = {d for i in promote for d in edges_all.get(i, set()) if d in set(public)}
+    wanted = declarations_needed(promote, edges_all, regions)
+    # A definition still inside `namespace { }` CANNOT be forward-declared from the header. The
+    # declaration would name `prosper::gpu::f` while the definition is `prosper::gpu::{anon}::f` --
+    # two different entities, both visible in the .cpp, so every call becomes ambiguous rather than
+    # resolving to the one that exists. Measured on gpu_capture.cpp: 18 such declarations turned
+    # "not declared in this scope" into "call of overloaded ... is ambiguous", which is the same
+    # broken header wearing a different error.
+    #
+    # There is no header this tool can write that fixes that, so it refuses and names the closure.
+    # The promote set has to be closed under "what does this call that is still internal", and the
+    # caller cannot be expected to derive that by hand from a 6,000-line file -- so print the exact
+    # argument to re-run with.
+    unbreakable = [i for i in wanted if anon.get(i)]
+    if unbreakable:
+        # Report the FIXED POINT, not one step of it. Each added region brings its own callees, so
+        # a single step just makes the caller run this again -- measured on gpu_capture.cpp, the
+        # first suggestion needed a second round and the second a third. Iterating here turns N
+        # rounds of copy-paste into one answer.
+        closure = set(promote)
+        while True:
+            grown = closure | {i for i in declarations_needed(sorted(closure), edges_all, regions)
+                               if anon.get(i)}
+            if grown == closure:
+                break
+            closure = grown
+        closure = sorted(closure)
+        names = ", ".join(regions[i]["name"] for i in unbreakable[:6])
+        more = f" and {len(unbreakable) - 6} more" if len(unbreakable) > 6 else ""
+        sys.exit(
+            f"refused: {len(unbreakable)} definition(s) the promoted code calls are still inside an\n"
+            f"anonymous namespace, and a header cannot declare those -- the declaration would name a\n"
+            f"DIFFERENT entity than the definition and make every call ambiguous:\n"
+            f"  {names}{more}\n\n"
+            f"The promote set must be closed under what it calls. Re-run with:\n"
+            f"  --regions {','.join(str(i) for i in closure)}\n\n"
+            f"(or add them to --exclude if they should stay, and stop calling them from promoted code)")
     src_lines = original.splitlines(keepends=True)
     protos = []
     for i in sorted(wanted):

--- a/prosper/tools/refactor/promote_internal.py
+++ b/prosper/tools/refactor/promote_internal.py
@@ -205,12 +205,14 @@ def canonical_include(source_rel: str, header_name: str) -> str:
 
 def preprocessor_depth_after(text: str) -> int:
     """Net `#if` nesting left open by TEXT. Zero means the text is balanced on its own."""
+    # COND_OPEN/COND_CLOSE, not str.startswith: `#  if` with spaces after the hash is legal and is
+    # spelled that way in this tree (src/hle/libc/hle_libc.cpp:20). Re-implementing the match more
+    # weakly here would make this helper disagree with conditional_depth() a few lines above it.
     depth = 0
     for raw in text.splitlines():
-        d = raw.strip()
-        if d.startswith("#if"):
+        if COND_OPEN.match(raw):
             depth += 1
-        elif d.startswith("#endif"):
+        elif COND_CLOSE.match(raw):
             depth = max(0, depth - 1)
     return depth
 
@@ -293,7 +295,17 @@ def build(map_data: dict, original: str, promote: list[int], header_rel: str,
     for i in drop:
         r = regions[i]
         del out_lines[r["start"] - 1:r["end"]]
+    # The include must land at conditional depth ZERO. The last preamble line can sit INSIDE a
+    # conditional the preamble leaves open -- on gpu_capture.cpp the preamble ends at line 46 and
+    # the matching `#endif` is line 47 -- so inserting there puts the internal header behind
+    # `#if defined(__linux__) || defined(__APPLE__)` while the promoted definitions are deleted
+    # UNCONDITIONALLY. The result compiles on Linux and fails on Windows with every promoted name
+    # undeclared: measured on this file, g++ 0 errors and x86_64-w64-mingw32-g++ 245. That is worse
+    # than the bug this tool had, because it is invisible to the platform the work is done on.
+    src_depth = conditional_depth(lines)
     last_pre = max(r["end"] for r in preamble)
+    while last_pre < len(lines) and src_depth[last_pre + 1] != 0:
+        last_pre += 1                             # walk out to the close of the open conditional
     insert_at = last_pre
     for i in sorted(promote):
         if regions[i]["start"] - 1 < insert_at:
@@ -392,6 +404,38 @@ SELF_MAP = {
 }
 
 
+# A preamble that ENDS INSIDE a conditional the source closes on the next line -- gpu_capture.cpp's
+# exact shape, and the one that made this tool emit a header and a source that disagree about which
+# platform they are for.
+PLACE_SRC = """#include <a>
+#if defined(X)
+#endif
+namespace ns {
+namespace {
+int helper() { return 1; }
+}  // namespace
+void user() { helper(); }
+}  // namespace ns
+"""
+
+PLACE_MAP = {
+    "file": "p.cpp", "total_lines": 9, "sha256": "",
+    "regions": [
+        {"index": 0, "start": 1, "end": 2, "role": "preamble", "name": "<a>",
+         "kind": "INCLUSION_DIRECTIVE"},
+        {"index": 1, "start": 3, "end": 4, "role": "open", "name": "ns"},
+        {"index": 2, "start": 5, "end": 5, "role": "open", "name": "<anonymous>"},
+        {"index": 3, "start": 6, "end": 6, "role": "body", "name": "helper",
+         "kind": "FUNCTION_DECL", "is_definition": True, "decl_line": 6},
+        {"index": 4, "start": 7, "end": 7, "role": "close", "name": "<anonymous>"},
+        {"index": 5, "start": 8, "end": 8, "role": "body", "name": "user",
+         "kind": "FUNCTION_DECL", "is_definition": True, "decl_line": 8},
+        {"index": 6, "start": 9, "end": 9, "role": "close", "name": "ns"},
+    ],
+    "edges": {},
+}
+
+
 def selftest() -> int:
     bad = 0
 
@@ -456,12 +500,23 @@ def selftest() -> int:
           "an unclosed `#if` in the copied preamble is detected")
     check(preprocessor_depth_after("#if defined(X)\n#include <b>\n#endif\n") == 0,
           "a balanced preamble is left alone")
-    unbal_map = {**SELF_MAP, "regions": [dict(r) for r in SELF_MAP["regions"]]}
-    unbal_src = "#include <a>\n#if defined(X)\n" + SELF_SRC.split("\n", 2)[2]
-    h_unbal, _, _ = build(unbal_map, unbal_src, [3, 4], "s_internal.hpp", "ns", "// n\n",
-                          "s_internal.hpp")
-    check(preprocessor_depth_after(h_unbal) == 0,
+    h_place, s_place, _ = build(PLACE_MAP, PLACE_SRC, [3], "p_internal.hpp", "ns", "// n\n",
+                                "p_internal.hpp")
+    check(preprocessor_depth_after(h_place) == 0,
           "the emitted header is preprocessor-balanced even when the preamble is not")
+    # PLACEMENT, which balance does not imply and which the balance arm above cannot see. The
+    # source's own include has to land at conditional depth ZERO: at the last preamble line it
+    # would sit inside `#if defined(X)`, so the header is included only on that platform while the
+    # promoted definitions are deleted unconditionally -- a source that compiles where the tool was
+    # run and fails everywhere else. Measured on gpu_capture.cpp before this was fixed: g++ 0
+    # errors, x86_64-w64-mingw32-g++ 245.
+    place_lines = s_place.splitlines(keepends=True)
+    inc_idx = next(i for i, l in enumerate(place_lines) if "p_internal.hpp" in l)
+    check(conditional_depth(place_lines)[inc_idx + 1] == 0,
+          "the include added to the SOURCE lands outside any preprocessor conditional")
+    # ... and it must still precede everything promoted code needs, so it cannot simply be appended.
+    check(any("namespace ns" in l for l in place_lines[inc_idx + 1:]),
+          "and still precedes the namespace it was lifted out of")
 
     # prototype_of is pure and therefore reachable from here, unlike the fixes that live in main().
     # The fixture's default argument CONTAINS PARENTHESES, which is the shape that breaks the
@@ -724,20 +779,31 @@ def main() -> int:
     # The promote set has to be closed under "what does this call that is still internal", and the
     # caller cannot be expected to derive that by hand from a 6,000-line file -- so print the exact
     # argument to re-run with.
-    unbreakable = [i for i in wanted if anon.get(i)]
+    # `not externally_linked(...)`, not `anon.get(...)`. This file documents at :139-151 why the
+    # anonymous-namespace walk alone is the wrong linkage test -- a `static` free function has
+    # internal linkage while sitting outside any anonymous namespace -- and the refusal below is a
+    # statement about linkage, so it has to use the predicate that knows that. Using the weaker one
+    # here would let a `static` callee through, and `prototype_of` would then emit `static ... f();`
+    # into the header, which is the ODR hazard the comment at :146 was written about.
+    unbreakable = [i for i in wanted if not externally_linked(i)]
     if unbreakable:
         # Report the FIXED POINT, not one step of it. Each added region brings its own callees, so
         # a single step just makes the caller run this again -- measured on gpu_capture.cpp, the
         # first suggestion needed a second round and the second a third. Iterating here turns N
         # rounds of copy-paste into one answer.
+        # Honour --exclude, or the suggestion is unusable: a region the caller deliberately kept
+        # back would be re-proposed every round, so the printed re-run reproduces the identical
+        # refusal. Excluding it is a real answer -- it means "stop calling this from promoted
+        # code" -- and the message says so.
         closure = set(promote)
         while True:
             grown = closure | {i for i in declarations_needed(sorted(closure), edges_all, regions)
-                               if anon.get(i)}
+                               if not externally_linked(i) and i not in excluded}
             if grown == closure:
                 break
             closure = grown
         closure = sorted(closure)
+        stuck = sorted(i for i in unbreakable if i in excluded)
         names = ", ".join(regions[i]["name"] for i in unbreakable[:6])
         more = f" and {len(unbreakable) - 6} more" if len(unbreakable) > 6 else ""
         sys.exit(
@@ -747,7 +813,10 @@ def main() -> int:
             f"  {names}{more}\n\n"
             f"The promote set must be closed under what it calls. Re-run with:\n"
             f"  --regions {','.join(str(i) for i in closure)}\n\n"
-            f"(or add them to --exclude if they should stay, and stop calling them from promoted code)")
+            + (f"\n{len(stuck)} of them are in --exclude and so are NOT in that list; those calls\n"
+               f"have to be removed from the promoted code instead: "
+               f"{', '.join(regions[i]['name'] for i in stuck[:4])}\n" if stuck else "")
+            + "\n(or add more to --exclude, and stop calling them from promoted code)")
     src_lines = original.splitlines(keepends=True)
     protos = []
     for i in sorted(wanted):

--- a/prosper/tools/refactor/promote_internal.py
+++ b/prosper/tools/refactor/promote_internal.py
@@ -250,7 +250,8 @@ def build(map_data: dict, original: str, promote: list[int], header_rel: str,
     head.append(pre_text)
     # The preamble is COPIED, and a copy can end inside a conditional the original closes later.
     # gpu_capture.cpp opens `#if defined(__linux__) || defined(__APPLE__)` among its includes and
-    # closes it far below, outside any preamble region -- so the verbatim copy shipped 3 `#if`
+    # closes it on the very next line, outside any preamble region -- so the verbatim copy
+    # shipped 3 `#if`
     # against 2 `#endif` and the header failed with "unterminated #if". The tool already models
     # preprocessor depth for the regions it PROMOTES; this applies the same care to the part it
     # replicates. Closing here is safe in a way that dropping would not be: every directive copied
@@ -779,7 +780,7 @@ def main() -> int:
     # The promote set has to be closed under "what does this call that is still internal", and the
     # caller cannot be expected to derive that by hand from a 6,000-line file -- so print the exact
     # argument to re-run with.
-    # `not externally_linked(...)`, not `anon.get(...)`. This file documents at :139-151 why the
+    # `not externally_linked(...)`, not `anon.get(...)`. This file documents at :129-134 why the
     # anonymous-namespace walk alone is the wrong linkage test -- a `static` free function has
     # internal linkage while sitting outside any anonymous namespace -- and the refusal below is a
     # statement about linkage, so it has to use the predicate that knows that. Using the weaker one
@@ -811,8 +812,11 @@ def main() -> int:
             f"anonymous namespace, and a header cannot declare those -- the declaration would name a\n"
             f"DIFFERENT entity than the definition and make every call ambiguous:\n"
             f"  {names}{more}\n\n"
-            f"The promote set must be closed under what it calls. Re-run with:\n"
-            f"  --regions {','.join(str(i) for i in closure)}\n\n"
+            + (f"The promote set must be closed under what it calls. Re-run with:\n"
+               f"  --regions {','.join(str(i) for i in closure)}\n\n"
+               if closure != sorted(promote) else
+               "Every callee that could close this set is already in --exclude, so there is no\n"
+               "--regions list that fixes it -- printing the one you typed would be a no-op.\n\n")
             + (f"\n{len(stuck)} of them are in --exclude and so are NOT in that list; those calls\n"
                f"have to be removed from the promoted code instead: "
                f"{', '.join(regions[i]['name'] for i in stuck[:4])}\n" if stuck else "")

--- a/prosper/tools/refactor/split_file.py
+++ b/prosper/tools/refactor/split_file.py
@@ -133,15 +133,38 @@ def check_structure(regions: list[dict], total_lines: int) -> list[str]:
     return problems
 
 
-def region_is_external(region: dict) -> bool:
-    """External linkage, from the USR clang recorded.
+def anon_map(regions: list[dict]) -> dict[int, bool]:
+    """Which regions sit inside an anonymous namespace, from the open/close markers in the map."""
+    stack: list[str] = []
+    out: dict[int, bool] = {}
+    for r in regions:
+        if r.get("role") == "open":
+            stack.append(r["name"])
+        out[r["index"]] = "<anonymous>" in stack
+        if r.get("role") == "close" and stack:
+            stack.pop()
+    return out
+
+
+def region_is_external(region: dict, in_anon_namespace: bool = False) -> bool:
+    """External linkage, from the USR clang recorded, falling back to the scope walk.
 
     Same rule as promote_internal's: an external entity's USR starts `c:@`, an internal one is
     file-prefixed. A `static` free function is internal WITHOUT being in an anonymous namespace, so
-    a scope walk alone gets it wrong.
+    the scope walk alone gets it wrong -- which is why the USR is preferred.
+
+    THE FALLBACK MATTERS AND THE FIRST VERSION HAD IT INVERTED. With no USR this returned False,
+    i.e. "internal", and the regions that actually lack one are `LINKAGE_SPEC` -- `extern "C"`, the
+    least internal thing in the language -- plus `INCLUSION_DIRECTIVE`. Measured: 0 of 155 body
+    regions in gpu_capture.cpp, but 7 of 333 in hle_kernel.cpp, four of them LINKAGE_SPEC. The one
+    reachable case happened to be a declaration, so the answer was right for the wrong reason, while
+    `extern "C" __attribute__((weak))` DEFINITIONS in the same file would have been refused
+    falsely. The scope walk is the honest fallback and the map already carries what it needs.
     """
     usr = region.get("usr") or ""
-    return usr.startswith("c:@") if usr else False
+    if usr:
+        return usr.startswith("c:@")
+    return not in_anon_namespace
 
 
 def unresolved_across_parts(map_data: dict, plan: dict[str, list[int]]) -> dict[int, set[str]]:
@@ -159,19 +182,35 @@ def unresolved_across_parts(map_data: dict, plan: dict[str, list[int]]) -> dict[
     internal-linkage helper from its callers does not fail at review, it fails at link".
     """
     regions = {r["index"]: r for r in map_data["regions"]}
+    anon = anon_map(map_data["regions"])
     edges = {int(a): {int(b) for b in d} for a, d in map_data.get("edges", {}).items()}
     owner = {i: out for out, idxs in plan.items() for i in idxs}
+    # A REPLICATED region is copied into every output, so a reference FROM one is satisfied
+    # everywhere -- but a reference from it TO an internal definition in one part only is not.
+    # Dropping these edges wholesale (they have no owner) discarded 18 of them on one real map.
+    replicated = [r["index"] for r in map_data["regions"]
+                  if r.get("role") in ("preamble", "open", "close")]
     missing: dict[int, set[str]] = {}
     for src, dests in edges.items():
-        if src not in owner:
-            continue
         for dest in dests:
-            if dest not in owner or owner[dest] == owner[src]:
+            if dest not in owner:
                 continue
             r = regions.get(dest, {})
-            if r.get("role") != "body" or region_is_external(r):
+            if r.get("role") != "body" or region_is_external(r, anon.get(dest, False)):
                 continue                      # visible across translation units; nothing to do
-            missing.setdefault(dest, set()).add(owner[src])
+            if src in owner:
+                if owner[dest] == owner[src]:
+                    continue
+                users = {owner[src]}
+            elif src in replicated:
+                # Copied into EVERY output, so it needs the definition in every output that is not
+                # the one holding it.
+                users = {o for o in plan if o != owner[dest]}
+                if not users:
+                    continue
+            else:
+                continue
+            missing.setdefault(dest, set()).update(users)
     return missing
 
 
@@ -369,9 +408,6 @@ def selftest() -> int:
     check(verify_reconstruction(SAMPLE_MAP, {"a.cpp": [1], "b.cpp": [2]}, tampered, SAMPLE),
           "reconstruction check FAILS when an output is altered")
 
-    if bad:
-        print("  the splitter's own guarantees are broken; it must not be run")
-        return 1
     # REFERENCES ACROSS THE CUT. Byte accounting cannot see this: the split below is a perfect
     # partition with perfect reconstruction, and does not compile. `beta` calls `alpha`, `alpha` has
     # internal linkage (a file-prefixed USR), and the plan puts them in different files.
@@ -392,7 +428,36 @@ def selftest() -> int:
     check(not unresolved_across_parts(ext_map, {"a.cpp": [1], "b.cpp": [2]}),
           "an EXTERNAL definition called across the cut is not flagged")
 
-    print("  [ok]   splitter self-test: replication, partition, tiling, #if, reconstruction")
+    # NO USR: the fallback is the scope walk, not a constant. An `extern "C"` definition records
+    # no USR and is EXTERNAL, so a bare `return False` refused it as internal -- the inverted
+    # default this replaced.
+    nousr = {**xref_map, "regions": [dict(r) for r in xref_map["regions"]]}
+    nousr["regions"][1]["usr"] = ""
+    check(not unresolved_across_parts(nousr, {"a.cpp": [1], "b.cpp": [2]}),
+          "a definition with no USR outside an anonymous namespace is treated as EXTERNAL")
+    anon_case = {**nousr, "regions": [dict(r) for r in nousr["regions"]]}
+    anon_case["regions"][0]["name"] = "<anonymous>"           # the open marker now names it
+    check(set(unresolved_across_parts(anon_case, {"a.cpp": [1], "b.cpp": [2]})) == {1},
+          "...and as INTERNAL when the scope walk says it is in an anonymous namespace")
+
+    # A REPLICATED region is copied into every output, so its references have to resolve in every
+    # output. Dropping those edges for want of an owner discarded 18 on a real map.
+    rep = {**xref_map, "regions": [dict(r) for r in xref_map["regions"]],
+           "edges": {"0": {"1": 1}}}                          # region 0 is the namespace `open`
+    check(set(unresolved_across_parts(rep, {"a.cpp": [1], "b.cpp": [2]})) == {1},
+          "a replicated region's reference to an internal definition is caught in the other part")
+
+    # THE GATE IS LAST, and it has to be: it used to sit in the middle of this function, so every
+    # arm added after it printed [FAIL] and returned 0 anyway. Three mutations that disabled the
+    # cross-reference check each printed a failure line and exited clean, and `main()`'s own
+    # `if selftest(): return 1` guard was defeated with it -- the tool would have run on a
+    # selftest it had already failed. Checking a mutation by reading the printed line rather than
+    # the exit status is what hid it; the two disagreed.
+    if bad:
+        print("  the splitter's own guarantees are broken; it must not be run")
+        return 1
+    print("  [ok]   splitter self-test: replication, partition, tiling, #if, reconstruction, "
+          "cross-part references")
     return 0
 
 
@@ -441,6 +506,18 @@ def main() -> int:
     # was lost, never that a line can still be USED where it ended up. Splitting gpu_capture.cpp's
     # serialize/deserialize into their own file passed all of them and then failed to compile with
     # 25 undeclared names, because internal-linkage definitions stayed in the other part.
+    # A map built on a partial AST describes a different file. The cross-reference check below is
+    # only as complete as the edges it reads, so a degraded parse would let it print [ok] having
+    # examined half of them -- the reassuring-silence failure this whole check exists to end.
+    if map_data.get("parse_errors"):
+        print(f"  [FAIL] the map records {map_data['parse_errors']} parse error(s); its region and "
+              f"reference data describe an incomplete AST.")
+        print("         Fix the parse and re-run map_symbols before splitting on it.")
+        return 1
+    if "parse_errors" not in map_data:
+        print("  [warn] this map predates parse-error recording; re-run map_symbols to have the "
+              "cross-reference check gated on a clean parse")
+
     stranded = unresolved_across_parts(map_data, plan)
     if stranded:
         regions = {r["index"]: r for r in map_data["regions"]}

--- a/prosper/tools/refactor/split_file.py
+++ b/prosper/tools/refactor/split_file.py
@@ -186,10 +186,13 @@ def unresolved_across_parts(map_data: dict, plan: dict[str, list[int]]) -> dict[
     edges = {int(a): {int(b) for b in d} for a, d in map_data.get("edges", {}).items()}
     owner = {i: out for out, idxs in plan.items() for i in idxs}
     # A PREAMBLE is copied into every output, so a reference from it to an internal definition in
-    # one part only is unsatisfied in the others. Restricted to `preamble` deliberately: an
-    # `open`/`close` region holds only the text clang gave no top-level cursor, since real code
-    # there would be its own body region, so that class is empty by construction -- and counting it
-    # was a live false-positive source. Every such edge measured on hle_kernel.cpp was a namespace
+    # one part only is unsatisfied in the others. NO SUCH EDGE HAS BEEN OBSERVED -- 0 on both real
+    # maps -- so this guards a class that is unobserved rather than impossible, and the distinction
+    # is deliberate: the `open`/`close` exclusion below IS airtight (a tiling fact -- real code
+    # between those braces would be its own body region), while "a preamble references nothing"
+    # rests on a C++ ordering argument, and map_symbols.py:211-215 says in its own words that a
+    # stray declaration above the first namespace lands in the preamble ON PURPOSE. Restricted to
+    # `preamble` because counting open/close was a live false-positive source. Every such edge measured on hle_kernel.cpp was a namespace
     # re-opening brace whose `.referenced` resolved to the namespace decl, and acting on them
     # refused every legal two-part plan for that file. `cross_refs` no longer emits them, and this
     # is the second guard rather than the only one.

--- a/prosper/tools/refactor/split_file.py
+++ b/prosper/tools/refactor/split_file.py
@@ -133,6 +133,48 @@ def check_structure(regions: list[dict], total_lines: int) -> list[str]:
     return problems
 
 
+def region_is_external(region: dict) -> bool:
+    """External linkage, from the USR clang recorded.
+
+    Same rule as promote_internal's: an external entity's USR starts `c:@`, an internal one is
+    file-prefixed. A `static` free function is internal WITHOUT being in an anonymous namespace, so
+    a scope walk alone gets it wrong.
+    """
+    usr = region.get("usr") or ""
+    return usr.startswith("c:@") if usr else False
+
+
+def unresolved_across_parts(map_data: dict, plan: dict[str, list[int]]) -> dict[int, set[str]]:
+    """Regions each output part references that live in ANOTHER part and cannot be seen from it.
+
+    This is the check that was missing, and its absence is not theoretical: splitting
+    gpu_capture.cpp's serialize/deserialize into their own file passed every existing check --
+    tiling, partition, byte-for-byte reconstruction -- and then failed to compile with 25 distinct
+    undeclared names (`Writer`, `Reader`, `kMagic`, `read_table`, ...), because those definitions
+    have internal linkage and stayed behind in the other part.
+
+    Every existing check here is byte accounting: it establishes that no LINE was lost. None of them
+    can see that a line ended up somewhere it cannot be used from. The reference matrix that answers
+    it is already in the map, put there by map_symbols precisely because "a split that separates an
+    internal-linkage helper from its callers does not fail at review, it fails at link".
+    """
+    regions = {r["index"]: r for r in map_data["regions"]}
+    edges = {int(a): {int(b) for b in d} for a, d in map_data.get("edges", {}).items()}
+    owner = {i: out for out, idxs in plan.items() for i in idxs}
+    missing: dict[int, set[str]] = {}
+    for src, dests in edges.items():
+        if src not in owner:
+            continue
+        for dest in dests:
+            if dest not in owner or owner[dest] == owner[src]:
+                continue
+            r = regions.get(dest, {})
+            if r.get("role") != "body" or region_is_external(r):
+                continue                      # visible across translation units; nothing to do
+            missing.setdefault(dest, set()).add(owner[src])
+    return missing
+
+
 def split(map_data: dict, plan: dict[str, list[int]], source_text: str,
           preamble_note: str = "") -> tuple[dict[str, str], list[str]]:
     """Pure: returns (outfile -> text, problems). Drives both the real run and --selftest."""
@@ -330,6 +372,26 @@ def selftest() -> int:
     if bad:
         print("  the splitter's own guarantees are broken; it must not be run")
         return 1
+    # REFERENCES ACROSS THE CUT. Byte accounting cannot see this: the split below is a perfect
+    # partition with perfect reconstruction, and does not compile. `beta` calls `alpha`, `alpha` has
+    # internal linkage (a file-prefixed USR), and the plan puts them in different files.
+    xref_map = {**SAMPLE_MAP, "regions": [dict(r) for r in SAMPLE_MAP["regions"]],
+                "edges": {"2": {"1": 3}}}
+    xref_map["regions"][1]["usr"] = "c:s.cpp@F@alpha#"        # internal linkage
+    xref_map["regions"][2]["usr"] = "c:s.cpp@F@beta#"
+    stranded = unresolved_across_parts(xref_map, {"a.cpp": [1], "b.cpp": [2]})
+    check(set(stranded) == {1},
+          f"an internal-linkage definition called from the other part is caught (got {stranded})")
+    check(not unresolved_across_parts(xref_map, {"a.cpp": [1, 2]}),
+          "and nothing is flagged when the caller and callee land in the same file")
+    # The linkage test is the discriminator, not the edge: an EXTERNAL definition is visible from
+    # the other translation unit, so splitting across it is legal and must not be refused. Without
+    # this arm the check could refuse every cross-part edge and still look correct above.
+    ext_map = {**xref_map, "regions": [dict(r) for r in xref_map["regions"]]}
+    ext_map["regions"][1]["usr"] = "c:@F@alpha#"              # external linkage
+    check(not unresolved_across_parts(ext_map, {"a.cpp": [1], "b.cpp": [2]}),
+          "an EXTERNAL definition called across the cut is not flagged")
+
     print("  [ok]   splitter self-test: replication, partition, tiling, #if, reconstruction")
     return 0
 
@@ -374,6 +436,31 @@ def main() -> int:
         return 1
     print(f"  [ok]   partition: {sum(len(v) for v in plan.values())} body region(s) -> "
           f"{len(plan)} file(s); namespace open/close replicated into each")
+
+    # REFERENCES ACROSS THE CUT. Every check above is byte accounting -- it establishes that no line
+    # was lost, never that a line can still be USED where it ended up. Splitting gpu_capture.cpp's
+    # serialize/deserialize into their own file passed all of them and then failed to compile with
+    # 25 undeclared names, because internal-linkage definitions stayed in the other part.
+    stranded = unresolved_across_parts(map_data, plan)
+    if stranded:
+        regions = {r["index"]: r for r in map_data["regions"]}
+        print(f"  [FAIL] {len(stranded)} definition(s) with internal linkage are referenced from a "
+              f"part they are not in:")
+        for i in sorted(stranded)[:10]:
+            users = ", ".join(sorted(stranded[i]))
+            print(f"           {regions[i].get('name', '?')}  (in "
+                  f"{[o for o, v in plan.items() if i in v][0]}, needed by {users})")
+        if len(stranded) > 10:
+            print(f"           ... and {len(stranded) - 10} more")
+        promote = ",".join(str(i) for i in sorted(stranded))
+        print("         These have to be visible from both sides before the cut. Promote them "
+              "first:")
+        print(f"           promote_internal.py --map <this map> --regions {promote} \\")
+        print("               --header <name>_internal.hpp --namespace prosper::gpu")
+        print("         then re-run map_symbols (the promotion changes every region index) and "
+              "re-plan.")
+        return 1
+    print(f"  [ok]   no internal-linkage definition is referenced from a part it is not in")
 
     if args.dry_run:
         for out, text in sorted(outputs.items()):

--- a/prosper/tools/refactor/split_file.py
+++ b/prosper/tools/refactor/split_file.py
@@ -185,11 +185,15 @@ def unresolved_across_parts(map_data: dict, plan: dict[str, list[int]]) -> dict[
     anon = anon_map(map_data["regions"])
     edges = {int(a): {int(b) for b in d} for a, d in map_data.get("edges", {}).items()}
     owner = {i: out for out, idxs in plan.items() for i in idxs}
-    # A REPLICATED region is copied into every output, so a reference FROM one is satisfied
-    # everywhere -- but a reference from it TO an internal definition in one part only is not.
-    # Dropping these edges wholesale (they have no owner) discarded 18 of them on one real map.
-    replicated = [r["index"] for r in map_data["regions"]
-                  if r.get("role") in ("preamble", "open", "close")]
+    # A PREAMBLE is copied into every output, so a reference from it to an internal definition in
+    # one part only is unsatisfied in the others. Restricted to `preamble` deliberately: an
+    # `open`/`close` region holds only the text clang gave no top-level cursor, since real code
+    # there would be its own body region, so that class is empty by construction -- and counting it
+    # was a live false-positive source. Every such edge measured on hle_kernel.cpp was a namespace
+    # re-opening brace whose `.referenced` resolved to the namespace decl, and acting on them
+    # refused every legal two-part plan for that file. `cross_refs` no longer emits them, and this
+    # is the second guard rather than the only one.
+    replicated = {r["index"] for r in map_data["regions"] if r.get("role") == "preamble"}
     missing: dict[int, set[str]] = {}
     for src, dests in edges.items():
         for dest in dests:
@@ -440,12 +444,20 @@ def selftest() -> int:
     check(set(unresolved_across_parts(anon_case, {"a.cpp": [1], "b.cpp": [2]})) == {1},
           "...and as INTERNAL when the scope walk says it is in an anonymous namespace")
 
-    # A REPLICATED region is copied into every output, so its references have to resolve in every
-    # output. Dropping those edges for want of an owner discarded 18 on a real map.
+    # A PREAMBLE is copied into every output, so its references have to resolve in every output.
     rep = {**xref_map, "regions": [dict(r) for r in xref_map["regions"]],
-           "edges": {"0": {"1": 1}}}                          # region 0 is the namespace `open`
+           "edges": {"0": {"1": 1}}}
+    rep["regions"][0] = {**rep["regions"][0], "role": "preamble"}
     check(set(unresolved_across_parts(rep, {"a.cpp": [1], "b.cpp": [2]})) == {1},
-          "a replicated region's reference to an internal definition is caught in the other part")
+          "a preamble's reference to an internal definition is caught in the other part")
+    # ...and an `open`/`close` source is NOT counted. That class is empty by construction -- real
+    # code there would be its own body region -- and counting it produced live false refusals: every
+    # such edge on hle_kernel.cpp was a namespace re-opening brace whose `.referenced` resolved to
+    # the namespace decl, which refused every legal two-part plan for that file.
+    ns_src = {**xref_map, "regions": [dict(r) for r in xref_map["regions"]],
+              "edges": {"0": {"1": 1}}}                       # region 0 stays the namespace `open`
+    check(not unresolved_across_parts(ns_src, {"a.cpp": [1], "b.cpp": [2]}),
+          "a namespace open/close is NOT treated as a replicated reference source")
 
     # THE GATE IS LAST, and it has to be: it used to sit in the middle of this function, so every
     # arm added after it printed [FAIL] and returned 0 anyway. Three mutations that disabled the
@@ -494,6 +506,18 @@ def main() -> int:
     print(f"  [ok]   map matches the file on disk (sha256 {actual[:12]})")
 
     plan = parse_plan(args.plan)
+    # BEFORE split() prints anything. A degraded parse degrades the TILING too, silently --
+    # regions_of pads the remainder with a TRAILER, so check_structure and reconstruction both pass
+    # on a map that does not describe the code. Two greens followed by "the map is unusable" reads
+    # as though the first two meant something.
+    if map_data.get("parse_errors"):
+        print(f"  [FAIL] the map records {map_data['parse_errors']} parse error(s); its region and "
+              f"reference data describe an incomplete AST.")
+        print("         Fix the parse and re-run map_symbols before splitting on it.")
+        return 1
+    if "parse_errors" not in map_data:
+        print("  [warn] this map predates parse-error recording; re-run map_symbols to have the "
+              "cross-reference check gated on a clean parse")
     outputs, problems = split(map_data, plan, original)
     if problems:
         for p in problems:
@@ -506,18 +530,6 @@ def main() -> int:
     # was lost, never that a line can still be USED where it ended up. Splitting gpu_capture.cpp's
     # serialize/deserialize into their own file passed all of them and then failed to compile with
     # 25 undeclared names, because internal-linkage definitions stayed in the other part.
-    # A map built on a partial AST describes a different file. The cross-reference check below is
-    # only as complete as the edges it reads, so a degraded parse would let it print [ok] having
-    # examined half of them -- the reassuring-silence failure this whole check exists to end.
-    if map_data.get("parse_errors"):
-        print(f"  [FAIL] the map records {map_data['parse_errors']} parse error(s); its region and "
-              f"reference data describe an incomplete AST.")
-        print("         Fix the parse and re-run map_symbols before splitting on it.")
-        return 1
-    if "parse_errors" not in map_data:
-        print("  [warn] this map predates parse-error recording; re-run map_symbols to have the "
-              "cross-reference check gated on a clean parse")
-
     stranded = unresolved_across_parts(map_data, plan)
     if stranded:
         regions = {r["index"]: r for r in map_data["regions"]}

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -370,7 +370,8 @@ def measure(path: pathlib.Path, flags: list[str], parse_target: pathlib.Path) ->
                 "unparsed_lines": unparsed, "unparsed_share": round(unparsed / total, 3),
                 "biggest": "<%d line(s) behind an inactive #if>" % unparsed,
                 "biggest_lines": unparsed, "biggest_share": round(unparsed / total, 3),
-                "lambda_lines": 0, "lambda_share_of_biggest": 0.0,
+                # No lambda share: it is not computed on this path either, and emitting 0.0 here
+                # was the same unmeasured-value-in-a-measured-shape the scored path was fixed for.
                 "verdict": "UNPARSED"}
     if not sized:
         return {"file": rel, "lines": total, "verdict": "OK", "regions": 0,
@@ -661,8 +662,19 @@ def main() -> int:
         # the developer's account name and directory layout. Paths are relative to the repository
         # root, which is where the tool is run from, so a consumer resolves them the same way the
         # compile database's own entries are resolved.
-        rel_rows = [{**r, "file": str(pathlib.Path(r["file"]).relative_to(root))
-                     if str(r["file"]).startswith(str(root)) else r["file"]} for r in rows]
+        # BOTH fields. The printed table strips `file` and `why`; the first version of this
+        # stripped only `file`, so the JSON went on publishing the absolute path in exactly the
+        # rows that name a problem -- the case the comment above was written about.
+        def _rel(row: dict) -> dict:
+            out = dict(row)
+            f = str(row.get("file", ""))
+            if f.startswith(str(root)):
+                out["file"] = str(pathlib.Path(f).relative_to(root))
+            if "why" in out:
+                out["why"] = out["why"].replace(str(root) + "/", "").replace(str(root), "")
+            return out
+
+        rel_rows = [_rel(r) for r in rows]
         args.json.write_text(json.dumps(rel_rows, indent=2))
         print(f"[survey] wrote {args.json} ({len(rel_rows)} row(s), paths relative to the repo root)")
     return 0

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -94,7 +94,12 @@ def _need_clang() -> None:
     global MS, ci, _SKIPPED_RANGES, _DISPOSE_RANGES
     if MS is not None:
         return
-    MS = _load_map_symbols()
+    # `MS` is this function's own re-entry guard, so it is assigned LAST. Assigned first, a second
+    # caller arriving mid-initialisation takes the early return above and then uses `ci` while it is
+    # still None. Unreachable from main(), which initialises before starting the pool -- and exactly
+    # reachable from any caller that uses survey_one/measure from a worker without doing that, which
+    # is how a module like this gets used.
+    mod = _load_map_symbols()
     import clang.cindex as _ci
     ci = _ci
     # Built here, not at module scope: the `ranges` member is an array of cindex's own SourceRange,
@@ -118,6 +123,7 @@ def _need_clang() -> None:
                  "and will not guess. Upgrade libclang (present since clang 3.7).")
     _SKIPPED_RANGES = lib.clang_getSkippedRanges
     _DISPOSE_RANGES = lib.clang_disposeSourceRangeList
+    MS = mod                                      # last: this is the guard other callers test
 
 
 # A region must reach this share of the file before the file counts as dominated by it. Below it,
@@ -391,8 +397,13 @@ def measure(path: pathlib.Path, flags: list[str], parse_target: pathlib.Path) ->
         "file": rel, "lines": total, "regions": len(sized),
         "biggest": big["name"], "biggest_lines": big_len,
         "biggest_share": round(big_len / total, 3),
-        "lambda_lines": lam,
-        "lambda_share_of_biggest": round(lam / big_len, 3) if big_len else 0.0,
+        # Only present when it was actually COMPUTED. The share is measured only for a dominated
+        # file, so emitting 0.0 for the rest publishes an unmeasured value in the same shape as a
+        # measured one -- a SPLIT file's "0%" and test_rdna2_to_spirv.cpp's real 3% would read as
+        # the same kind of fact. Absent means "not asked", which is the truth.
+        **({"lambda_lines": lam,
+            "lambda_share_of_biggest": round(lam / big_len, 3) if big_len else 0.0}
+           if big_len / total >= DOMINANT_SHARE else {}),
         "regions_over_%d" % SPLITTABLE_REGION_LINES:
             sum(1 for n, _ in sized if n >= SPLITTABLE_REGION_LINES),
         "unparsed_lines": unparsed,
@@ -631,8 +642,10 @@ def main() -> int:
                   f"{'':>44}  {why[:90]}")
             continue
         unp = r.get("unparsed_lines", 0) / max(r.get("lines", 1), 1)
+        lam = (f"{r['lambda_share_of_biggest']:>6.0%}" if "lambda_share_of_biggest" in r
+               else f"{'--':>6}")      # never computed: see measure()
         print(f"{r['verdict']:<11}{r['lines']:>7}{r.get('biggest_lines', 0):>7}"
-              f"{r.get('biggest_share', 0):>7.0%}{r.get('lambda_share_of_biggest', 0):>6.0%}"
+              f"{r.get('biggest_share', 0):>7.0%}{lam}"
               f"{unp:>6.0%}  {rel}\n{'':>44}  {r.get('biggest', '')}")
 
     counts: dict[str, int] = {}
@@ -640,8 +653,15 @@ def main() -> int:
         counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
     print("\n[survey] " + ", ".join(f"{k}={v}" for k, v in sorted(counts.items())))
     if args.json:
-        args.json.write_text(json.dumps(rows, indent=2))
-        print(f"[survey] wrote {args.json}")
+        # Repo-relative, like the printed table. This repository is public and a survey JSON is
+        # exactly the kind of artifact that gets pasted into an issue; the absolute form published
+        # the developer's account name and directory layout. Paths are relative to the repository
+        # root, which is where the tool is run from, so a consumer resolves them the same way the
+        # compile database's own entries are resolved.
+        rel_rows = [{**r, "file": str(pathlib.Path(r["file"]).relative_to(root))
+                     if str(r["file"]).startswith(str(root)) else r["file"]} for r in rows]
+        args.json.write_text(json.dumps(rel_rows, indent=2))
+        print(f"[survey] wrote {args.json} ({len(rel_rows)} row(s), paths relative to the repo root)")
     return 0
 
 

--- a/prosper/tools/refactor/survey_sizes.py
+++ b/prosper/tools/refactor/survey_sizes.py
@@ -100,6 +100,9 @@ def _need_clang() -> None:
     # reachable from any caller that uses survey_one/measure from a worker without doing that, which
     # is how a module like this gets used.
     mod = _load_map_symbols()
+    # map_symbols resolves libclang lazily too (so ITS selftest runs without one), so its own `ci`
+    # is still None here -- and `regions_of` dereferences it. Initialising ours is not enough.
+    mod._need_clang()
     import clang.cindex as _ci
     ci = _ci
     # Built here, not at module scope: the `ranges` member is an array of cindex's own SourceRange,


### PR DESCRIPTION
Fixes #3518. Fixes #3515. Fixes #3517.

**Scope:** one PR for all outstanding `prosper/tools/` work, per the project owner's direction — granular PRs earn their cost through `git bisect`, and tooling is not built, not linked and not run by CI, so no regression can bisect to it. Nothing here touches `src/`, `frontends/` or `tests/`.

## Why

`promote_internal.py` is the tool that makes a big translation unit splittable — it lifts internal-linkage declarations into a header so a second file can see them. Using it on `src/gpu/capture/gpu_capture.cpp` (6,515 lines) produced a header the compiler rejected immediately, under **five `[ok]` checks and no warnings**.

The tool prints *"now BUILD and run ctest; this tool does not verify its own work"*, which is honest. But all three defects below are decidable from data the tool already has, and the failure mode is the expensive kind: it reports success, and the cost lands at build time on someone reading a 700-line generated header.

## Three defects, found in sequence — each one hid the next

**1. The forward-declaration pass used a narrower rule than its own comment.**

```python
# Anything promoted code CALLS but that stayed behind needs a declaration in the header.
wanted = {d for i in promote for d in edges_all.get(i, set()) if d in set(public)}
```

`public` is the set referenced from *outside* the file. A promoted function calling an ordinary internal helper therefore got no declaration, and used it above its definition:

```
error: 'blob_max_bytes_from_env' was not declared in this scope
error: 'checked_mul' was not declared in this scope
error: 'resource_footprint_impl' was not declared in this scope
```

The `[warn] no declaration could be derived` branch that exists for exactly this could not fire either — those regions never entered the set it iterates.

**2. The copied preamble carried an unbalanced `#if`.**

The header's head is the source's preamble regions copied verbatim. `gpu_capture.cpp` opens `#if defined(__linux__) || defined(__APPLE__)` among its includes and closes it far below, outside any preamble region — so the header shipped **3 `#if` against 2 `#endif`** and died on `unterminated #if`. The tool already models preprocessor depth for the regions it *promotes*; it never applied that to the part it *replicates*.

**3. With both fixed, the build still failed — and the fix for (1) turned out to be impossible in principle.**

```
error: call of overloaded 'resource_footprint_impl(...)' is ambiguous
```

A definition still inside `namespace { }` **cannot be forward-declared from a header**. The declaration names `prosper::gpu::f` while the definition is `prosper::gpu::{anonymous}::f` — two different entities, both visible, so every call becomes ambiguous rather than resolving. No header fixes that.

So the tool now **refuses and names the closure**: the promote set must be closed under "what does this call that is still internal", and nobody derives that by hand from a 6,000-line file. It prints the exact `--regions` to re-run with.

That closure is iterated to a **fixed point**, not reported one step at a time — measured here, the first suggestion needed a second round and the second a third, so a single step just makes the caller run it again. Iterating turned the 29 regions I asked for into the **55 that are actually closed**, in one answer.

## Verification

End-to-end on the file that found it. Promoting the 55-region closure:

- writes a 1,373-line `gpu_capture_internal.hpp` and shrinks `gpu_capture.cpp` from **6,515 → 5,208** lines
- **builds clean**
- `ctest --no-tests=error -j4` → **455/455 passed**, exit 0

**That source change is not in this PR.** It is a step of the `gpu_capture.cpp` split and belongs with it; this is the tool fix alone.

Selftest arms, both mutation-checked — each reverts the fix and reddens **only** its own arm:

| mutation | reddens |
| --- | --- |
| restore the `public` filter | `a promoted region's callees that stay behind are ALL declared, public or not` |
| remove the preamble balancing | `the emitted header is preprocessor-balanced even when the preamble is not` |

The forward-declaration rule moved out of `main()` into `declarations_needed` **specifically so the selftest can reach it**. The selftest's own comment already noted that fixes living in `main()` are unreachable from it — and this rule was wrong for as long as it was unreachable. That is the part worth keeping in mind beyond this patch.

`python3 prosper/tools/refactor/promote_internal.py --selftest` → all arms ok. `diff --check` clean; 0 `Claude-Session:` trailers.

## Risk

Tooling only — no emulator code, nothing linked into any target. `promote_internal.py` is not invoked by the build or by CI; it is run by hand during a restructure. The change makes it refuse inputs it previously accepted and mis-handled, so the failure direction moves from "silently emits a broken header" to "declines and says what to do".

## Affected, deliberately

`gpu_capture.cpp` is untouched here. #3516 (`gpu_executor.cpp`) remains blocked on #3399, which edits that file.



---

## Round 2 — the fix was worse than the bug, and only Windows could see it

Review found that `build()` learned the copied preamble ends at conditional depth 1, balanced the **header**, and then used that same preamble end as the insertion point for the include it adds to the **source**. On `gpu_capture.cpp` the last preamble line is 46 and the matching `#endif` is 47, so the internal header was included behind `#if defined(__linux__) || defined(__APPLE__)` while the promoted definitions were deleted unconditionally.

Measured with the tool's own suggested closure — three arms and a control:

| arm | Linux `g++` | `x86_64-w64-mingw32-g++` |
| --- | --- | --- |
| **fixed** | 0 errors | **0 errors** |
| mutant (include at the last preamble line) | 0 errors | **208 errors** |
| control: unmodified file, same flags | 0 errors | 0 errors |

So the previous round's *"builds clean, 455/455 ctest"* was a **Linux-only claim that could not have seen this**, and it was stated without that qualification. The insertion point now walks out to conditional depth 0.

The selftest arm for the preamble fix asserted **balance**, which does not imply **placement** — moving the `#endif` to the end of the header leaves it green while the header wraps its whole namespace in a platform conditional. A new fixture reproduces `gpu_capture.cpp`'s exact shape and asserts the source's include lands at depth 0.

Also from that review: the refusal predicate used `anon.get(i)`, the test this file documents at `:139-151` as the wrong one (a `static` free function is internal linkage outside any anonymous namespace) — it uses `externally_linked()` now; the suggested `--regions` closure ignored `--exclude`, so the printed re-run reproduced the identical refusal; `preprocessor_depth_after` matches with the file's own `COND_OPEN`/`COND_CLOSE` rather than `str.startswith`, which disagreed on `#  if`; and a comment claiming the `#endif` sits "far below" now says "one line below", which is true.

## Round 3 — `--clusters`, and #3517

`map_symbols.py` has advertised a `--clusters` flag in its usage text with nothing behind it. Implemented, because choosing a split seam is exactly what it describes and `cross_refs` already computes the input. It reports the **cut cost** — the references crossing a boundary, i.e. the promote-to-header list. On `gpu_capture.cpp` at `--clusters 3`: 252 of 2,927, **9%**.

It states two things about itself: a group sitting *at* the size cap is the cap talking rather than a seam, and the part count is what the structure and cap allow rather than what was asked for.

**An early draft let attachment ignore the cap**, which funnelled every group into the largest connected component — one **6,374-line group out of 6,515**, reported as a **0% cut**. A split that is not a split, wearing a perfect score.

That arm needed two attempts and **the first was void**: the obvious fixture (two clusters joined by a weak edge) passes under both implementations, because the first pass already leaves few enough groups that the attachment loop never runs. The discriminating fixture makes the first pass leave *more* groups than requested — six 100-line regions at `parts=4`, so no two can merge under a 150-line cap — which is the only shape where the cap is what stands between six groups and one.

`map_symbols.py` had **no selftest and no ctest case**, so this would have shipped untested. It has both now (`refactor_map_symbols_clusters`), and its libclang import is lazy so the case runs where there is no libclang.

Folded in from #3517: the re-entry guard in `survey_sizes._need_clang` is published last rather than first; an unmeasured lambda share is omitted rather than printed as a measured `0%` beside real ones; `--json` emits repo-relative paths like the printed table already did; README wording corrected.

`ctest -R refactor_ --no-tests=error` → 3/3 passed.
