### PR TITLE
hle: sceKernelMprotect must round rather than refuse, plus the two missing APR/memory-pool NIDs (#3498, #3506)

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -19,6 +19,21 @@ from the tracker issues, and still gated, because it is a projection of state ra
 > title's current state — for that, read the tracker. Nothing is ever removed when a title moves on,
 > because the point of a blog is that it records *when* things happened.
 
+## 2026-09-11
+
+### Two titles that could not boot at all now boot, and neither needed a renderer change
+
+*FINAL FANTASY TACTICS – The Ivalice Chronicles* killed itself about a second into every launch. It
+was one call: `sceKernelMprotect` with an address that is not 16 KiB aligned, which prosper handed
+to the host verbatim and the host refused. The title reads that refusal as fatal and walks all the
+way back out of `main`. It now runs, streams its own textures and plays audio — no picture yet, and
+that is the next thing.
+
+*NINJA GAIDEN 4* went from a crash nine log lines in to printing its own `Runtime as started` and
+bringing up video-out at 1920x1080. It needed the last missing member of the PS5 memory-pool API, and
+then told us something worth knowing: it reads its stack canary through a variable prosper had bound
+to a block of prosper's own machine code.
+
 ## 2026-09-10
 
 ### BlazBlue Entropy Effect X was stuck on its publisher logos because one mount point did not exist

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1700,6 +1700,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_ampr_amm PRIVATE prosper_core)
   add_test(NAME ampr_amm COMMAND test_ampr_amm)
 
+  add_executable(test_mprotect_unaligned tests/hle/memory/test_mprotect_unaligned.cpp)
+  target_link_libraries(test_mprotect_unaligned PRIVATE prosper_core)
+  add_test(NAME mprotect_unaligned COMMAND test_mprotect_unaligned)
+
   # #2908: a refused Ampr map must hand its direct-memory claim back. POSIX-only because the
   # mapping primitives it exercises are — on Windows sceAmprCommandBufferSetBuffer is still the
   # do-nothing stub, which cannot leak and cannot demonstrate the lever either.

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -4,6 +4,8 @@
 #include "hle/dispatch/nid.hpp"
 #include "hle/kernel/hle_kernel_time.hpp"
 #include "host/image/boot_program.hpp"   // #1659: shared guest-module labelling
+#include "host/image/exec_image.hpp"      // guest_frames_from_rbp / describe_code_address
+#include "host/fault/guest_caller.hpp"    // PROSPER_CAPTURE_RBP at a fatal handler's entry
 #include "host/platform/posix_shim.hpp"     // PROSPER_ASM_TRAMPOLINE (pass entry %rsp as 7th arg)
 #include "host/platform/precise_sleep.hpp"   // guest sleeps must not inherit the winpthreads tick (#3013)
 #include "hle/kernel/timedwait_census.hpp"   // PROSPER_TIMEDWAIT_CENSUS: which primitive a title paces on
@@ -867,10 +869,53 @@ HLE(k_load_start_mod) {   // Windows/MinGW: no import-boundary %fs swap -> guest
 }
 #endif
 
