### PR TITLE
perf: sample the Windows working set and commit charge into the F8 capture

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -127,6 +127,11 @@ endif()
 add_library(prosper_performance_capture STATIC frontends/shared/perf/performance_capture.cpp)
 target_include_directories(prosper_performance_capture PUBLIC frontends)
 target_link_libraries(prosper_performance_capture PRIVATE prosper_build_revision)
+# Windows: the process memory sample (working set + commit charge) calls GetProcessMemoryInfo, which
+# lives in the PSAPI import library rather than the kernel32 set every target links by default.
+if(WIN32)
+  target_link_libraries(prosper_performance_capture PRIVATE psapi)
+endif()
 
 # --- tests (agentic-first: self-checking, exit-code = truth) -------------
 enable_testing()

--- a/prosper/frontends/shared/perf/performance_capture.cpp
+++ b/prosper/frontends/shared/perf/performance_capture.cpp
@@ -21,6 +21,8 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+// GetProcessMemoryInfo + PROCESS_MEMORY_COUNTERS_EX. psapi.h must follow windows.h.
+#include <psapi.h>
 #include <fcntl.h>
 #include <io.h>
 #include <sys/stat.h>
@@ -31,6 +33,10 @@
 
 #if defined(__linux__)
 #include <unistd.h>
+#endif
+
+#if defined(__APPLE__)
+#include <mach/mach.h>
 #endif
 
 namespace prosper::perf {
@@ -306,16 +312,18 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
     if (!out) {
         result.error = "could not open the reserved temporary capture for writing";
     } else {
-        const bool cpu_available = std::any_of(
-            capture->pre_samples.begin(), capture->pre_samples.end(),
-            [](const ProcessSample& sample) { return sample.process_cpu_ns.has_value(); }) ||
-            std::any_of(capture->post_samples.begin(), capture->post_samples.end(),
-            [](const ProcessSample& sample) { return sample.process_cpu_ns.has_value(); });
-        const bool rss_available = std::any_of(
-            capture->pre_samples.begin(), capture->pre_samples.end(),
-            [](const ProcessSample& sample) { return sample.rss_bytes.has_value(); }) ||
-            std::any_of(capture->post_samples.begin(), capture->post_samples.end(),
-            [](const ProcessSample& sample) { return sample.rss_bytes.has_value(); });
+        // One predicate for every optional process field, so a newly added field cannot get an
+        // availability flag whose "any sample carried it" rule quietly differs from its neighbours'.
+        const auto any_sample_has = [&capture](std::optional<uint64_t> ProcessSample::*field) {
+            const auto carried = [field](const ProcessSample& sample) {
+                return (sample.*field).has_value();
+            };
+            return std::any_of(capture->pre_samples.begin(), capture->pre_samples.end(), carried) ||
+                   std::any_of(capture->post_samples.begin(), capture->post_samples.end(), carried);
+        };
+        const bool cpu_available = any_sample_has(&ProcessSample::process_cpu_ns);
+        const bool rss_available = any_sample_has(&ProcessSample::rss_bytes);
+        const bool private_available = any_sample_has(&ProcessSample::private_bytes);
         out << std::setprecision(10);
         out << "{\"type\":\"header\",\"format\":\"prosper-performance-capture\","
                "\"version\":1,\"title_id\":" << json_string(capture->title_id)
@@ -328,7 +336,11 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
             << ",\"sample_interval_ns\":" << config_.sample_interval_ns
             << ",\"logical_cpus\":" << std::thread::hardware_concurrency()
             << ",\"process_cpu_available\":" << (cpu_available ? "true" : "false")
-            << ",\"rss_available\":" << (rss_available ? "true" : "false") << "}\n";
+            << ",\"rss_available\":" << (rss_available ? "true" : "false")
+            // Additive within format version 1: readers select every field by name, so a reader
+            // that predates this flag ignores it and a reader that expects it reads an older
+            // capture as "unavailable", which is exactly what an older capture knew.
+            << ",\"private_bytes_available\":" << (private_available ? "true" : "false") << "}\n";
 
         const auto write_sample = [&](const ProcessSample& sample, const char* phase) {
             out << "{\"type\":\"sample\",\"phase\":\"" << phase << "\",\"t_ns\":"
@@ -337,6 +349,8 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
             write_optional(out, sample.process_cpu_ns);
             out << ",\"rss_bytes\":";
             write_optional(out, sample.rss_bytes);
+            out << ",\"private_bytes\":";
+            write_optional(out, sample.private_bytes);
             out << ",\"guest_presents\":" << sample.guest_presents
                 << ",\"rendered_frames\":";
             write_optional(out, sample.rendered_frames);
@@ -568,6 +582,35 @@ ProcessSample collect_process_sample(uint64_t monotonic_ns, uint64_t guest_prese
         if (page_size > 0 && resident_pages <= UINT64_MAX / static_cast<uint64_t>(page_size))
             sample.rss_bytes = resident_pages * static_cast<uint64_t>(page_size);
     }
+    // Linux reports no committed-bytes counterpart to Windows' commit charge, so private_bytes stays
+    // empty here rather than being filled with a near-synonym of the resident set.
+#elif defined(_WIN32)
+    // Windows has no /proc/self/statm, which is why every .prperf taken here reported "RSS:
+    // unavailable on this platform/run" (#3448). GetProcessMemoryInfo carries both figures in one
+    // call: WorkingSetSize is the resident set -- the direct analogue of the Linux number -- and
+    // PrivateUsage is the commit charge, which is what actually grows with prosper's host-side
+    // caches. Both are recorded only when the query succeeds; a failed query leaves both empty so
+    // the header's availability flags stay truthful.
+    PROCESS_MEMORY_COUNTERS_EX counters{};
+    counters.cb = sizeof(counters);
+    if (::GetProcessMemoryInfo(::GetCurrentProcess(),
+                               reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&counters),
+                               sizeof(counters))) {
+        sample.rss_bytes = static_cast<uint64_t>(counters.WorkingSetSize);
+        sample.private_bytes = static_cast<uint64_t>(counters.PrivateUsage);
+    }
+#elif defined(__APPLE__)
+    // CONFIDENCE: LOW. Written from the documented mach interface. CI's macOS jobs compile it and
+    // run this file's test against it, but the change that added it was authored and measured on
+    // Windows and Linux only. MACH_TASK_BASIC_INFO is the 64-bit-safe flavor: TASK_BASIC_INFO's
+    // resident_size saturates at 4 GiB, which is below the working sets this capture is for.
+    // macOS's private footprint lives behind a different call (task_vm_info's phys_footprint), so
+    // private_bytes is left empty here rather than guessed at from a counter that does not mean it.
+    mach_task_basic_info_data_t info{};
+    mach_msg_type_number_t info_count = MACH_TASK_BASIC_INFO_COUNT;
+    if (::task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                    reinterpret_cast<task_info_t>(&info), &info_count) == KERN_SUCCESS)
+        sample.rss_bytes = static_cast<uint64_t>(info.resident_size);
 #endif
     return sample;
 }

