### PR TITLE
tools/refactor: a split needs a visible declaration, which linkage does not provide

### DIFF
--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -315,6 +315,16 @@ the compiler on that split: **23 names flagged, 25 reported by g++, and the two 
 `r` and `w`** -- local variables in cascading errors from `Reader r;` and `Writer w;`. No false
 positives on that file.
 
+**Linkage is not the test; a visible declaration is.** The first version of this check skipped any
+definition with external linkage, on the reasoning that another translation unit can name it. That
+is true of the *linker* and says nothing about the *compiler*: a function defined in a .cpp inside a
+named namespace and never declared in a header has external linkage and no declaration in scope
+anywhere else, so a split moves its callers into a file that links and does not compile. Splitting
+`rdna2_to_spirv.cpp` per shader stage passed the linkage-only check and failed on
+`safe_execz_branches` in three of five outputs -- while its sibling `safe_execz_branches_for_test`,
+identical in linkage, was fine because `rdna2_to_spirv.hpp` declares it. `map_symbols` records
+`declared_in_header` per region now, and that is what the check keys on.
+
 **The check cannot see inactive `#if` arms**, and that limit is not small: libclang parses one arm,
 so a map made on Linux carries no references from the 52% of `hle_kernel_mem.cpp` or the 30% of
 `hle_kernel.cpp` that sit behind a platform conditional. A split validated here can still strand a

--- a/prosper/tools/refactor/map_symbols.py
+++ b/prosper/tools/refactor/map_symbols.py
@@ -220,6 +220,40 @@ def regions_of(tu, target: pathlib.Path, total_lines: int, max_depth: int = 3) -
     return regions
 
 
+def usrs_declared_outside(tu, target: pathlib.Path) -> set[str]:
+    """USRs that some OTHER file in this translation unit also declares -- i.e. that a header
+    carries.
+
+    This is the difference between "links" and "compiles", and it is not the same question as
+    linkage. A function defined in a .cpp inside `namespace prosper::gpu`, never declared in a
+    header, has EXTERNAL linkage: clang's USR starts `c:@`, and the symbol is visible to the
+    linker. Move its callers to a second .cpp and the program still links -- and does not compile,
+    because no declaration is in scope.
+
+    Measured: splitting rdna2_to_spirv.cpp per shader stage passed a linkage-based cross-part check
+    and then failed on `safe_execz_branches` in three of the five outputs. Its sibling
+    `safe_execz_branches_for_test` IS declared in rdna2_to_spirv.hpp; it is not. Nothing about the
+    linkage of the two differs.
+
+    So a definition may be left in another part only if some header declares it, which is exactly
+    "this USR appears in a file other than the one being split".
+    """
+    out: set[str] = set()
+    tgt = target.resolve()
+
+    def walk(c) -> None:
+        f = c.location.file
+        if f is not None and pathlib.Path(f.name).resolve() != tgt:
+            u = c.get_usr()
+            if u:
+                out.add(u)
+        for k in c.get_children():
+            walk(k)
+
+    walk(tu.cursor)
+    return out
+
+
 def cross_refs(tu, target: pathlib.Path, regions: list[dict]) -> dict[int, dict[int, int]]:
     """region -> {other region: reference count}, for symbols defined in this same file."""
     # Own every declaration whose LOCATION falls inside a region, not just the region's own cursor.
@@ -548,6 +582,11 @@ def main() -> int:
 
     regions = regions_of(tu, target, total_lines)
     edges = cross_refs(tu, target, regions)
