### PR TITLE
agc: a mistyped render/present cadence must not become a divide by zero

### DIFF
--- a/prosper/src/hle/graphics/hle_agc.cpp
+++ b/prosper/src/hle/graphics/hle_agc.cpp
@@ -19,6 +19,7 @@
 #include "gpu/present/videoout_present.hpp"
 #include "gpu/execute/mb3_freelist.hpp"   // #1226: per-submit POOLSHIFT window probe
 #include "hle/graphics/render_cadence.hpp"  // #2837: is a requested render cadence actually sparse?
+#include "diagnostics/env_numeric.hpp"   // #2847: a mistyped cadence must not become 0
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -1936,10 +1937,15 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
         ? UINT64_MAX : flip_delta * period_ns;
     // A bounded sparse phase accelerates long intros, then cadence=1 rebuilds any temporal render
     // targets before a visual checkpoint. Screenshot exposes these as --render-every/--render-every-for-seconds.
+    // The cadence is a DIVISOR, so 0 is not "off" here -- it is a SIGFPE on the first draw submit.
+    // `atol` into a `long` could reach it two ways: `=0` directly, and any multiple of 2^32 (which
+    // is > 0 as a long and 0 once narrowed to unsigned), so the `v > 0` guard checked the wrong
+    // type. Parse strictly, cap below the narrowing, and keep the 0 -> 1 floor (#2847, #3267).
     static const unsigned render_every = [] {
-        const char* e = getenv("PROSPER_RENDER_EVERY");
-        long v = e ? atol(e) : 1;
-        return v > 0 ? (unsigned)v : 1u;
+        const uint64_t v = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_RENDER_EVERY", getenv("PROSPER_RENDER_EVERY"), 1ull, UINT32_MAX,
+            "draw submits");
+        return v ? (unsigned)v : 1u;
     }();
     static const uint64_t render_every_for_ms = [] {
         const char* e = getenv("PROSPER_RENDER_EVERY_FOR_MS");
@@ -2000,9 +2006,11 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
     // graphics/compute operation still executes and persistent targets advance on every submit.
     // Publish the first eligible frame, then one in every N so a consumer gets an image promptly.
     static const unsigned present_every = [] {
-        const char* e = getenv("PROSPER_PRESENT_EVERY");
-        long v = e ? atol(e) : 1;
-        return v > 0 ? (unsigned)v : 1u;
+        // Same divisor, same two routes to 0, same floor (#2847).
+        const uint64_t v = prosper::diag::env_u64_or_default_capped(
+            "PROSPER_PRESENT_EVERY", getenv("PROSPER_PRESENT_EVERY"), 1ull, UINT32_MAX,
+            "publication candidates");
+        return v ? (unsigned)v : 1u;
     }();
     static uint64_t publication_candidates = 0;
     const bool publish = (publication_candidates++ % present_every) == 0;

--- a/prosper/tests/diagnostics/test_env_numeric_sites.cpp
+++ b/prosper/tests/diagnostics/test_env_numeric_sites.cpp
@@ -149,6 +149,26 @@ static uint64_t dmem_old(const char* t) {
     return 16ull * 1024 * 1024 * 1024;
 }
 
+// --- src/hle/graphics/hle_agc.cpp : PROSPER_RENDER_EVERY / PROSPER_PRESENT_EVERY (#2847) -------
+// Both are DIVISORS on the GPU submit path, so 0 is not "off" -- it is `% 0`, i.e. SIGFPE on the
+// first draw submit. The old spelling guarded `v > 0` on a `long` and then narrowed to `unsigned`,
+// which the guard cannot see: every multiple of 2^32 is positive as a long and 0 as an unsigned.
+// The cap below the narrowing is what makes that unreachable; the `v ? v : 1` floor is the site's
+// pre-existing refusal of a literal `=0` and is kept.
+static uint64_t every_new(const char* n, const char* t) {
+    const uint64_t v = env_u64_or_default_capped(n, t, 1ull, UINT32_MAX, "draw submits");
+    return v ? (unsigned)v : 1u;
+}
+static uint64_t every_old(const char* t) {
+    // `long long` rather than the site's `long` deliberately: the narrowing the site suffered from
+    // only exists where `long` is 64 bits (LP64 -- Linux and macOS, where every one of this knob's
+    // routes runs). On LLP64 Windows `long` is already 32 bits, `atol` saturates to LONG_MAX and
+    // the cast narrows nothing, so mirroring `atol` literally would make the discriminator below
+    // pass on one platform and fail on the other for reasons that have nothing to do with the fix.
+    long long v = t ? std::atoll(t) : 1;
+    return v > 0 ? (unsigned)v : 1u;   // (unsigned)4294967296 == 0
+}
+
 // --- src/gpu/execute/gpu_executor.cpp : PROSPER_MAX_DISPATCH_GROUPS ----------------------------
 // Unset is 0 = "no cap", which is the right default and the wrong answer to a typo: the knob is
 // only ever set in order to impose a cap.
@@ -319,6 +339,15 @@ static const Site kSites[] = {
     {"hle_kernel_mem.cpp PROSPER_DMEM_BUDGET_MB", "PROSPER_DMEM_BUDGET_MB",
      dmem_new, dmem_old, "-1", 16ull * kGiB, "8192", 8192ull * kMiB},
 
+    // #2847. A malformed cadence keeps 1 -- i.e. renders/publishes everything, the pre-existing
+    // default -- rather than a plausible prefix. The SATURATING half of this site is not expressible
+    // in this table (2^32 is WELL-FORMED, so nothing is refused and the answer is the cap rather
+    // than the fallback); it is asserted directly in main() below.
+    {"hle_agc.cpp PROSPER_RENDER_EVERY", "PROSPER_RENDER_EVERY",
+     every_new, every_old, "500submits", 1ull, "500", 500ull},
+    {"hle_agc.cpp PROSPER_PRESENT_EVERY", "PROSPER_PRESENT_EVERY",
+     every_new, every_old, "30 submits", 1ull, "30", 30ull},
+
     {"gpu_executor.cpp PROSPER_MAX_DISPATCH_GROUPS", "PROSPER_MAX_DISPATCH_GROUPS",
      dispatch_cap_new, dispatch_cap_old,
      "750,000", 0ull /* refused: no cap, but the refusal SAYS so instead of capping at 750 */,
@@ -421,6 +450,25 @@ int main() {
                       s.good);
         check(good == s.good_expected, msg);
     }
+
+    // #2847: the cadence divisor is never 0, for ANY input. The table above cannot say this --
+    // `4294967296` is a well-formed decimal, so it is not refused and the fallback is not what
+    // answers it; the CAP below the narrowing is. The old spelling guarded `v > 0` on the `long`
+    // before narrowing, so every multiple of 2^32 passed the guard and became 0, and the submit
+    // path's `draw_submits++ % cadence` was then an integer division by zero (SIGFPE on x86-64).
+    static const char* const kCadenceInputs[] = {
+        "4294967296", "8589934592", "18446744073709551616", "0", "-1", "1e3", "", "1",
+    };
+    bool never_zero = true, old_hit_zero = false;
+    for (const char* input : kCadenceInputs) {
+        if (every_new("PROSPER_RENDER_EVERY", input) == 0) never_zero = false;
+        if (every_old(input) == 0) old_hit_zero = true;
+    }
+    check(never_zero, "hle_agc.cpp cadence: no input makes the divisor 0");
+    check(old_hit_zero,
+          "hle_agc.cpp cadence: ...and the old spelling DID reach 0 (the divide-by-zero)");
+    check(every_new("PROSPER_RENDER_EVERY", "4294967296") == 4294967295ull,
+          "hle_agc.cpp cadence: a value above the narrowing saturates to UINT32_MAX, not to 0");
 
     // Two properties of the shared grammar that every arm above depends on, asserted once here so a
     // failure points at the helper rather than at twenty sites.


### PR DESCRIPTION
Fixes #2847. Refs #3267.

## The failure

`PROSPER_RENDER_EVERY` and `PROSPER_PRESENT_EVERY` are **divisors** on the GPU submit path:

```cpp
const bool cadence_render = (draw_submits++ % cadence) == 0;
const bool publish = (publication_candidates++ % present_every) == 0;
```

so 0 is not "off" on these two knobs — it is integer division by zero, which is `SIGFPE` on x86-64.
Both were parsed the same way:

```cpp
const char* e = getenv("PROSPER_RENDER_EVERY");
long v = e ? atol(e) : 1;
return v > 0 ? (unsigned)v : 1u;      // v = 4294967296 is > 0; (unsigned)v == 0
```

The `> 0` guard is real, and it checks the **wrong type**: it runs before the narrowing, so every
multiple of 2^32 passes it as a positive `long` and becomes exactly 0 as an `unsigned`. A run with
`PROSPER_RENDER_EVERY=4294967296` dies on its first draw submit.

Nobody types 2^32, and that is not why this matters. The class is the point: `CLAUDE.md`'s rule for
these switches is that **a malformed value disables its own trigger rather than firing at an
unintended moment — a typo costs you a capture, never a wrong measurement.** These two were the
exception in both directions. `=4294967296` took the process down; `=500submits` silently selected a
cadence of 500 and nothing in the log said the shell had eaten the rest.

## The contract after this change

- The divisor is **never 0**, for any input whatsoever. That is now asserted directly, not argued.
- A **malformed** value keeps cadence **1** — render and publish everything, i.e. the pre-existing
  default and the conservative direction — and prints one `[env]` line naming the variable, the text
  it was given and the default it is keeping.
- A **well-formed but absurd** value saturates at `UINT32_MAX` rather than wrapping. That is
  deliberate and silent, per `env_numeric.hpp`'s documented policy: a huge number is an intention
  ("as sparse as possible"), not a typo, and a typo can no longer reach that path because it was
  already refused.
- `=0` still means 1, exactly as before (the site's own floor, kept).

## Approach

Both lambdas now go through `prosper::diag::env_u64_or_default_capped`
(`src/diagnostics/env_numeric.hpp`), the helper #3294 established, capped at `UINT32_MAX` so nothing
can reach the narrowing, with the site's `v ? v : 1` floor kept on top. No hand-rolled parse and no
bespoke message — the refusal text, the unit noun and the unset/empty-is-silent rule come from the
shared helper, so these read identically to the 30 sites already converted.

Grammar note: the pre-existing spelling was `atol`, i.e. **decimal only**, so the strict decimal
helper is the right one here rather than the `_auto` (hex-accepting) family. `0x10` parsed to 0 under
`atol` too; nothing that used to be well-formed at these sites is refused now.

## Regression arms

`tests/diagnostics/test_env_numeric_sites.cpp`, following that file's established shape — each arm
**mirrors** its site rather than calling it, because the site caches in a function-local `static` and
a test that armed the variable with `setenv` would go vacuous rather than red (#2214;
`tools/env/check_cached_env.py` is the gate for that class):

- Two table rows (`PROSPER_RENDER_EVERY=500submits`, `PROSPER_PRESENT_EVERY=30 submits`) asserting
  the refusal keeps 1, **and** that the old spelling did not — the discriminator that stops an arm
  passing vacuously on a site that never had the defect.
- A direct check in `main()` over `{4294967296, 8589934592, 18446744073709551616, 0, -1, 1e3, "", 1}`
  that **no** input makes the divisor 0, that the old spelling **did** reach 0, and that a value
  above the narrowing saturates to `UINT32_MAX` rather than to 0. The saturating half cannot be
  expressed as a table row: `4294967296` is well-formed, so the fallback is not what answers it.

The legacy mirror uses `long long` rather than the site's `long` on purpose, and says why in a
comment: the narrowing only exists where `long` is 64 bits (LP64 — Linux and macOS, where every route
that sets this knob runs). On LLP64 Windows `long` is already 32 bits and `atol` saturates to
`LONG_MAX`, so mirroring `atol` literally would make the discriminator platform-dependent for reasons
unrelated to the fix.

**Verified red without the fix.** `every_new` was temporarily replaced with the pre-fix arithmetic
verbatim, rebuilt and re-run: **4 failures, exit 1** —

```
[FAIL] hle_agc.cpp PROSPER_RENDER_EVERY: '500submits' keeps the default
[FAIL] hle_agc.cpp PROSPER_PRESENT_EVERY: '30 submits' keeps the default
[FAIL] hle_agc.cpp cadence: no input makes the divisor 0
[FAIL] hle_agc.cpp cadence: a value above the narrowing saturates to UINT32_MAX, not to 0
== FAILURES: 4 ==
```

The control was then reverted and the suite re-run green.

## Unaffected

- `PROSPER_RENDER_EVERY_FOR_MS` and `PROSPER_RENDER_SCALE` sit in the same function and are **not**
  touched here. Neither is a divisor: `_FOR_MS` is parsed into a `uint64_t` with no narrowing, and
  `RENDER_SCALE`'s 0 falls through its own `if (scale > 1)` guard. They are #3267 bucket-B rows and
  belong to that sweep, not to this divide-by-zero fix.
- Every run that sets a well-formed cadence behaves bit-identically. Snapshot routes set
  `PROSPER_RENDER_EVERY` to `1`, `30` and `500` (`tools/snapshot/snapshots.json`) and
  `tools/screenshot` passes `--render-every` through as decimal text; all unchanged.
- No renderer, decode or submit behaviour changes. The only observable difference on a malformed
  value is one `[env]` line on stderr plus the safe default.

## Risks

Low. The one behaviour change beyond the crash is that a value the shell mangled (`8 submits`,
`1,000`, a surviving quote) no longer selects a *partial* cadence — it keeps 1 and complains. That is
the intended direction: a run that renders everything is slower than asked for and correct, where a
run at a cadence nobody chose is fast and unattributable.

## Build and test

Environment note, stated because it bounds what these results can claim: this WSL image ships
`libvulkan-dev` **1.3.275**, and `frontends/shared/device/vulkan_runtime.hpp:11` needs
`VK_API_VERSION_1_4` since #3418. So `prosper_live_renderer`, `gpu_replay`, `prosper-app` and the
Vulkan-execution tests **cannot compile here on current `main` either** — it is environmental and
unrelated to this diff, which touches neither file. CI covers that chain. Targets built and tests run
below are named exactly.

```bash
cmake -S prosper -B prosper/build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
TMPDIR=<WORKTREE>/prosper/build-linux/tmpdir cmake --build prosper/build-linux -j5 \
    --target prosper_core test_env_numeric_sites          # exit 0
./prosper/build-linux/test_env_numeric_sites              # exit 0, 128 assertions, 0 failures
python3 prosper/tools/env/check_env_numeric_arms.py prosper   # exit 0
```

`prosper_core` is the target that compiles `src/hle/graphics/hle_agc.cpp`, so the changed site is
built and warning-free.

Full suite, after a keep-going build (`cmake --build . -- -k`) so everything that *can* link here does:

```
ctest --no-tests=error -j4 --timeout 600
76% tests passed, 112 tests failed out of 458      # exit 8
```

**458 tests discovered, 112 failed, 1 skipped** (`refactor_survey_measurement`), the rest passed.
Every one of the 112 was traced to this environment rather than to the diff, and the three causes are:

- **110** are the Vulkan chain: `prosper_live_renderer` and the 27 Vulkan-execution test targets fail
  to *link* here, so ctest reports them `Not Run` or `Failed` with `No such file or directory`
  (checked on `storage_readonly_control`). Cause is `VK_API_VERSION_1_4` vs this image's
  `libvulkan-dev` 1.3.275, above.
- **`profiling_access`** — `AssertionError: 511 != 493`, i.e. mode `0777` where it expects `0755`.
  The worktree is on `/mnt/c` (drvfs), which reports every file as 0777.
- **`snapshot_guard_logic`** — a byte-for-byte manifest round-trip, failing `b'{\r\n …' != b'{\n …'`:
  the checkout is CRLF because the host is Windows.

None of the three can be affected by this diff, and CI covers all of them on a Linux runner. Stated
in full rather than as "unrelated failures" because a 76% line needs its cause named, not asserted.

The same 112 (same 44 `Failed` / 68 `Not Run` split, same two non-Vulkan members) come up on
the unrelated sibling branch for #3304, which touches an entirely different set of files -- an
identical failure set across two different diffs is what an environmental cause looks like.


## #3267

This converts **2** of the 169 call sites that issue catalogues (both bucket B,
`hle_agc.cpp:1941` and `:2004` in its published list). **167 remain**, including the two siblings
named under *Unaffected* above. A comment on #3267 records what this PR took.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