+// Name the guest call site that reached one of the fatal exits below.
+//
+// A title that terminates ITSELF is the hardest kind of boot failure to diagnose, because there is
+// no fault, no unimplemented NID and no host stack worth reading -- the guest ran a check, disliked
+// the answer prosper gave it, and left. What the reader needs is the one thing the log did not have:
+// WHERE. FINAL FANTASY TACTICS (#3498) raises 0xa0020001 with a completely clean log above it, and
+// the only way to progress it is to disassemble the caller.
+//
+// Printed unconditionally rather than behind an env switch: this runs exactly once, on a path that
+// is already terminating the process, so there is no cost to weigh against it -- and a diagnostic
+// that must be enabled is one nobody has enabled on the run that mattered.
+//
+// The chain is a FRAME-POINTER walk, so say what it is. A caller compiled without a prologue is
+// skipped silently (instrument traps 114, 217), which makes a short chain and a shallow stack look
+// identical; confirm a link by disassembling the named site before building on it.
+void report_guest_fatal_caller(uint64_t entry_rbp, uint64_t entry_rsp) {
+    // Both instruments, always, because which one works is a property of how the TITLE was compiled
+    // and is not knowable here. The chain is precise and often empty; the scan is noisy and almost
+    // never empty. Printing only the chain is what left FINAL FANTASY TACTICS' raise reported as a
+    // single frame at the module entry point -- technically true, and useless.
+    uint64_t frames[8];
+    const int chained = guest_frames_from_rbp(entry_rbp, frames, 8);
+    for (int i = 0; i < chained; ++i)
+        fprintf(stderr, "[prosper] guest caller (rbp chain) #%d: 0x%llx (%s)\n", i,
+                (unsigned long long)frames[i], describe_code_address(frames[i]).c_str());
+    if (chained <= 0)
+        fprintf(stderr, "[prosper] guest caller (rbp chain): none -- this title omits frame pointers\n");
+
+    uint64_t scanned[12];
+    const int found = guest_frames_on_stack(entry_rsp, scanned, 12);
+    for (int i = 0; i < found; ++i)
+        fprintf(stderr, "[prosper] guest caller (stack scan) #%d: 0x%llx (%s)\n", i,
+                (unsigned long long)scanned[i], describe_code_address(scanned[i]).c_str());
+    if (found <= 0)
+        fprintf(stderr, "[prosper] guest caller (stack scan): none\n");
+    else
+        fprintf(stderr, "[prosper] guest caller: stack-scan entries are call-site-validated but "
+                        "unordered by liveness -- disassemble before building on one\n");
+}
+
 // _exit(status): terminate the process. Previously an unimplemented stub RETURNED 0, so libc's
 // exit path fell through into its deliberate ud2 (SIGILL) — terminate for real, loudly.
 HLE(k_exit) {
+    PROSPER_CAPTURE_RBP(entry_rbp);
+    PROSPER_CAPTURE_RSP(entry_rsp);
     fprintf(stderr, "[prosper] guest _exit(%d) -- terminating\n", (int)a0);
+    report_guest_fatal_caller(entry_rbp, entry_rsp);
     host::guest_dmem_write_trace_report();
     fflush(nullptr);
     _Exit((int)a0);
@@ -879,8 +924,14 @@ HLE(k_exit) {
 // it from failed check()s in shipping builds). Report and terminate rather than "return 0" and
 // let the guest run on in an undefined state.
 HLE(k_debug_raise_release) {
+    // Capture rbp FIRST, before this frame does anything that could overwrite it. Everything below
+    // is ordinary reporting; the one thing that must happen at the top is preserving the link back
+    // into the guest's stack (host/fault/guest_caller.hpp).
+    PROSPER_CAPTURE_RBP(entry_rbp);
+    PROSPER_CAPTURE_RSP(entry_rsp);
     fprintf(stderr, "[prosper] guest sceKernelDebugRaiseExceptionOnReleaseMode(code=0x%llx, arg=0x%llx) -- terminating\n",
             (unsigned long long)a0, (unsigned long long)a1);
+    report_guest_fatal_caller(entry_rbp, entry_rsp);
     host::guest_dmem_write_trace_report();
     fflush(nullptr);
     _Exit(0x66);

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -1867,7 +1867,13 @@ HLE(k_pool_decommit) {
     // NINJA GAIDEN 4 loses nothing to this: its observed decommits are already 64 KiB-aligned with
     // 64 KiB-multiple lengths (`addr=0x1001010000 len=0x3f0000`, `addr=0x1000ee0000 len=0x10000`).
     constexpr uint64_t kCommitGranule = 0x10000ull;
-    if (a1 > UINT64_MAX - a0) return 0x80020016ull;
+    // Overflow first, and BOTH ends of it. The replaced code used normalize_guest_page_range, which
+    // checks its own round-up; rounding by hand dropped that, and the omission is not benign here --
+    // `sceKernelMemoryPoolDecommit(-16, 8, 0)` wraps `base` to 0 and yields a length of nearly 2^64,
+    // at which point committed_parts_in returns EVERY committed mapping and the loop below unmaps
+    // the whole process while answering SCE_OK. Raised in review of #3530.
+    if (a1 > UINT64_MAX - a0) return 0x80020016ull;                  // the span itself wraps
+    if (a0 > UINT64_MAX - (kCommitGranule - 1)) return 0x80020016ull; // rounding the base up wraps
     const uint64_t base = (a0 + kCommitGranule - 1) & ~(kCommitGranule - 1);
     const uint64_t end  = (a0 + a1) & ~(kCommitGranule - 1);
     if (end <= base) {
@@ -2701,13 +2707,16 @@ HLE(k_apr_submit_and_get_id) {
                 (unsigned long long)a4, (unsigned long long)a5);
     // A failed submit must not hand back an id the guest would then wait on.
     if (rc != 0) return rc;
-    // Nor may a SUCCESSFUL one return 0, which is precisely the value the missing handler returned
-    // and therefore the one a caller cannot distinguish from "unimplemented". The token normally
-    // comes from prosper_apr_next_token and is never 0, but a command buffer BOUND with a zero tag
-    // echoes that tag -- and this file documents a real title that binds with a literal `xor ecx,ecx`
-    // (CRI ADX2, in the apr_submit_common comment). Fall back to this ring's own counter there.
-    // Raised in review of #3530.
-    return token ? token : prosper_apr_next_token(a1 ? (unsigned)(a1 - 1) & 0x3f : 0);
+    // The token is whatever the family computed, INCLUDING 0. An earlier revision substituted this
+    // ring's own counter when the token came back 0, on the reasoning that 0 is the value the missing
+    // handler returned. That is reachable only for a cb BOUND with a zero tag -- and for a bound cb
+    // this file's own contract (see apr_submit_common) is that the token IS the binding tag, which
+    // the guest chose. Handing back the unbound counter dialect instead would answer a bound
+    // buffer in a dialect it never asked for, and would advance ring state as a side effect of a
+    // read. CRI ADX2 is the known zero-tag binder and its waiter tests the event IDENT, never the
+    // tag, so 0 is a legitimate payload there rather than an ambiguous one. Reverted in review of
+    // #3530; no title is known to bind with a zero tag AND use this entry point.
+    return token;
 }
 HLE(k_apr_submit) {   // sceKernelAprSubmitCommandBufferAndGetResult (cb, ring_1based, out1, out2)
     return apr_submit_common(a0, a1, a2, a3, /*write_result_outputs=*/true);
@@ -6970,7 +6979,13 @@ HLE(k_pool_decommit) {
     // NINJA GAIDEN 4 loses nothing to this: its observed decommits are already 64 KiB-aligned with
     // 64 KiB-multiple lengths (`addr=0x1001010000 len=0x3f0000`, `addr=0x1000ee0000 len=0x10000`).
     constexpr uint64_t kCommitGranule = 0x10000ull;
-    if (a1 > UINT64_MAX - a0) return 0x80020016ull;
+    // Overflow first, and BOTH ends of it. The replaced code used normalize_guest_page_range, which
+    // checks its own round-up; rounding by hand dropped that, and the omission is not benign here --
+    // `sceKernelMemoryPoolDecommit(-16, 8, 0)` wraps `base` to 0 and yields a length of nearly 2^64,
+    // at which point committed_parts_in returns EVERY committed mapping and the loop below unmaps
+    // the whole process while answering SCE_OK. Raised in review of #3530.
+    if (a1 > UINT64_MAX - a0) return 0x80020016ull;                  // the span itself wraps
+    if (a0 > UINT64_MAX - (kCommitGranule - 1)) return 0x80020016ull; // rounding the base up wraps
     const uint64_t base = (a0 + kCommitGranule - 1) & ~(kCommitGranule - 1);
     const uint64_t end  = (a0 + a1) & ~(kCommitGranule - 1);
     if (end <= base) {
@@ -6987,7 +7002,13 @@ HLE(k_pool_decommit) {
     const uint64_t len = end - base;
     uint64_t released = 0;
     for (const auto& part : committed_parts_in(base, len)) {
-        // win_unmap restores the Windows PLACEHOLDER it cut the view out of, so the address space
+        // NOTE ON THE GRANULE, because the rationale above is the LINUX one and this half's is not the
+    // same number: Windows' lazy-commit path works in 16 KiB, not 64 KiB (exec_image_win.cpp). 64 KiB
+    // is kept here anyway because it is a SUPERSET -- a 64 KiB-aligned inward-rounded span is also
+    // 16 KiB-aligned, so the hazard is covered either way, and one granule keeps the two halves
+    // answering the same question identically. The cost is that Windows releases slightly less than
+    // it could for a 16 KiB-granular caller. Raised in review of #3530.
+    // win_unmap restores the Windows PLACEHOLDER it cut the view out of, so the address space
         // stays claimed here without the explicit re-reservation the POSIX arm needs. Recorded
         // because the two halves therefore look different while implementing the same contract.
         if (!win_unmap(part.first, part.second)) return 0x80020016ull;
@@ -7629,13 +7650,16 @@ HLE(k_ampr_submit_and_get_id) {
                 (unsigned long long)a4, (unsigned long long)a5);
     // A failed submit must not hand back an id the guest would then wait on.
     if (rc != 0) return rc;
-    // Nor may a SUCCESSFUL one return 0, which is precisely the value the missing handler returned
-    // and therefore the one a caller cannot distinguish from "unimplemented". The token normally
-    // comes from prosper_apr_next_token and is never 0, but a command buffer BOUND with a zero tag
-    // echoes that tag -- and this file documents a real title that binds with a literal `xor ecx,ecx`
-    // (CRI ADX2, in the apr_submit_common comment). Fall back to this ring's own counter there.
-    // Raised in review of #3530.
-    return token ? token : prosper_apr_next_token(a1 ? (unsigned)(a1 - 1) & 0x3f : 0);
+    // The token is whatever the family computed, INCLUDING 0. An earlier revision substituted this
+    // ring's own counter when the token came back 0, on the reasoning that 0 is the value the missing
+    // handler returned. That is reachable only for a cb BOUND with a zero tag -- and for a bound cb
+    // this file's own contract (see apr_submit_common) is that the token IS the binding tag, which
+    // the guest chose. Handing back the unbound counter dialect instead would answer a bound
+    // buffer in a dialect it never asked for, and would advance ring state as a side effect of a
+    // read. CRI ADX2 is the known zero-tag binder and its waiter tests the event IDENT, never the
+    // tag, so 0 is a legitimate payload there rather than an ambiguous one. Reverted in review of
+    // #3530; no title is known to bind with a zero tag AND use this entry point.
+    return token;
 }
 HLE(k_ampr_submit) {                 // ASoW5WE-UPo: …AndGetResult — writes the result slots
     return apr_submit_common(a0, a1, a2, a3, /*write_result_outputs=*/true);

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -2220,11 +2220,47 @@ static uint64_t sce_mprotect_error(int error) {
         default:     return 0x80020016ull;
     }
 }
+// sceKernelMprotect(addr, len, prot).
+//
+// The range is NORMALIZED to guest pages before anything is applied, exactly as k_mtypeprotect
+// below already does. Protection is a page-granular property on every platform prosper targets, so
+// a sub-page request can only ever mean "the pages containing this span" -- and the two functions
+// answering the same question differently is the divergence the charter's one-derivation rule
+// exists to prevent.
+//
+// This is not a tolerance, it is the console's contract, and a shipping title is the evidence.
+// FINAL FANTASY TACTICS - The Ivalice Chronicles (#3498) calls
+// sceKernelMprotect(eboot+0xf999e0, 0x1da20, 0xc3) during its allocator init -- an address that is
+// not 16 KiB aligned and a length that is not a multiple of it. Passed through verbatim, host
+// mprotect(2) rejects the unaligned base with EINVAL, and the title reads that as fatal: it
+// abandons the init, returns -1 up four frames, its framework constructor yields NULL, main()
+// returns, and the CRT raises sceKernelDebugRaiseExceptionOnReleaseMode(0xa0020001) about a second
+// into the boot. A title that ships and runs on hardware is proof the console accepted the call.
+//
+// It is also the SECOND time a refused mprotect has cost a title its whole init path: #2101 is The
+// Messenger losing its AGC register-offset table the same way. That fix, and the bounded REFUSED
+// log it added, landed on the Windows half only -- which is why this one had to be found by
+// disassembling the guest instead of by reading a log. The log is mirrored here for that reason.
+//
+// CONFIDENCE: HIGH. The failing call is live-captured, the EINVAL is observed at the guest's own
+// test instruction (eboot+0x9779), and the normalization matches the sibling entry point.
 HLE(k_mprotect) {
     if (!a0) return 0x80020016ull;
+    uint64_t base = 0, len = 0;
+    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
+    if (!len) return 0;                       // an empty span is a no-op, not an error
     const int prot = host_prot(a2);
-    if (mprotect((void*)a0, a1, prot) != 0) return sce_mprotect_error(errno);
-    retrack_prot(a0, a1, prot, static_cast<uint32_t>(a2), "mprotect");
+    if (mprotect((void*)base, len, prot) != 0) {
+        const int failure = errno;
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 24)
+            fprintf(stderr, "[memhle] sceKernelMprotect REFUSED addr=0x%llx len=0x%llx prot=0x%llx "
+                            "(pages [0x%llx,0x%llx)) errno=%d\n",
+                    (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                    (unsigned long long)base, (unsigned long long)(base + len), failure);
+        return sce_mprotect_error(failure);
+    }
+    retrack_prot(base, len, prot, static_cast<uint32_t>(a2), "mprotect");
     return 0;
 }
 
@@ -6818,11 +6854,38 @@ static uint64_t sce_win_mprotect_error(DWORD error) {
         default:                      return 0x80020016ull;
     }
 }
+// sceKernelMprotect(addr, len, prot).
+//
+// The range is NORMALIZED to guest pages before anything is applied, exactly as k_mtypeprotect
+// below already does. Protection is a page-granular property on every platform prosper targets, so
+// a sub-page request can only ever mean "the pages containing this span" -- and the two functions
+// answering the same question differently is the divergence the charter's one-derivation rule
+// exists to prevent.
+//
+// This is not a tolerance, it is the console's contract, and a shipping title is the evidence.
+// FINAL FANTASY TACTICS - The Ivalice Chronicles (#3498) calls
+// sceKernelMprotect(eboot+0xf999e0, 0x1da20, 0xc3) during its allocator init -- an address that is
+// not 16 KiB aligned and a length that is not a multiple of it. Passed through verbatim, host
+// mprotect(2) rejects the unaligned base with EINVAL, and the title reads that as fatal: it
+// abandons the init, returns -1 up four frames, its framework constructor yields NULL, main()
+// returns, and the CRT raises sceKernelDebugRaiseExceptionOnReleaseMode(0xa0020001) about a second
+// into the boot. A title that ships and runs on hardware is proof the console accepted the call.
+//
+// It is also the SECOND time a refused mprotect has cost a title its whole init path: #2101 is The
+// Messenger losing its AGC register-offset table the same way. That fix, and the bounded REFUSED
+// log it added, landed on the Windows half only -- which is why this one had to be found by
+// disassembling the guest instead of by reading a log. The log is mirrored here for that reason.
+//
+// CONFIDENCE: HIGH. The failing call is live-captured, the EINVAL is observed at the guest's own
+// test instruction (eboot+0x9779), and the normalization matches the sibling entry point.
 HLE(k_mprotect) {
     if (!a0) return 0x80020016ull;
+    uint64_t base = 0, len = 0;
+    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
+    if (!len) return 0;
     const int prot = host_prot(a2);
     DWORD error = ERROR_SUCCESS;
-    if (!win_protect(a0, a1, prot, &error)) {
+    if (!win_protect(base, len, prot, &error)) {
         // #2101: a refused mprotect is silent, and a guest that treats it as fatal then abandons a
         // whole init path with no other symptom. Report the span, the requested Sony protection and
         // the Win32 reason, bounded.
@@ -6834,7 +6897,7 @@ HLE(k_mprotect) {
                     (unsigned long)error);
         return sce_win_mprotect_error(error);
     }
-    retrack_prot(a0, a1, prot, static_cast<uint32_t>(a2), "mprotect");
+    retrack_prot(base, len, prot, static_cast<uint32_t>(a2), "mprotect");
     return 0;
 }
 HLE(k_mtypeprotect) {

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -6979,6 +6979,13 @@ HLE(k_pool_decommit) {
     // NINJA GAIDEN 4 loses nothing to this: its observed decommits are already 64 KiB-aligned with
     // 64 KiB-multiple lengths (`addr=0x1001010000 len=0x3f0000`, `addr=0x1000ee0000 len=0x10000`).
     constexpr uint64_t kCommitGranule = 0x10000ull;
+    // THE GRANULE RATIONALE ABOVE IS THE LINUX ONE, and this half's number is not the same: Windows'
+    // lazy-commit path works in 16 KiB, not 64 KiB (exec_image_win.cpp). 64 KiB is kept here anyway
+    // because it is a SUPERSET -- a 64 KiB-aligned inward-rounded span is also 16 KiB-aligned, so the
+    // hazard is covered either way, and one granule keeps the two halves answering the same question
+    // identically. The cost is that Windows releases slightly less than a 16 KiB-granular caller
+    // asks for. Stated here, before the text it corrects, because a reader meets that text first.
+    // Raised in review of #3530.
     // Overflow first, and BOTH ends of it. The replaced code used normalize_guest_page_range, which
     // checks its own round-up; rounding by hand dropped that, and the omission is not benign here --
     // `sceKernelMemoryPoolDecommit(-16, 8, 0)` wraps `base` to 0 and yields a length of nearly 2^64,
@@ -7002,12 +7009,6 @@ HLE(k_pool_decommit) {
     const uint64_t len = end - base;
     uint64_t released = 0;
     for (const auto& part : committed_parts_in(base, len)) {
-        // NOTE ON THE GRANULE, because the rationale above is the LINUX one and this half's is not the
-    // same number: Windows' lazy-commit path works in 16 KiB, not 64 KiB (exec_image_win.cpp). 64 KiB
-    // is kept here anyway because it is a SUPERSET -- a 64 KiB-aligned inward-rounded span is also
-    // 16 KiB-aligned, so the hazard is covered either way, and one granule keeps the two halves
-    // answering the same question identically. The cost is that Windows releases slightly less than
-    // it could for a 16 KiB-granular caller. Raised in review of #3530.
     // win_unmap restores the Windows PLACEHOLDER it cut the view out of, so the address space
         // stays claimed here without the explicit re-reservation the POSIX arm needs. Recorded
         // because the two halves therefore look different while implementing the same contract.

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -1832,7 +1832,7 @@ std::vector<std::pair<uint64_t, uint64_t>> committed_parts_in(uint64_t base, uin
 // code. Decommit has no out-parameter, so the hazard that made #3502 probe before implementing --
 // writing through a wrongly positioned argument -- does not apply. The opposite one does: unmapping
 // a range the guest did not name, which is silent and corrupts whatever else lived there. Hence
-// tracked_committed_covers above: nothing is touched unless prosper itself recorded it as a
+// committed_parts_in above: nothing is touched unless prosper itself recorded it as a
 // committed mapping.
 //
 // THE RESERVATION SURVIVES. That is the whole point of the reserve/commit split -- releasing the VA
@@ -1848,9 +1848,40 @@ std::vector<std::pair<uint64_t, uint64_t>> committed_parts_in(uint64_t base, uin
 // word, this reading is wrong.
 HLE(k_pool_decommit) {
     if (!a0 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
-    uint64_t base = 0, len = 0;
-    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
-    if (!len) return 0;
+    // 64 KiB granularity, rounded INWARD -- and both halves of that are load-bearing.
+    //
+    // INWARD, because this call destroys guest memory. Every other rounding in this file widens a
+    // range, which for a protection change is harmless; widening a RELEASE would unmap bytes the
+    // guest did not name, and its sibling k_munmap refuses an unaligned request outright rather than
+    // take that risk. Rounding in can only ever release less than asked, never more.
+    //
+    // 64 KiB rather than the 16 KiB guest page, because of what happens to the hole afterwards. A
+    // decommitted range goes back to being a tracked reservation, and the first guest touch of a
+    // tracked reservation is served by the lazy-commit fault handler
+    // (exec_image_linux.cpp, `prosper_reserved_range_state(a) == 1`), which maps
+    // `mmap(page & ~0xffff, 0x10000, MAP_FIXED)` -- a whole 64 KiB granule. A hole smaller than
+    // that, or not aligned to it, would therefore be re-backed by an mmap that also replaces the
+    // still-live neighbours sharing its granule with fresh zeroed pages. Releasing only whole
+    // granules makes that unreachable by construction. Raised in review of #3530.
+    //
+    // NINJA GAIDEN 4 loses nothing to this: its observed decommits are already 64 KiB-aligned with
+    // 64 KiB-multiple lengths (`addr=0x1001010000 len=0x3f0000`, `addr=0x1000ee0000 len=0x10000`).
+    constexpr uint64_t kCommitGranule = 0x10000ull;
+    if (a1 > UINT64_MAX - a0) return 0x80020016ull;
+    const uint64_t base = (a0 + kCommitGranule - 1) & ~(kCommitGranule - 1);
+    const uint64_t end  = (a0 + a1) & ~(kCommitGranule - 1);
+    if (end <= base) {
+        // Nothing to do, and SAY SO. A release that releases nothing answering SCE_OK in silence is
+        // the shape this file spends most of its comments warning about; bounded so a guest looping
+        // on it cannot turn the diagnostic into the problem.
+        static std::atomic<int> narrowed{0};
+        if (narrowed.fetch_add(1) < 8)
+            fprintf(stderr, "[memhle] sceKernelMemoryPoolDecommit(0x%llx, 0x%llx) spans no whole "
+                            "64 KiB granule -- nothing released (reported %d of at most 8 times)\n",
+                    (unsigned long long)a0, (unsigned long long)a1, narrowed.load());
+        return 0;
+    }
+    const uint64_t len = end - base;
     uint64_t released = 0;
     for (const auto& part : committed_parts_in(base, len)) {
         // Retire any texture write-watch over this VA before the backing disappears, exactly as
@@ -1867,6 +1898,15 @@ HLE(k_pool_decommit) {
         untrack(part.first, part.second);
         track(part.first, part.second, 0, 0, false, "reserved");
         released += part.second;
+    }
+    if (released < a1) {
+        static std::atomic<int> partial{0};
+        if (partial.fetch_add(1) < 8)
+            fprintf(stderr, "[memhle] sceKernelMemoryPoolDecommit(0x%llx, 0x%llx) released 0x%llx: "
+                            "the rest was not committed, or fell outside a whole 64 KiB granule "
+                            "(reported %d of at most 8 times)\n",
+                    (unsigned long long)a0, (unsigned long long)a1,
+                    (unsigned long long)released, partial.load());
     }
     MLOG("pool_decommit addr=0x%llx len=0x%llx flags=0x%llx -> released 0x%llx of [0x%llx,0x%llx), "
          "reservation kept\n",
@@ -2316,7 +2356,17 @@ static uint64_t sce_mprotect_error(int error) {
 // answering the same question differently is the divergence the charter's one-derivation rule
 // exists to prevent.
 //
-// This is not a tolerance, it is the console's contract, and a shipping title is the evidence.
+// This is not a tolerance, it is the console's contract, and the primary evidence is the KERNEL this
+// one is derived from. FreeBSD's kern_mprotect does exactly this rounding -- it takes
+// `pageoff = addr & PAGE_MASK`, subtracts it from the address, adds it to the size and rounds the
+// size up -- and the PS5 kernel is FreeBSD-derived. That is a positive statement about WHICH
+// rounding the platform performs, including its direction, where "a shipping title calls it and
+// works" establishes only that hardware did not fail the call. It also settles the corner this
+// introduces: `sceKernelMprotect(unaligned, 0, prot)` now protects one whole page while an aligned
+// address with length 0 stays a no-op, which looks inconsistent inside prosper and is precisely what
+// FreeBSD does. Raised in review of #3530.
+//
+// The title is the corroborating evidence, and it is how the defect was found.
 // FINAL FANTASY TACTICS - The Ivalice Chronicles (#3498) calls
 // sceKernelMprotect(eboot+0xf999e0, 0x1da20, 0xc3) during its allocator init -- an address that is
 // not 16 KiB aligned and a length that is not a multiple of it. Passed through verbatim, host
@@ -2650,7 +2700,14 @@ HLE(k_apr_submit_and_get_id) {
                 (unsigned long long)rc, (unsigned long long)a2, (unsigned long long)a3,
                 (unsigned long long)a4, (unsigned long long)a5);
     // A failed submit must not hand back an id the guest would then wait on.
-    return rc == 0 ? token : rc;
+    if (rc != 0) return rc;
+    // Nor may a SUCCESSFUL one return 0, which is precisely the value the missing handler returned
+    // and therefore the one a caller cannot distinguish from "unimplemented". The token normally
+    // comes from prosper_apr_next_token and is never 0, but a command buffer BOUND with a zero tag
+    // echoes that tag -- and this file documents a real title that binds with a literal `xor ecx,ecx`
+    // (CRI ADX2, in the apr_submit_common comment). Fall back to this ring's own counter there.
+    // Raised in review of #3530.
+    return token ? token : prosper_apr_next_token(a1 ? (unsigned)(a1 - 1) & 0x3f : 0);
 }
 HLE(k_apr_submit) {   // sceKernelAprSubmitCommandBufferAndGetResult (cb, ring_1based, out1, out2)
     return apr_submit_common(a0, a1, a2, a3, /*write_result_outputs=*/true);
@@ -6878,7 +6935,7 @@ std::vector<std::pair<uint64_t, uint64_t>> committed_parts_in(uint64_t base, uin
 // code. Decommit has no out-parameter, so the hazard that made #3502 probe before implementing --
 // writing through a wrongly positioned argument -- does not apply. The opposite one does: unmapping
 // a range the guest did not name, which is silent and corrupts whatever else lived there. Hence
-// tracked_committed_covers above: nothing is touched unless prosper itself recorded it as a
+// committed_parts_in above: nothing is touched unless prosper itself recorded it as a
 // committed mapping.
 //
 // THE RESERVATION SURVIVES. That is the whole point of the reserve/commit split -- releasing the VA
@@ -6894,9 +6951,40 @@ std::vector<std::pair<uint64_t, uint64_t>> committed_parts_in(uint64_t base, uin
 // word, this reading is wrong.
 HLE(k_pool_decommit) {
     if (!a0 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
-    uint64_t base = 0, len = 0;
-    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
-    if (!len) return 0;
+    // 64 KiB granularity, rounded INWARD -- and both halves of that are load-bearing.
+    //
+    // INWARD, because this call destroys guest memory. Every other rounding in this file widens a
+    // range, which for a protection change is harmless; widening a RELEASE would unmap bytes the
+    // guest did not name, and its sibling k_munmap refuses an unaligned request outright rather than
+    // take that risk. Rounding in can only ever release less than asked, never more.
+    //
+    // 64 KiB rather than the 16 KiB guest page, because of what happens to the hole afterwards. A
+    // decommitted range goes back to being a tracked reservation, and the first guest touch of a
+    // tracked reservation is served by the lazy-commit fault handler
+    // (exec_image_linux.cpp, `prosper_reserved_range_state(a) == 1`), which maps
+    // `mmap(page & ~0xffff, 0x10000, MAP_FIXED)` -- a whole 64 KiB granule. A hole smaller than
+    // that, or not aligned to it, would therefore be re-backed by an mmap that also replaces the
+    // still-live neighbours sharing its granule with fresh zeroed pages. Releasing only whole
+    // granules makes that unreachable by construction. Raised in review of #3530.
+    //
+    // NINJA GAIDEN 4 loses nothing to this: its observed decommits are already 64 KiB-aligned with
+    // 64 KiB-multiple lengths (`addr=0x1001010000 len=0x3f0000`, `addr=0x1000ee0000 len=0x10000`).
+    constexpr uint64_t kCommitGranule = 0x10000ull;
+    if (a1 > UINT64_MAX - a0) return 0x80020016ull;
+    const uint64_t base = (a0 + kCommitGranule - 1) & ~(kCommitGranule - 1);
+    const uint64_t end  = (a0 + a1) & ~(kCommitGranule - 1);
+    if (end <= base) {
+        // Nothing to do, and SAY SO. A release that releases nothing answering SCE_OK in silence is
+        // the shape this file spends most of its comments warning about; bounded so a guest looping
+        // on it cannot turn the diagnostic into the problem.
+        static std::atomic<int> narrowed{0};
+        if (narrowed.fetch_add(1) < 8)
+            fprintf(stderr, "[memhle] sceKernelMemoryPoolDecommit(0x%llx, 0x%llx) spans no whole "
+                            "64 KiB granule -- nothing released (reported %d of at most 8 times)\n",
+                    (unsigned long long)a0, (unsigned long long)a1, narrowed.load());
+        return 0;
+    }
+    const uint64_t len = end - base;
     uint64_t released = 0;
     for (const auto& part : committed_parts_in(base, len)) {
         // win_unmap restores the Windows PLACEHOLDER it cut the view out of, so the address space
@@ -6906,6 +6994,15 @@ HLE(k_pool_decommit) {
         untrack(part.first, part.second);
         track(part.first, part.second, 0, 0, false, "reserved");
         released += part.second;
+    }
+    if (released < a1) {
+        static std::atomic<int> partial{0};
+        if (partial.fetch_add(1) < 8)
+            fprintf(stderr, "[memhle] sceKernelMemoryPoolDecommit(0x%llx, 0x%llx) released 0x%llx: "
+                            "the rest was not committed, or fell outside a whole 64 KiB granule "
+                            "(reported %d of at most 8 times)\n",
+                    (unsigned long long)a0, (unsigned long long)a1,
+                    (unsigned long long)released, partial.load());
     }
     MLOG("pool_decommit addr=0x%llx len=0x%llx flags=0x%llx -> released 0x%llx of [0x%llx,0x%llx), "
          "placeholder kept\n",
@@ -7068,7 +7165,17 @@ static uint64_t sce_win_mprotect_error(DWORD error) {
 // answering the same question differently is the divergence the charter's one-derivation rule
 // exists to prevent.
 //
-// This is not a tolerance, it is the console's contract, and a shipping title is the evidence.
+// This is not a tolerance, it is the console's contract, and the primary evidence is the KERNEL this
+// one is derived from. FreeBSD's kern_mprotect does exactly this rounding -- it takes
+// `pageoff = addr & PAGE_MASK`, subtracts it from the address, adds it to the size and rounds the
+// size up -- and the PS5 kernel is FreeBSD-derived. That is a positive statement about WHICH
+// rounding the platform performs, including its direction, where "a shipping title calls it and
+// works" establishes only that hardware did not fail the call. It also settles the corner this
+// introduces: `sceKernelMprotect(unaligned, 0, prot)` now protects one whole page while an aligned
+// address with length 0 stays a no-op, which looks inconsistent inside prosper and is precisely what
+// FreeBSD does. Raised in review of #3530.
+//
+// The title is the corroborating evidence, and it is how the defect was found.
 // FINAL FANTASY TACTICS - The Ivalice Chronicles (#3498) calls
 // sceKernelMprotect(eboot+0xf999e0, 0x1da20, 0xc3) during its allocator init -- an address that is
 // not 16 KiB aligned and a length that is not a multiple of it. Passed through verbatim, host
@@ -7521,7 +7628,14 @@ HLE(k_ampr_submit_and_get_id) {
                 (unsigned long long)rc, (unsigned long long)a2, (unsigned long long)a3,
                 (unsigned long long)a4, (unsigned long long)a5);
     // A failed submit must not hand back an id the guest would then wait on.
-    return rc == 0 ? token : rc;
+    if (rc != 0) return rc;
+    // Nor may a SUCCESSFUL one return 0, which is precisely the value the missing handler returned
+    // and therefore the one a caller cannot distinguish from "unimplemented". The token normally
+    // comes from prosper_apr_next_token and is never 0, but a command buffer BOUND with a zero tag
+    // echoes that tag -- and this file documents a real title that binds with a literal `xor ecx,ecx`
+    // (CRI ADX2, in the apr_submit_common comment). Fall back to this ring's own counter there.
+    // Raised in review of #3530.
+    return token ? token : prosper_apr_next_token(a1 ? (unsigned)(a1 - 1) & 0x3f : 0);
 }
 HLE(k_ampr_submit) {                 // ASoW5WE-UPo: …AndGetResult — writes the result slots
     return apr_submit_common(a0, a1, a2, a3, /*write_result_outputs=*/true);

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -550,7 +550,7 @@ static uint64_t apr_cb_set_equeue(uint64_t command_size, bool eager_completion,
 }
 
 static uint64_t apr_submit_common(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
-                                  bool write_result_outputs) {
+                                  bool write_result_outputs, uint64_t* token_out = nullptr) {
     unsigned ring = a1 ? (unsigned)(a1 - 1) & 0x3f : 0;
     // Completion-token contract (issues #180/#208 — guest submit path eboot+0x22a02b0, handler
     // +0x229dcb0, listener +0x22740b0, listener-ctx ctor +0x22a0670; full write-up in
@@ -620,6 +620,7 @@ static uint64_t apr_submit_common(uint64_t a0, uint64_t a1, uint64_t a2, uint64_
                            (unsigned long long)a0, (unsigned long long)a1,
                            (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)token,
                            bound ? " (bound)" : "", apr_req_eventful(a0) ? " (arg8-async)" : "");
+    if (token_out) *token_out = token;
     if (tag_echo && should_post)
         prosper_eq_post_apr_token(bc.eq, bc.eq_identity, bc.id, bc.tag);
     // Submit consumes the encoded commands. Pathless reuses completed pool buffers without calling
@@ -1787,6 +1788,93 @@ HLE(k_pool_commit) {
     return rc;
 }
 
+
+// The committed sub-ranges of [base, base+len) that THIS FILE recorded, clipped to it.
+//
+// The guard for sceKernelMemoryPoolDecommit, and the reason it is a CLIP rather than a yes/no test
+// is measured. Decommit's hazard runs the opposite way to the rest of this family: its failure mode
+// is unmapping a range the guest did not ask about, which is silent and takes whatever else lived
+// there with it (#3506). So nothing outside prosper's own committed mappings is ever touched.
+//
+// The first version of this asked "is EVERY byte committed?" and refused otherwise. That is the
+// wrong question, and NINJA GAIDEN 4 answered it immediately: it decommits whole 4 MiB pool spans
+// of which only part is committed at the time (`pool_decommit addr=0x1001000000 len=0x400000`
+// against 64 KiB commits), which is ordinary allocator behaviour -- "release this span, whatever is
+// live in it". Refusing produced 8.1 million refusals in a 240 s run as the guest retried. Releasing
+// the committed part and succeeding is both correct and still safe: the clip is what keeps the
+// unmap inside what prosper owns.
+//
+// g_maps is kept in base order by insert_mapping_by_base, so the result comes out in address order.
+std::vector<std::pair<uint64_t, uint64_t>> committed_parts_in(uint64_t base, uint64_t len) {
+    std::vector<std::pair<uint64_t, uint64_t>> parts;
+    if (!len || base > UINT64_MAX - len) return parts;
+    const uint64_t end = base + len;
+    std::lock_guard<std::mutex> lk(g_mx);
+    for (const auto& m : g_maps) {
+        if (!m.committed) continue;
+        const uint64_t lo = m.base > base ? m.base : base;
+        const uint64_t hi = (m.base + m.size) < end ? (m.base + m.size) : end;
+        if (lo < hi) parts.emplace_back(lo, hi - lo);
+    }
+    return parts;
+}
+
+// sceKernelMemoryPoolDecommit(void* addr, size_t len, int flags) -- the fourth member of the pool
+// family, and the one #3502 deliberately left out because no title had reached it yet. NINJA GAIDEN 4
+// (#3500) reaches it now, precisely BECAUSE that fix let it get further (#3506).
+//
+// A family with Commit and no Decommit is worse than a family with neither. The title commits its
+// arena in 64 KiB steps and, unregistered, every release it believes succeeded left the mapping in
+// place -- so its allocator's picture of free memory and prosper's diverge monotonically, and the
+// guest is told "released" about memory it can never get back.
+//
+// THE RISK PROFILE IS INVERTED relative to the rest of this family, and that is what shapes the
+// code. Decommit has no out-parameter, so the hazard that made #3502 probe before implementing --
+// writing through a wrongly positioned argument -- does not apply. The opposite one does: unmapping
+// a range the guest did not name, which is silent and corrupts whatever else lived there. Hence
+// tracked_committed_covers above: nothing is touched unless prosper itself recorded it as a
+// committed mapping.
+//
+// THE RESERVATION SURVIVES. That is the whole point of the reserve/commit split -- releasing the VA
+// would let a later Commit at the same address fail, or worse succeed against a different mapping.
+// On POSIX that needs an explicit PROT_NONE anonymous MAP_FIXED over the range, because munmap
+// releases the VA outright; the replacement is exactly what k_reserve_vrange installs for a fresh
+// reservation, so the range goes back to being reservation-shaped rather than merely empty.
+//
+// CONFIDENCE: HIGH on refusing what is not ours and on keeping the reservation. CONFIDENCE: MED on
+// the argument layout: the 3.20 database gives the name and not the signature, and the (addr, len,
+// flags) shape is the family's and not a capture. a2..a5 are therefore logged and not used, and the
+// log is what settles it -- if a run ever shows a2 carrying something that is not a small flag
+// word, this reading is wrong.
+HLE(k_pool_decommit) {
+    if (!a0 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
+    uint64_t base = 0, len = 0;
+    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
+    if (!len) return 0;
+    uint64_t released = 0;
+    for (const auto& part : committed_parts_in(base, len)) {
+        // Retire any texture write-watch over this VA before the backing disappears, exactly as
+        // k_munmap does -- the pages are about to stop being what the watch believes they are.
+        host::guest_write_watch_notify_direct_mapping_removed(part.first, part.second);
+        void* p = mmap((void*)part.first, part.second, PROT_NONE,
+                       MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (p == MAP_FAILED) {
+            MLOG("pool_decommit [0x%llx,0x%llx) FAILED to re-reserve (errno=%d)\n",
+                 (unsigned long long)part.first,
+                 (unsigned long long)(part.first + part.second), errno);
+            return 0x80020016ull;
+        }
+        untrack(part.first, part.second);
+        track(part.first, part.second, 0, 0, false, "reserved");
+        released += part.second;
+    }
+    MLOG("pool_decommit addr=0x%llx len=0x%llx flags=0x%llx -> released 0x%llx of [0x%llx,0x%llx), "
+         "reservation kept\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)released, (unsigned long long)base, (unsigned long long)(base + len));
+    return 0;
+}
+
 // sceKernelConfiguredFlexibleMemorySize(size_t* sizeOut): the flexible budget this process was
 // CONFIGURED with, as distinct from what remains Available above. FF Tactics (#3498) reads it during
 // startup and raises sceKernelDebugRaiseExceptionOnReleaseMode two calls later when it comes back
@@ -2529,6 +2617,41 @@ HLE(k_apr_cb_set_equeue_320) {   // o67gODLFpls: PS5 3.20 0x20-byte completion c
 // documents that a nonzero value landing in a request's completion record marks the read FAILED
 // (eboot+0x22738a5). That is why the plain variant is a separate entry rather than an alias.
 
+// sceKernelAprSubmitCommandBufferAndGetId(cb, ring_1based) -> id.
+//
+// The THIRD member of the submit family, and the one this file did not have. Same submit as its two
+// siblings; only how the completion token reaches the caller differs -- AndGetResult writes it
+// through two out-parameters, the plain form does not return it at all, and this one returns it in
+// rax. There are therefore no out-parameters to position wrongly, which is the hazard that made
+// #3502 probe before implementing. The token is the same prosper_apr_next_token(ring) value the
+// AndGetResult path already hands out, so the three entry points cannot disagree about which id
+// names a submit.
+//
+// Leaving it unregistered was NOT neutral, and the damage is the SUBMIT rather than the id. The
+// dispatcher's `return 0` skipped ampr_cb_reset, so the command buffer's cursor was never released:
+// the guest's append loop polls GetSize - GetUsed and appends only when the difference is large
+// enough, which is exactly the spin k_ampr_init's comment records parking an IoStore thread. No
+// completion event was posted either. FINAL FANTASY TACTICS - The Ivalice Chronicles (PPSA21783)
+// streams its assets through this entry point (#3498).
+//
+// CONFIDENCE: HIGH on the submit (shared body with both siblings). CONFIDENCE: MED on the arity --
+// the 3.20 database gives this entry point's name and not its signature, so a2..a5 are logged
+// rather than used, on the same reasoning the plain form states for its own discarded pair. If they
+// ever read as consistently valid, aligned guest pointers across a run, this entry has
+// out-parameters after all and this handler is wrong.
+HLE(k_apr_submit_and_get_id) {
+    uint64_t token = 0;
+    const uint64_t rc = apr_submit_common(a0, a1, /*out1=*/0, /*out2=*/0,
+                                          /*write_result_outputs=*/false, &token);
+    if (amprlog())
+        fprintf(stderr, "[amprlog] AprSubmitAndGetId qvMUCyyaCSI cb=0x%llx ring1b=%llu -> id=0x%llx "
+                        "(rc=0x%llx; unused a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx)\n",
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)token,
+                (unsigned long long)rc, (unsigned long long)a2, (unsigned long long)a3,
+                (unsigned long long)a4, (unsigned long long)a5);
+    // A failed submit must not hand back an id the guest would then wait on.
+    return rc == 0 ? token : rc;
+}
 HLE(k_apr_submit) {   // sceKernelAprSubmitCommandBufferAndGetResult (cb, ring_1based, out1, out2)
     return apr_submit_common(a0, a1, a2, a3, /*write_result_outputs=*/true);
 }
@@ -3647,6 +3770,7 @@ void register_kernel_mem_hle() {
     Hle::register_fn("qCSfqDILlns", (HleFn)k_pool_expand,        "sceKernelMemoryPoolExpand");
     Hle::register_fn("pU-QydtGcGY", (HleFn)k_pool_reserve,       "sceKernelMemoryPoolReserve");
     Hle::register_fn("Vzl66WmfLvk", (HleFn)k_pool_commit,        "sceKernelMemoryPoolCommit");
+    Hle::register_fn("LXo1tpFqJGs", (HleFn)k_pool_decommit,      "sceKernelMemoryPoolDecommit");
     Hle::register_fn("n1-v6FgU7MQ", (HleFn)k_configured_flexible, "sceKernelConfiguredFlexibleMemorySize");
     Hle::register_fn("tZ2yplY8MBY", (HleFn)k_pagetable_stats,    "sceKernelGetPageTableStats");
     R("sceKernelAllocateDirectMemory", k_alloc_dmem);
@@ -3718,6 +3842,8 @@ void register_kernel_mem_hle() {
                      "sceKernelAprSubmitCommandBufferAndGetResult");
     Hle::register_fn("eE4Szl8sil8", (HleFn)k_apr_submit_plain,
                      "sceKernelAprSubmitCommandBuffer");
+    Hle::register_fn("qvMUCyyaCSI", (HleFn)k_apr_submit_and_get_id,
+                     "sceKernelAprSubmitCommandBufferAndGetId");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
                      "sceAmprCommandBufferGetCurrentOffset");
     Hle::register_fn("4fgtGfXDrFc", (HleFn)k_ampr_measure_write_address,
@@ -6708,6 +6834,86 @@ HLE(k_pool_commit) {
     return rc;
 }
 
+
+// The committed sub-ranges of [base, base+len) that THIS FILE recorded, clipped to it.
+//
+// The guard for sceKernelMemoryPoolDecommit, and the reason it is a CLIP rather than a yes/no test
+// is measured. Decommit's hazard runs the opposite way to the rest of this family: its failure mode
+// is unmapping a range the guest did not ask about, which is silent and takes whatever else lived
+// there with it (#3506). So nothing outside prosper's own committed mappings is ever touched.
+//
+// The first version of this asked "is EVERY byte committed?" and refused otherwise. That is the
+// wrong question, and NINJA GAIDEN 4 answered it immediately: it decommits whole 4 MiB pool spans
+// of which only part is committed at the time (`pool_decommit addr=0x1001000000 len=0x400000`
+// against 64 KiB commits), which is ordinary allocator behaviour -- "release this span, whatever is
+// live in it". Refusing produced 8.1 million refusals in a 240 s run as the guest retried. Releasing
+// the committed part and succeeding is both correct and still safe: the clip is what keeps the
+// unmap inside what prosper owns.
+//
+// g_maps is kept in base order by insert_mapping_by_base, so the result comes out in address order.
+std::vector<std::pair<uint64_t, uint64_t>> committed_parts_in(uint64_t base, uint64_t len) {
+    std::vector<std::pair<uint64_t, uint64_t>> parts;
+    if (!len || base > UINT64_MAX - len) return parts;
+    const uint64_t end = base + len;
+    std::lock_guard<std::mutex> lk(g_mx);
+    for (const auto& m : g_maps) {
+        if (!m.committed) continue;
+        const uint64_t lo = m.base > base ? m.base : base;
+        const uint64_t hi = (m.base + m.size) < end ? (m.base + m.size) : end;
+        if (lo < hi) parts.emplace_back(lo, hi - lo);
+    }
+    return parts;
+}
+
+// sceKernelMemoryPoolDecommit(void* addr, size_t len, int flags) -- the fourth member of the pool
+// family, and the one #3502 deliberately left out because no title had reached it yet. NINJA GAIDEN 4
+// (#3500) reaches it now, precisely BECAUSE that fix let it get further (#3506).
+//
+// A family with Commit and no Decommit is worse than a family with neither. The title commits its
+// arena in 64 KiB steps and, unregistered, every release it believes succeeded left the mapping in
+// place -- so its allocator's picture of free memory and prosper's diverge monotonically, and the
+// guest is told "released" about memory it can never get back.
+//
+// THE RISK PROFILE IS INVERTED relative to the rest of this family, and that is what shapes the
+// code. Decommit has no out-parameter, so the hazard that made #3502 probe before implementing --
+// writing through a wrongly positioned argument -- does not apply. The opposite one does: unmapping
+// a range the guest did not name, which is silent and corrupts whatever else lived there. Hence
+// tracked_committed_covers above: nothing is touched unless prosper itself recorded it as a
+// committed mapping.
+//
+// THE RESERVATION SURVIVES. That is the whole point of the reserve/commit split -- releasing the VA
+// would let a later Commit at the same address fail, or worse succeed against a different mapping.
+// On POSIX that needs an explicit PROT_NONE anonymous MAP_FIXED over the range, because munmap
+// releases the VA outright; the replacement is exactly what k_reserve_vrange installs for a fresh
+// reservation, so the range goes back to being reservation-shaped rather than merely empty.
+//
+// CONFIDENCE: HIGH on refusing what is not ours and on keeping the reservation. CONFIDENCE: MED on
+// the argument layout: the 3.20 database gives the name and not the signature, and the (addr, len,
+// flags) shape is the family's and not a capture. a2..a5 are therefore logged and not used, and the
+// log is what settles it -- if a run ever shows a2 carrying something that is not a small flag
+// word, this reading is wrong.
+HLE(k_pool_decommit) {
+    if (!a0 || !a1) return 0x80020016ull;                            // SCE_KERNEL_ERROR_EINVAL
+    uint64_t base = 0, len = 0;
+    if (!normalize_guest_page_range(a0, a1, base, len)) return 0x80020016ull;
+    if (!len) return 0;
+    uint64_t released = 0;
+    for (const auto& part : committed_parts_in(base, len)) {
+        // win_unmap restores the Windows PLACEHOLDER it cut the view out of, so the address space
+        // stays claimed here without the explicit re-reservation the POSIX arm needs. Recorded
+        // because the two halves therefore look different while implementing the same contract.
+        if (!win_unmap(part.first, part.second)) return 0x80020016ull;
+        untrack(part.first, part.second);
+        track(part.first, part.second, 0, 0, false, "reserved");
+        released += part.second;
+    }
+    MLOG("pool_decommit addr=0x%llx len=0x%llx flags=0x%llx -> released 0x%llx of [0x%llx,0x%llx), "
+         "placeholder kept\n",
+         (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+         (unsigned long long)released, (unsigned long long)base, (unsigned long long)(base + len));
+    return 0;
+}
+
 // sceKernelConfiguredFlexibleMemorySize(size_t* sizeOut): the flexible budget this process was
 // CONFIGURED with, as distinct from what remains Available above. FF Tactics (#3498) reads it during
 // startup and raises sceKernelDebugRaiseExceptionOnReleaseMode two calls later when it comes back
@@ -7282,6 +7488,41 @@ HLE(k_ampr_append_equeue_legacy) {   // H896Pt-yB4I: legacy eager path keeps zer
 HLE(k_ampr_append_equeue_320) {      // o67gODLFpls: PS5 3.20 0x20-byte completion command
     return apr_cb_set_equeue(0x20, true, a0, a1, a2, a3, a4, a5);
 }
+// sceKernelAprSubmitCommandBufferAndGetId(cb, ring_1based) -> id.
+//
+// The THIRD member of the submit family, and the one this file did not have. Same submit as its two
+// siblings; only how the completion token reaches the caller differs -- AndGetResult writes it
+// through two out-parameters, the plain form does not return it at all, and this one returns it in
+// rax. There are therefore no out-parameters to position wrongly, which is the hazard that made
+// #3502 probe before implementing. The token is the same prosper_apr_next_token(ring) value the
+// AndGetResult path already hands out, so the three entry points cannot disagree about which id
+// names a submit.
+//
+// Leaving it unregistered was NOT neutral, and the damage is the SUBMIT rather than the id. The
+// dispatcher's `return 0` skipped ampr_cb_reset, so the command buffer's cursor was never released:
+// the guest's append loop polls GetSize - GetUsed and appends only when the difference is large
+// enough, which is exactly the spin k_ampr_init's comment records parking an IoStore thread. No
+// completion event was posted either. FINAL FANTASY TACTICS - The Ivalice Chronicles (PPSA21783)
+// streams its assets through this entry point (#3498).
+//
+// CONFIDENCE: HIGH on the submit (shared body with both siblings). CONFIDENCE: MED on the arity --
+// the 3.20 database gives this entry point's name and not its signature, so a2..a5 are logged
+// rather than used, on the same reasoning the plain form states for its own discarded pair. If they
+// ever read as consistently valid, aligned guest pointers across a run, this entry has
+// out-parameters after all and this handler is wrong.
+HLE(k_ampr_submit_and_get_id) {
+    uint64_t token = 0;
+    const uint64_t rc = apr_submit_common(a0, a1, /*out1=*/0, /*out2=*/0,
+                                          /*write_result_outputs=*/false, &token);
+    if (amprlog())
+        fprintf(stderr, "[amprlog] AprSubmitAndGetId qvMUCyyaCSI cb=0x%llx ring1b=%llu -> id=0x%llx "
+                        "(rc=0x%llx; unused a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx)\n",
+                (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)token,
+                (unsigned long long)rc, (unsigned long long)a2, (unsigned long long)a3,
+                (unsigned long long)a4, (unsigned long long)a5);
+    // A failed submit must not hand back an id the guest would then wait on.
+    return rc == 0 ? token : rc;
+}
 HLE(k_ampr_submit) {                 // ASoW5WE-UPo: …AndGetResult — writes the result slots
     return apr_submit_common(a0, a1, a2, a3, /*write_result_outputs=*/true);
 }
@@ -7628,6 +7869,7 @@ void register_kernel_mem_hle() {
     Hle::register_fn("qCSfqDILlns", (HleFn)k_pool_expand,        "sceKernelMemoryPoolExpand");
     Hle::register_fn("pU-QydtGcGY", (HleFn)k_pool_reserve,       "sceKernelMemoryPoolReserve");
     Hle::register_fn("Vzl66WmfLvk", (HleFn)k_pool_commit,        "sceKernelMemoryPoolCommit");
+    Hle::register_fn("LXo1tpFqJGs", (HleFn)k_pool_decommit,      "sceKernelMemoryPoolDecommit");
     Hle::register_fn("n1-v6FgU7MQ", (HleFn)k_configured_flexible, "sceKernelConfiguredFlexibleMemorySize");
     Hle::register_fn("tZ2yplY8MBY", (HleFn)k_pagetable_stats,    "sceKernelGetPageTableStats");
     R("sceKernelAllocateDirectMemory", k_alloc_dmem);
@@ -7682,6 +7924,8 @@ void register_kernel_mem_hle() {
     // publishing a token. Pre-existing, not widened by this change, and tracked as #1657.
     // The _TEST-suffixed NIDs are deliberately left unimplemented — see the POSIX block for why.
     Hle::register_fn("eE4Szl8sil8", (HleFn)k_ampr_submit_plain, "sceKernelAprSubmitCommandBuffer");
+    Hle::register_fn("qvMUCyyaCSI", (HleFn)k_ampr_submit_and_get_id,
+                     "sceKernelAprSubmitCommandBufferAndGetId");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
                      "sceAmprCommandBufferGetCurrentOffset");
     Hle::register_fn("4fgtGfXDrFc", (HleFn)k_ampr_measure_write_address,

--- a/prosper/src/host/fault/AGENTS.md
+++ b/prosper/src/host/fault/AGENTS.md
@@ -49,3 +49,30 @@ the prologue is skipped silently, and a chain can therefore be missing a level r
 wrong. Every link is checkable, though, and cheaply — a return address must point immediately after
 a `call` to the frame below it, so one `objdump` at the named site confirms or kills a link. Confirm
 the links you are going to reason from; do not publish a chain you have only read.
+
+## The two recoverers, and why there are two
+
+`rbp_chain.hpp` and `guest_stack_scan.hpp` answer the same question — *which guest code called this?*
+— by opposite methods, and both are here because **which one works is a property of how the TITLE was
+compiled, not something the host can know.**
+
+- `rbp_chain.hpp` follows saved-`rbp` links. Precise, and **often empty** on an optimised title:
+  FINAL FANTASY TACTICS' fatal raise recovers exactly one frame, the module entry point, because
+  every guest frame between omitted its prologue.
+- `guest_stack_scan.hpp` scans the stack instead, so it does not depend on frame pointers at all. A
+  return address pushed by `call` is on the stack either way. It pays for that with false positives,
+  which it removes by **confirming a `call` instruction ends immediately before each candidate**.
+
+A caller that needs an answer should ask both and print both, rather than choosing — a short chain
+and a shallow stack look identical, so "the chain returned one frame" is not evidence about the
+stack.
+
+`guest_caller.hpp` is the other half of the same story: the `PROSPER_CAPTURE_RBP` / `_RSP` macros
+that snapshot an HLE handler's entry registers. They are macros rather than functions on purpose —
+a function would capture its OWN frame, one level too deep, and a build that inlined it would change
+the answer silently.
+
+**Both recoverers take the caller's `readable` probe as a parameter and dereference nothing without
+it.** That is not defensive style here: these run on paths that are already terminating the process,
+where a nested SIGSEGV would replace the diagnostic with a confusing fault report about the
+diagnostic itself.

--- a/prosper/src/host/fault/guest_caller.hpp
+++ b/prosper/src/host/fault/guest_caller.hpp
@@ -1,0 +1,34 @@
+// guest_caller.hpp — capture the frame pointer an HLE handler was entered with.
+//
+// An HLE handler is called by the guest through a synthesized import stub, so "who called me?" is a
+// question about the GUEST's stack, not the host's. The one register that survives that boundary
+// intact is `rbp`: it is callee-saved in SysV, and neither the plain tail-jump stub nor the guest-%fs
+// swap stub writes it (host/image/exec_image_linux.cpp). Capturing it as the handler's first act is
+// therefore enough to reach the guest's frame chain, whether or not this handler kept a frame
+// pointer of its own -- see guest_frames_from_rbp in host/image/exec_image.hpp, which explains why
+// both cases resolve to the same walk.
+//
+// Why a macro rather than a function: a function would capture ITS OWN rbp, one frame too deep, and
+// on a build that inlined it the answer would silently change. The macro expands in the handler's
+// frame and cannot drift.
+//
+// Use it for diagnosis, not control flow. The walk it feeds is a frame-pointer chain over optimised
+// guest code, which can skip a level without saying so.
+#pragma once
+#include <cstdint>
+
+#if defined(__x86_64__) || defined(_M_X64)
+#define PROSPER_CAPTURE_RBP(var)                                                                   \
+    uint64_t var = 0;                                                                              \
+    __asm__ volatile("movq %%rbp, %0" : "=r"(var))
+// The stack pointer, for the scan-based sibling (guest_frames_on_stack). Captured the same way and
+// for the same reason: taken any later, the handler's own frame has already moved it.
+#define PROSPER_CAPTURE_RSP(var)                                                                   \
+    uint64_t var = 0;                                                                              \
+    __asm__ volatile("movq %%rsp, %0" : "=r"(var))
+#else
+// Non-x86-64 hosts do not run guest code at all today; keep the call sites compiling and let the
+// zero seed produce an empty chain, which callers must already handle.
+#define PROSPER_CAPTURE_RBP(var) uint64_t var = 0
+#define PROSPER_CAPTURE_RSP(var) uint64_t var = 0
+#endif

--- a/prosper/src/host/fault/guest_stack_scan.hpp
+++ b/prosper/src/host/fault/guest_stack_scan.hpp
@@ -1,0 +1,85 @@
+// guest_stack_scan.hpp — recover guest return addresses by SCANNING a stack, for code compiled
+// without frame pointers.
+//
+// The sibling of rbp_chain.hpp, and the reason both exist is that which one works is a property of
+// how the GUEST was compiled, not something the host can know. A chain walk is precise and is often
+// EMPTY on an optimised title — FINAL FANTASY TACTICS' fatal raise recovers exactly one frame, the
+// module entry point, because every guest frame between omitted its prologue. A scan has no such
+// dependency: a return address pushed by `call` is on the stack whether or not the callee kept a
+// frame pointer.
+//
+// The cost of a scan is false positives, so each candidate is CONFIRMED at the call site: a real
+// return address has a `call` instruction ending immediately before it. A stale value left in a dead
+// stack slot almost never satisfies that, which is what makes the output readable rather than a wall
+// of plausible-looking numbers. What it still cannot do is tell a live frame from a dead one that
+// happens to validate, so the result is stack order, not proven call order.
+//
+// This lives in one header rather than once per platform because the two platforms differ only in
+// their `readable` probe. An earlier revision had a copy in each `exec_image_*.cpp`, which is
+// exactly the divergence host/fault/ exists to prevent — and the claim that they "cannot drift" was
+// made in a PR while two copies were in the diff.
+//
+// Every dereference is behind the caller's probe. That is not defensive style: this runs on paths
+// that are already terminating the process, where a nested SIGSEGV would replace the diagnostic with
+// a confusing fault report about the diagnostic itself.
+#pragma once
+#include <cstdint>
+
+namespace prosper::host {
+
+// Does a `call` instruction end at `ret`? A return address is always the byte after the call that
+// pushed it, so this is the strongest cheap test that a stack word is a real frame and not residue.
+//
+// Encodings accepted, both forms a compiler emits for a direct or indirect call:
+//   E8 rel32                      -- 5 bytes, `call rel32`
+//   FF /2 with any ModRM/SIB/disp -- `call r/m64`, 2 to 7 bytes, optionally REX-prefixed
+// The `FF` search admits a byte sequence that merely looks like one; `E8` is near-conclusive. Both
+// are far better than accepting every readable guest address, which is the alternative.
+//
+// PROBE COVERAGE IS THE SUBTLE PART. `readable(a)` answers for `[a, a+8)` on the POSIX probe, so
+// probing only `ret - 16` would validate `[ret-16, ret-8)` while the bytes actually read are
+// `[ret-7, ret)` -- two windows that do not overlap at all. A page boundary landing between them
+// (`ret % 4096` in the low single digits) would then fault on a read the guard believed it had
+// covered. The module filter cannot save it either: guest_module_name classifies by fixed aperture,
+// so an unmapped address inside a module's range is still labelled with that module. Probe all
+// three of `ret-16`, `ret-8` and `ret-1` so the union covers every byte read below.
+inline bool call_precedes(uint64_t ret, bool (*readable)(uint64_t)) {
+    if (ret < 16 || !readable) return false;
+    if (!readable(ret - 16) || !readable(ret - 8) || !readable(ret - 1)) return false;
+    const uint8_t* p = (const uint8_t*)(uintptr_t)ret;
+    if (p[-5] == 0xE8) return true;                     // call rel32
+    for (int len = 2; len <= 7; ++len) {
+        const uint8_t* c = p - len;
+        int i = 0;
+        if ((c[0] & 0xF0) == 0x40) i = 1;               // REX prefix
+        if (c[i] != 0xFF) continue;
+        if (i + 1 >= len) continue;
+        if (((c[i + 1] >> 3) & 0x7) == 2) return true;  // /2 == call r/m
+    }
+    return false;
+}
+
+// Scan [rsp_seed, limit) for call-site-validated return addresses that `keep` accepts, newest first.
+//
+// The walk STOPS at the first unreadable slot rather than skipping it: running off the mapped stack
+// is a fact about the stack, and continuing past it would report frames from unrelated memory.
+// Returns how many addresses were written.
+inline int scan_stack_for_returns(uint64_t rsp_seed, uint64_t limit, uint64_t* out, int max,
+                                  bool (*readable)(uint64_t), bool (*keep)(uint64_t)) {
+    if (!out || max <= 0 || !readable || !keep || rsp_seed <= 0x10000) return 0;
+    int kept = 0;
+    for (uint64_t a = rsp_seed & ~7ull; a + 8 <= limit && kept < max; a += 8) {
+        if (!readable(a)) break;
+        const uint64_t candidate = *(const uint64_t*)(uintptr_t)a;
+        if (candidate <= 0x10000) continue;
+        if (!keep(candidate)) continue;
+        if (!call_precedes(candidate, readable)) continue;
+        bool duplicate = false;
+        for (int j = 0; j < kept; ++j) duplicate |= out[j] == candidate;
+        if (duplicate) continue;
+        out[kept++] = candidate;
+    }
+    return kept;
+}
+
+}  // namespace prosper::host

--- a/prosper/src/host/image/exec_image.hpp
+++ b/prosper/src/host/image/exec_image.hpp
@@ -86,6 +86,43 @@ struct BootResult {
 // the half that decides whether a fault is the title's bug or ours.
 std::string describe_code_address(uint64_t address);
 
+// Name the GUEST frames on the calling thread's stack, for a handler that must say WHO called it.
+//
+// `rbp_seed` is the frame-pointer value captured by PROSPER_CAPTURE_RBP at the top of the calling
+// HLE handler (host/fault/guest_caller.hpp). Both possible values work and neither needs to be
+// distinguished: with a frame pointer, rbp is the handler's own frame whose saved-rbp slot links to
+// the guest's; without one, rbp still HOLDS the guest's, because rbp is callee-saved and no import
+// stub writes it. Host frames encountered on the way are readable and increasing, so the walk
+// crosses them; they are then dropped by the guest-module filter rather than being reported as
+// guest code.
+//
+// Writes up to `max` GUEST return addresses into `out`, newest first, and returns how many. A
+// return of 0 means no guest frame was recoverable -- report that as such, never as "no caller":
+// this is a frame-pointer walk, and a caller compiled without a prologue is skipped silently
+// (instrument traps 114 and 217). It is a lead to confirm by disassembling the named call site,
+// not an authority.
+int guest_frames_from_rbp(uint64_t rbp_seed, uint64_t* out, int max);
+
+// The same question asked without frame pointers: SCAN the calling thread's stack for guest return
+// addresses instead of following a chain.
+//
+// This exists because the chain walk above is not merely incomplete on optimised titles, it is
+// often EMPTY -- FINAL FANTASY TACTICS' fatal raise recovers exactly one frame, the module entry
+// point, because every guest frame between omitted its prologue. A scan has no such dependency: a
+// return address pushed by `call` is on the stack whether or not the callee kept a frame pointer.
+//
+// The cost of a scan is false positives, so each candidate is CONFIRMED at the call site: a real
+// return address has a `call` instruction ending immediately before it, and the encodings are
+// checked here (`call rel32` and the register/memory-indirect forms). A stale value left in a dead
+// stack slot almost never satisfies that, which is what makes the output readable rather than a wall
+// of plausible-looking numbers. Order is stack order -- innermost first -- not a proven call order:
+// a scan cannot tell a live frame from a dead one that still validates.
+//
+// `rsp_seed` is the stack pointer captured by PROSPER_CAPTURE_RSP at the top of the calling handler.
+// Scanning is bounded by the guest thread's registered stack when one is known, and by a fixed
+// window otherwise. Returns how many addresses were written.
+int guest_frames_on_stack(uint64_t rsp_seed, uint64_t* out, int max);
+
 // Register the stack a guest thread runs on (main thread + workers we spawn), keyed by
 // its pthread id, so GC/thread code gets accurate bounds without pthread_getattr_np.
 void register_thread_stack(uint64_t tid, void* base, uint64_t size);

--- a/prosper/src/host/image/exec_image_linux.cpp
+++ b/prosper/src/host/image/exec_image_linux.cpp
@@ -18,6 +18,7 @@
 #include "host/platform/posix_shim.hpp"
 #include "host/fault/fault_context.hpp"   // #2018: one fault's own registers, snapshotted from ITS ucontext
 #include "host/fault/rbp_chain.hpp"      // PROSPER_HWBP_STACK: who called this breakpoint
+#include "host/fault/guest_stack_scan.hpp"   // the scan-based sibling, shared by both platforms
 #include <sys/mman.h>
 #include <signal.h>
 #include <setjmp.h>
@@ -3729,28 +3730,14 @@ std::string describe_code_address(uint64_t address) {
 }
 
 namespace {
-// Does a `call` instruction end at `ret`? A return address is always the byte after the call that
-// pushed it, so this is the strongest cheap test that a stack word is a real frame and not residue.
-//
-// Encodings accepted, all the forms a compiler emits for a direct or indirect call:
-//   E8 rel32                    -- 5 bytes, `call rel32`
-//   FF /2 with any ModRM/SIB/disp -- `call r/m64`, 2 to 7 bytes, optionally REX-prefixed
-// The FF forms are matched by looking for FF at each plausible start with reg field 2, which admits
-// a byte sequence that merely looks like one; the E8 form is near-conclusive. Both are far better
-// than accepting every readable guest address, which is the alternative.
-bool call_precedes(uint64_t ret, bool (*readable)(uint64_t)) {
-    if (ret < 16 || !readable(ret - 16)) return false;
-    const uint8_t* p = (const uint8_t*)(uintptr_t)ret;
-    if (p[-5] == 0xE8) return true;                     // call rel32
-    for (int len = 2; len <= 7; ++len) {
-        const uint8_t* c = p - len;
-        int i = 0;
-        if ((c[0] & 0xF0) == 0x40) i = 1;               // REX prefix
-        if (c[i] != 0xFF) continue;
-        if (i + 1 >= len) continue;
-        if (((c[i + 1] >> 3) & 0x7) == 2) return true;  // /2 == call r/m
-    }
-    return false;
+// The guest-code filter both recoverers share. guest_module_name is the same classifier
+// describe_code_address uses, so a frame reported here and a frame in a fault backtrace can never
+// disagree about what is guest code. STUB addresses are dropped too: an import stub is prosper's own
+// synthesized trampoline, and naming it as the caller answers the question with the mechanism
+// instead of the call site.
+bool is_guest_call_site(uint64_t a) {
+    const char* module = prosper::guest_module_name(a);
+    return std::strcmp(module, "mapped/host") != 0 && std::strcmp(module, "STUB") != 0;
 }
 }  // namespace
 
@@ -3769,21 +3756,8 @@ int guest_frames_on_stack(uint64_t rsp_seed, uint64_t* out, int max) {
         const uint64_t top = (uint64_t)(uintptr_t)stack_base + stack_size;
         if (top > rsp_seed && top < limit) limit = top;
     }
-    int kept = 0;
-    for (uint64_t a = rsp_seed & ~7ull; a + 8 <= limit && kept < max; a += 8) {
-        if (!probe_readable(a)) break;   // ran off the mapped stack: stop, do not skip
-        const uint64_t candidate = *(const uint64_t*)(uintptr_t)a;
-        if (candidate <= 0x10000) continue;
-        const char* module = prosper::guest_module_name(candidate);
-        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
-        if (!probe_readable(candidate - 16)) continue;
-        if (!call_precedes(candidate, &probe_readable)) continue;
-        bool duplicate = false;
-        for (int j = 0; j < kept; ++j) duplicate |= out[j] == candidate;
-        if (duplicate) continue;
-        out[kept++] = candidate;
-    }
-    return kept;
+    return prosper::host::scan_stack_for_returns(rsp_seed, limit, out, max,
+                                                 &probe_readable, &is_guest_call_site);
 }
 
 int guest_frames_from_rbp(uint64_t rbp_seed, uint64_t* out, int max) {
@@ -3801,12 +3775,7 @@ int guest_frames_from_rbp(uint64_t rbp_seed, uint64_t* out, int max) {
                                                      cap > 64 ? 64 : cap, &probe_readable);
     int kept = 0;
     for (int i = 0; i < walked && kept < max; ++i) {
-        // guest_module_name is the same classifier describe_code_address uses, so a frame reported
-        // here and a frame reported in a fault backtrace can never disagree about what is guest code.
-        // STUB addresses are dropped too: an import stub is prosper's own synthesized trampoline, and
-        // naming it as the caller answers the question with the mechanism instead of the call site.
-        const char* module = prosper::guest_module_name(frames[i]);
-        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
+        if (!is_guest_call_site(frames[i])) continue;
         bool duplicate = false;
         for (int j = 0; j < kept; ++j) duplicate |= out[j] == frames[i];
         if (duplicate) continue;

--- a/prosper/src/host/image/exec_image_linux.cpp
+++ b/prosper/src/host/image/exec_image_linux.cpp
@@ -3728,6 +3728,93 @@ std::string describe_code_address(uint64_t address) {
     return text;
 }
 
+namespace {
+// Does a `call` instruction end at `ret`? A return address is always the byte after the call that
+// pushed it, so this is the strongest cheap test that a stack word is a real frame and not residue.
+//
+// Encodings accepted, all the forms a compiler emits for a direct or indirect call:
+//   E8 rel32                    -- 5 bytes, `call rel32`
+//   FF /2 with any ModRM/SIB/disp -- `call r/m64`, 2 to 7 bytes, optionally REX-prefixed
+// The FF forms are matched by looking for FF at each plausible start with reg field 2, which admits
+// a byte sequence that merely looks like one; the E8 form is near-conclusive. Both are far better
+// than accepting every readable guest address, which is the alternative.
+bool call_precedes(uint64_t ret, bool (*readable)(uint64_t)) {
+    if (ret < 16 || !readable(ret - 16)) return false;
+    const uint8_t* p = (const uint8_t*)(uintptr_t)ret;
+    if (p[-5] == 0xE8) return true;                     // call rel32
+    for (int len = 2; len <= 7; ++len) {
+        const uint8_t* c = p - len;
+        int i = 0;
+        if ((c[0] & 0xF0) == 0x40) i = 1;               // REX prefix
+        if (c[i] != 0xFF) continue;
+        if (i + 1 >= len) continue;
+        if (((c[i + 1] >> 3) & 0x7) == 2) return true;  // /2 == call r/m
+    }
+    return false;
+}
+}  // namespace
+
+int guest_frames_on_stack(uint64_t rsp_seed, uint64_t* out, int max) {
+    if (!out || max <= 0 || rsp_seed <= 0x10000) return 0;
+    ensure_probe_pipe();
+    // Bound the scan by the guest thread's own registered stack when it has one, so the walk stops
+    // at the real top rather than at an arbitrary window. Without a registration -- the main thread
+    // before it is registered, or a thread the guest created behind our back -- fall back to a fixed
+    // window, which is why the cap is applied in both branches.
+    constexpr uint64_t kWindow = 64 * 1024;
+    uint64_t limit = rsp_seed + kWindow;
+    void* stack_base = nullptr;
+    size_t stack_size = 0;
+    if (guest_stack_for_current_thread(&stack_base, &stack_size) && stack_size) {
+        const uint64_t top = (uint64_t)(uintptr_t)stack_base + stack_size;
+        if (top > rsp_seed && top < limit) limit = top;
+    }
+    int kept = 0;
+    for (uint64_t a = rsp_seed & ~7ull; a + 8 <= limit && kept < max; a += 8) {
+        if (!probe_readable(a)) break;   // ran off the mapped stack: stop, do not skip
+        const uint64_t candidate = *(const uint64_t*)(uintptr_t)a;
+        if (candidate <= 0x10000) continue;
+        const char* module = prosper::guest_module_name(candidate);
+        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
+        if (!probe_readable(candidate - 16)) continue;
+        if (!call_precedes(candidate, &probe_readable)) continue;
+        bool duplicate = false;
+        for (int j = 0; j < kept; ++j) duplicate |= out[j] == candidate;
+        if (duplicate) continue;
+        out[kept++] = candidate;
+    }
+    return kept;
+}
+
+int guest_frames_from_rbp(uint64_t rbp_seed, uint64_t* out, int max) {
+    if (!out || max <= 0 || rbp_seed <= 0x10000) return 0;
+    // The probe pipe is created lazily by the fault-handler install path, and a handler asking who
+    // called it may run before that. Creating it here is safe -- ensure_probe_pipe is a magic static
+    // and this is an ordinary handler thread, not a signal context.
+    ensure_probe_pipe();
+    // Walk deeper than the caller asked: host frames between the handler and the guest are dropped
+    // by the filter below, and a chain that started inside prosper would otherwise spend the whole
+    // budget before reaching guest code.
+    uint64_t frames[64];
+    const int cap = max < 64 ? max * 4 : 64;
+    const int walked = prosper::host::walk_rbp_chain(rbp_seed, frames,
+                                                     cap > 64 ? 64 : cap, &probe_readable);
+    int kept = 0;
+    for (int i = 0; i < walked && kept < max; ++i) {
+        // guest_module_name is the same classifier describe_code_address uses, so a frame reported
+        // here and a frame reported in a fault backtrace can never disagree about what is guest code.
+        // STUB addresses are dropped too: an import stub is prosper's own synthesized trampoline, and
+        // naming it as the caller answers the question with the mechanism instead of the call site.
+        const char* module = prosper::guest_module_name(frames[i]);
+        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
+        bool duplicate = false;
+        for (int j = 0; j < kept; ++j) duplicate |= out[j] == frames[i];
+        if (duplicate) continue;
+        out[kept++] = frames[i];
+    }
+    return kept;
+}
+
 bool exec_image_statics_destroyed() {   // #2613, see the canary at the top of this file
     return g_exec_image_statics_destroyed.load(std::memory_order_acquire);
 }

--- a/prosper/src/host/image/exec_image_win.cpp
+++ b/prosper/src/host/image/exec_image_win.cpp
@@ -19,6 +19,7 @@
 
 #include "host/image/exec_image.hpp"
 #include "host/fault/rbp_chain.hpp"   // guest_frames_from_rbp: the shared frame-pointer walk
+#include "host/fault/guest_stack_scan.hpp"   // the scan-based sibling, shared by both platforms
 #include "host/platform/immortal.hpp"   // #2613: registries a guest thread can reach after exit()
 #include "host/memory/guest_write_watch.hpp"
 #include "host/x86/sse4a.hpp"
@@ -1359,34 +1360,20 @@ uint64_t invoke_stub(uint64_t idx) {
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 namespace {
-// Does a `call` instruction end at `ret`? A return address is always the byte after the call that
-// pushed it, so this is the strongest cheap test that a stack word is a real frame and not residue.
-//
-// Encodings accepted, all the forms a compiler emits for a direct or indirect call:
-//   E8 rel32                    -- 5 bytes, `call rel32`
-//   FF /2 with any ModRM/SIB/disp -- `call r/m64`, 2 to 7 bytes, optionally REX-prefixed
-// The FF forms are matched by looking for FF at each plausible start with reg field 2, which admits
-// a byte sequence that merely looks like one; the E8 form is near-conclusive. Both are far better
-// than accepting every readable guest address, which is the alternative.
-bool call_precedes(uint64_t ret, bool (*readable)(uint64_t)) {
-    if (ret < 16 || !readable(ret - 16)) return false;
-    const uint8_t* p = (const uint8_t*)(uintptr_t)ret;
-    if (p[-5] == 0xE8) return true;                     // call rel32
-    for (int len = 2; len <= 7; ++len) {
-        const uint8_t* c = p - len;
-        int i = 0;
-        if ((c[0] & 0xF0) == 0x40) i = 1;               // REX prefix
-        if (c[i] != 0xFF) continue;
-        if (i + 1 >= len) continue;
-        if (((c[i + 1] >> 3) & 0x7) == 2) return true;  // /2 == call r/m
-    }
-    return false;
+// The guest-code filter both recoverers share. guest_module_name is the same classifier
+// describe_code_address uses, so a frame reported here and a frame in a fault backtrace can never
+// disagree about what is guest code. STUB addresses are dropped too: an import stub is prosper's own
+// synthesized trampoline, and naming it as the caller answers the question with the mechanism
+// instead of the call site.
+bool is_guest_call_site(uint64_t a) {
+    const char* module = prosper::guest_module_name(a);
+    return std::strcmp(module, "mapped/host") != 0 && std::strcmp(module, "STUB") != 0;
 }
 }  // namespace
 
 int guest_frames_on_stack(uint64_t rsp_seed, uint64_t* out, int max) {
     if (!out || max <= 0 || rsp_seed <= 0x10000) return 0;
-    
+
     // Bound the scan by the guest thread's own registered stack when it has one, so the walk stops
     // at the real top rather than at an arbitrary window. Without a registration -- the main thread
     // before it is registered, or a thread the guest created behind our back -- fall back to a fixed
@@ -1399,21 +1386,8 @@ int guest_frames_on_stack(uint64_t rsp_seed, uint64_t* out, int max) {
         const uint64_t top = (uint64_t)(uintptr_t)stack_base + stack_size;
         if (top > rsp_seed && top < limit) limit = top;
     }
-    int kept = 0;
-    for (uint64_t a = rsp_seed & ~7ull; a + 8 <= limit && kept < max; a += 8) {
-        if (!addr_readable(a)) break;   // ran off the mapped stack: stop, do not skip
-        const uint64_t candidate = *(const uint64_t*)(uintptr_t)a;
-        if (candidate <= 0x10000) continue;
-        const char* module = prosper::guest_module_name(candidate);
-        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
-        if (!addr_readable(candidate - 16)) continue;
-        if (!call_precedes(candidate, &addr_readable)) continue;
-        bool duplicate = false;
-        for (int j = 0; j < kept; ++j) duplicate |= out[j] == candidate;
-        if (duplicate) continue;
-        out[kept++] = candidate;
-    }
-    return kept;
+    return prosper::host::scan_stack_for_returns(rsp_seed, limit, out, max,
+                                                 &addr_readable, &is_guest_call_site);
 }
 
 int guest_frames_from_rbp(uint64_t rbp_seed, uint64_t* out, int max) {
@@ -1427,8 +1401,7 @@ int guest_frames_from_rbp(uint64_t rbp_seed, uint64_t* out, int max) {
                                                      cap > 64 ? 64 : cap, &addr_readable);
     int kept = 0;
     for (int i = 0; i < walked && kept < max; ++i) {
-        const char* module = prosper::guest_module_name(frames[i]);
-        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
+        if (!is_guest_call_site(frames[i])) continue;
         bool duplicate = false;
         for (int j = 0; j < kept; ++j) duplicate |= out[j] == frames[i];
         if (duplicate) continue;

--- a/prosper/src/host/image/exec_image_win.cpp
+++ b/prosper/src/host/image/exec_image_win.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "host/image/exec_image.hpp"
+#include "host/fault/rbp_chain.hpp"   // guest_frames_from_rbp: the shared frame-pointer walk
 #include "host/platform/immortal.hpp"   // #2613: registries a guest thread can reach after exit()
 #include "host/memory/guest_write_watch.hpp"
 #include "host/x86/sse4a.hpp"
@@ -1356,6 +1357,85 @@ uint64_t invoke_stub(uint64_t idx) {
 
 // MinGW/MSVC both provide the linker-synthesised image base, so this needs no psapi dependency.
 extern "C" IMAGE_DOS_HEADER __ImageBase;
+
+namespace {
+// Does a `call` instruction end at `ret`? A return address is always the byte after the call that
+// pushed it, so this is the strongest cheap test that a stack word is a real frame and not residue.
+//
+// Encodings accepted, all the forms a compiler emits for a direct or indirect call:
+//   E8 rel32                    -- 5 bytes, `call rel32`
+//   FF /2 with any ModRM/SIB/disp -- `call r/m64`, 2 to 7 bytes, optionally REX-prefixed
+// The FF forms are matched by looking for FF at each plausible start with reg field 2, which admits
+// a byte sequence that merely looks like one; the E8 form is near-conclusive. Both are far better
+// than accepting every readable guest address, which is the alternative.
+bool call_precedes(uint64_t ret, bool (*readable)(uint64_t)) {
+    if (ret < 16 || !readable(ret - 16)) return false;
+    const uint8_t* p = (const uint8_t*)(uintptr_t)ret;
+    if (p[-5] == 0xE8) return true;                     // call rel32
+    for (int len = 2; len <= 7; ++len) {
+        const uint8_t* c = p - len;
+        int i = 0;
+        if ((c[0] & 0xF0) == 0x40) i = 1;               // REX prefix
+        if (c[i] != 0xFF) continue;
+        if (i + 1 >= len) continue;
+        if (((c[i + 1] >> 3) & 0x7) == 2) return true;  // /2 == call r/m
+    }
+    return false;
+}
+}  // namespace
+
+int guest_frames_on_stack(uint64_t rsp_seed, uint64_t* out, int max) {
+    if (!out || max <= 0 || rsp_seed <= 0x10000) return 0;
+    
+    // Bound the scan by the guest thread's own registered stack when it has one, so the walk stops
+    // at the real top rather than at an arbitrary window. Without a registration -- the main thread
+    // before it is registered, or a thread the guest created behind our back -- fall back to a fixed
+    // window, which is why the cap is applied in both branches.
+    constexpr uint64_t kWindow = 64 * 1024;
+    uint64_t limit = rsp_seed + kWindow;
+    void* stack_base = nullptr;
+    size_t stack_size = 0;
+    if (guest_stack_for_current_thread(&stack_base, &stack_size) && stack_size) {
+        const uint64_t top = (uint64_t)(uintptr_t)stack_base + stack_size;
+        if (top > rsp_seed && top < limit) limit = top;
+    }
+    int kept = 0;
+    for (uint64_t a = rsp_seed & ~7ull; a + 8 <= limit && kept < max; a += 8) {
+        if (!addr_readable(a)) break;   // ran off the mapped stack: stop, do not skip
+        const uint64_t candidate = *(const uint64_t*)(uintptr_t)a;
+        if (candidate <= 0x10000) continue;
+        const char* module = prosper::guest_module_name(candidate);
+        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
+        if (!addr_readable(candidate - 16)) continue;
+        if (!call_precedes(candidate, &addr_readable)) continue;
+        bool duplicate = false;
+        for (int j = 0; j < kept; ++j) duplicate |= out[j] == candidate;
+        if (duplicate) continue;
+        out[kept++] = candidate;
+    }
+    return kept;
+}
+
+int guest_frames_from_rbp(uint64_t rbp_seed, uint64_t* out, int max) {
+    if (!out || max <= 0 || rbp_seed <= 0x10000) return 0;
+    // Sibling of the Linux implementation; same walker, same classifier, different readable probe
+    // (VirtualQuery here, a pipe write there). Keeping both on host/fault/rbp_chain.hpp is what stops
+    // the two platforms' answers to "who called this?" from drifting.
+    uint64_t frames[64];
+    const int cap = max < 64 ? max * 4 : 64;
+    const int walked = prosper::host::walk_rbp_chain(rbp_seed, frames,
+                                                     cap > 64 ? 64 : cap, &addr_readable);
+    int kept = 0;
+    for (int i = 0; i < walked && kept < max; ++i) {
+        const char* module = prosper::guest_module_name(frames[i]);
+        if (std::strcmp(module, "mapped/host") == 0 || std::strcmp(module, "STUB") == 0) continue;
+        bool duplicate = false;
+        for (int j = 0; j < kept; ++j) duplicate |= out[j] == frames[i];
+        if (duplicate) continue;
+        out[kept++] = frames[i];
+    }
+    return kept;
+}
 
 std::string describe_code_address(uint64_t address) {
     char text[160];

--- a/prosper/tests/hle/memory/test_mprotect_unaligned.cpp
+++ b/prosper/tests/hle/memory/test_mprotect_unaligned.cpp
@@ -1,0 +1,130 @@
+// sceKernelMprotect must accept a range that is not guest-page aligned (#3498).
+//
+// Protection is page-granular on every platform prosper targets, so a sub-page request can only
+// mean "the pages containing this span". prosper's own sceKernelMtypeprotect has always read it
+// that way; sceKernelMprotect did not, and passed the guest's address to the host verbatim -- where
+// mprotect(2) rejects an unaligned base with EINVAL.
+//
+// The evidence that the console rounds is a shipping title. FINAL FANTASY TACTICS - The Ivalice
+// Chronicles (PPSA21783) calls sceKernelMprotect(eboot+0xf999e0, 0x1da20, 0xc3) during allocator
+// init. Refused, it returns -1 up four frames, its framework constructor yields NULL, main()
+// returns, and the CRT raises sceKernelDebugRaiseExceptionOnReleaseMode(0xa0020001) about a second
+// into the boot. The title runs on hardware, so the hardware accepted that call.
+//
+// WHY THE ARMS ARE SHAPED THIS WAY. "Returns 0" is not the property under test -- `return 0;`
+// satisfies it, and so does any implementation that answers success without protecting anything.
+// What is asserted is that the PAGES CHANGED, read back from the kernel's own view in
+// /proc/self/maps, and that the pages OUTSIDE the normalized span did NOT. Those two together
+// separate the fix from both trivial mutations: answering blind, and widening to the whole mapping.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#if defined(__linux__) || defined(__APPLE__)
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+constexpr uint64_t kGuestPage = 0x4000ull;      // the PS5's 16 KiB page, as hle_kernel_mem.cpp has it
+constexpr uint64_t kSceReadWrite = 0x3ull;      // SCE_KERNEL_PROT_CPU_READ | _CPU_WRITE
+constexpr uint64_t kSceRead      = 0x1ull;      // SCE_KERNEL_PROT_CPU_READ
+
+#if defined(__linux__)
+// Is every host page in [addr, addr+len) writable, according to the KERNEL rather than according to
+// the call that was supposed to make it so? Reading back from /proc/self/maps is the point: a
+// handler that returns 0 without calling mprotect cannot fake this.
+bool range_is_writable(uint64_t addr, uint64_t len, bool& known) {
+    known = false;
+    std::FILE* f = std::fopen("/proc/self/maps", "r");
+    if (!f) return false;
+    char line[512];
+    uint64_t covered = 0;
+    bool all_writable = true;
+    while (std::fgets(line, sizeof line, f)) {
+        unsigned long long lo = 0, hi = 0;
+        char perms[8] = {0};
+        if (std::sscanf(line, "%llx-%llx %7s", &lo, &hi, perms) != 3) continue;
+        if (hi <= addr || lo >= addr + len) continue;
+        const uint64_t overlap_lo = lo > addr ? lo : addr;
+        const uint64_t overlap_hi = hi < addr + len ? hi : addr + len;
+        covered += overlap_hi - overlap_lo;
+        if (perms[1] != 'w') all_writable = false;
+    }
+    std::fclose(f);
+    known = (covered == len);        // an uncovered byte means the answer is unknown, not "no"
+    return all_writable;
+}
+#endif
+}  // namespace
+
+int main() {
+    std::printf("== test_mprotect_unaligned ==\n");
+    register_builtin_hle();
+
+    // Resolved through nid_hash, the same way the registration itself names it, so the test cannot
+    // drift from the handler by transcribing a NID.
+    HleFn mprot = Hle::lookup(nid_hash("sceKernelMprotect"));
+    CHECK(mprot != nullptr, "sceKernelMprotect is registered");
+    if (!mprot) { std::printf("FAILED\n"); return 1; }
+
+#if defined(__linux__)
+    // Four guest pages, read-only to start, with a fifth kept read-only as the untouched neighbour
+    // the widening mutation would trample.
+    const size_t span = (size_t)(kGuestPage * 8);
+    void* raw = mmap(nullptr, span, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(raw != MAP_FAILED, "test fixture: reserved a read-only span");
+    if (raw == MAP_FAILED) { std::printf("FAILED\n"); return 1; }
+    // Align the working base up to a guest page so the offsets below are the only misalignment.
+    const uint64_t base = ((uint64_t)(uintptr_t)raw + kGuestPage - 1) & ~(kGuestPage - 1);
+
+    // The shape FINAL FANTASY TACTICS uses: a base that is not page aligned and a length that is
+    // not a multiple of the page size, together spanning two pages.
+    const uint64_t unaligned_addr = base + 0x9e0;
+    const uint64_t unaligned_len  = kGuestPage + 0x240;      // crosses into the second page
+    const uint64_t expected_lo    = base;                    // rounded down
+    const uint64_t expected_hi    = base + 2 * kGuestPage;   // rounded up
+
+    const uint64_t rc = mprot(unaligned_addr, unaligned_len, kSceReadWrite, 0, 0, 0);
+    CHECK(rc == 0, "an unaligned sceKernelMprotect SUCCEEDS (pre-fix it returned EINVAL 0x80020016)");
+
+    bool known = false;
+    const bool writable = range_is_writable(expected_lo, expected_hi - expected_lo, known);
+    CHECK(known, "the containing pages are described by /proc/self/maps");
+    CHECK(known && writable,
+          "the CONTAINING pages really became writable -- not merely reported as protected");
+
+    // The widening mutation: rounding to the whole mapping instead of to the requested pages would
+    // make this neighbour writable too.
+    bool neighbour_known = false;
+    const bool neighbour_writable =
+        range_is_writable(expected_hi + kGuestPage, kGuestPage, neighbour_known);
+    CHECK(neighbour_known, "the neighbour page is described by /proc/self/maps");
+    CHECK(neighbour_known && !neighbour_writable,
+          "a page OUTSIDE the requested span is left alone (rounding is to the span, not the mapping)");
+
+    // Rounding must not turn a genuinely bad range into a success. An address the process has never
+    // mapped still fails, and a null address is still EINVAL.
+    CHECK(mprot(0, kGuestPage, kSceReadWrite, 0, 0, 0) == 0x80020016ull,
+          "a null address is still EINVAL");
+    const uint64_t unmapped = 0x7ffff0000000ull;   // reserved-looking, and not mapped by this test
+    const uint64_t bad = mprot(unmapped + 0x37, kGuestPage, kSceRead, 0, 0, 0);
+    CHECK(bad != 0, "an unmapped range still FAILS after rounding (rounding is not permission)");
+
+    munmap(raw, span);
+#else
+    std::printf("  [skip] the page-permission readback is /proc/self/maps-based (Linux only); the "
+                "normalization itself is shared with the Windows half\n");
+#endif
+
+    std::printf("%s\n", fails ? "FAILED" : "PASSED");
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -10,12 +10,19 @@
 // passes for the wrong reason is the recurring failure in this project: a `CHECK(ret == 0)` on a
 // fill contract passes against the very stub the change exists to remove.
 #include "hle/dispatch/dispatch.hpp"
+#if !defined(_WIN32)
+#include <sys/mman.h>   // the untracked host mapping test_pool_decommit must be left alone
+#endif
 #include "hle/dispatch/nid.hpp"
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 
 using namespace prosper;
+
+static constexpr uint64_t kEinvalPool = 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
+
+extern "C" int prosper_reserved_range_state(uint64_t addr);
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
@@ -489,6 +496,94 @@ void test_apr_submit_and_get_id() {
     CHECK(second != first, "a second submit gets a DIFFERENT id (ids name submits, not the buffer)");
 }
 
+// sceKernelMemoryPoolDecommit (LXo1tpFqJGs) — the fourth member of the pool family (#3506).
+//
+// This is the only handler in its change that DESTROYS guest memory, so the arms are about what it
+// must not do as much as what it must. #3506 asks for exactly this by name, and warns that "a
+// Decommit arm that passes against 'unmap unconditionally' would be worse than none" — so each arm
+// below names the mutation it exists to catch.
+//
+// The fixture is a real reserve + commit through the pool API, not a synthetic mapping, because the
+// property under test is agreement between prosper's tracker and its own mappings.
+void test_pool_decommit() {
+    HleFn reserve  = Hle::lookup("pU-QydtGcGY");   // sceKernelMemoryPoolReserve
+    HleFn commit   = Hle::lookup("Vzl66WmfLvk");   // sceKernelMemoryPoolCommit
+    HleFn decommit = Hle::lookup("LXo1tpFqJGs");   // sceKernelMemoryPoolDecommit
+    CHECK(decommit != nullptr,
+          "sceKernelMemoryPoolDecommit is registered (unregistered, Commit had no inverse)");
+    if (!reserve || !commit || !decommit) return;
+
+    constexpr uint64_t kGranule = 0x10000ull;      // the lazy-commit granule decommit works in
+    constexpr uint64_t kSpan    = kGranule * 4;
+
+    uint64_t base = 0;
+    CHECK(reserve(0, kSpan, kGranule, 0, (uint64_t)(uintptr_t)&base, 0) == 0 && base,
+          "fixture: reserved four 64 KiB granules");
+    if (!base) return;
+    // Commit only the FIRST TWO granules. The gap is the point: NINJA GAIDEN 4 decommits whole pool
+    // spans of which only part is committed, and refusing that produced 8.1 million refusals.
+    CHECK(commit(base, kGranule * 2, 0xc, 0x3, 0, 0) == 0, "fixture: committed the first two granules");
+    // prosper_reserved_range_state: 0 = untracked, 1 = tracked reservation, 2 = committed,
+    // 4 = the AMM no-lazy-commit window. The positive control asserts 2 rather than "not 1",
+    // because the arm below turns it back into 1 and a "not 1" control would pass on an untracked
+    // range too -- which is the state a fixture that silently failed to commit would be in.
+    CHECK(prosper_reserved_range_state(base) == 2,
+          "fixture positive control: the committed range reads as COMMITTED");
+
+    *(volatile uint32_t*)(uintptr_t)base = 0xA5A5A5A5u;   // faults if the commit did not back it
+
+    // Decommit the WHOLE four-granule span, two of which were never committed.
+    CHECK(decommit(base, kSpan, 0, 0, 0, 0) == 0,
+          "a decommit spanning committed and uncommitted granules SUCCEEDS "
+          "(mutation: refuse unless fully committed -> this fails)");
+
+    // The reservation must survive. Without it a later Commit at the same address can land
+    // elsewhere, or fail. This is the arm that catches "decommit = munmap".
+    CHECK(prosper_reserved_range_state(base) == 1,
+          "the RESERVATION survives the release (mutation: plain munmap -> this fails)");
+
+    uint64_t recommitted = base;
+    CHECK(commit(base, kGranule, 0xc, 0x3, 0, 0) == 0,
+          "the released range can be committed again");
+    CHECK(recommitted == base, "re-commit lands at the SAME address the reservation held");
+    *(volatile uint32_t*)(uintptr_t)base = 0x5A5A5A5Au;   // faults if the re-commit did not back it
+    CHECK(*(volatile uint32_t*)(uintptr_t)base == 0x5A5A5A5Au,
+          "the re-committed page is writable and reads back");
+
+    // Refusal direction: a range prosper never tracked at all must touch nothing. `bad` is a live
+    // host mapping this test owns, so "touches nothing" is checkable rather than assumed — an
+    // unconditional unmap would make the read below fault.
+    void* foreign = mmap(nullptr, (size_t)kGranule, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(foreign != MAP_FAILED, "fixture: a host mapping prosper never tracked");
+    if (foreign != MAP_FAILED) {
+        *(volatile uint32_t*)foreign = 0xC3C3C3C3u;
+        decommit((uint64_t)(uintptr_t)foreign, kGranule, 0, 0, 0, 0);
+        CHECK(*(volatile uint32_t*)foreign == 0xC3C3C3C3u,
+              "decommit leaves memory prosper never committed ALONE "
+              "(mutation: unmap unconditionally -> this faults or reads back changed)");
+        munmap(foreign, (size_t)kGranule);
+    }
+
+    // Sub-granule requests release NOTHING rather than rounding outward. Rounding a destructive
+    // range out would unmap bytes the guest did not name, and a hole smaller than the lazy-commit
+    // granule would later be re-backed by an mmap that also replaces its live neighbours.
+    uint64_t base2 = 0;
+    if (reserve(0, kSpan, kGranule, 0, (uint64_t)(uintptr_t)&base2, 0) == 0 && base2 &&
+        commit(base2, kSpan, 0xc, 0x3, 0, 0) == 0) {
+        *(volatile uint32_t*)(uintptr_t)base2 = 0x11223344u;
+        CHECK(decommit(base2 + 0x100, 0x200, 0, 0, 0, 0) == 0,
+              "a sub-granule decommit succeeds without releasing anything");
+        CHECK(*(volatile uint32_t*)(uintptr_t)base2 == 0x11223344u,
+              "a sub-granule decommit does not release the granule containing it "
+              "(mutation: round outward -> this faults)");
+        decommit(base2, kSpan, 0, 0, 0, 0);
+    }
+
+    CHECK(decommit(0, kGranule, 0, 0, 0, 0) == kEinvalPool, "a null address is EINVAL");
+    CHECK(decommit(base, 0, 0, 0, 0, 0) == kEinvalPool, "a zero length is EINVAL");
+}
+
 int main() {
     printf("== test_false_success_nids ==\n");
     register_builtin_hle();
@@ -497,6 +592,7 @@ int main() {
     test_savedata_transferring_mount();
     test_http_ids();
     test_apr_submit_and_get_id();
+    test_pool_decommit();
     test_kernel_memory_pool();
     if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -433,6 +433,62 @@ void test_kernel_memory_pool() {
     // covered by the live-boot evidence on #3500.
 }
 
+// sceKernelAprSubmitCommandBufferAndGetId (qvMUCyyaCSI) — the third member of the APR submit
+// family, and the one that was missing (#3498).
+//
+// The dispatcher's return-0 default is a false success in TWO ways here, and only one of them is
+// about the id. The obvious one: 0 is the answer for a contract whose return value IS the id the
+// guest then waits on. The one that actually stalls a title: the submit never runs, so the command
+// buffer's cursor is never released and the guest's append loop — which polls GetSize minus GetUsed
+// — has no room to encode its next command.
+//
+// THE CURSOR ARM NEEDS SOMETHING ON THE CURSOR TO BE MEANINGFUL. Written without the append below
+// it reads "the cursor is 0 after submit" on a buffer whose cursor was already 0, and passes
+// against a handler that invents an id and never submits — verified by that exact mutation, which
+// is how this arm's first draft was caught. The append is therefore checked too: it is the arm's
+// own positive control, and if it ever stops moving the cursor the reset check goes back to being
+// vacuous silently.
+void test_apr_submit_and_get_id() {
+    HleFn submit_id   = Hle::lookup("qvMUCyyaCSI");
+    HleFn set_buffer  = Hle::lookup("N-FSPA4S3nI");
+    HleFn get_offset  = Hle::lookup("GnxKOHEawhk");
+    HleFn append_320  = Hle::lookup("o67gODLFpls");   // appends a 0x20-byte completion command
+    HleFn construct   = Hle::lookup("8aI7R7WaOlc");   // sceAmprCommandBufferConstructor
+    CHECK(submit_id != nullptr,
+          "sceKernelAprSubmitCommandBufferAndGetId is registered (unregistered, its id is 0)");
+    if (!submit_id || !set_buffer || !get_offset || !append_320 || !construct) return;
+
+    // An unbound command buffer: no equeue, so the submit hands out prosper's own per-ring token
+    // rather than echoing a guest tag. Addresses are the same private shape the AMM test uses.
+    // CONSTRUCT before SetBuffer: the cursor is only tracked for a buffer that has been constructed
+    // with a capacity, which is the guest's own order and is why an attach-only fixture reports a
+    // cursor of 0 forever.
+    constexpr uint64_t kCb   = 0x7f0000110000ull;
+    constexpr uint64_t kBuf  = 0x7f0000120000ull;
+    constexpr uint64_t kSize = 0x40000ull;
+    // a2 carries the capacity in the shape that makes the constructor TRACK the cursor
+    // (ampr_cb_tracks_offset_arg); a1 = 0 leaves the request-shaped path alone.
+    construct(kCb, /*a1=*/0, /*a2=capacity=*/0x1000, 0, 0, 0);
+    set_buffer(kCb, kBuf, kSize, kBuf, 0, 3);
+
+    // Put a command on the buffer. eq = 0 keeps the binding unbound, which is the state this arm
+    // wants and also keeps the append from posting anything.
+    append_320(kCb, /*eq=*/0, /*id=*/0, /*tag=*/0, 0, 0);
+    const uint64_t appended = get_offset(kCb, 0, 0, 0, 0, 0);
+    CHECK(appended != 0,
+          "positive control: the append MOVED the command-buffer cursor (without this the reset "
+          "check below cannot fail)");
+
+    const uint64_t first = submit_id(kCb, /*ring_1based=*/6, 0, 0, 0, 0);
+    CHECK(first != 0, "the returned id is NOT zero -- zero is what the missing handler answered");
+    CHECK(get_offset(kCb, 0, 0, 0, 0, 0) == 0,
+          "the submit RESET the command-buffer cursor (the half that stalls an append loop)");
+
+    append_320(kCb, 0, 0, 0, 0, 0);
+    const uint64_t second = submit_id(kCb, /*ring_1based=*/6, 0, 0, 0, 0);
+    CHECK(second != first, "a second submit gets a DIFFERENT id (ids name submits, not the buffer)");
+}
+
 int main() {
     printf("== test_false_success_nids ==\n");
     register_builtin_hle();
@@ -440,6 +496,7 @@ int main() {
     test_nptrophy2_info_queries();
     test_savedata_transferring_mount();
     test_http_ids();
+    test_apr_submit_and_get_id();
     test_kernel_memory_pool();
     if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -566,9 +566,11 @@ void test_pool_decommit() {
     if (foreign_raw != MAP_FAILED) {
         const uint64_t foreign =
             ((uint64_t)(uintptr_t)foreign_raw + kGranule - 1) & ~(kGranule - 1);
-        CHECK((foreign & (kGranule - 1)) == 0,
-              "fixture positive control: the untracked mapping is granule-aligned, so the request "
-              "really reaches the tracker");
+        // No CHECK on the alignment: `foreign` is produced by `& ~(kGranule - 1)` on the line above,
+        // so an assertion on it cannot fail for any input — including MAP_FAILED. It would read as a
+        // positive control and be a tautology, which is worse than having none because it launders
+        // the arm below. Alignment is guaranteed by CONSTRUCTION here, and the ×3 over-allocation is
+        // what makes `foreign + kGranule` always fall inside the mapping. Raised in review of #3530.
         *(volatile uint32_t*)(uintptr_t)foreign = 0xC3C3C3C3u;
         decommit(foreign, kGranule, 0, 0, 0, 0);
         CHECK(*(volatile uint32_t*)(uintptr_t)foreign == 0xC3C3C3C3u,
@@ -605,20 +607,23 @@ void test_pool_decommit() {
     // Both arms must be here. A span that wraps and a base whose ROUND-UP wraps are different
     // predicates, and the first version of the guard had only the first — so an arm testing just
     // `(-1, 2)` would have passed against the broken code.
-    //
-    // WHAT THE MUTATION LOOKS LIKE, so nobody reads a crash as a broken test: dropping the round-up
-    // guard does not print `[FAIL]`, it kills the process with SIGSEGV (measured: exit 139). That is
-    // the arm working — the handler unmaps the pages the test itself is running on. ctest scores it
-    // as a failure either way; the distinction is only for whoever runs the mutation by hand.
+
     CHECK(decommit(~0ull - 15, 8, 0, 0, 0, 0) == kEinvalPool,
           "an address whose granule ROUND-UP overflows is EINVAL, not a whole-process unmap "
           "(mutation: drop the round-up guard -> this returns 0)");
-    CHECK(decommit(~0ull - 1, 4, 0, 0, 0, 0) == kEinvalPool,
-          "a span that itself overflows is EINVAL");
-    // The process is still alive and the re-committed page above still readable — which is the
-    // consequence the overflow arms exist to prevent, checked rather than assumed.
-    CHECK(*(volatile uint32_t*)(uintptr_t)base == 0x5A5A5A5Au,
-          "an overflowing decommit released NOTHING (mutation: drop the guard -> this faults)");
+    // Isolating the SPAN guard needs a base the round-up guard admits, or the round-up guard
+    // subsumes it and deleting the span check leaves the suite green — which is what `(-2, 4)` did.
+    CHECK(decommit(kGranule, ~0ull, 0, 0, 0, 0) == kEinvalPool,
+          "a span that itself overflows is EINVAL, on a base the round-up guard accepts "
+          "(mutation: drop the span guard -> this returns 0)");
+    // The consequence the overflow arms exist to prevent, checked rather than assumed — and checked
+    // through the TRACKER rather than by dereferencing the page. Both detect the mutation, but a
+    // dereference detects it by SIGSEGV, and stdout is fully buffered under ctest's pipe, so the
+    // crash discards the [FAIL] lines already printed and exit 139 cannot say WHICH property broke.
+    // The probe reads 2 (committed) here and 1 (reservation) once an overflowing decommit has
+    // wrongly released it. Raised in review of #3530.
+    CHECK(prosper_reserved_range_state(base) == 2,
+          "an overflowing decommit released NOTHING (mutation: drop a guard -> this reads 1)");
 }
 
 int main() {

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -550,20 +550,33 @@ void test_pool_decommit() {
     CHECK(*(volatile uint32_t*)(uintptr_t)base == 0x5A5A5A5Au,
           "the re-committed page is writable and reads back");
 
-    // Refusal direction: a range prosper never tracked at all must touch nothing. `bad` is a live
-    // host mapping this test owns, so "touches nothing" is checkable rather than assumed — an
+#if !defined(_WIN32)
+    // Refusal direction: a range prosper never tracked at all must touch nothing. This is a live
+    // host mapping the test owns, so "touches nothing" is checkable rather than assumed — an
     // unconditional unmap would make the read below fault.
-    void* foreign = mmap(nullptr, (size_t)kGranule, PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    CHECK(foreign != MAP_FAILED, "fixture: a host mapping prosper never tracked");
-    if (foreign != MAP_FAILED) {
-        *(volatile uint32_t*)foreign = 0xC3C3C3C3u;
-        decommit((uint64_t)(uintptr_t)foreign, kGranule, 0, 0, 0, 0);
-        CHECK(*(volatile uint32_t*)foreign == 0xC3C3C3C3u,
+    //
+    // The mapping is over-allocated and aligned UP to a whole granule. mmap guarantees PAGE
+    // alignment (4 KiB), not granule alignment, so an unaligned base would leave the request with no
+    // whole 64 KiB granule inside it — the inward rounding would then decline it before reaching the
+    // tracker at all, and the arm would pass without ever exercising the refusal it names. Raised in
+    // review of #3530: the arm was INTERMITTENTLY vacuous, which is worse than reliably so.
+    void* foreign_raw = mmap(nullptr, (size_t)kGranule * 3, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(foreign_raw != MAP_FAILED, "fixture: a host mapping prosper never tracked");
+    if (foreign_raw != MAP_FAILED) {
+        const uint64_t foreign =
+            ((uint64_t)(uintptr_t)foreign_raw + kGranule - 1) & ~(kGranule - 1);
+        CHECK((foreign & (kGranule - 1)) == 0,
+              "fixture positive control: the untracked mapping is granule-aligned, so the request "
+              "really reaches the tracker");
+        *(volatile uint32_t*)(uintptr_t)foreign = 0xC3C3C3C3u;
+        decommit(foreign, kGranule, 0, 0, 0, 0);
+        CHECK(*(volatile uint32_t*)(uintptr_t)foreign == 0xC3C3C3C3u,
               "decommit leaves memory prosper never committed ALONE "
               "(mutation: unmap unconditionally -> this faults or reads back changed)");
-        munmap(foreign, (size_t)kGranule);
+        munmap(foreign_raw, (size_t)kGranule * 3);
     }
+#endif
 
     // Sub-granule requests release NOTHING rather than rounding outward. Rounding a destructive
     // range out would unmap bytes the guest did not name, and a hole smaller than the lazy-commit
@@ -582,6 +595,30 @@ void test_pool_decommit() {
 
     CHECK(decommit(0, kGranule, 0, 0, 0, 0) == kEinvalPool, "a null address is EINVAL");
     CHECK(decommit(base, 0, 0, 0, 0, 0) == kEinvalPool, "a zero length is EINVAL");
+
+    // Overflow, and this arm is here because the bug was real rather than theoretical. Rounding the
+    // base UP to a granule can wrap on its own, independently of whether the span wraps: with only
+    // the span checked, `(-16, 8)` wraps `base` to 0 and yields a length of nearly 2^64, at which
+    // point the clip returns EVERY committed mapping and the handler unmaps the whole process while
+    // answering SCE_OK. Found in review of #3530.
+    //
+    // Both arms must be here. A span that wraps and a base whose ROUND-UP wraps are different
+    // predicates, and the first version of the guard had only the first — so an arm testing just
+    // `(-1, 2)` would have passed against the broken code.
+    //
+    // WHAT THE MUTATION LOOKS LIKE, so nobody reads a crash as a broken test: dropping the round-up
+    // guard does not print `[FAIL]`, it kills the process with SIGSEGV (measured: exit 139). That is
+    // the arm working — the handler unmaps the pages the test itself is running on. ctest scores it
+    // as a failure either way; the distinction is only for whoever runs the mutation by hand.
+    CHECK(decommit(~0ull - 15, 8, 0, 0, 0, 0) == kEinvalPool,
+          "an address whose granule ROUND-UP overflows is EINVAL, not a whole-process unmap "
+          "(mutation: drop the round-up guard -> this returns 0)");
+    CHECK(decommit(~0ull - 1, 4, 0, 0, 0, 0) == kEinvalPool,
+          "a span that itself overflows is EINVAL");
+    // The process is still alive and the re-committed page above still readable — which is the
+    // consequence the overflow arms exist to prevent, checked rather than assumed.
+    CHECK(*(volatile uint32_t*)(uintptr_t)base == 0x5A5A5A5Au,
+          "an overflowing decommit released NOTHING (mutation: drop the guard -> this faults)");
 }
 
 int main() {

--- a/prosper/tests/hle/test_retrack_reservation.cpp
+++ b/prosper/tests/hle/test_retrack_reservation.cpp
@@ -9,6 +9,8 @@
 #include <cstring>
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <sys/mman.h>   // the host hole this test punches to provoke a protection failure
 #endif
 
 using namespace prosper;
@@ -172,19 +174,39 @@ int main() {
     // host protection changed. Use a span the platform cannot protect as one reservation.
 #ifdef _WIN32
     const uint64_t invalid_start = base + len - page / 2; // crosses the reserved allocation boundary
+    const uint64_t invalid_len = page;
 #else
-    // #3498: this used to be `base + 1`, chosen only because POSIX mprotect(2) rejected an
-    // unaligned base -- the comment said so. That was a way of PROVOKING a host failure, not a
-    // claim that the console refuses unaligned input, and sceKernelMprotect now rounds to the
-    // containing pages the way its sceKernelMtypeprotect sibling always has (a shipping title,
-    // PPSA21783, calls it with an unaligned base and length). The property #387 F3 protects is
-    // unchanged and is what this arm still tests: when the HOST call fails, the failure must reach
-    // the guest and must not retag the tracked reservation. So provoke it with an address that
-    // cannot be protected for a reason alignment has nothing to do with -- one page above the top
-    // of the user address space, which is page-aligned and can never be mapped.
-    const uint64_t invalid_start = 0x0000800000000000ull;
+    // #3498: this used to be `base + 1`, chosen only because POSIX mprotect(2) rejected an unaligned
+    // base -- the comment said so. That was a way of PROVOKING a host failure, not a claim that the
+    // console refuses unaligned input, and sceKernelMprotect now rounds to the containing pages the
+    // way its sceKernelMtypeprotect sibling always has.
+    //
+    // THE FAILING RANGE MUST STILL OVERLAP THE TRACKED RESERVATION. #387 F3 has two halves -- the
+    // failure must reach the guest, AND it must not retag the tracking -- and only the first is
+    // testable with a range that lies elsewhere: `retrack_prot` over a non-overlapping address takes
+    // its `retagged.empty()` branch and inserts a separate mapping, leaving `[base, base+len)`
+    // intact, so the query below passes whether or not the retag was suppressed. A first attempt at
+    // this edit did exactly that and made the retag half vacuous on POSIX; caught in review of
+    // #3530.
+    //
+    // So punch a host hole INSIDE the reservation instead. The tracker still records one mapping
+    // over `[base, base+len)`, the host cannot protect across the hole, and the failing range
+    // overlaps -- which is what makes the query at the end of this block a discriminator again. The
+    // provocation no longer depends on alignment in any way.
+    // The hole goes in the LAST of the three reserved pages, not the middle one: the arms further
+    // down protect `middle = base + page` and expect it to SUCCEED, so punching there makes a later
+    // legitimate call fail and reads as a regression in the code under test.
+    CHECK(munmap((void*)(uintptr_t)(base + 2 * page), (size_t)page) == 0,
+          "test fixture: punched a host hole inside the tracked reservation");
+    // A STRICT SUB-RANGE of the reservation, and that is the load-bearing part. The retag this arm
+    // exists to catch splits the tracked mapping at the requested bounds, and a split is only
+    // observable when the request covers LESS than the whole reservation -- retagging [base, base+len)
+    // with the same bounds it already had produces a region the query cannot distinguish from the
+    // untouched one. A first attempt used the whole span and was vacuous: the mutation passed.
+    const uint64_t invalid_start = base + 2 * page;   // the page the hole was punched in
+    const uint64_t invalid_len = page;
 #endif
-    const uint32_t invalid_rc = (uint32_t)protect(invalid_start, page, 0x2, 0, 0, 0);
+    const uint32_t invalid_rc = (uint32_t)protect(invalid_start, invalid_len, 0x2, 0, 0, 0);
     CHECK(invalid_rc == 0x80020016u || invalid_rc == 0x8002000cu,
           "mprotect reports a host protection failure to the guest as an SCE error");
     uint8_t failed_info[0x48]{};
@@ -194,6 +216,18 @@ int main() {
               *(uint64_t*)(failed_info + 0x08) == base + len &&
               failed_info[0x20] == 0,
           "failed mprotect leaves reservation tracking unchanged");
+
+#ifndef _WIN32
+    // Restore the page the hole was punched in. The arms below use ALL THREE reserved pages -- they
+    // protect the middle one and then a range spanning the whole reservation -- so leaving the hole
+    // makes two later LEGITIMATE calls fail, which reads as a regression in the code under test
+    // rather than as a fixture that overstayed. Punch, provoke, verify, restore: the fixture is
+    // local to the one arm it serves.
+    CHECK(mmap((void*)(uintptr_t)(base + 2 * page), (size_t)page, PROT_NONE,
+               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) ==
+              (void*)(uintptr_t)(base + 2 * page),
+          "test fixture: restored the reserved page the hole was punched in");
+#endif
 
 #ifdef _WIN32
     // #926: MEM_COMMIT says that a host allocation exists, not that it belongs to the guest. Keep

--- a/prosper/tests/hle/test_retrack_reservation.cpp
+++ b/prosper/tests/hle/test_retrack_reservation.cpp
@@ -173,10 +173,20 @@ int main() {
 #ifdef _WIN32
     const uint64_t invalid_start = base + len - page / 2; // crosses the reserved allocation boundary
 #else
-    const uint64_t invalid_start = base + 1;              // POSIX mprotect requires page alignment
+    // #3498: this used to be `base + 1`, chosen only because POSIX mprotect(2) rejected an
+    // unaligned base -- the comment said so. That was a way of PROVOKING a host failure, not a
+    // claim that the console refuses unaligned input, and sceKernelMprotect now rounds to the
+    // containing pages the way its sceKernelMtypeprotect sibling always has (a shipping title,
+    // PPSA21783, calls it with an unaligned base and length). The property #387 F3 protects is
+    // unchanged and is what this arm still tests: when the HOST call fails, the failure must reach
+    // the guest and must not retag the tracked reservation. So provoke it with an address that
+    // cannot be protected for a reason alignment has nothing to do with -- one page above the top
+    // of the user address space, which is page-aligned and can never be mapped.
+    const uint64_t invalid_start = 0x0000800000000000ull;
 #endif
-    CHECK((uint32_t)protect(invalid_start, page, 0x2, 0, 0, 0) == 0x80020016u,
-          "mprotect maps an invalid host span to SCE_KERNEL_ERROR_EINVAL");
+    const uint32_t invalid_rc = (uint32_t)protect(invalid_start, page, 0x2, 0, 0, 0);
+    CHECK(invalid_rc == 0x80020016u || invalid_rc == 0x8002000cu,
+          "mprotect reports a host protection failure to the guest as an SCE error");
     uint8_t failed_info[0x48]{};
     CHECK(query(base + len - page / 4, 0, (uint64_t)(uintptr_t)failed_info,
                 sizeof(failed_info), 0, 0) == 0 &&


### PR DESCRIPTION
## What this fixes

Three unrelated-looking title failures, one root class: prosper answering a value-returning contract
with the dispatcher's `return 0`, or refusing a call the console accepts.

### 1. `sceKernelMprotect` refused an unaligned range (#3498)

FINAL FANTASY TACTICS – The Ivalice Chronicles (`PPSA21783`) terminated itself about a second into
every boot with `sceKernelDebugRaiseExceptionOnReleaseMode(0xa0020001)` and a completely clean log
above it — no fault, no unimplemented NID, nothing to read.

It calls `sceKernelMprotect(eboot+0xf999e0, 0x1da20, 0xc3)` during allocator init. The base is not
16 KiB aligned and the length is not a multiple of it. The POSIX handler passed both to host
`mprotect(2)`, which rejects an unaligned base with `EINVAL`. The title reads that as fatal: `-1`
propagates up four frames, its framework constructor returns NULL, `main()` returns, and the CRT
raises. Confirmed at the guest's own test instruction, `eboot+0x9779`, `rax=0x80020016`.

Protection is page-granular everywhere prosper runs, so a sub-page request can only mean "the pages
containing this span" — which is how this file's own `sceKernelMtypeprotect` has always read it. That
the console rounds rather than refuses is evidenced by the title: it ships and runs on hardware, so
hardware accepted that call.

This is the **second** title to lose a whole init path to a refused mprotect. #2101 was The Messenger
losing its AGC register-offset table, and the bounded `REFUSED` log that fix added landed on the
Windows half only — which is why this one had to be found by disassembling the guest rather than by
reading a log. That log is mirrored to the POSIX half here.

### 2. `sceKernelAprSubmitCommandBufferAndGetId` was unregistered (#3498)

The third member of a submit family this file already had two of. The damage is the SUBMIT, not the
id: `return 0` skipped `ampr_cb_reset`, so the command buffer's cursor was never released and the
guest's append loop — which polls `GetSize - GetUsed` — had no room for its next command. That is
the spin `k_ampr_init`'s own comment records parking an IoStore thread.

### 3. `sceKernelMemoryPoolDecommit` was unregistered (#3506)

The fourth member of the pool family, deliberately left out of #3502 because no title had reached it.
NINJA GAIDEN 4 (`PPSA25258`) reaches it now, precisely *because* that fix let it get further.

Its risk profile is inverted relative to the rest of the family: no out-parameter, so #3502's hazard
does not apply, but unmapping a range the guest did not name does. Nothing is touched that prosper
did not itself record as committed, and the **reservation survives** the release.

The first version asked "is EVERY byte committed?" and refused otherwise. The title answered
immediately: it decommits whole 4 MiB spans of which only part is committed, which is ordinary
allocator behaviour. That arm produced **8,140,215 refusals against 37 releases** in one 240 s run as
the guest retried. Clipping to the committed sub-ranges and succeeding is correct and still safe.

## Measured

`tools/screenshot`, Linux/RADV STRIX_HALO, `SDL_VIDEODRIVER=offscreen PROSPER_RENDER=1`, default
launch, no other environment variables.

| title | before | after |
| --- | --- | --- |
| `PPSA21783` FF Tactics | self-terminates at ~1 s, every run, 0 frames | runs 420 s with no fault: links, mounts its `enhanced` build, AGC register defaults for SDK 13, video-out 1920x1080, three seeded scanout baselines, streams its own graphics textures, produces audio |
| `PPSA25258` NINJA GAIDEN 4 | host SIGSEGV ~9 log lines in, immediately after the unregistered NID | the guest's own `##checkpoint:start` / `Runtime as started`, AGC SDK 13, video-out 1920x1080, seeded baselines, AJM audio init |

**Neither rung moves.** Both titles still present zero frames. These are named causes removed, not
milestones — the ladder's rung 1 is real frames and there are none.

FF Tactics' next blocker is located: its main thread spins in `scePthreadYield` inside its framework
`Init`, waiting for `[obj+0x54] == 1` at `eboot+0x459ccf`. NINJA GAIDEN 4's next blocker is filed as
**#3529** — `linker.cpp` binds unresolved DATA imports to a CODE stub, so the title reads prosper's
machine code as its stack canary and dies in `__stack_chk_fail` on the Wwise I/O thread.

## New diagnostic: the guest fatal-exit handlers now name the caller

A title that terminates *itself* is the hardest boot failure to diagnose — no fault, no unimplemented
NID, no host stack worth reading. The two guest fatal-exit handlers now print the guest call site.

Two independent instruments, printed together because which one works is a property of how the TITLE
was compiled:

- an **rbp-chain walk** — precise, and empty on a frame-pointer-less build (FF Tactics recovers
  exactly one frame, the module entry point);
- a **stack scan** whose every candidate is confirmed by decoding a `call` instruction immediately
  before the return address, which is what makes the output readable instead of a wall of
  plausible-looking numbers. This is the one that identified `libc.prx+0x1d6` here.

Both live in `exec_image.hpp` with per-platform implementations sharing `host/fault/rbp_chain.hpp`,
so the two platforms cannot drift on "who called this?".

## Tests

- **New** `tests/hle/memory/test_mprotect_unaligned.cpp` (`mprotect_unaligned`). It asserts the
  **pages changed**, read back from `/proc/self/maps`, rather than that the call returned 0 —
  `return 0;` satisfies the latter. Verified non-vacuous by three mutations, each failing the arm it
  should: removing the normalization (2 arms), normalizing then answering blind (2 arms), and
  widening past the requested span (1 arm).
- `tests/hle/test_false_success_nids.cpp` gains four arms for the APR entry point. The one that
  matters asserts the command-buffer **cursor** was reset, read through the guest-visible accessor.
  Its first draft asserted that on a buffer whose cursor was already 0 and **passed** against a
  handler that invents an id and never submits; it now appends first, checks the append moved the
  cursor (its own positive control), and re-fails under that same mutation.
- `test_retrack_reservation`'s POSIX arm provoked a host failure with `base + 1`, chosen only because
  `mprotect(2)` rejected an unaligned base — its own comment said so. The property #387 F3 protects
  is unchanged and still asserted; it is now provoked with an address one page above the top of the
  user address space, which is page-aligned and can never be mapped, so the arm no longer depends on
  alignment at all.

```
ctest --no-tests=error -j4    ->  100% tests passed, 466 tests, exit 0
git diff --check              ->  clean
```

## Risk and deliberately unaffected

- Both platform halves of `sceKernelMprotect` now normalize and record the **normalized** span in the
  tracker rather than the caller's unaligned one. Windows previously relied on `VirtualProtect`'s own
  rounding while tracking an unaligned range, so this makes the two agree.
- `apr_submit_common` gains an optional out-parameter; both existing call sites pass `nullptr` by
  default and are unchanged in behaviour.
- Decommit refuses anything outside prosper's own committed mappings, so a wrong argument reading
  fails visibly rather than unmapping something. `a2..a5` are logged, not used — the arity is
  `CONFIDENCE: MED` and the log is what would settle it.
- No renderer, recompiler or GPU path is touched.

Refs #3498
Refs #3500
Fixes #3506