+    # Whether a header also declares each region's symbol. See usrs_declared_outside: this is what
+    # decides if a definition can be left in another part, and linkage is not a substitute for it.
+    declared = usrs_declared_outside(tu, target)
+    for r in regions:
+        r["declared_in_header"] = bool(r.get("usr") and r["usr"] in declared)
 
     bodies = [r for r in regions if r["role"] == "body"]
     print(f"== {target.relative_to(root)}: {total_lines} lines, {len(regions)} region(s) "

--- a/prosper/tools/refactor/split_file.py
+++ b/prosper/tools/refactor/split_file.py
@@ -170,6 +170,10 @@ def region_is_external(region: dict, in_anon_namespace: bool = False) -> bool:
 def unresolved_across_parts(map_data: dict, plan: dict[str, list[int]]) -> dict[int, set[str]]:
     """Regions each output part references that live in ANOTHER part and cannot be seen from it.
 
+    Two ways a definition is unreachable, and only the first is about linkage: it has INTERNAL
+    linkage, so another translation unit cannot name it at all; or it has external linkage and NO
+    HEADER DECLARES IT, so the call links but does not compile.
+
     This is the check that was missing, and its absence is not theoretical: splitting
     gpu_capture.cpp's serialize/deserialize into their own file passed every existing check --
     tiling, partition, byte-for-byte reconstruction -- and then failed to compile with 25 distinct
@@ -203,8 +207,28 @@ def unresolved_across_parts(map_data: dict, plan: dict[str, list[int]]) -> dict[
             if dest not in owner:
                 continue
             r = regions.get(dest, {})
-            if r.get("role") != "body" or region_is_external(r, anon.get(dest, False)):
-                continue                      # visible across translation units; nothing to do
+            if r.get("role") != "body":
+                continue
+            # A DECLARATION has to be in scope, which external linkage does not provide. A function
+            # defined in this .cpp inside a named namespace and never declared in a header has
+            # external linkage -- the symbol links -- and still fails to compile from a second .cpp,
+            # because nothing declares it there. Splitting rdna2_to_spirv.cpp per shader stage
+            # passed the linkage-only version of this check and then failed on `safe_execz_branches`
+            # in three of five outputs; its sibling `safe_execz_branches_for_test` is declared in
+            # the header and it is not, with no difference in linkage between them.
+            #
+            # `declared_in_header` is the right question and the map now carries it. Linkage is
+            # still consulted for maps that predate the field, where it is the best available
+            # approximation -- and an over-refusal there is the safe direction.
+            # ORDER MATTERS. Internal linkage is decisive on its own: a `static` or
+            # anonymous-namespace definition cannot be used from another translation unit however
+            # it is declared, because a declaration elsewhere names a DIFFERENT entity. Only once
+            # linkage is external does the declaration question arise.
+            if not region_is_external(r, anon.get(dest, False)):
+                pass                          # internal: unreachable from another part, always
+            elif r.get("declared_in_header", True):
+                continue                      # external AND declared: either part can call it
+            # else: external but nothing declares it -- links, does not compile. Caught.
             if src in owner:
                 if owner[dest] == owner[src]:
                     continue
@@ -435,6 +459,23 @@ def selftest() -> int:
     check(not unresolved_across_parts(ext_map, {"a.cpp": [1], "b.cpp": [2]}),
           "an EXTERNAL definition called across the cut is not flagged")
 
+    # DECLARED IN A HEADER beats linkage, because they answer different questions: linkage says
+    # the symbol resolves at link time, a declaration says the call compiles at all. A definition
+    # with EXTERNAL linkage and no header declaration must still be promoted.
+    decl = {**xref_map, "regions": [dict(r) for r in xref_map["regions"]]}
+    decl["regions"][1]["usr"] = "c:@F@alpha#"                 # external linkage...
+    decl["regions"][1]["declared_in_header"] = False          # ...but nothing declares it
+    check(set(unresolved_across_parts(decl, {"a.cpp": [1], "b.cpp": [2]})) == {1},
+          "an EXTERNAL definition that no header declares is still caught")
+    decl["regions"][1]["declared_in_header"] = True
+    check(not unresolved_across_parts(decl, {"a.cpp": [1], "b.cpp": [2]}),
+          "...and is not caught once a header declares it")
+    # An INTERNAL definition is unreachable from another part however it is declared.
+    decl["regions"][1]["usr"] = "c:s.cpp@F@alpha#"
+    decl["regions"][1]["declared_in_header"] = True
+    check(set(unresolved_across_parts(decl, {"a.cpp": [1], "b.cpp": [2]})) == {1},
+          "an INTERNAL-linkage definition is caught even if something declares it")
+
     # NO USR: the fallback is the scope walk, not a constant. An `extern "C"` definition records
     # no USR and is EXTERNAL, so a bare `return False` refused it as internal -- the inverted
     # default this replaced.
@@ -536,8 +577,8 @@ def main() -> int:
     stranded = unresolved_across_parts(map_data, plan)
     if stranded:
         regions = {r["index"]: r for r in map_data["regions"]}
-        print(f"  [FAIL] {len(stranded)} definition(s) with internal linkage are referenced from a "
-              f"part they are not in:")
+        print(f"  [FAIL] {len(stranded)} definition(s) cannot be reached from a part that "
+              f"references them:")
         for i in sorted(stranded)[:10]:
             users = ", ".join(sorted(stranded[i]))
             print(f"           {regions[i].get('name', '?')}  (in "
@@ -552,7 +593,8 @@ def main() -> int:
         print("         then re-run map_symbols (the promotion changes every region index) and "
               "re-plan.")
         return 1
-    print(f"  [ok]   no internal-linkage definition is referenced from a part it is not in")
+    print("  [ok]   every cross-part reference resolves: internal-linkage definitions stay with "
+          "their callers, and external ones are declared in a header")
 
     if args.dry_run:
         for out, text in sorted(outputs.items()):


### PR DESCRIPTION
Found by building a split the check had passed.

Splitting `rdna2_to_spirv.cpp` per shader stage satisfied every check — tiling, partition, byte-for-byte reconstruction, and the cross-part reference check from #3519 — then failed to compile with `safe_execz_branches` undeclared in **three of five** outputs.

The check skipped it for having **external linkage**. That is a fact about the *linker* and irrelevant to the *compiler*: the function is defined in the .cpp inside `namespace prosper::gpu` and declared in no header, so moving its callers to a second file yields a call that resolves at link time with no declaration in scope at compile time.

Its sibling settles that this is not about linkage. `safe_execz_branches_for_test` is **identical in linkage** — both USRs start `c:@` — and is fine, because `rdna2_to_spirv.hpp` declares it and nothing declares the other:

```
safe_execz_branches           declared_in_header=False  usr_external=True
safe_execz_branches_for_test  declared_in_header=True   usr_external=True
```

`map_symbols` records `declared_in_header` per region now — whether another file in the TU also declares that USR, which is exactly *a header carries it* — and the splitter keys on that.

## The order was wrong first, and its own arm caught it

Internal linkage is decisive alone: a `static` or anonymous-namespace definition is unreachable from another TU **however it is declared**, because a declaration elsewhere names a different entity. Only once linkage is external does the declaration question arise. My first version tested `declared_in_header` first, which skips exactly the case the check exists for — caught by the new arm rather than by a build.

## Verification

Three arms, each mutation-verified against the **exit code**: an external definition no header declares is caught; the same one is not caught once declared; an internal-linkage definition is caught whatever declares it. Reversing the two tests reddens the third by name.

End to end: the plan that failed to build is refused before anything is written, naming `safe_execz_branches` and the three parts that need it.

`ctest -R refactor_ --no-tests=error` 4/4. Maps predating the field fall back to linkage, where over-refusal is the safe direction.

## Risk

Tooling only. The change makes the splitter refuse plans it previously accepted and mis-handled.