### PR TITLE
gpu_replay: say which shader dump writes SPIR-V and which writes guest RDNA2

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -4034,18 +4034,6 @@ if(TARGET prosper_live_renderer AND TARGET prosper_core)
   add_test(NAME present_blit COMMAND test_present_blit)
 endif()
 
-# ---------------------------------------------------------------------------
-# Per-case scratch directory for every registered test (#1613).
-#
-# Tests that must touch the real filesystem take their paths from
-# tests/fixtures/test_scratch.h, which reads PROSPER_TEST_SCRATCH_DIR. Giving each ctest
-# *case* its own root is what makes `ctest -j` safe: one test binary is
-# sometimes registered as several cases (game_compute_exec and
-# game_compute_exec_no_adaptive_storage_result are the same executable), so
-# per-binary uniqueness is not enough. The helper adds a pid component
-# underneath, which separates concurrent ctest invocations from different
-# worktrees. The root is inside the build directory, never /tmp — see the
-# header for why that matters on this machine.
 # #3372: gpu_replay's two graphics shader dumps produce OPPOSITE things -- --dump-shader writes
 # prosper's recompiled SPIR-V, --dump-shader-raw writes the guest RDNA2 that fed it -- and the
 # flag names alone do not say which way round. An investigation read the RDNA2 out of the flag
@@ -4063,6 +4051,19 @@ if(TARGET gpu_replay AND Python3_Interpreter_FOUND)
     "PROSPER_GPU_REPLAY_BIN=$<TARGET_FILE:gpu_replay>")
 endif()
 
+
+# ---------------------------------------------------------------------------
+# Per-case scratch directory for every registered test (#1613).
+#
+# Tests that must touch the real filesystem take their paths from
+# tests/fixtures/test_scratch.h, which reads PROSPER_TEST_SCRATCH_DIR. Giving each ctest
+# *case* its own root is what makes `ctest -j` safe: one test binary is
+# sometimes registered as several cases (game_compute_exec and
+# game_compute_exec_no_adaptive_storage_result are the same executable), so
+# per-binary uniqueness is not enough. The helper adds a pid component
+# underneath, which separates concurrent ctest invocations from different
+# worktrees. The root is inside the build directory, never /tmp — see the
+# header for why that matters on this machine.
 #
 # This must stay at the very end of the file: it snapshots the DIRECTORY TESTS
 # property, so any add_test() below it would not be covered. A test that did get

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -4046,6 +4046,23 @@ endif()
 # underneath, which separates concurrent ctest invocations from different
 # worktrees. The root is inside the build directory, never /tmp — see the
 # header for why that matters on this machine.