--- a/prosper/frontends/shared/perf/performance_capture.hpp
+++ b/prosper/frontends/shared/perf/performance_capture.hpp
@@ -19,6 +19,14 @@ struct ProcessSample {
     uint64_t monotonic_ns = 0;
     std::optional<uint64_t> process_cpu_ns;
     std::optional<uint64_t> rss_bytes;
+    // Private/committed bytes, where the host counts them separately from the resident set. The two
+    // diverge materially under prosper's host-side caches: on Windows the working set counts only
+    // pages resident right now and shares image pages with every other process, and it understated
+    // this process by ~5 GB against the commit charge in #3448's measured GTA V run -- so the
+    // resident set alone cannot answer the cache-pressure question this field exists for.
+    // Empty where the platform exposes no equivalent counter, and empty when the query fails: a zero
+    // would assert a process holding no committed memory, which is never what "unavailable" means.
+    std::optional<uint64_t> private_bytes;
     uint64_t guest_presents = 0;
     // The CPU handoff path exposes present_frame_seq(). The shared-device GPU-present path skips
     // that handoff, so its production counter is unavailable rather than zero.

--- a/prosper/frontends/shared/tests/test_performance_capture.cpp
+++ b/prosper/frontends/shared/tests/test_performance_capture.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -35,6 +36,7 @@ prosper::perf::ProcessSample sample(uint64_t at, uint64_t counter) {
     out.monotonic_ns = at;
     out.process_cpu_ns = counter * 70;
     out.rss_bytes = 4096 + counter;
+    out.private_bytes = 8192 + counter;
     out.guest_presents = counter * 3;
     out.rendered_frames = counter * 2;
     out.host_presented_frames = counter;
@@ -161,7 +163,12 @@ int main() {
         capture.record_compute(record);
     }
 
-    capture.observe_sample(sample(600, 6));
+    // A host that counts no committed bytes separately from its resident set reports the field as
+    // unavailable, not as zero, and the artifact has to keep those apart -- so one post sample omits
+    // it while every other sample carries one.
+    auto unavailable_private_bytes = sample(600, 6);
+    unavailable_private_bytes.private_bytes.reset();
+    capture.observe_sample(unavailable_private_bytes);
     auto unavailable_render_count = sample(700, 7);
     unavailable_render_count.rendered_frames.reset();
     capture.observe_sample(unavailable_render_count);
@@ -195,6 +202,10 @@ int main() {
           "serialized artifact contains the exact post-trigger population");
     check(count_text(text, "\"rendered_frames\":null") == 1,
           "an unavailable rendered-frame population serializes as JSON null");
+    check(count_text(text, "\"private_bytes\":null") == 1,
+          "an unavailable committed-bytes population serializes as JSON null, never as zero");
+    check(text.find("\"rss_available\":true,\"private_bytes_available\":true") != std::string::npos,
+          "the header states availability for each memory field the samples carried");
     check(count_text(text, "\"type\":\"renderer\"") == 2 &&
           count_text(text, "\"type\":\"compute\"") == 1,
           "serialized detail counts match the bounded retained records");
@@ -244,6 +255,31 @@ int main() {
     for (const auto& entry : fs::directory_iterator(dir))
         part_files += entry.path().extension() == ".part";
     check(part_files == 0, "graceful cancellation removes the unfinished private part");
+
+    // The live host sampler, on whatever platform this test is running. Every check above feeds the
+    // ring synthetic samples, so the suite stayed green for as long as the real sampler returned an
+    // empty resident set on every platform but Linux (#3448). The bounds are deliberately wide: the
+    // claim is that a real counter was read, not what this process happens to weigh.
+    const prosper::perf::ProcessSample live = prosper::perf::collect_process_sample(
+        prosper::perf::monotonic_now_ns(), 0, std::nullopt, 0);
+    const auto shown = [](const std::optional<uint64_t>& value) {
+        return value ? std::to_string(*value) : std::string("unavailable");
+    };
+    std::cout << "host process sample: rss=" << shown(live.rss_bytes)
+              << " private=" << shown(live.private_bytes) << '\n';
+    const auto plausible = [](const std::optional<uint64_t>& value) {
+        return value && *value >= 64 * 1024 && *value < (1ull << 44);
+    };
+    check(live.rss_bytes.has_value(), "the host process sampler reports a resident set size");
+    check(plausible(live.rss_bytes), "the reported resident set is a plausible process footprint");
+#if defined(_WIN32)
+    check(live.private_bytes.has_value(),
+          "Windows reports the commit charge alongside the working set");
+    check(plausible(live.private_bytes), "the reported commit charge is a plausible footprint");
+#else
+    check(!live.private_bytes.has_value(),
+          "a host with no separate committed-bytes counter leaves the field unavailable, not zero");
+#endif
 
     fs::remove_all(dir, ec);
     std::cout << (failures ? "FAIL" : "PASS") << ": " << checks << " checks, "

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -723,6 +723,14 @@ capture/replay without requiring an importable system Python module.
   total/mean/max time, and bounded address list. Mixed batches and older v1 captures report their
   compute time as explicitly unknown identity rather than inventing a program attribution.
 
+  The memory axis is two fields, not one, and both are per-platform. `rss_bytes` is the resident
+  set: `/proc/self/statm` on Linux, `WorkingSetSize` on Windows, `MACH_TASK_BASIC_INFO`'s
+  `resident_size` on macOS. `private_bytes` is the commit charge and exists only on Windows
+  (`PrivateUsage`), where it is the figure that tracks prosper's host-side caches -- the working set
+  understated one measured GTA V run by ~5 GB (#3448). Either field is reported as **unavailable**
+  rather than zero when the host has no such counter or the query failed, and captures written
+  before a field existed simply read as unavailable; both are additive within format version 1.
+
   For unattended agent runs, set `PROSPER_PERF_CAPTURE_AFTER_MS=N` to make one automatic arm
   attempt after `N` milliseconds from entry into the app loop. This uses the exact F8 artifact path
   and five-second pre/post windows without desktop focus, synthetic input, screenshots, frame dumps,

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -423,6 +423,10 @@ def summarize(records):
         "host_fps": _counter_rate(post, "host_presented_frames", seconds or 0) if seconds else None,
     }
     rss = [record.get("rss_bytes") for record in post if record.get("rss_bytes") is not None]
+    # Additive field: captures written before it, and hosts with no committed-bytes counter, simply
+    # carry no value. `is not None` rather than a truth test, so a real zero stays a measurement.
+    private = [record.get("private_bytes") for record in post
+               if record.get("private_bytes") is not None]
 
     graphics_total = _total(renderer, "total_ms")
     compute_total = _total(compute, "total_ms")
@@ -559,6 +563,8 @@ def summarize(records):
         "cpu_cores": cpu_cores,
         "rss_min": min(rss) if rss else None,
         "rss_max": max(rss) if rss else None,
+        "private_min": min(private) if private else None,
+        "private_max": max(private) if private else None,
         "rates": rates,
         "graphics_total_ms": graphics_total,
         "compute_total_ms": compute_total,
@@ -661,6 +667,11 @@ def print_summary(summary):
         print("RSS: unavailable on this platform/run")
     else:
         print(f"RSS: {summary['rss_min'] / 2**20:.1f}..{summary['rss_max'] / 2**20:.1f} MiB")
+    if summary["private_min"] is None:
+        print("private/committed: unavailable on this platform/run")
+    else:
+        print(f"private/committed: {summary['private_min'] / 2**20:.1f}.."
+              f"{summary['private_max'] / 2**20:.1f} MiB")
     rates = summary["rates"]
     print(f"rates: guest flips={_fmt_rate(rates['guest_fps'])} "
           f"rendered={_fmt_rate(rates['rendered_fps'])} host-presented={_fmt_rate(rates['host_fps'])}")

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -365,6 +365,41 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         self.assertIsNone(summary["rates"]["rendered_fps"])
         self.assertIsNone(summary["pacing_note"])
 
+    def _printed(self, summary):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            print_summary(summary)
+        return buffer.getvalue()
+
+    def test_committed_bytes_are_reported_when_the_capture_carries_them(self):
+        # Windows records the commit charge alongside the working set (#3448), because the two
+        # diverge by gigabytes under prosper's host-side caches and only the second one tracks them.
+        samples = [dict(sample, private_bytes=value)
+                   for sample, value in zip(SAMPLES, (3 * 2**20, 5 * 2**20))]
+        summary = summarize(capture(samples))
+        self.assertEqual((summary["private_min"], summary["private_max"]),
+                         (3 * 2**20, 5 * 2**20))
+        self.assertIn("private/committed: 3.0..5.0 MiB", self._printed(summary))
+
+    def test_capture_without_committed_bytes_still_reads_cleanly(self):
+        # The backward-compatibility arm. SAMPLES carries no `private_bytes` key at all, which is
+        # the exact shape of every .prperf written before the field existed: it must validate, it
+        # must summarize, and it must say unavailable rather than inventing a number.
+        records = capture(SAMPLES)
+        validate_capture(records)
+        summary = summarize(records)
+        self.assertIsNone(summary["private_min"])
+        self.assertIsNone(summary["private_max"])
+        self.assertIn("private/committed: unavailable on this platform/run",
+                      self._printed(summary))
+
+    def test_zero_committed_bytes_is_a_measurement_not_an_absence(self):
+        # A zero and an absence are different claims, and a truth test on the population would
+        # merge them -- reporting a measured zero as "unavailable on this platform/run".
+        summary = summarize(capture([dict(sample, private_bytes=0) for sample in SAMPLES]))
+        self.assertEqual(summary["private_min"], 0)
+        self.assertIn("private/committed: 0.0..0.0 MiB", self._printed(summary))
+
     def test_dropped_counts_are_reported_not_added_to_population(self):
         summary = summarize(capture(SAMPLES, renderer=[{"total_ms": 1}], dropped=(7, 9)))
         self.assertEqual(summary["counts"]["renderer"], 1)


### PR DESCRIPTION
Fixes #3448.

## Failure scenario

`collect_process_sample` read the resident set from `/proc/self/statm` under `#if defined(__linux__)`
and nothing else, so `ProcessSample::rss_bytes` stayed empty on every other platform. Every `.prperf`
taken on Windows therefore printed `RSS: unavailable on this platform/run`, and the memory axis was
missing on exactly the platform where host-side cache pressure is the live performance question: a
capture that carries no memory series can neither support nor refute a cache-pressure hypothesis, and
the numbers in #3448 had to be taken with `Get-Process` beside the run, where they cannot be
correlated with the capture window.

The reporting side was already platform-neutral and needed only the new field; the sampler was the
whole defect.

## Contract

- `rss_bytes` is the process **resident set**, from whichever counter the host exposes:
  `/proc/self/statm` (Linux), `WorkingSetSize` (Windows), `MACH_TASK_BASIC_INFO`'s `resident_size`
  (macOS).
- `private_bytes` is the **commit charge**, recorded only where the host counts it separately from
  the resident set — today that is Windows' `PrivateUsage`.
- Either field is **empty when the host has no such counter or the query fails**. Empty is not zero:
  the header's existing `rss_available` flag and the new `private_bytes_available` flag are computed
  from the samples, and the report prints `unavailable on this platform/run` rather than a number.
- The `.prperf` format stays at **version 1**.

## Approach

`_WIN32` arm: one `GetProcessMemoryInfo` call with `PROCESS_MEMORY_COUNTERS_EX` fills both figures,
and both are assigned only inside the success branch. `psapi` is linked on `WIN32` — the function is
not in the default kernel32 set.

`__APPLE__` arm: `task_info` / `MACH_TASK_BASIC_INFO` for the resident set only. `MACH_TASK_BASIC_INFO`
rather than `TASK_BASIC_INFO` because the latter's `resident_size` saturates at 4 GiB, below the
working sets this capture exists for. macOS's private footprint lives behind a different call
(`task_vm_info`'s `phys_footprint`), so `private_bytes` is left empty there rather than filled from a
counter that does not mean it. **Marked `CONFIDENCE: LOW` and not verified by me** — see *what I could
not verify* below.

**Why a separate field rather than overloading `rss_bytes`** (the issue left this open): the two
answer different questions and diverge in both directions, so one field would have to pick a lie.
In #3448's GTA V run the working set understated the commit charge by ~5 GB, and only the commit
charge tracks the caches. In the small test process measured here the inequality inverts —
`rss=5,431,296` against `private=864,256`, because the working set counts shared image pages this
process did not commit. A single field would make `RSS` mean something different per platform and per
workload; two fields let the report say which counter it read.

**Backward compatibility.** The record schema is JSON-lines and every reader selects by name, so the
addition is compatible in both directions without a version bump: an older `.prperf` has no
`private_bytes` key and reads as unavailable, and a reader that predates the field ignores the new
key. Bumping the version would have been the incompatible choice — `validate_capture` compares the
version for **equality**, so `version: 2` would reject every capture already on disk. Verified against
a real pre-fix Windows capture (below).

## Invariants

- A failed query leaves both optionals empty, so `rss_available` keeps meaning "some sample carried a
  real measurement".
- A measured zero is serialized as `0` and reported as `0.0 MiB`; only an absent measurement prints
  `unavailable`. The reader filters on `is not None`, not on truthiness.
- The sampler stays allocation-free and syscall-cheap: it runs at 4 Hz on the app thread whether or
  not F8 is ever pressed.
- The three availability flags are now computed by one predicate, so a newly added field cannot pick
  up an availability rule that quietly differs from its neighbours'.

## Affected / deliberately unaffected

Affected: the process sampler, the capture header and sample records, and the offline report's memory
line. Deliberately unaffected: the capture format version, the pre/post windowing, every renderer and
compute record, the classification logic, and `rss_bytes` on Linux (same bytes from the same file).
Linux gains no `private_bytes` — it has no commit-charge counterpart, and filling it with a near
synonym of the resident set would make the field mean different things per platform.

## Risks

- The macOS arm is compiled and executed by CI's macOS jobs but was not authored or run on a macOS
  host. If it is wrong at runtime it is wrong in the direction of the status quo (an empty optional);
  if it is wrong at compile time the macOS jobs go red, which is the fail-visible direction.
- `psapi` is a new link dependency for `prosper_performance_capture` on Windows. It is a standard
  import library present in both MinGW and MSVC toolchains, and the propagation through CMake's
  static-library `PRIVATE` (`LINK_ONLY`) interface is exercised by the linked test binary and by the
  full Windows build below.
- `PrivateUsage` is commit charge, not physical memory. The report labels it `private/committed` so
  it is not read as a second RSS.

## Build and test

Every status below was read from the command itself (bare, or redirected to a log with the status
taken outside the wrapper) — no build or test result here came through a pipe.

**Windows — MinGW UCRT g++ + Ninja + Vulkan SDK 1.4.350. This is the platform being fixed, and it
built and ran here.**

```
cmake -S prosper -B prosper/build-win -G Ninja \
      -DCMAKE_C_COMPILER=<mingw>/gcc.exe -DCMAKE_CXX_COMPILER=<mingw>/g++.exe \
      -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-win -j6                 # exit 0, 645/645 targets
ctest --test-dir prosper/build-win --no-tests=error --output-on-failure --timeout 600
```

ctest: **334 tests discovered, 330 passed, 2 skipped, 2 failed, exit 8**. Both failures are
environmental and provably untouched by this PR:

- `session_start` — `AssertionError: 9009 != 0 : Python was not found; run without arguments to
  install from the Microsoft Store...`. Windows' App Execution Alias intercepting `python`; the test
  never reaches repository content.
- `build_revision_refresh` — the mini-project it generates crashes its own `revision_query.exe` with
  `exit status 3221225477` (0xC0000005). That project includes only `prosper/cmake/ProsperBuildRevision.cmake`
  and links only `test_build_revision`; it never references `prosper_performance_capture` or any file
  in this diff, and the neighbouring `check_build_revision` passes.

The `performance_capture` case (#133) passes and now exercises the live sampler, printing what it
read so the numbers are in the log rather than asserted blind:

```
host process sample: rss=5431296 private=864256
PASS: 48 checks, 0 failures
```

**Linux (WSL Ubuntu-24.04) — regression check, targeted.**

```
cmake --build prosper/build-linux -j5 --target test_performance_capture     # exit 0
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure -R performance_capture
```

**3 tests discovered, 3 passed, exit 0** (`prosper_app_performance_capture_schedule`,
`performance_capture`, `performance_capture_report_logic`). On Linux the same live-sampler check
asserts the opposite arm: `rss_bytes` present, `private_bytes` absent rather than zero.

A **full** Linux build is not attainable in this environment and I did not get one: it stops at
`prosper_live_renderer` with

```
prosper/frontends/shared/device/vulkan_runtime.hpp:11:51: error: 'VK_API_VERSION_1_4' was not
declared in this scope
```

because this WSL has `libvulkan-dev 1.3.275.0-1build1` (`VK_HEADER_VERSION_COMPLETE` = 1.3) while the
runtime header requires 1.4. That file is not in this diff, everything up to 78% built, and the
Vulkan-dependent chain is covered by the Windows build above and by CI's Linux job.

**Offline report tests**: `python tools/perf/test_performance_capture_report.py` — **40 tests, OK,
exit 0**.

**End-to-end on Windows.** A real `.prperf` written by the live sampler, read by the updated report
(exit 0):

```
RSS: 20.5..44.5 MiB
private/committed: 16.9..40.9 MiB
```

Both series track an 8 MiB-per-sample allocation the emitting process made during the window — the
growth the pre-fix capture could not show at all.

**Backward compatibility, against a real pre-fix capture** (`perf_capture_PPSA25009_...prperf`,
written on Windows on 2026-08-07: `rss_bytes: null`, and no `private_bytes` key anywhere in the
file). It validates and summarizes cleanly, exit 0:

```
RSS: unavailable on this platform/run
private/committed: unavailable on this platform/run
```

**Mutation arms — each new test was confirmed to fail without the fix.**

- The three new reader tests, against `origin/main`'s `performance_capture_report.py`:
  `FAILED (errors=3)` of 40, `KeyError: 'private_min'`.
- The C++ test, compiled against a copy of the sampler with only the `_WIN32` memory arm removed:
  `host process sample: rss=unavailable private=unavailable`, `FAIL: 48 checks, 4 failures`, exit 1 —
  i.e. exactly the pre-fix behaviour this PR is about.

**Gates**: `git diff --check` clean; `check_contribution_shape.py --selftest` 17 arms / 0 failed, and
`--base origin/main` reports "7 changed path(s), both rules satisfied"; `check_numbered_table.py` over
every tracked `.md` clean; no `Claude-Session:` trailers (`grep -c` = 0).

## CI

All 13 checks green on the exact head `c41fd62`: `Linux`, `Windows MinGW`, `Windows App`,
`macOS (x86_64 / Rosetta 2)`, `macOS App (SDL3 + MoltenVK)`, `Linux App`, `Linux App Package`,
`Host ASan + UBSan`, `Host TSan`, `Contribution shape`, `Docs` (+2 skipping). Two of them cover
paths my local builds could not: `Windows App` links the perf library into the SDL frontend (the
`psapi` propagation my `PROSPER_APP=OFF` build did not exercise), and the macOS job both compiles
and runs the `__APPLE__` arm.

## What I could not verify

- **macOS**: no macOS host here, so the `__APPLE__` arm was never executed *by me* and is marked
  `CONFIDENCE: LOW` in the source. It is not unexecuted, though: CI's `macOS (x86_64 / Rosetta 2)`
  job compiled it and ran `performance_capture` against it — `132/316 Test #132: performance_capture
  ... Passed`, 100% of 316 — which means the live-sampler check passed there, i.e. `task_info`
  returned a plausible resident set and `private_bytes` was correctly left unavailable. What remains
  unverified is only whether `resident_size` is the *right* macOS counter to call RSS; the call
  itself works. The arm can be dropped without affecting the Windows fix if a reviewer prefers.
- **MSVC**: the Windows toolchain here is MinGW UCRT, which is also what CI's Windows job uses. The
  `PROCESS_MEMORY_COUNTERS_EX` / `psapi` usage is not MinGW-specific, but no MSVC build was run.
- **A live game capture**: verified with the real sampler writing a real capture file, not by pressing
  F8 during a GTA V run. The field it adds is the one #3448 wants for that run.
- **A clean full ctest on either platform**: Windows has the two environmental failures above, and
  Linux cannot build its Vulkan chain here at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

