### PR TITLE
worktree_reclaim: removal status must not land on the --json stdout (#3397)

### DIFF
--- a/prosper/tools/test_worktree_reclaim.py
+++ b/prosper/tools/test_worktree_reclaim.py
@@ -15,6 +15,8 @@ Run directly, or via ctest as worktree_reclaim_tool.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
 import subprocess
@@ -530,7 +532,7 @@ def test_removal_rechecks_state_rather_than_trusting_the_census() -> None:
         try:
             time.sleep(0.4)
             removed = W.recheck_and_remove(str(repo), trees["racy"], "origin/main", 12.0,
-                                           False, False, False, 0, False)
+                                           False, False, False, 0, False, say=print)
             check("recheck refuses", removed, False)
             check("tree still on disk", wt.is_dir(), True)
         finally:
@@ -642,6 +644,136 @@ def test_fd_and_map_references_are_holders() -> None:
         check("removable once the mapping is gone", trees["fdheld"].state, "REMOVABLE")
 
 
+def _parses(text: str) -> bool:
+    try:
+        json.loads(text)
+        return True
+    except ValueError:
+        return False
+
+
+def test_json_stdout_carries_only_the_census() -> None:
+    """`--json` stdout must be ONE parseable document, removals included (#3397).
+
+    The defect this pins was not a failed removal: `--json --remove --yes --only <tree>` removed
+    the tree and exited 0, then appended a `  REMOVED ...` prose line after the JSON on stdout,
+    so the caller's `jq` failed on a run that had done exactly what was asked. A consumer cannot
+    tell that from a broken tool, and the natural reactions -- re-run it, or stop trusting the
+    guards -- are both worse than the bug.
+
+    Removal is MOCKED here, and not merely for speed. This suite runs on machines where other
+    lanes hold live worktrees, and removing a tree a shell sits in wedges that shell
+    irrecoverably. Intercepting the single `git worktree remove` argv exercises the success AND
+    the failure branch with nothing deleted -- and the failure branch has no other route at all,
+    since provoking a real `git worktree remove` failure means first building a tree that every
+    guard above it already refuses.
+
+    Every arm asserts WHICH STREAM a line landed on, never merely that the text exists. Sending
+    the census to stderr too would satisfy "no prose on stdout" while destroying the tool, and
+    silencing the status lines would satisfy it while leaving an interactive removal with no
+    record of what it deleted -- so the complete census and the human-mode control are both
+    pinned below.
+    """
+    print("\n[--json stdout is exactly one document]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        safe = add_wt(repo, "safe", "feat/safe")
+        age(safe, admin_of(repo, "safe"))
+
+        real_run = W.run
+        removals: list[list[str]] = []
+
+        def make_run(rc: int, err: str):
+            def fake_run(cmd, cwd=None, timeout=W.GIT_TIMEOUT):
+                if "worktree" in cmd and "remove" in cmd:
+                    removals.append(list(cmd))
+                    return rc, "", err
+                return real_run(cmd, cwd=cwd, timeout=timeout)
+            return fake_run
+
+        def run_main(argv: list[str], rc: int = 0, err: str = "") -> tuple[str, str, int]:
+            out, errs = io.StringIO(), io.StringIO()
+            W.run = make_run(rc, err)
+            try:
+                with contextlib.redirect_stdout(out), contextlib.redirect_stderr(errs):
+                    code = W.main(argv)
+            finally:
+                W.run = real_run
+            return out.getvalue(), errs.getvalue(), code
+
+        def call_recheck(tree) -> tuple[bool, str, str]:
+            out, errs = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(errs):
+                removed = W.recheck_and_remove(
+                    str(repo), tree, "origin/main", 12.0, False, False, False, 0, False,
+                    say=lambda *a: print(*a, file=sys.stderr))
+            return removed, out.getvalue(), errs.getvalue()
+
+        base = ["--repo", str(repo), "--no-github", "--no-fds", "--no-maps", "--json"]
+
+        # --- the reported case: an ACTUAL removal, in --json mode -------------------------
+        out, errs, code = run_main(base + ["--remove", "--yes"])
+        check("removal run exits 0", code, 0)
+        check("removal really was attempted", len(removals), 1, str(removals))
+        check("but nothing was deleted (mocked)", safe.is_dir(), True)
+        check("stdout parses as one JSON document", _parses(out), True,
+              f"tail={out.strip().splitlines()[-1][:120] if out.strip() else out!r}")
+        if _parses(out):
+            doc = json.loads(out)
+            check("stdout census still lists every tree",
+                  sorted(Path(w["path"]).name for w in doc["worktrees"]),
+                  sorted([repo.name, "safe"]))
+            check("stdout census still marks the candidate removable",
+                  [w["removable"] for w in doc["worktrees"] if w["path"].endswith("safe")], [True])
+        check("REMOVED went to stderr", "REMOVED" in errs, True, errs[-200:])
+        check("REMOVED did NOT go to stdout", "REMOVED" in out, False)
+        check("the run summary went to stderr", "removed 1 of 1" in errs, True, errs[-200:])
+
+        # --- the failure branch: git refusing must not pollute stdout either --------------
+        removals.clear()
+        out, errs, code = run_main(base + ["--remove", "--yes"], rc=1,
+                                   err="fatal: validation failed, cannot remove working tree")
+        check("failed removal still exits 0", code, 0)
+        check("failed-removal stdout parses", _parses(out), True, out.strip()[-120:])
+        check("FAILED went to stderr", "FAILED" in errs, True, errs[-200:])
+        check("FAILED did NOT go to stdout", "FAILED" in out, False)
+        check("summary reports nothing removed", "removed 0 of 1" in errs, True, errs[-200:])
+
+        # --- the refusal branch, via a guard that fires only at RE-CHECK time -------------
+        # The census is taken before the tree is dirtied, so this candidate is refused inside
+        # the removal loop rather than by the census -- the one path whose REFUSE line the
+        # census can never emit on its behalf.
+        census, _ = survey(repo)
+        check("census says removable before the edit", census["safe"].state, "REMOVABLE")
+        (safe / "file.txt").write_text("an agent edited this after the census\n")
+        try:
+            removed, out, errs = call_recheck(census["safe"])
+            check("recheck refused the dirtied tree", removed, False)
+            check("REFUSE went to stderr", "REFUSE" in errs, True, errs[-200:])
+            check("recheck wrote nothing to stdout", out, "")
+        finally:
+            (safe / "file.txt").write_text("base\n")
+
+        # --- and the SKIP branch, for a tree that vanished between census and removal -----
+        gone = W.Worktree(path=str(root / "vanished"), real=str(root / "vanished"))
+        removed, out, errs = call_recheck(gone)
+        check("unregistered tree is skipped", removed, False)
+        check("SKIP went to stderr", "SKIP" in errs, True, errs[-200:])
+        check("SKIP wrote nothing to stdout", out, "")
+
+        # --- control: WITHOUT --json the same lines must still reach stdout ---------------
+        # Re-age first: restoring file.txt above set its mtime, which legitimately trips the
+        # `recent` guard and would otherwise leave this control asserting on a run with no
+        # candidates -- i.e. passing vacuously in the one direction it exists to rule out.
+        age(safe, admin_of(repo, "safe"))
+        removals.clear()
+        out, errs, code = run_main(["--repo", str(repo), "--no-github", "--no-fds", "--no-maps",
+                                    "--remove", "--yes"])
+        check("human mode still attempted the removal", len(removals), 1, str(removals))
+        check("human mode prints REMOVED on stdout", "REMOVED" in out, True, out[-200:])
+
+
 def main() -> int:
     for fn in (
         test_positive_and_mutations,
@@ -657,6 +789,7 @@ def main() -> int:
         test_removal_rechecks_state_rather_than_trusting_the_census,
         test_holder_matching_survives_path_aliasing,
         test_fd_and_map_references_are_holders,
+        test_json_stdout_carries_only_the_census,
     ):
         fn()
     print()

--- a/prosper/tools/worktree_reclaim.py
+++ b/prosper/tools/worktree_reclaim.py
@@ -81,6 +81,7 @@ import os
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 
@@ -804,8 +805,16 @@ def report(trees: list[Worktree], meta: dict, do_redact: bool, verbose: bool) ->
 
 def recheck_and_remove(repo: str, t: Worktree, base: str, min_idle_hours: float,
                        scan_fds: bool, scan_maps: bool, use_github: bool,
-                       gh_limit: int, do_redact: bool) -> bool:
+                       gh_limit: int, do_redact: bool, *,
+                       say: Callable[..., None]) -> bool:
     """Re-probe the local guards against fresh state, then remove. Returns True on removal.
+
+    `say` is the caller's status sink and is deliberately REQUIRED rather than defaulting to
+    `print`. Every SKIP/REFUSE/FAILED/REMOVED line below is human prose, and in `--json` mode
+    stdout is a machine-readable document that a trailing prose line makes unparseable (#3397).
+    A default would make the polluting case the one nobody has to think about, which is exactly
+    how the defect arrived: `main` moved its own messages to stderr and this function was left
+    printing to stdout.
 
     The census is deliberately not trusted for anything local. An agent can cd into a tree between
     the scan and the delete, and that race is the entire reason the scan exists, so the worktree
@@ -828,7 +837,7 @@ def recheck_and_remove(repo: str, t: Worktree, base: str, min_idle_hours: float,
     fresh = list_worktrees(repo)
     cur = next((w for w in fresh if w.real == t.real), None)
     if cur is None:
-        print(f"  SKIP {fmt(t.real)}: no longer registered")
+        say(f"  SKIP {fmt(t.real)}: no longer registered")
         return False
 
     probe_idle(cur)  # before probe_status, for the reason given in probe_idle
@@ -845,19 +854,19 @@ def recheck_and_remove(repo: str, t: Worktree, base: str, min_idle_hours: float,
              holder_scan_ok=holder_scan_ok)
 
     if not cur.removable:
-        print(f"  REFUSE {fmt(cur.real)}: {', '.join(cur.blockers) or 'no merge evidence'}")
+        say(f"  REFUSE {fmt(cur.real)}: {', '.join(cur.blockers) or 'no merge evidence'}")
         return False
     if cur.merged_by != t.merged_by:
-        print(f"  REFUSE {fmt(cur.real)}: merge evidence changed since census")
+        say(f"  REFUSE {fmt(cur.real)}: merge evidence changed since census")
         return False
 
     # No --force, ever: git's own dirty check is a second independent line of defence, and the
     # branch ref is deliberately left in place so no commit becomes unreachable.
     rc, _, err = run(["git", "-C", repo, "worktree", "remove", cur.real])
     if rc != 0:
-        print(f"  FAILED {fmt(cur.real)}: {err.strip()[:200]}")
+        say(f"  FAILED {fmt(cur.real)}: {err.strip()[:200]}")
         return False
-    print(f"  REMOVED {fmt(cur.real)}  ({cur.merged_by}, idle {cur.idle_hours:.1f}h)")
+    say(f"  REMOVED {fmt(cur.real)}  ({cur.merged_by}, idle {cur.idle_hours:.1f}h)")
     return True
 
 
@@ -941,6 +950,9 @@ def main(argv: list[str] | None = None) -> int:
         report(trees, meta, args.redact, args.verbose)
 
     # In --json mode every human line goes to stderr, so stdout stays a parseable document.
+    # This sink is threaded into recheck_and_remove as well: its per-tree status lines used to
+    # print straight to stdout, which left a successful `--json --remove --yes` run emitting a
+    # valid census followed by prose that `jq` then refused (#3397).
     say = (lambda *a: print(*a, file=sys.stderr)) if args.json else print
 
     if args.prune:
@@ -972,7 +984,7 @@ def main(argv: list[str] | None = None) -> int:
         1 for t in candidates
         if recheck_and_remove(repo, t, args.base, args.min_idle_hours,
                               not args.no_fds, not args.no_maps,
-                              not args.no_github, args.gh_limit, args.redact)
+                              not args.no_github, args.gh_limit, args.redact, say=say)
     )
     say(f"\nremoved {removed} of {len(candidates)} candidate(s)")
     return 0


### PR DESCRIPTION
Fixes #3397.

## Failure scenario

`prosper/tools/worktree_reclaim.py --json` promises stdout is a machine-readable census, and
`main` deliberately routes its own human messages to stderr so that promise holds. The removal
loop was left behind: `recheck_and_remove` printed its `SKIP` / `REFUSE` / `FAILED` / `REMOVED`
lines straight to stdout.

So `--json --remove --yes --only <finished-worktree>` **removes the tree and exits 0**, then
appends a line like

```
  REMOVED <WORKTREE>  (squash-pr#3384, idle 41.2h)
```

after the closing `}`. A caller piping that into `jq` gets a parse error on a run that did exactly
what it was asked to do. This is an output-contract defect, not a failed removal and not evidence
that any safety guard was bypassed — but a consumer cannot tell those apart, and both natural
reactions (re-run the removal, or stop trusting the guards) are worse than the bug.

## Contract

In `--json` mode, **stdout is exactly one JSON document and nothing else**; every human status
line goes to stderr. Without `--json`, status lines keep going to stdout, where a person running
an interactive removal needs to see what was deleted.

## Approach

`recheck_and_remove` takes the caller's status sink as a **required keyword-only `say`
parameter**, and `main` passes the same sink it already computes from `args.json`. The four
`print` call sites become `say`.

`say` is required rather than defaulting to `print` on purpose: a default makes the
stdout-polluting case the one no caller has to think about, which is precisely how the split
arrived — `main` moved its messages to stderr and this function silently kept the old behaviour.
There is one other caller, an existing test arm, and it now names its sink too.

## Invariants

- The JSON census on stdout is unchanged in content and structure.
- Guard behaviour, ordering, re-check semantics, exit codes and the `_GH_CACHE` reuse are all
  untouched; this PR changes **which stream text is written to**, nothing else.
- Non-`--json` output is byte-identical to before.

## Regression arm

New `test_json_stdout_carries_only_the_census` in `prosper/tools/test_worktree_reclaim.py`
(registered already as ctest `worktree_reclaim_tool`; no CMake change needed).

**Removal is mocked** — a `W.run` wrapper intercepts the single `git worktree remove` argv and
returns a chosen rc. Two reasons, and neither is speed:

1. This suite runs on machines where other lanes hold live worktrees, and the charter records
   that removing a tree a shell sits in wedges that shell irrecoverably. The arm deletes nothing.
2. It is the only route to the `FAILED` branch at all: provoking a real `git worktree remove`
   failure means first building a tree that every guard above it already refuses, so the code
   would never be reached.

The arm asserts **which stream** each line landed on, never merely that the text exists, and
carries three controls so that a degenerate "fix" cannot pass it:

- the stdout census must still list every tree and still mark the candidate removable — so
  "print nothing on stdout" fails;
- without `--json`, `REMOVED` must still appear on stdout — so "silence the status lines" fails;
- the refusal arm dirties the tree **after** the census, so the `REFUSE` line is emitted from
  inside the removal loop rather than by the census, which is the one path the census cannot
  produce on its behalf.

Branches covered: `REMOVED` (success), `FAILED` (git rc≠0), `REFUSE` (guard fires at re-check),
`SKIP` (tree unregistered between census and removal).

## Without-fix verification

With the fix reverted locally (the four `say(` calls in `recheck_and_remove` put back to
`print(`, signature untouched) the suite goes **red: exit 1, 10 failed checks**, including
`stdout parses as one JSON document: got False` with the tail line
`  REMOVED .../safe  (ancestor, idle 400.0h)`. Restored, and green again.

## Affected / unaffected

Affected: the stream `worktree_reclaim.py` writes removal status to under `--json`.
Unaffected: every guard, the census content, exit codes, human-mode output, and every other tool.

## Risks

Low. The one behavioural change is stream selection. The signature change is internal to this
tool and its test; no other file in the repository references `recheck_and_remove`.

## Commands and results

```
# the registered ctest case, via ctest
ctest --test-dir prosper/build-linux --no-tests=error -R worktree_reclaim_tool --output-on-failure
  -> 1/1 passed, 0 failed, exit 0   (worktree_reclaim_tool, 2.34 s)

# the suite directly, for the per-check count
python3 prosper/tools/test_worktree_reclaim.py
  -> exit 0, 97 `ok` checks, 0 FAIL, "all worktree_reclaim checks passed"
     (was 74 `ok` before this PR; the new arm adds 23)

# mutation arm: fix reverted
python3 prosper/tools/test_worktree_reclaim.py
  -> exit 1, 10 FAIL

# real-repo smoke, dry of any candidate, on the actual checkout
python prosper/tools/worktree_reclaim.py --json --no-github --no-fds --no-maps \
    --remove --yes --only __no_such_tree__ 2>err | python -c "import json,sys; ..."
  -> "parsed ok, trees: 9"; the "Removing 0 tree(s)" / "removed 0 of 0 candidate(s)" prose
     appeared on stderr
```

No C++ was rebuilt and no full `ctest` run was made: the diff is two Python files with no
compiled dependant, so a full suite could only report on code this PR cannot reach. CI runs the
whole thing regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
