### PR TITLE
env: PROSPER_WAITCAP must not remove its own cap, and a typo must not pick the lever's OFF arm

### DIFF
--- a/prosper/src/diagnostics/AGENTS.md
+++ b/prosper/src/diagnostics/AGENTS.md
@@ -74,6 +74,15 @@ a typo silently ran a different experiment than the one asked for (#3253, after 
 measurement). `env_u64_or_default*` refuses loudly and keeps the default; the accepted grammar is
 exactly `[0-9]+`.
 
+`env_tristate_or_unset` in the same header is the one non-numeric member, and it exists because an
+A/B **lever** has a third answer that a number cannot express: `PROSPER_POST_SUBMIT_VISIBILITY` is
+`1` forced on, `0` forced off, and UNSET meaning "follow the SDK version the guest asked for". Read
+with `strtol` that collapsed -- `=on`, `=true`, `=yes` and `=enabled` all parse to 0, so every word
+spelling ran the FORCED-OFF arm and the site announced it as deliberate (#3304). It accepts
+`1`/`on`/`true`/`yes`/`enabled` and `0`/`off`/`false`/`no`/`disabled` in either case, plus `0x1` and
+`0x0` because the site it was written for read base 0; anything else -- including a number that is
+neither 0 nor 1 -- is UNSET with a line naming the value, never a silent third arm.
+
 Both headers take the variable's NAME as a literal argument, and `check_cached_env.py` treats any
 callee containing `env` as an environment WRITE — so a new reader here has to be added to that
 script's `ENV_READERS` set or it reads as an arming. That coupling is the one non-obvious thing about

--- a/prosper/src/diagnostics/env_numeric.hpp
+++ b/prosper/src/diagnostics/env_numeric.hpp
@@ -144,6 +144,48 @@ inline uint64_t env_u64_or_default_auto_capped(const char* name, const char* tex
     return value < cap ? value : cap;
 }
 
+// --- for a knob whose three answers are ON, OFF and "not set at all" ------------------------------
+//
+// A tri-state A/B lever (`PROSPER_POST_SUBMIT_VISIBILITY`, #1226/#2217) has a deliberate third
+// answer: `1` forces the contract on, `0` forces it off, and UNSET means "follow the SDK version the
+// guest asked for". Read with `strtol(e, nullptr, 0)` that collapses, because strtol answers **0**
+// for text it cannot parse -- so `=on`, `=true`, `=yes` and `=enabled`, every spelling an operator
+// reaches for, select the FORCED-OFF arm, and the site then announces "FORCED OFF" as though it had
+// been asked for. On an ordinary switch that is a lost experiment. On a lever whose verdict is still
+// open it is a MISLABELLED measurement, which is worse than no measurement at all (#3304).
+//
+// So the grammar is: `1` / `on` / `true` / `yes` / `enabled` -> 1, `0` / `off` / `false` / `no` /
+// `disabled` -> 0, either case; `0x1` and `0x0` too, because the sites converted here read base 0
+// and refusing a spelling that used to work is this header changing a well-formed setting (the same
+// N1 rule the `_auto` family exists for). Anything else -- INCLUDING a number that is neither 0 nor
+// 1, which strtol used to turn into a silent forced-ON -- is **unset** (-1) with a line on stderr
+// naming the value. Never a silent third answer. Unset or empty is -1 in silence.
+inline bool env_word_matches_nocase(const char* text, const char* lower_word) {
+    for (;; ++text, ++lower_word) {
+        if (!*lower_word) return !*text;
+        char c = *text;
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+        if (c != *lower_word) return false;
+    }
+}
+
+inline int env_tristate_or_unset(const char* name, const char* text) {
+    if (!text || !*text) return -1;   // unset or empty: not a typo, and not a third arm
+    static const char* const kOn[] = {"on", "true", "yes", "enabled"};
+    static const char* const kOff[] = {"off", "false", "no", "disabled"};
+    for (const char* word : kOn)
+        if (env_word_matches_nocase(text, word)) return 1;
+    for (const char* word : kOff)
+        if (env_word_matches_nocase(text, word)) return 0;
+    uint64_t value = 0;
+    if (parse_u64_auto_base(text, &value) && value <= 1) return static_cast<int>(value);
+    std::fprintf(stderr,
+                 "[env] %s='%s' is neither on nor off -- treating it as UNSET and changing NOTHING. "
+                 "Accepted: 1/on/true/yes/enabled, 0/off/false/no/disabled (either case)\n",
+                 name, text);
+    return -1;
+}
+
 // --- for a knob whose "unset" answer is NOT a number ---------------------------------------------
 //
 // `PROSPER_COMPUTE_IMAGE_CACHE_MB` unset means "derive the budget from device memory", so there is

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -2927,7 +2927,10 @@ std::atomic<bool> g_post_submit_visibility{false};
 
 // #1226 (arc7) A/B lever, default OFF and log-only in the sense that it changes nothing unless
 // set: `PROSPER_POST_SUBMIT_VISIBILITY=1` forces this model on regardless of the SDK version the
-// guest asked for, `=0` forces it off. It exists because the per-fold census (see
+// guest asked for, `=0` forces it off. (`on`/`true`/`yes`/`enabled` and `off`/`false`/`no`/
+// `disabled` work too, in either case; anything ELSE -- including a number that is neither 0 nor 1
+// -- is treated as unset and says so, because a typo must not pick an arm of a live experiment.
+// #3304.) It exists because the per-fold census (see
 // `ARCRUNNER_STATUS.md` § arc7) localised ArcRunner's corruption to the guest's builder thread
 // being released MID-FOLD by completion writes prosper applies while it is still executing the rest
 // of the same command buffer — and ArcRunner requests SDK version 10, so the post-submit contract
@@ -2935,8 +2938,13 @@ std::atomic<bool> g_post_submit_visibility{false};
 // pre-13 title is a separate question this lever does not answer; it makes the experiment runnable.
 bool post_submit_visibility_enabled() {
     static const int forced = [] {
-        const char* e = getenv("PROSPER_POST_SUBMIT_VISIBILITY");
-        const int v = e ? (int)strtol(e, nullptr, 0) : -1;
+        // #3304: the tri-state is right and the PARSE was not. `strtol` answers 0 for text it
+        // cannot read, so `=on`, `=true`, `=yes` and `=enabled` all landed on the FORCED-OFF arm
+        // and printed the line below as though that had been asked for -- a confidently mislabelled
+        // result on a lever whose verdict is open (#2217/#2219/#2223). A value that is neither on
+        // nor off is now UNSET (follow the SDK version) and says so; it is never a silent third arm.
+        const int v = prosper::diag::env_tristate_or_unset("PROSPER_POST_SUBMIT_VISIBILITY",
+                                                           getenv("PROSPER_POST_SUBMIT_VISIBILITY"));
         if (v == 1)
             fprintf(stderr, "[agc] POST-SUBMIT-VISIBILITY FORCED ON (#1226 A/B) — completion writes "
                             "stay private until the submit scope closes, regardless of SDK version\n");

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -17,6 +17,7 @@
 #include "hle/sync/pthread_slot.hpp"   // #2596: resolve a guest sync slot the way libkernel does
 #include "hle/sync/sync_futex.hpp"
 #include "hle/sync/sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
+#include "diagnostics/env_numeric.hpp"   // #3304: a mistyped PROSPER_WAITCAP must not remove the cap
 #include <pthread.h>
 #include <chrono>
 #if defined(__linux__)
@@ -1659,7 +1660,14 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
         if (a4) {
             uint64_t us = *(uint32_t*)P(a4);
             static const uint64_t cap = [] {   // parsed once (cf. punch_secs in hle_kernel_mem.cpp)
-                const char* e = getenv("PROSPER_WAITCAP"); return e ? (uint64_t)atoll(e) : 0; }();
+                // #3304: `atoll("-1")` is UINT64_MAX, which is NON-ZERO, so it passed the `cap &&`
+                // guard below and then `us > cap` could never be true -- an operator who armed a
+                // wait cap silently got none. `=5ms` was a 5 us cap and `=fast` was 0, i.e. off
+                // while looking set. Refuse loudly instead; 0 (no cap) stays the default.
+                return prosper::diag::env_u64_or_default(
+                    "PROSPER_WAITCAP", getenv("PROSPER_WAITCAP"), 0ull, "us",
+                    "0 = no cap: a timed wait runs for as long as the guest asked");
+            }();
             if (cap && us > cap) us = cap;
             if (evlog()) fprintf(stderr, "[ev]   WAIT.empty req=%lluus\n", (unsigned long long)us);
             s->cv.wait_for(lk, std::chrono::microseconds(us), pred);

--- a/prosper/tests/diagnostics/test_env_numeric_sites.cpp
+++ b/prosper/tests/diagnostics/test_env_numeric_sites.cpp
@@ -263,6 +263,30 @@ static uint64_t image_cache_old(const char* t) {
     return mib * 1024ull * 1024ull;
 }
 
+// --- src/hle/kernel/hle_kernel_time.cpp : PROSPER_WAITCAP (#3304) ------------------------------
+// A diagnostic bound on a TIMED equeue wait, in microseconds; 0 means "no cap". The old spelling
+// was `(uint64_t)atoll(e)`, so `-1` became UINT64_MAX -- non-zero, therefore PAST the `cap &&`
+// guard, and then `us > cap` could never be true. An operator who armed a cap silently got none,
+// which is the exact inversion of what they asked for and is invisible in the log.
+static uint64_t waitcap_new(const char* n, const char* t) {
+    return env_u64_or_default(n, t, 0ull, "us",
+                              "0 = no cap: a timed wait runs for as long as the guest asked");
+}
+static uint64_t waitcap_old(const char* t) { return t ? (uint64_t)std::atoll(t) : 0ull; }
+
+// --- src/gpu/pm4/command_processor.cpp : PROSPER_POST_SUBMIT_VISIBILITY (#3304) ----------------
+// The one TRI-STATE in the converted set: -1 unset (follow the SDK version), 1 forced on, 0 forced
+// off. `strtol` answers 0 for text it cannot parse, so every word spelling selected the FORCED-OFF
+// arm of a live experiment and announced it as deliberate. kTriStateUnset carries the -1 through
+// this file's uint64_t table.
+static const uint64_t kTriStateUnset = (uint64_t)(int64_t)-1;
+static uint64_t psv_new(const char* n, const char* t) {
+    return (uint64_t)(int64_t)prosper::diag::env_tristate_or_unset(n, t);
+}
+static uint64_t psv_old(const char* t) {
+    return t ? (uint64_t)(int64_t)(int)std::strtol(t, nullptr, 0) : kTriStateUnset;
+}
+
 static const uint64_t kMiB = 1024ull * 1024ull;
 static const uint64_t kGiB = 1024ull * kMiB;
 
@@ -400,6 +424,24 @@ static const Site kSites[] = {
      "64 MB", 16ull * kMiB, "64", 64ull * kMiB},
     {"live_compute.cpp PROSPER_MAX_GPU_COMPARE_IMAGE_MB", "PROSPER_MAX_GPU_COMPARE_IMAGE_MB",
      mib_cap_size_new<2>, mib_cap_old<2>, "32mb", 2ull * kMiB, "8", 8ull * kMiB},
+
+    // #3304. WAITCAP's malformed answers are the two ends of its own policy: `-1` used to REMOVE
+    // the cap (UINT64_MAX passes the `cap &&` guard and no wait can exceed it) and `5ms` used to
+    // impose a 5 us one. Both now keep 0, and the refusal says that 0 means no cap so an operator
+    // is not told "keeping the default" and left believing they still have a bound.
+    {"hle_kernel_time.cpp PROSPER_WAITCAP (cap removed)", "PROSPER_WAITCAP",
+     waitcap_new, waitcap_old, "-1", 0ull, "5000", 5000ull},
+    {"hle_kernel_time.cpp PROSPER_WAITCAP (unit suffix)", "PROSPER_WAITCAP",
+     waitcap_new, waitcap_old, "5ms", 0ull, "250", 250ull},
+
+    // #3304. The tri-state. `2` is the sharpest row: strtol answered 2, which the site read as
+    // `forced != 0`, i.e. FORCED ON -- and unlike 0 and 1 it printed NOTHING, so the run was armed
+    // and silent. The word spellings are asserted in main() below, where the accepted set can be
+    // stated directly rather than one row at a time.
+    {"command_processor.cpp PROSPER_POST_SUBMIT_VISIBILITY (neither 0 nor 1)",
+     "PROSPER_POST_SUBMIT_VISIBILITY", psv_new, psv_old, "2", kTriStateUnset, "1", 1ull},
+    {"command_processor.cpp PROSPER_POST_SUBMIT_VISIBILITY (near-miss word)",
+     "PROSPER_POST_SUBMIT_VISIBILITY", psv_new, psv_old, "enable", kTriStateUnset, "0", 0ull},
 };
 int main() {
     char msg[512];
@@ -421,6 +463,33 @@ int main() {
                       s.good);
         check(good == s.good_expected, msg);
     }
+
+    // #3304: the spellings an operator actually types. Every one of these used to reach strtol,
+    // which answers 0 for all of them -- so `=on` and `=true` ran the FORCED-OFF arm of an open
+    // experiment (#2217/#2219/#2223) and printed "FORCED OFF" as though that had been asked for.
+    // The second loop is the discriminator: it requires the old spelling to have answered OFF for
+    // each word, so these arms cannot pass vacuously on a site that never had the defect.
+    static const char* const kOnWords[] = {"on", "ON", "On", "true", "TRUE", "yes", "enabled"};
+    static const char* const kOffWords[] = {"off", "OFF", "false", "no", "disabled"};
+    bool on_words_on = true, on_words_were_off = true, off_words_off = true;
+    for (const char* word : kOnWords) {
+        if (psv_new("PROSPER_POST_SUBMIT_VISIBILITY", word) != 1) on_words_on = false;
+        if (psv_old(word) != 0) on_words_were_off = false;
+    }
+    for (const char* word : kOffWords)
+        if (psv_new("PROSPER_POST_SUBMIT_VISIBILITY", word) != 0) off_words_off = false;
+    check(on_words_on, "PROSPER_POST_SUBMIT_VISIBILITY: on/true/yes/enabled select the ON arm");
+    check(on_words_were_off,
+          "PROSPER_POST_SUBMIT_VISIBILITY: ...and every one of them used to select FORCED OFF");
+    check(off_words_off, "PROSPER_POST_SUBMIT_VISIBILITY: off/false/no/disabled select the OFF arm");
+    check(psv_new("PROSPER_POST_SUBMIT_VISIBILITY", "1") == 1 &&
+          psv_new("PROSPER_POST_SUBMIT_VISIBILITY", "0") == 0 &&
+          psv_new("PROSPER_POST_SUBMIT_VISIBILITY", "0x1") == 1 &&
+          psv_new("PROSPER_POST_SUBMIT_VISIBILITY", "0x0") == 0,
+          "PROSPER_POST_SUBMIT_VISIBILITY: the numeric spellings the site already accepted still work");
+    check(psv_new("PROSPER_POST_SUBMIT_VISIBILITY", nullptr) == kTriStateUnset &&
+          psv_new("PROSPER_POST_SUBMIT_VISIBILITY", "") == kTriStateUnset,
+          "PROSPER_POST_SUBMIT_VISIBILITY: unset and empty stay UNSET, and follow the SDK version");
 
     // Two properties of the shared grammar that every arm above depends on, asserted once here so a
     // failure points at the helper rather than at twenty sites.

--- a/prosper/tools/env/check_cached_env.py
+++ b/prosper/tools/env/check_cached_env.py
@@ -73,6 +73,12 @@ def armed_callee(name: str) -> bool:
 ENV_READERS = frozenset((
     "getenv", "std_getenv",
     "env_u64_or_default", "env_u64_or_default_capped",
+    # The rest of env_numeric.hpp's entry points, on the same argument: each takes the variable's
+    # NAME as a literal first argument purely so a refusal can name it. The first four were listed
+    # when they were the only ones; the _auto family, env_u64_or_report and env_tristate_or_unset
+    # (#3304) were not, and the heuristic above counts any callee containing "env" as a WRITE.
+    "env_u64_or_default_auto", "env_u64_or_default_auto_capped",
+    "env_u64_or_report", "env_tristate_or_unset",
 ))
 
 SCAN_DIRS = ("src", "frontends", "tools", "tests")

--- a/prosper/tools/env/check_env_numeric_arms.py
+++ b/prosper/tools/env/check_env_numeric_arms.py
@@ -35,7 +35,8 @@ from pathlib import Path
 # one site this gate could not see, while the success line below asserted full coverage (#3267 N2).
 # Adding a helper to that header without adding it here re-opens exactly that hole.
 CALL_RE = re.compile(
-    r'env_u64_or_(?:default(?:_auto)?(?:_capped)?|report)\s*\(\s*\n?\s*"(PROSPER_[A-Z_0-9]+)"')
+    r'(?:env_u64_or_(?:default(?:_auto)?(?:_capped)?|report)|env_tristate_or_unset)'
+    r'\s*\(\s*\n?\s*"(PROSPER_[A-Z_0-9]+)"')
 ARM_RE = re.compile(r'"(PROSPER_[A-Z_0-9]+)"')
 SKIP_DIRS = {"build-linux", "build-windows", "third_party", ".git", "tmpdir"}
 TEST = Path("tests/diagnostics/test_env_numeric_sites.cpp")


### PR DESCRIPTION
Fixes #3304. Refs #3267.

Two `PROSPER_*` reads where a malformed value does something **worse than nothing** — one removes a
bound, one silently selects an arm of a live experiment. Neither appears in #3267's published
catalogue, so #3294's bucket-A sweep did not see them. Neither is a regression; both predate that
work.

## 1. `PROSPER_WAITCAP` silently removed the cap it was set to arm

`src/hle/kernel/hle_kernel_time.cpp`, bounding a **timed** equeue wait:

```cpp
const char* e = getenv("PROSPER_WAITCAP"); return e ? (uint64_t)atoll(e) : 0;
...
if (cap && us > cap) us = cap;
```

`atoll("-1")` is `-1`; cast to `uint64_t` it is `UINT64_MAX`, which is **non-zero**, so it passes the
`cap &&` guard — and then `us > UINT64_MAX` can never be true. The clamp never fires. An operator who
armed a wait cap got no wait cap, and nothing said so. `=5ms` was a **5 microsecond** cap and `=fast`
was 0, i.e. off while looking set.

Now `env_u64_or_default("PROSPER_WAITCAP", …, 0, "us", "0 = no cap: …")`. The `default_note` matters
here for the same reason it did on `PROSPER_MAX_DISPATCH_GROUPS`: this knob's default is itself the
permissive sentinel, so telling someone who typed a value *in order to impose a bound* that we are
"keeping the default (0)" is true and useless. The line says they still have no cap.

## 2. `PROSPER_POST_SUBMIT_VISIBILITY`: a typo did not mean "unset", it meant **forced off**

`src/gpu/pm4/command_processor.cpp`:

```cpp
const char* e = getenv("PROSPER_POST_SUBMIT_VISIBILITY");
const int v = e ? (int)strtol(e, nullptr, 0) : -1;
```

The tri-state is deliberate and correct — `-1` unset (follow the SDK version), `1` forced on, `0`
forced off. The **parse** collapsed it. `strtol` returns 0 for anything it cannot read, so `=on`,
`=true`, `=yes`, `=enabled` — and an empty value — all landed on **FORCED OFF** and printed
`[agc] POST-SUBMIT-VISIBILITY FORCED OFF (#1226 A/B)` as though it had been asked for.

This is the reason this PR exists rather than being folded into the bucket-B sweep. The knob is a
**live experiment lever on an open question**: `CLAUDE.md` and `ARCRUNNER_STATUS.md` record its
verdict as undecided with the frontend as the variable (#2217), the race it probes is named in #2219,
and #2223 is the *Sonic Frontiers* regression that keeps it from becoming the default. An A/B run
spelled `=on` would have produced a confidently-labelled "lever on" result that was the **forced-off
arm**, with a log line asserting deliberateness. That is the apparatus masquerading as the subject,
on exactly the kind of question where it costs the most.

Measured while writing the arms, and not in the issue: `=2` was worse again. `strtol` gave 2, the
site's `forced >= 0` accepted it and `forced != 0` forced the model **ON** — and neither the `v == 1`
nor the `v == 0` branch printed, so that arm ran completely silently.

## Approach

`PROSPER_WAITCAP` uses the existing `env_u64_or_default`. The tri-state cannot: no numeric fallback
expresses "unset", and the point is refusing to guess. So this adds one function to
`src/diagnostics/env_numeric.hpp`, in the style of the `_auto` family and `env_u64_or_report` that
are already there:

```cpp
int env_tristate_or_unset(const char* name, const char* text);   // -1 unset, 0 off, 1 on
```

Accepted: `1` / `on` / `true` / `yes` / `enabled` → 1, and `0` / `off` / `false` / `no` / `disabled`
→ 0, in either case. Also `0x1` and `0x0`, because this site read **base 0** and refusing a spelling
that used to work would be the header changing a well-formed setting — the same N1 rule the `_auto`
family exists for. **Anything else**, including a number that is neither 0 nor 1, is **unset** with a
line on stderr naming the value and listing what is accepted. Never a silent third answer.

Accepting the word spellings is an addition beyond what the issue asked for; it is documented in the
header, in `src/diagnostics/AGENTS.md`, and in the refusal message itself. The argument for it is
that `=on` is what an operator types, and "refuse it" and "understand it" both remove the hazard,
while only the second removes the failed run. Everything already published uses `=1`
(`ARCRUNNER_STATUS.md`, `CRISIS_CORE_STATUS.md`, `COMPATIBILITY.md`), which is unchanged.

Both gates were updated, because both can be silently defeated by a new helper:

- `tools/env/check_env_numeric_arms.py` — its `CALL_RE` now matches `env_tristate_or_unset`, so a
  site parsed through it with no arm fails the gate. (Verified: before the arms were written, the
  gate failed naming both new knobs.)
- `tools/env/check_cached_env.py` — `ENV_READERS` gains `env_tristate_or_unset` **and** the three
  older readers that were never listed (`env_u64_or_default_auto`, `_auto_capped`,
  `env_u64_or_report`). That script treats any callee containing `env` as an environment *write*, so
  an unlisted reader reads as an arming; `src/diagnostics/AGENTS.md` already documents the coupling.

## Regression arms

`tests/diagnostics/test_env_numeric_sites.cpp`, following that file's established shape — each arm
**mirrors** its site rather than calling it, because both sites cache in a function-local `static`
and a test that armed the variable with `setenv` would go vacuous rather than red (#2214). Every
table row carries the file's discriminator leg: the old spelling must answer *differently*, so an arm
cannot pass vacuously on a site that never had the defect.

- `PROSPER_WAITCAP`: `-1` (the removed cap) and `5ms` (the 5 us cap) both keep 0; `5000` and `250`
  still select what was asked.
- `PROSPER_POST_SUBMIT_VISIBILITY`: `2` and `enable` keep **unset**; `1` and `0` still force.
- In `main()`, the spelling set stated directly: every word in
  `{on, ON, On, true, TRUE, yes, enabled}` selects the ON arm **and every one of them used to select
  FORCED OFF**; `{off, OFF, false, no, disabled}` select OFF; `1`, `0`, `0x1`, `0x0` still work; unset
  and empty stay unset.

**Verified red without the fix.** Both mirrors were temporarily replaced with the pre-fix arithmetic
verbatim, rebuilt and re-run: **6 failures, exit 1** —

```
[FAIL] hle_kernel_time.cpp PROSPER_WAITCAP (cap removed): '-1' keeps the default
[FAIL] hle_kernel_time.cpp PROSPER_WAITCAP (unit suffix): '5ms' keeps the default
[FAIL] command_processor.cpp PROSPER_POST_SUBMIT_VISIBILITY (neither 0 nor 1): '2' keeps the default
[FAIL] command_processor.cpp PROSPER_POST_SUBMIT_VISIBILITY (near-miss word): 'enable' keeps the default
[FAIL] PROSPER_POST_SUBMIT_VISIBILITY: on/true/yes/enabled select the ON arm
[FAIL] PROSPER_POST_SUBMIT_VISIBILITY: unset and empty stay UNSET, and follow the SDK version
== FAILURES: 6 ==
```

(The last of those is the empty-value case — `PROSPER_POST_SUBMIT_VISIBILITY=` also forced OFF.) The
control was then reverted and the suite re-run green.

## Unaffected

- `=1`, `=0`, `=0x1`, `=0x0` and unset behave exactly as before, so every published route and every
  recorded A/B in `ARCRUNNER_STATUS.md` is unchanged. No doc needed rewriting.
- The `POST-SUBMIT-VISIBILITY FORCED ON/OFF` announcements, the SDK-version default, and
  `g_post_submit_visibility` are untouched — only the parse changed.
- `PROSPER_WAITCAP` unset still means no cap; a well-formed cap still clamps identically.
- No behavioural change on any path where these variables are not set.

## Risks

- `PROSPER_POST_SUBMIT_VISIBILITY=2` (and any other number outside {0, 1}) now means **unset**, where
  it used to silently force the model on. That is the intended correction — nothing documents such a
  spelling, and it printed nothing, so no recorded run can have relied on it — but it is a behaviour
  change and worth a reviewer's eye.
- `env_tristate_or_unset` is a new entry point in a header several lanes are converting sites through
  (#3267). Its grammar is deliberately narrower than `strtol`'s and wider than the decimal helper's;
  if that split is wrong, it is wrong for every future tri-state that copies it.

## Build and test

Environment note, stated because it bounds what these results can claim: this WSL image ships
`libvulkan-dev` **1.3.275**, and `frontends/shared/device/vulkan_runtime.hpp:11` needs
`VK_API_VERSION_1_4` since #3418. So `prosper_live_renderer`, `gpu_replay`, `prosper-app` and the
Vulkan-execution tests **cannot compile here on current `main` either** — environmental, and
unrelated to this diff, which touches none of those files. CI covers that chain.

```bash
cmake -S prosper -B prosper/build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
TMPDIR=<WORKTREE>/prosper/build-linux/tmpdir cmake --build prosper/build-linux -j5 \
    --target prosper_core test_env_numeric_sites          # exit 0
./prosper/build-linux/test_env_numeric_sites              # exit 0, 136 assertions, 0 failures
python3 prosper/tools/env/check_env_numeric_arms.py prosper   # exit 0: 36 knobs parsed, every one armed
python3 prosper/tools/env/check_cached_env.py prosper         # exit 0: all checks passed
```

`prosper_core` is the target that compiles both changed sites
(`src/hle/kernel/hle_kernel_time.cpp`, `src/gpu/pm4/command_processor.cpp`), so both are built and
warning-free.

Full suite, after a keep-going build (`cmake --build . -- -k`) so everything that *can* link here does:

```
ctest --no-tests=error -j4 --timeout 600
76% tests passed, 112 tests failed out of 458      # exit 8
```

**458 tests discovered, 112 failed, 1 skipped** (`refactor_survey_measurement`), the rest passed.
Every one of the 112 was traced to this environment rather than to the diff, and the three causes are:

- **110** are the Vulkan chain: `prosper_live_renderer` and the 27 Vulkan-execution test targets fail
  to *link* here, so ctest reports them `Not Run` or `Failed` with `No such file or directory`
  (checked on `storage_readonly_control`). Cause is `VK_API_VERSION_1_4` vs this image's
  `libvulkan-dev` 1.3.275, above.
- **`profiling_access`** — `AssertionError: 511 != 493`, i.e. mode `0777` where it expects `0755`.
  The worktree is on `/mnt/c` (drvfs), which reports every file as 0777.
- **`snapshot_guard_logic`** — a byte-for-byte manifest round-trip, failing `b'{\r\n …' != b'{\n …'`:
  the checkout is CRLF because the host is Windows.

None of the three can be affected by this diff, and CI covers all of them on a Linux runner. Stated
in full rather than as "unrelated failures" because a 76% line needs its cause named, not asserted.

## #3267

This converts **2** of the 169 call sites that issue catalogues — and neither was in it, which is the
more useful fact: the catalogue is a census of a *shape* (`strtoull`/`atoi` with the end pointer
discarded) and both of these are that shape with a bound or an experiment arm behind it. **167
remain** by the issue's count, plus whatever else the catalogue does not list. A comment on #3267
records what this PR took.