+# #3372: gpu_replay's two graphics shader dumps produce OPPOSITE things -- --dump-shader writes
+# prosper's recompiled SPIR-V, --dump-shader-raw writes the guest RDNA2 that fed it -- and the
+# flag names alone do not say which way round. An investigation read the RDNA2 out of the flag
+# whose name suggested SPIR-V and lost a session to it. The usage legend is the fix, so something
+# has to fail when the legend is dropped; nothing else in the tree can. Behavioural rather than a
+# source grep: it runs the real binary and reads what an operator would actually see.
+if(TARGET gpu_replay AND Python3_Interpreter_FOUND)
+  add_test(NAME gpu_replay_cli_contract
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/gpu_replay/test_cli_contract.py")
+  # SKIP_RETURN_CODE so "gpu_replay was not built" reports as (Skipped) by name rather than as a
+  # pass -- the tool needs Vulkan and is genuinely absent in some environments.
+  set_tests_properties(gpu_replay_cli_contract PROPERTIES TIMEOUT 300 SKIP_RETURN_CODE 77)
+  set_property(TEST gpu_replay_cli_contract APPEND PROPERTY ENVIRONMENT
+    "PROSPER_GPU_REPLAY_BIN=$<TARGET_FILE:gpu_replay>")
+endif()
+
 #
 # This must stay at the very end of the file: it snapshots the DIRECTORY TESTS
 # property, so any add_test() below it would not be covered. A test that did get

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -1132,8 +1132,10 @@ composite/scanout draws; a single `--draw N` remains supported.
 `--dump-resource DRAW:vs|ps:BINDING PATH` writes one captured resource's exact backing bytes for
 external numeric/image inspection without dereferencing the original guest address.
 `--dump-shader DRAW:vs|fs PATH` writes the captured SPIR-V module for validation/disassembly.
-Capture v19+ also supports `--dump-realized-shader DRAW:vs|fs PATH`, which writes the exact bounded raw
-RDNA2 source for a successfully realized graphics stage; use that output with `shader_inspect`.
+Capture v19+ also supports `--dump-shader-raw DRAW:vs|fs PATH` (alias: `--dump-realized-shader`),
+which writes the exact bounded raw RDNA2 source for a successfully realized graphics stage; use that
+output with `shader_inspect`. Note the pairing: the plain flag gives prosper's SPIR-V, the `-raw`
+flag gives the guest's RDNA2 that produced it (#3372).
 `--dump-compute N PATH` writes one realized compute SPIR-V module, and
 `--dump-compute-resource N:BINDING PATH` writes its exact pre-dispatch storage-buffer bytes.
 `--dump-post-compute-resource N:BINDING PATH` is the execution-side counterpart for storage images: it

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -626,10 +626,14 @@ The VS/FS streams use the same content-addressed 64 KiB-per-stage,
 64 MiB-total store as failed-shader diagnostics. Captures v1-v18 remain readable; because they did not retain
 realized-stage source identities, this command reports the raw stream as unavailable instead of guessing.
 
-`PROSPER_SHADER_DUMP_SUCCESS=DIR` does **not** work under `gpu_replay` — every caller of its
-hook is in the live executor, which the replay path never reaches. `gpu_replay` now says so on
-startup when the variable is set, because an empty directory otherwise reads as “that program
-never compiled”. Use the per-draw flags above instead.
+`PROSPER_SHADER_DUMP_SUCCESS=DIR` is honoured **only in the modes that recompile**. A plain replay
+runs the capsule's stored SPIR-V and recompiles nothing, so nothing calls the hook and the
+directory stays empty — which reads as “that program never compiled”, the trap
+`src/gpu/diagnostics/AGENTS.md` warns about. `--recompile-raw` and `--retry-failed-*` **do**
+recompile, through `compute_recompile.hpp` → `gpu::recompile_compute_shader_cached`, which
+calls the hook on every exit path, so the variable works under those. `gpu_replay` warns on
+startup when the variable is set and the invocation will not reach it. For one shader by draw, use
+the per-draw flags above.
 
 Selected draw ranges and ordered prefixes write the BMP at the final selected draw target's extent when
 the returned RGBA byte count confirms that native size. Presentation-scaled replays retain the capsule's

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -372,7 +372,7 @@ render-state resolve, executor ordering, detile) — it is the right guard for c
 ./build-linux/gpu_replay --dump-rtt-seed 0x7f9f504b0000 /tmp/history.bmp \
   --inspect-only /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
-./build-linux/gpu_replay --dump-realized-shader 18:fs /tmp/fragment-rdna2.bin /tmp/submit.prgcap
+./build-linux/gpu_replay --dump-shader-raw 18:fs /tmp/fragment-rdna2.bin /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute 0 /tmp/compute.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute-raw 0 /tmp/compute-rdna2.bin --inspect-only /tmp/submit.prgcap
 ./build-linux/gpu_replay --compute-only 0 /tmp/submit.prgcap
@@ -504,7 +504,7 @@ prints). The recompiler snapshots that instruction's destination VGPR (and the n
 the vertex-position export to it, so the geometry-probe capture reads the value back per vertex. Output shows
 both float and raw hex (intermediate values are frequently integers/bitfields — read the hex for those).
 
-Workflow: `shader_inspect` the draw's VS (`--dump-realized-shader N:vs`) to find the PC whose value you want,
+Workflow: `shader_inspect` the draw's VS (`--dump-shader-raw N:vs`) to find the PC whose value you want,
 then `PROSPER_SHADER_TAP=<pc> PROSPER_GEOM_PROBE=N`. This answers "is prosper fetching the right vertex data /
 computing the right intermediate?" without an oracle — it revealed GTA V #1163's mask draws fetch plausible
 large-integer control coordinates (so the off-screen result is data-driven, not garbage). Vertex stage only; the
@@ -543,7 +543,7 @@ PROSPER_FS_TAP=6:27 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
 The fragment-stage sibling of `PROSPER_SHADER_TAP`, for "why is this **pixel** the wrong colour?" — capture a
 fragment shader's intermediate at instruction `PC` (the same PC `shader_inspect` prints) and **redirect the
 MRT0 colour export to it**, so semantic draw `DRAW`'s pixels in the rendered frame *are* the value visualised. Unlike the
-VS tap it needs no separate capture — the output BMP is the readout. Point `--dump-realized-shader DRAW:fs` +
+VS tap it needs no separate capture — the output BMP is the readout. Point `--dump-shader-raw DRAW:fs` +
 `shader_inspect` at the FS to find the PC (an `image_sample`/MIMG result, a UV, a pre-blend colour), then
 `PROSPER_FS_TAP=DRAW:PC`. gpu_replay re-recompiles only that draw's FS (needs a v19+ capsule with the raw FS
 stream); the rest of the frame renders normally, so read the tapped draw's region.
@@ -614,12 +614,22 @@ before recompiling; a plain replay of stored SPIR-V uses the modules exactly as 
 the point of a plain replay. If you are comparing a replay's vertex interface against the live
 renderer's, use one of the two that re-derive.
 
-`--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. `DRAW` is the semantic ID printed by
-`--inspect-only`, as it is for the probes above. Capture v19 adds
-`--dump-realized-shader DRAW:vs|vs-main|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized
-draw stage, suitable for `shader_inspect`. The VS/FS streams use the same content-addressed 64 KiB-per-stage,
+**The two graphics shader dumps produce opposite things, and the flag names have misled an
+investigation before (#3372).** `--dump-shader DRAW:vs|fs PATH` writes **prosper's recompiled
+SPIR-V**; `--dump-shader-raw DRAW:vs|vs-main|fs PATH` (capture v19+) writes **the guest's raw
+RDNA2 words** that fed it, suitable for `shader_inspect`. The `-raw` suffix means the same thing
+it does in the `--dump-compute` / `--dump-compute-raw` pair: the recompiler's input rather than
+its output. `--dump-realized-shader` remains accepted as an alias for `--dump-shader-raw`.
+`DRAW` is the semantic ID printed by `--inspect-only`, as it is for the probes above.
+
+The VS/FS streams use the same content-addressed 64 KiB-per-stage,
 64 MiB-total store as failed-shader diagnostics. Captures v1-v18 remain readable; because they did not retain
 realized-stage source identities, this command reports the raw stream as unavailable instead of guessing.
+
+`PROSPER_SHADER_DUMP_SUCCESS=DIR` does **not** work under `gpu_replay` — every caller of its
+hook is in the live executor, which the replay path never reaches. `gpu_replay` now says so on
+startup when the variable is set, because an empty directory otherwise reads as “that program
+never compiled”. Use the per-draw flags above instead.
 
 Selected draw ranges and ordered prefixes write the BMP at the final selected draw target's extent when
 the returned RGBA byte count confirms that native size. Presentation-scaled replays retain the capsule's
@@ -723,7 +733,7 @@ These environment variables are localization probes, not fixes, and their output
 regression oracle.
 
 Every user-facing `DRAW` selector (`--draw`, `--dump-resource`, `--dump-shader`,
-`--override-resource`, `--dump-realized-shader`, `PROSPER_GEOM_PROBE`, and `PROSPER_FS_TAP`) uses
+`--override-resource`, `--dump-shader-raw`, `PROSPER_GEOM_PROBE`, and `PROSPER_FS_TAP`) uses
 the stable semantic draw ID
 printed as `draw[ID]` by `--inspect-only`. The adjacent `item=I` is only the compact realized-vector offset;
 it can differ after an unrealized draw and is never a selector. Mixed `operation[N]` ordinals remain a separate,

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -94,8 +94,9 @@ void usage(const char* argv0) {
                  "                                      --dump-realized-shader)\n"
                  "  --dump-compute N PATH               recompiled SPIR-V for dispatch N\n"
                  "  --dump-compute-raw N PATH           the guest's raw RDNA2 for dispatch N\n"
-                 "\nPROSPER_SHADER_DUMP_SUCCESS is a live-renderer variable and does NOTHING\n"
-                 "here; use the per-draw flags above.\n");
+                 "\nPROSPER_SHADER_DUMP_SUCCESS is honoured only in the modes that RECOMPILE\n"
+                 "(--recompile-raw, --retry-failed-*); a plain replay runs stored SPIR-V and\n"
+                 "writes nothing for it. Use the per-draw flags above.\n");
 }
 
 std::vector<uint8_t> inspect_rtt_seed(const prosper::gpu::GpuCaptureRttSeed& seed) {
@@ -2166,17 +2167,6 @@ static bool clear_environment(const char* name) {
 }
 
 int main(int argc, char** argv) {
-    // #3372: every caller of maybe_dump_successful_shader() lives in the live executor
-    // (src/gpu/execute/gpu_executor.cpp); the replay path never reaches one. Saying so is not
-    // cosmetic -- an empty dump directory reads as "that program never compiled", which is
-    // exactly the trap src/gpu/diagnostics/AGENTS.md warns about.
-    if (std::getenv("PROSPER_SHADER_DUMP_SUCCESS"))
-        std::fprintf(stderr,
-                     "[gpureplay] PROSPER_SHADER_DUMP_SUCCESS is set but does NOTHING here: it is a\n"
-                     "            live-renderer variable, and gpu_replay does not reach its\n"
-                     "            hook. No file will be written for it. Use --dump-shader\n"
-                     "            DRAW:vs|fs (recompiled SPIR-V) or --dump-shader-raw\n"
-                     "            DRAW:vs|vs-main|fs (guest RDNA2) instead.\n");
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool recompile_raw = false;
     bool graph_only = false, bundle_zero_boundary = false, bundle_ds_summary = false;
@@ -2449,6 +2439,26 @@ int main(int argc, char** argv) {
     }
     if (legacy_htile_before_stencil)
         set_environment("PROSPER_GPU_REPLAY_LEGACY_HTILE_BEFORE_STENCIL", "1");
+    // #3372, corrected in review: whether gpu_replay reaches maybe_dump_successful_shader()
+    // depends on the MODE, and the first version of this notice asserted it never does.
+    // A plain replay executes the capsule's STORED SPIR-V and recompiles nothing, so the hook
+    // is never called and the directory stays empty -- which reads as "that program never
+    // compiled", the trap src/gpu/diagnostics/AGENTS.md warns about. But --recompile-raw and
+    // --retry-failed-* DO recompile, through tools/gpu_replay/compute_recompile.hpp ->
+    // gpu::recompile_compute_shader_cached (gpu_executor.cpp), which calls the hook on every
+    // exit path -- so under those modes the variable works. Warn only when this invocation
+    // genuinely will not reach it; a notice that is wrong in one mode is the same defect at the
+    // point of use that this change exists to remove.
+    const bool replay_recompiles = recompile_raw || !retry_failed_chain_spec.empty() ||
+                                   !retry_failed_stage_spec.empty();
+    if (std::getenv("PROSPER_SHADER_DUMP_SUCCESS") && !replay_recompiles)
+        std::fprintf(stderr,
+                     "[gpureplay] PROSPER_SHADER_DUMP_SUCCESS is set, but a plain replay runs the\n"
+                     "            capsule's STORED SPIR-V and recompiles nothing, so no file\n"
+                     "            will be written for it. --recompile-raw and --retry-failed-*\n"
+                     "            DO recompile and DO honour it. For one shader by draw, use\n"
+                     "            --dump-shader DRAW:vs|fs (recompiled SPIR-V) or\n"
+                     "            --dump-shader-raw DRAW:vs|vs-main|fs (guest RDNA2).\n");
     // An argument that silently does nothing is the class this PR spent three rounds removing.
     if (resource_override_submit_no && !resource_override_requested) {
         std::fprintf(stderr,

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -71,7 +71,7 @@ void usage(const char* argv0) {
                          "[--dump-rtt-seed ADDR PATH] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
                          "[--dump-compute-raw N PATH] "
-                         "[--dump-realized-shader DRAW:vs|vs-main|fs PATH] "
+                         "[--dump-shader-raw DRAW:vs|vs-main|fs PATH] "
                          "[--override-compute-spv N PATH] "
                          "[--dump-failed-shader FAILURE:STAGE PATH] "
                          "[--retry-failed-chain FAILURE] "
@@ -82,6 +82,20 @@ void usage(const char* argv0) {
                          "[--require-post-change] [--expect-post-hash HASH] "
                          "[--legacy-htile-before-stencil] "
                          "<capture.prgcap> [output.bmp]\n", argv0);
+    // #3372: these four flags dump two DIFFERENT things, and the names alone do not say
+    // which. Reading the guest RDNA2 out of a flag whose name suggested SPIR-V cost one
+    // investigation a session, so the synopsis above is not left to speak for itself.
+    std::fprintf(stderr,
+                 "\nshader dumps -- what each one WRITES:\n"
+                 "  --dump-shader DRAW:vs|fs PATH       prosper's recompiled SPIR-V\n"
+                 "  --dump-shader-raw DRAW:vs|vs-main|fs PATH\n"
+                 "                                      the guest's raw RDNA2 words that\n"
+                 "                                      fed it (accepted alias:\n"
+                 "                                      --dump-realized-shader)\n"
+                 "  --dump-compute N PATH               recompiled SPIR-V for dispatch N\n"
+                 "  --dump-compute-raw N PATH           the guest's raw RDNA2 for dispatch N\n"
+                 "\nPROSPER_SHADER_DUMP_SUCCESS is a live-renderer variable and does NOTHING\n"
+                 "here; use the per-draw flags above.\n");
 }
 
 std::vector<uint8_t> inspect_rtt_seed(const prosper::gpu::GpuCaptureRttSeed& seed) {
@@ -2152,6 +2166,17 @@ static bool clear_environment(const char* name) {
 }
 
 int main(int argc, char** argv) {
+    // #3372: every caller of maybe_dump_successful_shader() lives in the live executor
+    // (src/gpu/execute/gpu_executor.cpp); the replay path never reaches one. Saying so is not
+    // cosmetic -- an empty dump directory reads as "that program never compiled", which is
+    // exactly the trap src/gpu/diagnostics/AGENTS.md warns about.
+    if (std::getenv("PROSPER_SHADER_DUMP_SUCCESS"))
+        std::fprintf(stderr,
+                     "[gpureplay] PROSPER_SHADER_DUMP_SUCCESS is set but does NOTHING here: it is a\n"
+                     "            live-renderer variable, and gpu_replay does not reach its\n"
+                     "            hook. No file will be written for it. Use --dump-shader\n"
+                     "            DRAW:vs|fs (recompiled SPIR-V) or --dump-shader-raw\n"
+                     "            DRAW:vs|vs-main|fs (guest RDNA2) instead.\n");
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool recompile_raw = false;
     bool graph_only = false, bundle_zero_boundary = false, bundle_ds_summary = false;
@@ -2342,7 +2367,11 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-shader" && i + 2 < argc) {
             shader_spec = argv[++i]; shader_path = argv[++i];
         }
-        else if (std::string(argv[i]) == "--dump-realized-shader" && i + 2 < argc) {
+        // #3372: --dump-shader-raw is the spelling that matches the --dump-compute /
+        // --dump-compute-raw pair, where -raw already means "the guest RDNA2 that fed it".
+        // --dump-realized-shader keeps working: it is cited in docs/ and in existing scripts.
+        else if ((std::string(argv[i]) == "--dump-shader-raw" ||
+                  std::string(argv[i]) == "--dump-realized-shader") && i + 2 < argc) {
             realized_shader_spec = argv[++i]; realized_shader_path = argv[++i];
         }
         else if (std::string(argv[i]) == "--dump-compute" && i + 2 < argc) {

--- a/prosper/tools/gpu_replay/test_cli_contract.py
+++ b/prosper/tools/gpu_replay/test_cli_contract.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# test_cli_contract.py (#3372) -- the gpu_replay CLI must SAY what its two shader dumps produce.
+#
+# This is not a style guard. --dump-shader writes prosper's recompiled SPIR-V and the raw flag
+# writes the guest's RDNA2 words that fed it; an investigation read the RDNA2 out of the flag whose
+# name suggested SPIR-V, concluded no SPIR-V was obtainable, and filed #3372 -- a session lost to a
+# usage string that listed the flags without saying which way round they go. Nothing else in the
+# tree can fail when that wording is dropped, so this does.
+#
+# It drives the real binary rather than grepping the source: the point is what an operator SEES.
+import os
+import subprocess
+import sys
+
+REPLAY = os.environ.get("PROSPER_GPU_REPLAY_BIN")
+if not REPLAY or not os.path.exists(REPLAY):
+    # 77 -> ctest reports "(Skipped)" BY NAME. Exiting 0 here would make "the tool was never
+    # built" and "the contract holds" the same result, which is the failure this file exists
+    # to prevent. gpu_replay needs Vulkan, so it is genuinely absent in some environments.
+    print("gpu_replay binary not built (PROSPER_GPU_REPLAY_BIN unset or missing) -- skipping")
+    sys.exit(77)
+
+failures = []
+
+
+def check(condition, message):
+    if condition:
+        print("  [ok]   %s" % message)
+    else:
+        print("  [FAIL] %s" % message)
+        failures.append(message)
+
+
+def run(args, env_extra=None):
+    env = dict(os.environ)
+    env.pop("PROSPER_SHADER_DUMP_SUCCESS", None)
+    if env_extra:
+        env.update(env_extra)
+    done = subprocess.run([REPLAY] + args, capture_output=True, text=True, env=env, timeout=120)
+    return done.stdout + done.stderr
+
+
+print("== test_gpu_replay_cli_contract ==")
+
+# No arguments -> usage. The legend must travel with it.
+usage = run([])
+check("--dump-shader-raw" in usage, "usage names --dump-shader-raw")
+check("--dump-realized-shader" in usage,
+      "usage still names the --dump-realized-shader alias, so existing scripts stay discoverable")
+
+# The two directions must each be spelled out, and on the correct flag. Find the legend line for
+# each flag and assert what it claims -- asserting only that both words appear SOMEWHERE would
+# pass with the meanings swapped, which is the exact defect #3372 reports.
+lines = usage.splitlines()
+
+
+def legend_line(flag):
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith(flag + " ") or stripped.startswith(flag + "	"):
+            return stripped
+    return ""
+
+
+spirv_line = legend_line("--dump-shader")
+check("SPIR-V" in spirv_line and "RDNA2" not in spirv_line,
+      "--dump-shader is described as producing SPIR-V, not RDNA2")
+
+# The raw flag wraps onto continuation lines, so take the legend block after it.
+raw_index = next((i for i, l in enumerate(lines) if "--dump-shader-raw" in l and "[" not in l), None)
+check(raw_index is not None, "usage carries a legend entry for --dump-shader-raw")
+raw_block = " ".join(lines[raw_index:raw_index + 4]) if raw_index is not None else ""
+check("RDNA2" in raw_block, "--dump-shader-raw is described as producing the guest RDNA2")
+check("alias" in raw_block and "--dump-realized-shader" in raw_block,
+      "the legend names --dump-realized-shader as the alias of --dump-shader-raw")
+
+# The compute pair is the naming precedent the graphics pair now follows; if it ever stops saying
+# so, the -raw suffix loses the meaning this fix leaned on.
+compute_raw = legend_line("--dump-compute-raw")
+check("RDNA2" in compute_raw, "--dump-compute-raw is described as producing the guest RDNA2")
+
+# An armed-but-inert diagnostic must announce itself. An empty output directory otherwise reads as
+# "that program never compiled" -- the trap src/gpu/diagnostics/AGENTS.md warns about.
+armed = run([], {"PROSPER_SHADER_DUMP_SUCCESS": "ignored-by-this-tool"})
+check("PROSPER_SHADER_DUMP_SUCCESS" in armed,
+      "gpu_replay says PROSPER_SHADER_DUMP_SUCCESS is set when it is")
+check("NOTHING" in armed or "does not" in armed or "no file" in armed.lower(),
+      "gpu_replay says the variable will produce no file here")
+
+quiet = run([])
+check("is set but does NOTHING here" not in quiet,
+      "the notice stays silent when the variable is unset")
+
+print("%d failure(s)" % len(failures))
+sys.exit(1 if failures else 0)

--- a/prosper/tools/gpu_replay/test_cli_contract.py
+++ b/prosper/tools/gpu_replay/test_cli_contract.py
@@ -79,16 +79,58 @@ check("alias" in raw_block and "--dump-realized-shader" in raw_block,
 compute_raw = legend_line("--dump-compute-raw")
 check("RDNA2" in compute_raw, "--dump-compute-raw is described as producing the guest RDNA2")
 
+# The legend must not restate the absolute claim the notice used to make.
+check("only in the modes that RECOMPILE" in usage,
+      "the usage legend scopes PROSPER_SHADER_DUMP_SUCCESS to the recompiling modes")
+
 # An armed-but-inert diagnostic must announce itself. An empty output directory otherwise reads as
 # "that program never compiled" -- the trap src/gpu/diagnostics/AGENTS.md warns about.
-armed = run([], {"PROSPER_SHADER_DUMP_SUCCESS": "ignored-by-this-tool"})
-check("PROSPER_SHADER_DUMP_SUCCESS" in armed,
-      "gpu_replay says PROSPER_SHADER_DUMP_SUCCESS is set when it is")
-check("NOTHING" in armed or "does not" in armed or "no file" in armed.lower(),
-      "gpu_replay says the variable will produce no file here")
+#
+# But it is inert only in SOME modes, and the first version of this notice claimed it was inert
+# in all of them. --recompile-raw and --retry-failed-* recompile through compute_recompile.hpp ->
+# gpu::recompile_compute_shader_cached, which calls maybe_dump_successful_shader on every exit
+# path, so the variable genuinely works there. A notice that is wrong in one mode is the same
+# wrong-text-at-the-point-of-use defect this whole file exists to guard, one level up -- so both
+# directions are pinned below, not just the warning.
+
+def notice_block(text):
+    """Just the PROSPER_SHADER_DUMP_SUCCESS notice, never the usage synopsis.
+
+    Measured necessity, not caution: searching the whole output for '--recompile-raw' PASSES
+    against the pre-fix binary, because the synopsis lists the flag. Two of these arms were
+    green in both directions until this helper existed -- the same defect they are guarding.
+    """
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if "PROSPER_SHADER_DUMP_SUCCESS" in line and line.lstrip().startswith("[gpureplay]"):
+            block = [lines[i]]
+            for cont in lines[i + 1:]:
+                if not cont.startswith("            "):
+                    break
+                block.append(cont)
+            return " ".join(block)
+    return ""
+
+
+armed_all = run([], {"PROSPER_SHADER_DUMP_SUCCESS": "ignored-on-this-path"})
+armed = notice_block(armed_all)
+check(armed != "",
+      "a plain replay says PROSPER_SHADER_DUMP_SUCCESS is set when it is")
+check("no file" in armed.lower() or "NOTHING" in armed,
+      "...and says no file will be written for it on that path")
+check("--recompile-raw" in armed,
+      "...and names a mode that DOES honour it, rather than implying it never works")
+
+# The other direction. A capture path that does not exist is fine: the notice is emitted after
+# argument parsing and before the capture is opened, so if it were unconditional it would still
+# appear here. It must not.
+recompiling = run(["--recompile-raw", "no-such-capture.prgcap"],
+                  {"PROSPER_SHADER_DUMP_SUCCESS": "honoured-on-this-path"})
+check(notice_block(recompiling) == "",
+      "--recompile-raw does NOT claim the variable is inert -- it honours it")
 
 quiet = run([])
-check("is set but does NOTHING here" not in quiet,
+check(notice_block(quiet) == "",
       "the notice stays silent when the variable is unset")
 
 print("%d failure(s)" % len(failures))


### PR DESCRIPTION
Fixes #3372.

## The failure scenario

`gpu_replay --dump-shader DRAW:vs PATH` writes prosper's **recompiled SPIR-V**.
`--dump-realized-shader DRAW:vs PATH` writes the **guest's raw RDNA2 words** that fed it. The names
read the opposite way round, and the usage string listed both flags with no indication which was
which.

The consequence is on the record: an investigation read the RDNA2 out of the flag whose name
suggested SPIR-V, saw a `bfa00003` magic that `spirv-dis` rejected, concluded that no SPIR-V was
obtainable from a capsule, and filed #3372 against a capability that had been present all along.
The reporter's own correction says it cost "a session's worth of sequencing".

Nothing was broken. The tool could always do the thing; the text at the point of use could not be
read correctly.

## Behavioural contract

- Each of the four shader-dump flags states what it **writes**, in the usage output.
- `--dump-shader-raw` is the primary spelling for the guest-RDNA2 dump; `--dump-realized-shader`
  keeps working, unchanged — it is cited in `docs/` and in `tools/shader_conformance/scan.py`.
- `PROSPER_SHADER_DUMP_SUCCESS`, which cannot work under `gpu_replay`, says so instead of writing
  nothing in silence.

## Approach

Three changes, in ascending order of how much they matter:

**1. The usage text now carries a legend** naming what each dump produces. This is the actual fix.
The README's reference section was already correct at `:617` — so what failed was not the
documentation, it was the text an operator sees at the moment of use. Fixing only prose would have
left the trap armed for everyone who does not read a 700-line README first.

**2. `--dump-shader-raw` added as an alias-compatible rename.** `-raw` already means "the
recompiler's input rather than its output" in the adjacent `--dump-compute` / `--dump-compute-raw`
pair, documented in this same README. The graphics pair now matches that convention instead of
contradicting it. Both spellings parse to one code path, so this cannot break a caller.

This goes slightly beyond the issue's re-scoped suggestion, which asked only for wording. The
justification: the issue's own diagnosis is that the names are "the opposite way round from what the
words suggest", and wording alone leaves the misleading name as the only name. It is four lines and
backward compatible.

**3. `PROSPER_SHADER_DUMP_SUCCESS` announces that it will write nothing on the paths where that is true.**

> **Corrected after review — the first version of this section was wrong.** It claimed the replay path reaches `maybe_dump_successful_shader` on no path at all. It does reach it under `--recompile-raw` and `--retry-failed-*`, which recompile through `tools/gpu_replay/compute_recompile.hpp` → `gpu::recompile_compute_shader_cached`, and that function calls the hook on every exit path. I inherited the claim from #3372's own text and shipped it as an assertion — in the change whose subject is wrong text at the point of use. See commit `427c38b9`.

A plain replay runs the capsule's stored SPIR-V and recompiles nothing, so the directory stays empty — and an empty directory reads as “that program never compiled”, the trap `src/gpu/diagnostics/AGENTS.md` warns about and the one the reporter fell into. The notice is now emitted after argument parsing and gated on the mode, so it fires exactly when it is true, and names the modes that do honour the variable.

## Docs: what was repointed and what was left

Per the charter's test — *a record of what was true keeps the old name; anything a reader would run
or follow gets repointed*:

| repointed (recipes / present tense) | left alone (records) |
| --- | --- |
| `gpu_replay/README.md` example, VS-tap and FS-tap workflows, selector list, reference paragraph | `GAME_COMPAT_ORCHESTRATION.md` instrument-trap row 63 |
| `tools/AGENTS.md` capability description | `docs/ASTERIX_BABYLON_STATUS.md` past-run account |

`tools/shader_conformance/scan.py` was left on the old spelling deliberately: it works unchanged via
the alias, and repointing it would have put a behaviour-neutral edit in a file this PR otherwise
does not touch.

## Regression arm

`gpu_replay_cli_contract` (new, test #335) drives the **real binary** and reads what an operator
would see, rather than grepping the source for a string.

The discriminating detail: it locates the legend line **for each flag** and asserts what that line
claims. Asserting merely that "SPIR-V" and "RDNA2" both appear somewhere in the output would pass
with the two meanings swapped — which is the exact defect being fixed, so that weaker test would
have been void.

It skips with **77** (`SKIP_RETURN_CODE`, reported by name as `(Skipped)`) where `gpu_replay` was not
built. Exiting 0 there would make "the tool does not exist" and "the contract holds" the same
result.

### Does it fail without the fix?

Yes — measured, not asserted. Built `gpu_replay` from **pristine `origin/main`** in a separate
worktree and ran this same test against it:

```
8 failure(s)     WITHOUT_FIX_EXIT=1
```

The two checks that *do* pass on pristine main are the two that should: the old usage already names
`--dump-realized-shader`, and the new notice is correctly silent when the variable is unset. Against
this branch's binary: **10/10, exit 0**.

### Is the alias real, or just documented?

Negative control included, since "the flag appears in usage" is not "the flag is accepted":

| invocation | result |
| --- | --- |
| `--dump-shader-bogus 0:vs out.bin missing.prgcap` | rejected, usage dumped |
| `--dump-shader-raw 0:vs out.bin missing.prgcap` | accepted, proceeds to open the capture |
| `--dump-realized-shader 0:vs out.bin missing.prgcap` | accepted, identical behaviour |

## Affected / deliberately unaffected

- **Unaffected:** every existing flag, every existing spelling, all dump behaviour, all replay
  behaviour. No runtime code path changes; `gpu_replay.cpp`'s only non-text change is one added
  `||` in argument parsing and one `getenv` check at the top of `main`.
- **Affected:** usage output, one new ctest case, four doc sites.

## Risks

Low. The largest is the new `if(TARGET gpu_replay ...)` block in `CMakeLists.txt`: it is placed
before the trailing `PROSPER_TEST_SCRATCH_DIR` loop, which snapshots the `TESTS` directory property
and would not have covered a test registered after it. Verified the new case is enumerated
(`Test #335`).

## Verification

Platform note, stated because it bounds what this evidence covers: **this machine's WSL has Vulkan
1.3.275 headers, and `frontends/shared/device/vulkan_runtime.hpp:11` needs `VK_API_VERSION_1_4`**, so
the live-renderer chain — and therefore `gpu_replay` — cannot be built under WSL here at all. All
execution evidence below is **Windows/MinGW with Vulkan SDK 1.4.350.0**. Linux coverage is limited to
a successful CMake configure.

```
cmake -S prosper -B <build> -G Ninja -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build <build> --target gpu_replay -j 6        -> exit 0, gpu_replay linked
cmake --build <build> -j 6                            -> exit 0 (528 targets)
ctest --test-dir <build> --no-tests=error -R gpu_replay --output-on-failure
    -> 7/7 passed, exit 0   (#276 output_extent, #277 shader_dump, #278 resource_override,
                             #279 post_compute_resource, #280 pixel_inputs, #335 cli_contract, +1)
```

Docs gate over every tracked `.md`, run because this PR touches three of them:

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py   -> 0 errors
```

That gate earned its place here: it caught me writing `README.md` back as **cp1252** in an earlier
revision of this branch, which mis-encoded an em dash and two quotes into invalid UTF-8. Repaired by
re-deriving the file from `origin/main` and re-applying the edits with explicit UTF-8; the gate is
clean and the final three-dot diff against `origin/main` is 5 files, with no EOL or encoding churn.

`git diff --check`: clean. Session-trailer gate: 0.

Full-suite Windows ctest is running; I will post the count and exit code as a comment on this PR
before merging rather than claiming it here.
