### PR TITLE
loader: unresolved DATA imports must not bind to a code stub, and AddAmprEvent must keep the guest's udata (#3529, #3500)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -671,6 +671,11 @@ if(TARGET prosper_core)
              COMMAND test_nid "${GAME_DUMP}/eboot.bin")
   endif()
 
+  # #3529: the initial value of an unresolved DATA import. Pure -- no dump, no mapping.
+  add_executable(test_import_data_seed tests/hle/dispatch/test_import_data_seed.cpp)
+  target_link_libraries(test_import_data_seed PRIVATE prosper_core)
+  add_test(NAME import_data_seed COMMAND test_import_data_seed)
+
   add_executable(test_hle_registered tests/hle/test_hle_registered.cpp)
   target_link_libraries(test_hle_registered PRIVATE prosper_core)
   add_test(NAME hle_functions_registered COMMAND test_hle_registered)

--- a/prosper/src/hle/dispatch/import_data_seed.cpp
+++ b/prosper/src/hle/dispatch/import_data_seed.cpp
@@ -1,0 +1,23 @@
+#include "import_data_seed.hpp"
+#include "nid.hpp"
+
+#include <cstring>
+
+namespace prosper {
+
+bool seed_import_data(const std::string& nid, uint8_t* slot, size_t size) {
+    if (!slot) return false;
+    // Hashed at first use rather than written as a literal, for the reason nid_census's --self-check
+    // exists: a hard-coded 11-character string is unverifiable by inspection, while `nid_hash` is
+    // the same function the loader resolves imports with. If the two ever disagreed, everything
+    // would disagree together instead of this one table silently missing.
+    static const std::string kStackChkGuard = nid_hash("__stack_chk_guard");
+    if (nid == kStackChkGuard && size >= sizeof(uint64_t)) {
+        const uint64_t v = kStackGuardValue;
+        memcpy(slot, &v, sizeof v);
+        return true;
+    }
+    return false;
+}
+
+} // namespace prosper

--- a/prosper/src/hle/dispatch/import_data_seed.hpp
+++ b/prosper/src/hle/dispatch/import_data_seed.hpp
@@ -1,0 +1,46 @@
+// import_data_seed.hpp — the initial value of an unresolved Sony DATA import.
+//
+// The dispatcher answers unresolved FUNCTION imports; this answers the handful of unresolved
+// *variables*. Both are the same question — "prosper is this Sony library, what does it provide?" —
+// asked about an object instead of an entry point, which is why it lives beside the dispatcher.
+//
+// Everything not listed here stays ZERO. Zero is the honest default for a variable whose contents
+// prosper does not know: it is stable, it is what a reader gets from a fresh page, and for a
+// pointer-shaped object it makes the guest take its own null branch instead of dereferencing
+// whatever bytes happened to be there.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace prosper {
+
+// The stack canary prosper supplies through `__stack_chk_guard`.
+//
+// WHY A VALUE AT ALL, AND WHY THIS ONE. `__stack_chk_guard` is a libkernel *variable*, and libkernel
+// is prosper — so supplying it is reimplementation, not invention. Every function a title compiled
+// with `-fstack-protector` stores it into its frame on entry and compares on return, so the only
+// property the contract needs is that both reads agree; the platform additionally makes it non-zero
+// and per-process random.
+//
+// Non-zero rather than zero is the choice that PRESERVES measured behaviour. Before #3529 this
+// import was bound into the code-stub aperture, so every title in the local corpus — all 60 of
+// them, 728 bindings — has been reading prosper's own machine code here and booting with it. That
+// value is non-zero and stable, which is exactly why a defect this universal stayed invisible.
+// Leaving the slot zero would therefore have been the novel change, and it would also silently
+// disable `-fstack-protector` in every guest.
+//
+// The low byte is 0x00 on purpose (the "terminator canary" convention): a string-based overflow that
+// runs through the canary cannot copy past it without writing the NUL. The remaining bytes spell
+// "PROSPER" in memory order, so a canary slot is recognisable on sight in a stack dump. Fixed rather
+// than randomised so a run is reproducible — prosper has no attacker model, and a deterministic
+// boot is worth more here than an unpredictable canary.
+inline constexpr uint64_t kStackGuardValue = 0x52455053'4F525000ull;
+// little-endian bytes, in memory order: 00 'P' 'R' 'O' 'S' 'P' 'E' 'R'
+
+// Write the initial bytes of the data import `nid` into `slot` (`size` bytes available).
+// Returns true when a value was written, false when the slot should be left as it is (zero).
+// `slot` is assumed zero-filled on entry, so a partial write is still well-defined.
+bool seed_import_data(const std::string& nid, uint8_t* slot, size_t size);
+
+} // namespace prosper

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -1735,9 +1735,15 @@ HLE(k_eq_getcount){
 // individually. See the discrimination comment in prosper_eq_post_apr_token below.
 // CONFIDENCE: HIGH — ctor seeding, walk bounds, unconditional last:=cnt store, handler match/hash/
 // null-entry paths all from static disassembly; tag-echo event consumption live-verified (#180).
+uint64_t prosper_eq_apr_udata(uint64_t eq, int64_t id);   // defined below, with the registry
+
 namespace {
     constexpr int16_t EVFILT_AMPR_MODELED = -24;   // guest never reads filter; distinct on purpose
-    struct AprEqReg { uint64_t eq; int64_t id; };
+    // udata is the guest's own pointer, handed to sceKernelAddAmprEvent and handed BACK on every
+    // completion event through sceKernelGetEventUserData. It is not decoration: NINJA GAIDEN 4's
+    // Wwise I/O hook dereferences it directly (`call sceKernelGetEventUserData; mov edi,[rax]` at
+    // eboot+0x28c319c), so dropping it is a null pointer handed to the guest (#3500).
+    struct AprEqReg { uint64_t eq; int64_t id; uint64_t udata = 0; };
     // Own mutex (NOT g_eq_mx): the post path calls eq_post/eq_find, which lock g_eq_mx themselves.
     // Detached APR delivery threads can outlive main, so the mutex and every container they touch
     // are one intentionally immortal heap object. Heap placement also keeps the hot mutex out of
@@ -1756,9 +1762,9 @@ namespace {
         return (eq_identity << 6) | (ring & 0x3f);
     }
     void apr_post(uint64_t eq, uint64_t eq_identity, int64_t id,
-                  unsigned ring, uint64_t token, bool coalesce) {   // no APR lock held
+                  unsigned ring, uint64_t token, bool coalesce, uint64_t udata) {   // no APR lock held
         SceKEvent e{}; e.ident = id + (int64_t)ring; e.filter = EVFILT_AMPR_MODELED;
-        e.data = (int64_t)token; e.udata = 0;
+        e.data = (int64_t)token; e.udata = udata;
         eq_post(eq, e, coalesce, eq_identity);
     }
 }
@@ -1820,6 +1826,9 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
                 nanosleep(&ts, nullptr);
                 for (auto& p : batch) {
                     SceKEvent e{}; e.ident = 0; e.filter = EVFILT_AMPR_MODELED; e.data = (int64_t)p.token;
+                    // Both dialects hand the udata back; the guest reads it through the same
+                    // accessor regardless of which one delivered the event.
+                    e.udata = prosper_eq_apr_udata(p.eq, 0);
                     eq_post(p.eq, e, /*coalesce=*/false, p.eq_identity);
                 }
                 lk.lock();
@@ -1887,7 +1896,9 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
             std::lock_guard lk(state.mx);
             hwm = state.tag_hwm[hwm_key];
         }
-        apr_post(eq, eq_identity, id, ring, ((uint64_t)ring << 58) | hwm, counter_dialect);
+        // Resolved BEFORE the post, not inside it: apr_post runs with no APR lock held on purpose.
+        apr_post(eq, eq_identity, id, ring, ((uint64_t)ring << 58) | hwm, counter_dialect,
+                 prosper_eq_apr_udata(eq, id));
     }).detach();
 }
 // Assign the next completion token for `ring` (0-based, 6 bits) — for UNBOUND submits only, whose
@@ -1905,15 +1916,33 @@ uint64_t prosper_apr_next_token(unsigned ring) {
 // by the guest via record polling, and replaying invented counters would regress the listener's
 // ctor-seeded per-ring last-processed (see the block comment above; the pre-#208 replay was the
 // root cause of the #180 range-walk fault).
-void prosper_eq_add_apr(uint64_t eq, int64_t id) {
+void prosper_eq_add_apr(uint64_t eq, int64_t id, uint64_t udata) {
     AprTokenState& state = apr_token_state();
     std::lock_guard lk(state.mx);
     for (auto& r : state.eq_regs)
-        if (r.eq == eq && r.id == id) return;   // idempotent
-    state.eq_regs.push_back({ eq, id });
+        if (r.eq == eq && r.id == id) {
+            // Idempotent, but UPGRADING: several paths register the same (eq, id) and only
+            // sceKernelAddAmprEvent carries the guest's udata — the command-buffer binding and the
+            // measure-sizing compatibility call both pass 0. A plain early return would keep
+            // whichever arrived first, so a real pointer would be lost whenever one of those ran
+            // before AddAmprEvent. Never overwrite a real udata with 0.
+            if (udata && !r.udata) r.udata = udata;
+            return;
+        }
+    state.eq_regs.push_back({ eq, id, udata });
+}
+
+// The udata registered for this (eq, id), or 0 if none. Separate from the post path because that
+// path runs with no APR lock held and must not take one -- it calls eq_post, which locks g_eq_mx.
+uint64_t prosper_eq_apr_udata(uint64_t eq, int64_t id) {
+    AprTokenState& state = apr_token_state();
+    std::lock_guard lk(state.mx);
+    for (const auto& r : state.eq_regs)
+        if (r.eq == eq && r.id == id) return r.udata;
+    return 0;
 }
 HLE(k_add_ampr_event) {   // sceKernelAddAmprEvent(eq, id, udata)
-    if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
+    if (a0) prosper_eq_add_apr(a0, (int64_t)a1, a2);
     if (evlog()) fprintf(stderr, "[ev] AddAmprEvent eq=0x%llx id=%lld udata=0x%llx\n",
         (unsigned long long)a0, (long long)a1, (unsigned long long)a2);
     return 0;

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -353,7 +353,7 @@ static uint64_t ampr_arglog(const char* tag, uint64_t a0, uint64_t a1, uint64_t 
 }
 
 uint64_t prosper_apr_next_token(unsigned ring);                          // hle_kernel_time.cpp
-void prosper_eq_add_apr(uint64_t eq, int64_t id);                        // "
+void prosper_eq_add_apr(uint64_t eq, int64_t id, uint64_t udata);        // "
 uint64_t prosper_eq_identity(uint64_t eq);                               // " (lifetime guard)
 void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
                                int64_t id, uint64_t token);              // " (tag echo, #208)
@@ -506,7 +506,7 @@ static uint64_t apr_cb_set_equeue(uint64_t command_size, bool eager_completion,
                                  uint64_t a0, uint64_t a1, uint64_t a2,
                                  uint64_t a3, uint64_t a4, uint64_t a5) {
     ampr_arglog("H896Pt-yB4I(CbSetEqueue)", a0, a1, a2, a3, a4, a5);
-    if (a1) prosper_eq_add_apr(a1, (int64_t)a2);
+    if (a1) prosper_eq_add_apr(a1, (int64_t)a2, 0);   // binding call carries no udata
     bool start_worker = false;
     if (a0) {
         AprBoundState& state = apr_bound_state();
@@ -2643,7 +2643,7 @@ HLE(k_ampr_measure_write_equeue) { // sSAUCCU1dv4 = sceAmprMeasureCommandSizeWri
     // DOLL's older SDK wrapper passes the live event queue and APR id here while constructing its
     // listener. Until prosper executes the encoded command itself, preserve that registration as
     // a compatibility side effect. Sonic's sizing call passes a null queue and remains pure.
-    if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
+    if (a0) prosper_eq_add_apr(a0, (int64_t)a1, 0);   // sizing call carries no udata
     return 20;
 }
 HLE(k_ampr_destruct_320) {

--- a/prosper/src/host/image/AGENTS.md
+++ b/prosper/src/host/image/AGENTS.md
@@ -21,7 +21,12 @@ what produces that set — it is where `<dump>/Media/Plugins/…` becomes a `Lin
   replacements of Sony libraries, and this is what keeps them from being linked and shadowing
   prosper's own implementations.
 - **`exec_image_{linux,win}.cpp`** behind `exec_image.hpp` — the per-platform mapping substrate.
-  Platform divergence belongs *here*, not in `boot_program.cpp`.
+  Platform divergence belongs *here*, not in `boot_program.cpp`. It owns **two** fixed apertures,
+  not one: the executable import-stub table at `BOOT_STUB` (`install_stubs`) and the writable,
+  never-executable import-DATA table at `BOOT_IMPORT_DATA` (`install_import_data`, #3529). They are
+  separate address windows on purpose — `callback_fs.hpp` reads any return address inside
+  `[0x600000000, 0x700000000)` as an import-stub frame, so nothing else may live there, and a guest
+  store to an unresolved variable must not be able to reach executable pages.
 - **`runtime_module_load.*`** — the guest asking for a module after boot, as opposed to the fixed
   preload list. True runtime PRX loading is not implemented (#639), which is why the preload list
   carries so many optional entries: they exist so a first P/Invoke resolves instead of hanging.

--- a/prosper/src/host/image/boot_program.cpp
+++ b/prosper/src/host/image/boot_program.cpp
@@ -323,7 +323,7 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     std::vector<LinkInput> in = boot_link_inputs(d);
 
     std::string e;
-    if (!link_program(in, BOOT_STUB, p, &e)) return fail("link failed: " + e);
+    if (!link_program(in, BOOT_STUB, BOOT_IMPORT_DATA, p, &e)) return fail("link failed: " + e);
     // Loud, self-describing report of every auto-linked plugin the linker refused: which module was
     // dropped, the exact NID that collided, and which already-linked module owns it.
     for (const auto& s : p.skipped_modules)
@@ -345,10 +345,10 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
         if (p.aliased_exports.size() > shown)
             printf("export alias: ... and %zu more\n", p.aliased_exports.size() - shown);
     }
-    printf("linked %zu modules; %zu imports (%zu cross-module, %zu stub slots); %zu init fns; "
-           "%zu aliased exports\n",
+    printf("linked %zu modules; %zu imports (%zu cross-module, %zu stub slots, %zu data slots); "
+           "%zu init fns; %zu aliased exports\n",
            p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(),
-           p.init_fns.size(), p.aliased_exports.size());
+           p.data_slots.size(), p.init_fns.size(), p.aliased_exports.size());
 
     // Diagnostics: linking complete.
     diagnostics::record_boot_phase(diagnostics::BootPhase::LINKING);
@@ -400,6 +400,12 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     // is synchronised either way (dispatch_append_slots), this just avoids the copy.
     p.slots.reserve(p.slots.size() + 1024);
     if (!install_stubs(p.slots, p.stub_base, p.stub_size, &e)) return fail("stubs failed: " + e);
+    // The writable aperture behind every unresolved DATA import (#3529). Installed here rather than
+    // lazily: the guest reaches a data import during the very first init_array below (libc's own
+    // startup writes __stack_chk_guard), so the pages must exist before run_guest_inits runs.
+    p.data_slots.reserve(p.data_slots.size() + 128);
+    if (!install_import_data(p.data_slots, p.data_base, p.data_stride, &e))
+        return fail("import data failed: " + e);
     install_trap_handler();
 
     // Diagnostics: stubs and trap handler installed.

--- a/prosper/src/host/image/boot_program.hpp
+++ b/prosper/src/host/image/boot_program.hpp
@@ -51,6 +51,15 @@ inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
 // (Kept clear of the ad-hoc stub bases a few unit tests pass to install_stubs — 0x680000000,
 // 0x710000000, 0x720000000, 0x730000000 — so a future test that boots a program and loads a module
 // in one process cannot alias them.)
+// The import-DATA aperture (#3529): one writable, non-executable, zero-filled page per unresolved
+// STT_OBJECT import. Deliberately OUTSIDE [0x600000000, 0x700000000) -- callback_fs.hpp reads any
+// return address in that window as an import-stub frame, and exec_image.hpp's comment above
+// kStubApertureBytes says nothing else may be mapped in it. Also clear of the ad-hoc stub bases a
+// few unit tests pass to install_stubs (0x680000000, 0x710000000-0x730000000) and of the runtime
+// PRX pool below.
+inline constexpr uint64_t BOOT_IMPORT_DATA     = 0x7c0000000ull;
+inline constexpr uint64_t BOOT_IMPORT_DATA_END = 0x7d0000000ull;   // 256 MiB, as for the stubs
+
 inline constexpr uint64_t BOOT_RUNTIME_MODULE_BASE   = 0x800000000ull;
 inline constexpr uint64_t BOOT_RUNTIME_MODULE_STRIDE = 0x8000000ull;   // 128 MiB
 inline constexpr unsigned BOOT_RUNTIME_MODULE_SLOTS  = 48;
@@ -98,6 +107,11 @@ inline const char* guest_module_name(uint64_t a) {
     // which slot holds which module is a run-local fact, so the offset is reported modulo the
     // stride and the exact module comes from the loader's own [loadmod] line.
     if (a >= BOOT_RUNTIME_MODULE_BASE && a < BOOT_RUNTIME_MODULE_END) return "runtime-prx";
+    // Deliberately labelled but NOT added to guest_va_in_module below: the label makes a fault
+    // report say which unresolved variable was touched, while guest_va_in_module feeds
+    // guest_va_in_module_code, and this aperture is data. A stack scan must not mistake it for a
+    // guest return address.
+    if (a >= BOOT_IMPORT_DATA && a < BOOT_IMPORT_DATA_END) return "import-data";
     return "mapped/host";
 }
 inline uint64_t guest_module_offset(uint64_t a) {
@@ -121,6 +135,7 @@ inline uint64_t guest_module_offset(uint64_t a) {
     if (a >= BOOT_STUB          && a < 0x610000000ull)     return a - BOOT_STUB;
     if (a >= BOOT_RUNTIME_MODULE_BASE && a < BOOT_RUNTIME_MODULE_END)
         return (a - BOOT_RUNTIME_MODULE_BASE) % BOOT_RUNTIME_MODULE_STRIDE;
+    if (a >= BOOT_IMPORT_DATA && a < BOOT_IMPORT_DATA_END) return a - BOOT_IMPORT_DATA;
     return a;
 }
 // End of the import-stub aperture. install_stubs reserves this whole window (never more), so a stub

--- a/prosper/src/host/image/exec_image.hpp
+++ b/prosper/src/host/image/exec_image.hpp
@@ -36,6 +36,34 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
 // Publishes the grown table to the dispatcher after the last new stub is written.
 bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err);
 
+// The aperture the import-DATA table lives in, sized like the stub aperture. install_import_data
+// claims exactly this much from `data_base`; for the production base it is
+// [BOOT_IMPORT_DATA, BOOT_IMPORT_DATA_END).
+inline constexpr uint64_t kImportDataApertureBytes = 0x10000000ull;   // 256 MiB
+
+// Create the import-DATA region at `data_base`: one `stride`-byte, zero-filled, READ|WRITE (never
+// EXEC) slot per unresolved STT_OBJECT import (#3529).
+//
+// Reads of an unresolved variable then see an honest zero, and a write lands on a page that holds
+// nothing but that variable — instead of on the executable stub table, where it silently rewrote a
+// trampoline. Non-executable is the second half of that: a control transfer to a data import now
+// faults where it is raised rather than executing whatever bytes are there.
+//
+// No initial values are supplied. prosper does not know what an unimplemented Sony variable
+// contains, and zero is the one answer that is at least self-consistent — a guest that stores its
+// own value reads that value back, and one that never stores reads the same zero every time.
+bool install_import_data(const std::vector<ImportSlot>& slots, uint64_t data_base,
+                         uint64_t stride, std::string* err);
+
+// Extend the import-DATA region for slots appended after install_import_data ran, mirroring
+// append_stubs (a runtime sceKernelLoadStartModule can import a variable too). Already-mapped pages
+// are never remapped: relocated guest code holds addresses inside them and a MAP_FIXED would
+// discard whatever the guest has already written there.
+bool append_import_data(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err);
+
+// Address of the idx-th import-data slot (for tests/bring-up). 0 when none is installed.
+uint64_t import_data_addr(uint64_t idx);
+
 // Install the fault handler for genuine guest faults during a run.
 void install_trap_handler();
 

--- a/prosper/src/host/image/exec_image_linux.cpp
+++ b/prosper/src/host/image/exec_image_linux.cpp
@@ -13,6 +13,7 @@
 #include "host/symbols/il2cpp_symbols.hpp" // #2551: name the C# method containing an IL2CPP address
 #include "hle/dispatch/nid.hpp"
 #include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/import_data_seed.hpp"   // #3529: initial value of an unresolved DATA import
 
 #if defined(__linux__) || defined(__APPLE__)
 #include "host/platform/posix_shim.hpp"
@@ -86,6 +87,8 @@ namespace {
     ExecImageDestructionCanary g_exec_image_destruction_canary;
 
     uint64_t g_base = 0, g_stub_base = 0, g_stub_size = 0, g_nstubs = 0;
+    // Import-DATA aperture (#3529): base, per-slot stride and how many slots are mapped.
+    uint64_t g_data_base = 0, g_data_stride = 0, g_ndata = 0;
     // #1659: label guest addresses through the shared, module-aware helpers instead of subtracting a
     // literal base. These sites hard-coded 0x400000000 — the eboot's address BEFORE #825 relocated it
     // to 0x410000000 — so every printed offset was 0x10000000 too high and did not round-trip through
@@ -3196,6 +3199,80 @@ bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::s
                     slots[i].nid.c_str(), nm.c_str());
         }
     return true;
+}
+
+// --- import-DATA aperture (#3529) ------------------------------------------------------------
+//
+// One zero-filled READ|WRITE page-multiple per unresolved STT_OBJECT import. Never PROT_EXEC: the
+// defect this replaces let a guest STORE rewrite executable stub bytes, and refusing execute here
+// means a control transfer into a data import faults at the transfer instead of running whatever
+// the guest last wrote.
+bool install_import_data(const std::vector<ImportSlot>& slots, uint64_t data_base,
+                         uint64_t stride, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    if (!data_base) return fail("import-data base is 0");
+    if (!stride) return fail("import-data stride is 0");
+    const uint64_t n = slots.size();
+    // A title whose every data import resolved cross-module (or that has none) maps nothing: a
+    // 0-byte mmap fails with EINVAL. Record the empty table and succeed, as install_stubs does.
+    if (n == 0) { g_data_base = data_base; g_data_stride = stride; g_ndata = 0; return true; }
+    const uint64_t region = page_up(n * stride);
+    if (region > kImportDataApertureBytes) return fail("import data table exceeds its aperture");
+    void* want = (void*)data_base;
+    void* got = prosper_mmap_noreplace(want, region, PROT_READ | PROT_WRITE,
+                                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (got == MAP_FAILED || got != want) return fail("mmap import data region failed");
+    // MAP_ANONYMOUS is already zero-filled. Zero is the value for everything prosper cannot answer
+    // honestly; the few Sony variables it CAN answer are written here (import_data_seed.hpp).
+    for (uint64_t i = 0; i < n; i++)
+        seed_import_data(slots[i].nid, (uint8_t*)got + i * stride, (size_t)stride);
+    g_data_base = data_base; g_data_stride = stride; g_ndata = n;
+    if (getenv("PROSPER_STUBDUMP")) {
+        for (uint64_t i = 0; i < n; i++) {
+            const std::string& nm = g_nid_db ? g_nid_db->resolve(slots[i].nid) : std::string();
+            fprintf(stderr, "[import-data] #%llu at 0x%llx %s::%s %s\n", (unsigned long long)i,
+                    (unsigned long long)(data_base + i * stride), slots[i].lib.c_str(),
+                    slots[i].nid.c_str(), nm.c_str());
+        }
+    }
+    return true;
+}
+
+bool append_import_data(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    if (!g_data_stride) return fail("append_import_data before install_import_data");
+    const uint64_t n = slots.size();
+    if (first_new > n || first_new != g_ndata)
+        return fail("append_import_data: slot table is not an extension");
+    if (first_new == n) return true;
+    // Grow by the pages the new slots need only. The mapped pages are NEVER remapped: guest code is
+    // already relocated against them and they hold whatever the guest has stored so far.
+    const uint64_t mapped_end = page_up(g_ndata * g_data_stride);
+    const uint64_t need_end   = page_up(n * g_data_stride);
+    if (need_end > kImportDataApertureBytes) return fail("import data table exceeds its aperture");
+    if (need_end > mapped_end) {
+        void* want = (void*)(g_data_base + mapped_end);
+        void* got = prosper_mmap_noreplace(want, need_end - mapped_end, PROT_READ | PROT_WRITE,
+                                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (got == MAP_FAILED || got != want) return fail("mmap import data extension failed");
+    }
+    for (uint64_t i = first_new; i < n; i++)
+        seed_import_data(slots[i].nid,
+                         (uint8_t*)(uintptr_t)(g_data_base + i * g_data_stride),
+                         (size_t)g_data_stride);
+    g_ndata = n;
+    if (getenv("PROSPER_STUBDUMP"))
+        for (uint64_t i = first_new; i < n; i++) {
+            const std::string& nm = g_nid_db ? g_nid_db->resolve(slots[i].nid) : std::string();
+            fprintf(stderr, "[import-data] +#%llu at 0x%llx %s::%s %s\n", (unsigned long long)i,
+                    (unsigned long long)(g_data_base + i * g_data_stride), slots[i].lib.c_str(),
+                    slots[i].nid.c_str(), nm.c_str());
+        }
+    return true;
+}
+
+uint64_t import_data_addr(uint64_t idx) {
+    return g_data_stride ? g_data_base + idx * g_data_stride : 0;
 }
 
 // #312 label-slot write watch (PROSPER_WATCH_LABEL=1): called by the AGC fence builder with the

--- a/prosper/src/host/image/exec_image_linux.cpp
+++ b/prosper/src/host/image/exec_image_linux.cpp
@@ -3240,8 +3240,15 @@ bool install_import_data(const std::vector<ImportSlot>& slots, uint64_t data_bas
 
 bool append_import_data(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err) {
     auto fail = [&](const char* s){ if (err) *err = s; return false; };
-    if (!g_data_stride) return fail("append_import_data before install_import_data");
     const uint64_t n = slots.size();
+    // NOTHING TO APPEND IS SUCCESS, and this test must come BEFORE the aperture requirement below.
+    // runtime_load_start_module calls this unconditionally, and an embedder that only ever called
+    // install_stubs has no data aperture at all -- which described every runtime PRX load, including
+    // the hermetic `runtime_prx_load` test, until this order was fixed. Requiring an aperture in
+    // order to append zero slots to it made the aperture a hard prerequisite of ALL runtime module
+    // loading. Raised in review of #3541.
+    if (first_new == n && first_new == g_ndata) return true;
+    if (!g_data_stride) return fail("append_import_data before install_import_data");
     if (first_new > n || first_new != g_ndata)
         return fail("append_import_data: slot table is not an extension");
     if (first_new == n) return true;

--- a/prosper/src/host/image/exec_image_win.cpp
+++ b/prosper/src/host/image/exec_image_win.cpp
@@ -1333,8 +1333,15 @@ bool install_import_data(const std::vector<ImportSlot>& slots, uint64_t data_bas
 
 bool append_import_data(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err) {
     auto fail = [&](const char* s){ if (err) *err = s; return false; };
-    if (!g_data_stride) return fail("append_import_data before install_import_data");
     const uint64_t n = slots.size();
+    // NOTHING TO APPEND IS SUCCESS, and this test must come BEFORE the aperture requirement below.
+    // runtime_load_start_module calls this unconditionally, and an embedder that only ever called
+    // install_stubs has no data aperture at all -- which described every runtime PRX load, including
+    // the hermetic `runtime_prx_load` test, until this order was fixed. Requiring an aperture in
+    // order to append zero slots to it made the aperture a hard prerequisite of ALL runtime module
+    // loading. Raised in review of #3541.
+    if (first_new == n && first_new == g_ndata) return true;
+    if (!g_data_stride) return fail("append_import_data before install_import_data");
     if (first_new > n || first_new != g_ndata)
         return fail("append_import_data: slot table is not an extension");
     if (first_new == n) return true;

--- a/prosper/src/host/image/exec_image_win.cpp
+++ b/prosper/src/host/image/exec_image_win.cpp
@@ -26,6 +26,7 @@
 #include "host/x86/x86_read_decode.hpp"
 #include "hle/dispatch/nid.hpp"
 #include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/import_data_seed.hpp"   // #3529: initial value of an unresolved DATA import
 #include "host/abi/sysv_ms_bridge.hpp"    // #2955: signature-driven SysV->MS x64 import bridge
 #include "host/image/boot_program.hpp"   // #1659: shared guest-module labelling (BOOT_* bases)
 #include "host/symbols/il2cpp_symbols.hpp" // #2551: name the C# method containing an IL2CPP address
@@ -177,6 +178,8 @@ using GuestInitFn = PROSPER_SYSV_ABI void (*)(uint64_t argc, uint64_t argp);
 
 namespace {
     uint64_t g_base = 0, g_stub_base = 0, g_stub_size = 0, g_nstubs = 0;
+    // Import-DATA aperture (#3529): base, per-slot stride and how many slots are committed.
+    uint64_t g_data_base = 0, g_data_stride = 0, g_ndata = 0;
     uint64_t g_image_end = 0;   // g_base + max_vaddr: end of the guest module's mapped range
     // PROSPER_NULL_PAGE: back low-address null-field READS with zero (parity with the Linux SIGSEGV
     // handler). Windows reserves the bottom 64 KiB [0,0x10000) as the null dead-zone and VirtualAlloc
@@ -1291,6 +1294,75 @@ bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::s
                     slots[i].nid.c_str(), nm.c_str());
         }
     return true;
+}
+
+// --- import-DATA aperture (#3529) ------------------------------------------------------------
+//
+// One zero-filled READWRITE (never EXECUTE) slot per unresolved STT_OBJECT import, so a guest read
+// of an unimplemented Sony variable sees zero and a guest write cannot reach the executable stub
+// table. Reserve/commit is split exactly as install_stubs does it, and for the same reason: a
+// 64 KiB-granular reservation made later at this one's 4 KiB-aligned end would round back into it.
+bool install_import_data(const std::vector<ImportSlot>& slots, uint64_t data_base,
+                         uint64_t stride, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    if (!data_base) return fail("import-data base is 0");
+    if (!stride) return fail("import-data stride is 0");
+    const uint64_t n = slots.size();
+    if (!VirtualAlloc((void*)(uintptr_t)data_base, kImportDataApertureBytes, MEM_RESERVE,
+                      PAGE_NOACCESS))
+        return fail("VirtualAlloc import-data aperture reservation failed");
+    if (n == 0) { g_data_base = data_base; g_data_stride = stride; g_ndata = 0; return true; }
+    const uint64_t region = page_up(n * stride);
+    if (region > kImportDataApertureBytes) return fail("import data table exceeds its aperture");
+    void* got = VirtualAlloc((void*)(uintptr_t)data_base, region, MEM_COMMIT, PAGE_READWRITE);
+    if (!got || got != (void*)(uintptr_t)data_base) return fail("VirtualAlloc import data failed");
+    // Freshly committed pages are zero-filled. Zero is the value for everything prosper cannot
+    // answer honestly; the few Sony variables it CAN answer are written here (import_data_seed.hpp).
+    for (uint64_t i = 0; i < n; i++)
+        seed_import_data(slots[i].nid, (uint8_t*)got + i * stride, (size_t)stride);
+    g_data_base = data_base; g_data_stride = stride; g_ndata = n;
+    if (getenv("PROSPER_STUBDUMP"))
+        for (uint64_t i = 0; i < n; i++) {
+            const std::string& nm = g_nid_db ? g_nid_db->resolve(slots[i].nid) : std::string();
+            fprintf(stderr, "[import-data] #%llu at 0x%llx %s::%s %s\n", (unsigned long long)i,
+                    (unsigned long long)(data_base + i * stride), slots[i].lib.c_str(),
+                    slots[i].nid.c_str(), nm.c_str());
+        }
+    return true;
+}
+
+bool append_import_data(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    if (!g_data_stride) return fail("append_import_data before install_import_data");
+    const uint64_t n = slots.size();
+    if (first_new > n || first_new != g_ndata)
+        return fail("append_import_data: slot table is not an extension");
+    if (first_new == n) return true;
+    const uint64_t mapped_end = page_up(g_ndata * g_data_stride);
+    const uint64_t need_end   = page_up(n * g_data_stride);
+    if (need_end > kImportDataApertureBytes) return fail("import data table exceeds its aperture");
+    if (need_end > mapped_end) {
+        void* want = (void*)(uintptr_t)(g_data_base + mapped_end);
+        void* got = VirtualAlloc(want, need_end - mapped_end, MEM_COMMIT, PAGE_READWRITE);
+        if (!got || got != want) return fail("VirtualAlloc import data extension failed");
+    }
+    for (uint64_t i = first_new; i < n; i++)
+        seed_import_data(slots[i].nid,
+                         (uint8_t*)(uintptr_t)(g_data_base + i * g_data_stride),
+                         (size_t)g_data_stride);
+    g_ndata = n;
+    if (getenv("PROSPER_STUBDUMP"))
+        for (uint64_t i = first_new; i < n; i++) {
+            const std::string& nm = g_nid_db ? g_nid_db->resolve(slots[i].nid) : std::string();
+            fprintf(stderr, "[import-data] +#%llu at 0x%llx %s::%s %s\n", (unsigned long long)i,
+                    (unsigned long long)(g_data_base + i * g_data_stride), slots[i].lib.c_str(),
+                    slots[i].nid.c_str(), nm.c_str());
+        }
+    return true;
+}
+
+uint64_t import_data_addr(uint64_t idx) {
+    return g_data_stride ? g_data_base + idx * g_data_stride : 0;
 }
 
 void install_sigaltstack() {}   // Windows delivers exceptions on the runtime's own guard stack

--- a/prosper/src/host/image/runtime_module_load.cpp
+++ b/prosper/src/host/image/runtime_module_load.cpp
@@ -47,6 +47,7 @@ std::recursive_mutex g_mx;       // serialises the whole load; also guards every
 Program* g_prog = nullptr;
 std::deque<RuntimeModule> g_loaded;
 std::unordered_map<std::string, uint32_t> g_nid_to_slot;   // NID -> import stub-slot index
+std::unordered_map<std::string, uint32_t> g_nid_to_data_slot;   // NID -> import-DATA slot index (#3529)
 TlsSymbolMap g_tls_symbols;      // exported TLS symbol NID -> {defining module id, in-block offset}
 unsigned g_next_base_slot = 0;
 
@@ -95,12 +96,18 @@ void runtime_module_loader_init(Program* p) {
     g_loaded.clear();
     g_next_base_slot = 0;
     g_nid_to_slot.clear();
+    g_nid_to_data_slot.clear();
     g_tls_symbols.clear();
     if (!p) return;
     // The linker deduped stub slots by NID but kept that map local to link_program. Rebuild it so a
     // runtime module's import of an already-stubbed NID reuses the SAME slot: a second slot for the
     // same NID would double-count it in the unimplemented-call census and emit a duplicate stub.
     for (size_t i = 0; i < p->slots.size(); i++) g_nid_to_slot.emplace(p->slots[i].nid, (uint32_t)i);
+    // Same reconstruction for the data aperture: a runtime module importing a variable an already
+    // linked module also imports must land on the SAME slot, or the two modules would read and
+    // write different copies of what the guest believes is one object (#3529).
+    for (size_t i = 0; i < p->data_slots.size(); i++)
+        g_nid_to_data_slot.emplace(p->data_slots[i].nid, (uint32_t)i);
     // Cross-module general-dynamic TLS: same construction as link_program's, so a runtime module's
     // DTPMOD64/DTPOFF64 pair against a pre-linked module resolves through one record.
     for (size_t i = 0; i < p->mods.size() && i < p->imgs.size(); i++) {
@@ -180,14 +187,25 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
     // pop the module, drop any TLS template it appended (re-publishing the shorter list is safe —
     // nothing was relocated against that module id), and forget any NID it claimed a stub slot for.
     const size_t tls_templates_before = g_prog->tls_templates.size();
-    std::vector<std::string> claimed_nids;
+    // The data-slot table is appended to DIRECTLY (unlike the stub table, which is staged in a local
+    // vector and published in one synchronised append), so a failure between the import loop and
+    // append_import_data would otherwise leave entries in it that no mapping backs -- and the next
+    // load's `first_new != g_ndata` extension check would then refuse forever. Once
+    // append_import_data has succeeded the entries are real and are LEFT in place, exactly as the
+    // stub table's are: relocated guest code may already address them.
+    const size_t data_slots_before = g_prog->data_slots.size();
+    bool data_appended = false;
+    std::vector<std::string> claimed_nids, claimed_data_nids;
     auto abandon = [&](uint64_t err) {
         g_loaded.pop_back();
         if (g_prog->tls_templates.size() > tls_templates_before) {
             g_prog->tls_templates.resize(tls_templates_before);
             set_tls_modules(g_prog->tls_templates.data(), g_prog->tls_templates.size());
         }
+        if (!data_appended && g_prog->data_slots.size() > data_slots_before)
+            g_prog->data_slots.resize(data_slots_before);
         for (const auto& nid : claimed_nids) g_nid_to_slot.erase(nid);
+        for (const auto& nid : claimed_data_nids) g_nid_to_data_slot.erase(nid);
         return err;
     };
 
@@ -235,8 +253,11 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
 
     // --- Imports: an export of an already-loaded module beats a stub slot, exactly as at boot. ---
     const size_t first_new_slot = g_prog->slots.size();
+    // The data-slot append boundary is `data_slots_before`, captured above with the rollback state
+    // rather than here: one value, so a rollback cannot restore to a different point than the
+    // append started from.
     std::vector<ImportSlot> new_slots;
-    size_t cross = 0, stubbed = 0;
+    size_t cross = 0, stubbed = 0, bound_data = 0;
     for (const auto& imp : rm.mod->imports) {
         auto ex = g_prog->exports.find(imp.nid);
         if (ex != g_prog->exports.end()) { img.import_addr[imp.sym_index] = ex->second; cross++; continue; }
@@ -249,6 +270,21 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
             }
         }
         if (from_runtime) continue;
+        // A DATA import goes to the writable aperture, never to an executable stub (#3529) --
+        // the same rule link_program applies at boot, applied to a module loaded later.
+        if (imp.elf_type == STT_OBJECT) {
+            auto dslot = g_nid_to_data_slot.find(imp.nid);
+            if (dslot == g_nid_to_data_slot.end()) {
+                const uint32_t idx = (uint32_t)g_prog->data_slots.size();
+                g_prog->data_slots.push_back({ imp.lib_name, imp.nid });
+                dslot = g_nid_to_data_slot.emplace(imp.nid, idx).first;
+                claimed_data_nids.push_back(imp.nid);   // rolled back by abandon()
+            }
+            img.import_addr[imp.sym_index] =
+                g_prog->data_base + (uint64_t)dslot->second * g_prog->data_stride;
+            bound_data++;
+            continue;
+        }
         auto slot = g_nid_to_slot.find(imp.nid);
         if (slot == g_nid_to_slot.end()) {
             // Slot indices are assigned now and the vector is grown in ONE synchronised append
@@ -271,6 +307,14 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
         fprintf(stderr, "[loadmod] '%s': %s -> ENOMEM\n", guest_path, e.c_str());
         return abandon(kEnomem);
     }
+    // Same ordering rule for the data aperture: the pages must exist before apply_relocations
+    // points guest code at them. Unlike the stub table this appends directly to g_prog->data_slots
+    // (nothing indexes it from another thread), so the vector is already grown here.
+    if (!append_import_data(g_prog->data_slots, data_slots_before, &e)) {
+        fprintf(stderr, "[loadmod] '%s': %s -> ENOMEM\n", guest_path, e.c_str());
+        return abandon(kEnomem);   // abandon() rolls the unbacked entries back
+    }
+    data_appended = true;
 
     apply_relocations(*rm.mod, img, &g_tls_symbols, nullptr);
 
@@ -312,10 +356,10 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
 
     fprintf(stderr,
             "[loadmod] loaded '%s' -> %s @ 0x%llx (%zu exports, %zu imports: %zu cross-module, "
-            "%zu stubbed, %zu new slots) handle=0x%llx\n",
+            "%zu stubbed, %zu data, %zu new slots) handle=0x%llx\n",
             guest_path, rm.name.c_str(), (unsigned long long)base, rm.nids.size(),
-            rm.mod->imports.size(), cross, stubbed, g_prog->slots.size() - first_new_slot,
-            (unsigned long long)rm.handle);
+            rm.mod->imports.size(), cross, stubbed, bound_data,
+            g_prog->slots.size() - first_new_slot, (unsigned long long)rm.handle);
 
     // --- Start it. DT_INIT (module_start) first, then DT_INIT_ARRAY, matching the order
     // link_program + run_guest_inits use for a pre-linked dependent module. The init_array entries

--- a/prosper/src/host/image/runtime_module_load.cpp
+++ b/prosper/src/host/image/runtime_module_load.cpp
@@ -202,10 +202,17 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
             g_prog->tls_templates.resize(tls_templates_before);
             set_tls_modules(g_prog->tls_templates.data(), g_prog->tls_templates.size());
         }
-        if (!data_appended && g_prog->data_slots.size() > data_slots_before)
+        // The slot table and its NID map roll back TOGETHER or not at all. Erasing the NIDs while
+        // keeping the slots -- which is what happened on the two abandon() paths reached after
+        // data_appended became true -- leaves a slot nothing can find, so the next module importing
+        // the same variable allocates a SECOND one and two modules see one guest variable at two
+        // addresses. That is precisely the condition this file's own comment above forbids. Raised
+        // in review of #3541.
+        if (!data_appended && g_prog->data_slots.size() > data_slots_before) {
             g_prog->data_slots.resize(data_slots_before);
+            for (const auto& nid : claimed_data_nids) g_nid_to_data_slot.erase(nid);
+        }
         for (const auto& nid : claimed_nids) g_nid_to_slot.erase(nid);
-        for (const auto& nid : claimed_data_nids) g_nid_to_data_slot.erase(nid);
         return err;
     };
 

--- a/prosper/src/loader/AGENTS.md
+++ b/prosper/src/loader/AGENTS.md
@@ -22,11 +22,17 @@ half, made a guest store rewrite an executable stub, silently and with arbitrary
 `Symbol`/`Import` carry `elf_type` at all: nothing else in an undefined symbol entry distinguishes
 the two cases (shndx 0, value 0 and size 0 for both).
 
-The distinction is not a corner case. 60 of the 62 local dumps import at least one `STT_OBJECT`
-symbol; the population is dominated by C++ ABI objects (`__cxxabiv1` vtables, `_ZTV*`/`_ZTI*`) plus
-`__stack_chk_guard`, which alone appears in 596 shipped modules. Most of them resolve cross-module
-against the title's own `libc.prx` and never reach an aperture — `tools/nid_census --data-only`
-reports which do, over the loader's real link set.
+The distinction is not a corner case. Across the 60 local dumps, **all 60** import
+`__stack_chk_guard` and 53 import an unnamed `libSceLibcInternal` object; over the set the loader
+actually links that is **417 unresolved OBJECT bindings across exactly four distinct NIDs**. Most
+data imports resolve cross-module and never reach a slot at all — these four are the ones that do.
+
+**Quote link-set figures here, not disk figures.** An earlier version of this paragraph said
+`__stack_chk_guard` "appears in 596 shipped modules", taken from a recursive scan of every module
+file present in every dump (808 modules). `boot_link_inputs` links roughly 303 of them, so that
+figure described a population the linker never sees and overstated the bindings by about 2.4x. The
+per-title counts were correct in both scopes, which is what made the binding count easy to repeat
+unchecked.
 
 Two properties of the link that surprise people, both load-bearing:
 

--- a/prosper/src/loader/AGENTS.md
+++ b/prosper/src/loader/AGENTS.md
@@ -41,7 +41,9 @@ that do, and every title in the corpus has at least two.
 
 **Quote link-set figures, not disk figures, and take them from the tool.** Two earlier revisions of
 this paragraph got it wrong the same way, the second while correcting the first. "596 shipped
-modules" came from passing *module paths* to `nid_census` individually, where each `.prx` becomes its
+modules" came from passing *module paths* to `nid_census` individually — that scan sees 808
+modules with 728 importing the guard, so the mechanism is verified, though the exact figure 596 has
+not been reproduced — where each `.prx` becomes its
 own "title" and cross-module exclusion degenerates — a recursive population of 808 modules the linker
 never links. The replacement then called the link set "roughly 303 modules", which is a **binding**
 count written where a module count goes. Both times the per-title counts were right, which is

--- a/prosper/src/loader/AGENTS.md
+++ b/prosper/src/loader/AGENTS.md
@@ -3,15 +3,30 @@
 This folder decides **what gets loaded, where it lands, and what every import resolves to**. It takes
 a list of `LinkInput`s (the eboot plus its dependent and optional PRXs), builds each module's image
 at a fixed base, and produces the global export table plus one `ImportSlot` per unresolved import —
-either another module's export (a real cross-module call) or an HLE stub slot. It is host-agnostic:
-mapping the images and installing the stubs is `src/host/image`'s job, and the HLE handlers behind
-the slots are `src/hle`'s.
+another module's export (a real cross-module call), an HLE code stub, or a slot in the writable
+import-data aperture. It is host-agnostic: mapping the images and installing the apertures is
+`src/host/image`'s job, and the HLE handlers behind the stub slots are `src/hle`'s.
 
 The boundary worth stating: **`src/host/image/boot_program.cpp` decides which modules are
 *candidates*; this folder decides what those candidates *mean* together.** Policy about the
 candidate list that is more than a filename — anything needing imports, exports or link order to
 answer — belongs here as a pure function over parsed data, so it can be tested without a game dump.
 `support_modules.hpp` is the worked example.
+
+**An unresolved import goes to one of TWO apertures, and the ELF symbol type is what chooses.** A
+function import is bound to an executable stub that calls its handler; a `STT_OBJECT` import is
+bound to a writable, non-executable, zero-filled slot, because it names a *variable* the guest
+dereferences and may store through. Until #3529 there was one aperture and every import went to it,
+so a data import made the guest read prosper's own machine code as its value — and, the serious
+half, made a guest store rewrite an executable stub, silently and with arbitrary delay. This is why
+`Symbol`/`Import` carry `elf_type` at all: nothing else in an undefined symbol entry distinguishes
+the two cases (shndx 0, value 0 and size 0 for both).
+
+The distinction is not a corner case. 60 of the 62 local dumps import at least one `STT_OBJECT`
+symbol; the population is dominated by C++ ABI objects (`__cxxabiv1` vtables, `_ZTV*`/`_ZTI*`) plus
+`__stack_chk_guard`, which alone appears in 596 shipped modules. Most of them resolve cross-module
+against the title's own `libc.prx` and never reach an aperture — `tools/nid_census --data-only`
+reports which do, over the loader's real link set.
 
 Two properties of the link that surprise people, both load-bearing:
 

--- a/prosper/src/loader/AGENTS.md
+++ b/prosper/src/loader/AGENTS.md
@@ -22,17 +22,30 @@ half, made a guest store rewrite an executable stub, silently and with arbitrary
 `Symbol`/`Import` carry `elf_type` at all: nothing else in an undefined symbol entry distinguishes
 the two cases (shndx 0, value 0 and size 0 for both).
 
-The distinction is not a corner case. Across the 60 local dumps, **all 60** import
-`__stack_chk_guard` and 53 import an unnamed `libSceLibcInternal` object; over the set the loader
-actually links that is **417 unresolved OBJECT bindings across exactly four distinct NIDs**. Most
-data imports resolve cross-module and never reach a slot at all — these four are the ones that do.
+The distinction is not a corner case, and these figures are the tool's own — `nid_census
+--data-only` over the 60 local dump roots, whose default scope is already the loader's link set:
 
-**Quote link-set figures here, not disk figures.** An earlier version of this paragraph said
-`__stack_chk_guard` "appears in 596 shipped modules", taken from a recursive scan of every module
-file present in every dump (808 modules). `boot_link_inputs` links roughly 303 of them, so that
-figure described a population the linker never sees and overstated the bindings by about 2.4x. The
-per-title counts were correct in both scopes, which is what made the binding count easy to repeat
-unchecked.
+```text
+scope: 2284 distinct imported NIDs over 338 module(s) read, 0 unreadable
+424 DATA binding(s) (ELF STT_OBJECT) unresolved by any sibling module, over 60 of 60 input(s);
+a further 1566 were satisfied cross-module
+
+f7uOxY9mM1U  __stack_chk_guard   libkernel            60 of 60 titles
+djxxOmW6-aw  __progname          libkernel            60 of 60 titles
+ZT4ODD2Ts9o  (unnamed)           libSceLibcInternal   51 titles
+GAtITrgxKDE  (unnamed)           libSceNet             1 title
+```
+
+Most data imports resolve cross-module and never reach a slot — 1566 of them. These four are the ones
+that do, and every title in the corpus has at least two.
+
+**Quote link-set figures, not disk figures, and take them from the tool.** Two earlier revisions of
+this paragraph got it wrong the same way, the second while correcting the first. "596 shipped
+modules" came from passing *module paths* to `nid_census` individually, where each `.prx` becomes its
+own "title" and cross-module exclusion degenerates — a recursive population of 808 modules the linker
+never links. The replacement then called the link set "roughly 303 modules", which is a **binding**
+count written where a module count goes. Both times the per-title counts were right, which is
+precisely what let the number underneath them travel unchecked.
 
 Two properties of the link that surprise people, both load-bearing:
 

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -53,11 +53,16 @@ ExportSubsumption measure_export_subsumption(
     return r;
 }
 
-bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
+bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base, uint64_t data_base,
                   Program& out, std::string* err) {
     auto fail = [&](const std::string& s) { if (err) *err = s; return false; };
     if (inputs.empty()) return fail("no modules to link");
+    // Neither aperture may be absent. A zero data_base would put an unresolved variable at a low
+    // address the guest then dereferences, and reusing stub_base for both is exactly #3529.
+    if (!stub_base || !data_base) return fail("link_program: stub_base and data_base are required");
+    if (stub_base == data_base) return fail("link_program: stub and data apertures must differ");
     out.stub_base = stub_base;
+    out.data_base = data_base;
 
     // --- Pass 1: load every module and build its image at its base. ---
     // NID -> path of the accepted module that exports it, in list order. Mirrors the
@@ -141,8 +146,21 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         out.mod_exports.push_back(std::move(me));
     }
 
-    // --- Pass 2: resolve every import. Cross-module export beats a stub slot. ---
-    std::unordered_map<std::string, uint32_t> nid_to_slot;   // dedupe stub slots by NID
+    // --- Pass 2: resolve every import. Cross-module export beats a local slot. ---
+    //
+    // An import that nothing exports is bound to one of TWO apertures, chosen by the symbol's ELF
+    // type. A function goes to an executable stub that calls its handler; a variable (STT_OBJECT)
+    // goes to a writable, non-executable, zero-filled data slot, because the guest will dereference
+    // it and may store through it. See Program::data_slots for what binding a variable to a
+    // trampoline did (#3529).
+    //
+    // Only STT_OBJECT is diverted. STT_NOTYPE, STT_FUNC and everything else keep the stub they have
+    // always had: NOTYPE is genuinely ambiguous and is overwhelmingly a function in practice, and a
+    // stub is the answer that at least runs. The two apertures dedupe INDEPENDENTLY, so the same NID
+    // imported as a function by one module and as an object by another gets one of each -- each
+    // module then reads the binding its own symbol table asked for.
+    std::unordered_map<std::string, uint32_t> nid_to_slot;        // dedupe code stubs by NID
+    std::unordered_map<std::string, uint32_t> nid_to_data_slot;   // dedupe data slots by NID
     for (size_t i = 0; i < out.mods.size(); i++) {
         const Module& m = *out.mods[i];
         LoadedImage& img = out.imgs[i];
@@ -152,6 +170,19 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
             if (ex != exports.end()) {
                 img.import_addr[imp.sym_index] = ex->second;     // real cross-module target
                 out.resolved_cross_module++;
+                continue;
+            }
+            if (imp.elf_type == STT_OBJECT) {
+                auto it = nid_to_data_slot.find(imp.nid);
+                uint32_t slot;
+                if (it != nid_to_data_slot.end()) slot = it->second;
+                else {
+                    slot = (uint32_t)out.data_slots.size();
+                    out.data_slots.push_back({ imp.lib_name, imp.nid });
+                    nid_to_data_slot.emplace(imp.nid, slot);
+                }
+                img.import_addr[imp.sym_index] = out.data_base + (uint64_t)slot * out.data_stride;
+                out.bound_data++;
                 continue;
             }
             auto it = nid_to_slot.find(imp.nid);

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -58,11 +58,36 @@ struct LinkInput {
 struct Program {
     std::vector<std::unique_ptr<Module>> mods;   // unique_ptr: stable addresses for imports[]
     std::vector<LoadedImage>             imgs;    // parallel to mods
-    std::vector<ImportSlot>              slots;   // unresolved imports -> stub slots
+    std::vector<ImportSlot>              slots;   // unresolved FUNCTION imports -> code stub slots
     std::vector<uint64_t>                init_fns; // dependent-module init fns, in call order
     std::vector<TlsModuleDesc>           tls_templates; // indexed by module TLS id (0 = unused)
     uint64_t entry = 0;                            // main module entry
     uint64_t stub_base = 0, stub_size = 96;   // 96 contains the largest guest-%fs swap stub (94 bytes)
+
+    // Unresolved DATA imports (ELF STT_OBJECT) -> slots in a separate, writable, NON-executable,
+    // zero-initialised aperture. A data import names a VARIABLE, not an entry point: the guest
+    // dereferences it, and it may STORE through it (libc initialises `__stack_chk_guard` that way).
+    //
+    // Before #3529 these shared the code-stub aperture with function imports, which produced two
+    // distinct defects. A read returned the first bytes of an emitted trampoline -- on NINJA GAIDEN
+    // 4 (PPSA25258) the stack canary read 0x000000bf, the `mov edi, 0` that opens `emit_unimpl` --
+    // so every `-fstack-protector` epilogue compared a machine-code word against a saved 0 and
+    // called `__stack_chk_fail`. And a WRITE landed on prosper's own executable pages, silently
+    // rewriting whichever stub occupied the slot, after which that import jumped into altered code
+    // at an arbitrarily later moment.
+    //
+    // The population is not exotic: 60 of the 62 local dumps import at least one STT_OBJECT symbol
+    // and `__stack_chk_guard` alone appears in 596 shipped modules (tools/nid_census --data-only).
+    // Whether a given one reaches a stub depends on the title's own libc: an import a sibling module
+    // defines is bound to that definition and never comes here.
+    std::vector<ImportSlot> data_slots;
+    uint64_t data_base = 0;
+    // One page per data object. The size of an imported variable is NOT knowable here -- an
+    // undefined symbol carries st_size 0 throughout this corpus -- so the stride is chosen to be
+    // larger than any plausible scalar or small struct rather than derived. Untouched pages cost no
+    // physical memory, so a generous stride is close to free and keeps an over-long store inside its
+    // own slot instead of on its neighbour's.
+    uint64_t data_stride = 4096;
 
     // Global export table: NID -> absolute guest address (first definition wins). Retained so the
     // HLE can serve sceKernelDlsym by name (nid_hash(name)) against loaded modules — e.g. resolve
@@ -104,8 +129,9 @@ struct Program {
     struct AliasedExport { std::string nid, winner_path, loser_path; uint64_t winner, loser; };
     std::vector<AliasedExport> aliased_exports;
 
-    // Stats for reporting.
-    size_t total_imports = 0, resolved_cross_module = 0, stubbed = 0;
+    // Stats for reporting. Every import lands in exactly one bucket:
+    // total_imports == resolved_cross_module + stubbed + bound_data.
+    size_t total_imports = 0, resolved_cross_module = 0, stubbed = 0, bound_data = 0;
 };
 
 // The exported NIDs a module contributes to the global export table: defined (non-import),
@@ -136,7 +162,13 @@ struct ExportSubsumption {
 
 // Link the given modules (the first is the main executable). Applies relocations.
 // Returns false with *err on failure.
-bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
+//
+// `stub_base` roots the executable import-stub aperture and `data_base` the writable import-DATA
+// aperture; the two must not overlap and neither may be 0. `data_base` is a required argument rather
+// than a defaulted one on purpose: there is no safe fallback for a data import (binding it into the
+// code aperture is the defect #3529 records, and binding it near address 0 is worse), so a caller
+// that has not mapped an aperture must be a compile error rather than a silent regression.
+bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base, uint64_t data_base,
                   Program& out, std::string* err);
 
 } // namespace prosper

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -76,16 +76,26 @@ struct Program {
     // rewriting whichever stub occupied the slot, after which that import jumped into altered code
     // at an arbitrarily later moment.
     //
-    // The population is not exotic: across the 60 local dumps, ALL 60 import `__stack_chk_guard`,
-    // and 53 import an unnamed libSceLibcInternal object. Over the set the loader actually LINKS
-    // that is 417 unresolved OBJECT bindings spanning exactly four distinct NIDs.
+    // The population is not exotic, and these figures are the TOOL'S OWN -- `nid_census --data-only`
+    // over the 60 local dump roots, whose default scope is already the loader's link set:
     //
-    // Quote link-set figures, not disk figures. An earlier revision of this comment said "596
-    // shipped modules", which came from a RECURSIVE scan of every module present in every dump --
-    // 808 of them. `boot_link_inputs` links about 303, so that number described a population the
-    // linker never sees and overstated the bindings by roughly 2.4x. The TITLE counts were right
-    // either way, which is exactly what made the binding count easy to miss. Corrected in review of
-    // #3541.
+    //   scope: 2284 distinct imported NIDs over 338 module(s) read, 0 unreadable
+    //   424 DATA binding(s) unresolved by any sibling module, over 60 of 60 input(s);
+    //   a further 1566 were satisfied cross-module
+    //
+    //   f7uOxY9mM1U  __stack_chk_guard   libkernel            60 of 60 titles
+    //   djxxOmW6-aw  __progname          libkernel            60 of 60 titles
+    //   ZT4ODD2Ts9o  (unnamed)           libSceLibcInternal   51 titles
+    //   GAtITrgxKDE  (unnamed)           libSceNet             1 title
+    //
+    // QUOTE LINK-SET FIGURES, NOT DISK FIGURES, and take them from the tool. Two earlier revisions
+    // of this comment got it wrong in the same way and the second was written while correcting the
+    // first: "596 shipped modules" came from passing MODULE PATHS to nid_census individually, where
+    // each .prx becomes its own "title" and cross-module exclusion degenerates -- a recursive
+    // population of 808 modules the linker never links. The replacement then said the link set is
+    // "roughly 303 modules", which is a BINDING count written where a module count goes. The
+    // per-title counts survived both errors intact, which is exactly what made the numbers under
+    // them easy to repeat unchecked. Corrected in review of #3541.
     // Whether a given one reaches a stub depends on the title's own libc: an import a sibling module
     // defines is bound to that definition and never comes here.
     std::vector<ImportSlot> data_slots;

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -76,8 +76,16 @@ struct Program {
     // rewriting whichever stub occupied the slot, after which that import jumped into altered code
     // at an arbitrarily later moment.
     //
-    // The population is not exotic: 60 of the 62 local dumps import at least one STT_OBJECT symbol
-    // and `__stack_chk_guard` alone appears in 596 shipped modules (tools/nid_census --data-only).
+    // The population is not exotic: across the 60 local dumps, ALL 60 import `__stack_chk_guard`,
+    // and 53 import an unnamed libSceLibcInternal object. Over the set the loader actually LINKS
+    // that is 417 unresolved OBJECT bindings spanning exactly four distinct NIDs.
+    //
+    // Quote link-set figures, not disk figures. An earlier revision of this comment said "596
+    // shipped modules", which came from a RECURSIVE scan of every module present in every dump --
+    // 808 of them. `boot_link_inputs` links about 303, so that number described a population the
+    // linker never sees and overstated the bindings by roughly 2.4x. The TITLE counts were right
+    // either way, which is exactly what made the binding count easy to miss. Corrected in review of
+    // #3541.
     // Whether a given one reaches a stub depends on the title's own libc: an import a sibling module
     // defines is bound to that definition and never comes here.
     std::vector<ImportSlot> data_slots;

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -90,7 +90,9 @@ struct Program {
     //
     // QUOTE LINK-SET FIGURES, NOT DISK FIGURES, and take them from the tool. Two earlier revisions
     // of this comment got it wrong in the same way and the second was written while correcting the
-    // first: "596 shipped modules" came from passing MODULE PATHS to nid_census individually, where
+    // first: "596 shipped modules" came from passing MODULE PATHS to nid_census individually (the
+    // mechanism is verified -- that scan sees 808 modules, 728 importing the guard -- though the
+    // exact figure 596 has not been reproduced), where
     // each .prx becomes its own "title" and cross-module exclusion degenerates -- a recursive
     // population of 808 modules the linker never links. The replacement then said the link set is
     // "roughly 303 modules", which is a BINDING count written where a module count goes. The

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -215,10 +215,15 @@ std::optional<Module> Module::load(const std::string& path, std::string* err) {
         // A real Sony import is an undefined (shndx 0, value 0) NID-encoded symbol.
         // The null symbol (index 0) and any non-NID undefined symbols are not imports.
         sym.is_import = (s.st_shndx == 0 && s.st_value == 0 && h1 != std::string::npos);
+        // ELF64_ST_TYPE(st_info). Carried through so the linker can tell a data import from a
+        // function import (#3529) -- nothing else in the entry does: an undefined symbol has
+        // shndx 0, value 0 and, in this corpus, size 0 whether it is a variable or a function.
+        sym.elf_type = (uint8_t)(s.st_info & 0xf);
         auto it = m.import_libs.find(sym.lib_id);
         sym.lib_name = (it != m.import_libs.end()) ? it->second : (sym.lib_id >= 0 ? "lib#" + std::to_string(sym.lib_id) : "");
         m.symbols.push_back(sym);
-        if (sym.is_import) m.imports.push_back({ sym.nid, sym.lib_name, (uint32_t)i });
+        if (sym.is_import)
+            m.imports.push_back({ sym.nid, sym.lib_name, (uint32_t)i, sym.elf_type });
     }
     // relocations: RELA + JMPREL
     auto read_relocs = [&](uint64_t va, uint64_t sz, bool plt) {
@@ -377,7 +382,7 @@ size_t apply_relocations(const Module& m, LoadedImage& img,
     };
     auto sym_addr = [&](uint32_t sym) -> uint64_t {
         auto it = img.import_addr.find(sym);
-        if (it != img.import_addr.end()) return it->second;          // import -> stub
+        if (it != img.import_addr.end()) return it->second;   // import -> stub or data slot
         if (sym < m.symbols.size()) return img.base + m.symbols[sym].value; // internal def
         return 0;
     };

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -60,6 +60,15 @@ struct Reloc {
     int64_t  addend = 0;
     bool     is_plt = false;
 };
+// ELF symbol types (the low nibble of st_info, i.e. ELF64_ST_TYPE). Retained on every parsed symbol
+// because a FUNCTION import and a DATA import must be bound to different things: a function import
+// is bound to an executable trampoline, while a data import names a VARIABLE the guest reads and
+// writes. Binding a variable to a trampoline makes the guest read prosper's machine code as its
+// value, and — the serious half — makes a guest store overwrite executable stub bytes (#3529). The
+// type is the only thing in the symbol table that distinguishes the two cases.
+enum : uint8_t { STT_NOTYPE = 0, STT_OBJECT = 1, STT_FUNC = 2, STT_SECTION = 3,
+                 STT_FILE = 4, STT_COMMON = 5, STT_TLS = 6 };
+
 struct Symbol {
     std::string raw;       // "NID#libId#modId" (or plain)
     std::string nid;       // the NID part
@@ -67,11 +76,13 @@ struct Symbol {
     uint16_t    shndx = 0;
     uint64_t    value = 0;
     bool        is_import = false; // undefined + value 0
+    uint8_t     elf_type = STT_NOTYPE;  // ELF64_ST_TYPE(st_info)
     std::string lib_name;  // resolved from lib_id
 };
 struct Import {            // one unresolved external symbol
     std::string nid, lib_name;
     uint32_t    sym_index = 0;
+    uint8_t     elf_type = STT_NOTYPE;  // ELF64_ST_TYPE(st_info) of the defining symbol entry
 };
 
 // Defining-module identity for a TLS export. DTPMOD64 and DTPOFF64 form one tls_index pair, so

--- a/prosper/tests/fixtures/synth_prx.h
+++ b/prosper/tests/fixtures/synth_prx.h
@@ -82,8 +82,18 @@ struct SynthModuleSpec {
     // Exported NIDs, in symbol-table order. Export `i` is defined at `synth_export_va(i)`.
     std::vector<std::string> exports;
     // Imported NIDs, in symbol-table order. Import `i`'s GOT slot is at `synth_got_va(i)` and is
-    // filled by an R_X86_64_JUMP_SLOT relocation.
+    // filled by an R_X86_64_JUMP_SLOT relocation. These carry STT_FUNC.
     std::vector<std::string> imports;
+    // DATA imports (#3529). Emitted after `imports` in symbol-table order, with STT_OBJECT instead
+    // of STT_FUNC and an R_X86_64_GLOB_DAT relocation rather than a JUMP_SLOT -- which is how a real
+    // module references an imported variable. Their GOT slots continue the same array, so data
+    // import `j` is at `synth_got_va(imports.size() + j)`.
+    //
+    // A separate vector rather than a type field on `imports` so a test can hold everything else
+    // fixed and move ONE NID between the two lists: that pair is the mutation that shows the
+    // linker's aperture choice is driven by the symbol type and not by the NID, the library, or the
+    // position.
+    std::vector<std::string> data_imports;
     // Emit DT_INIT / DT_INIT_ARRAY (with the RELATIVE relocation that fills the array's one entry).
     bool init = true;
 
@@ -119,8 +129,9 @@ inline std::vector<uint8_t> synth_prx_bytes(const SynthModuleSpec& spec, std::st
     using namespace detail;
     auto fail = [&](const char* m) { if (err) *err = m; return std::vector<uint8_t>(); };
     if (spec.exports.size() > kSynthMaxExports) return fail("too many exports for the fixture layout");
-    if (spec.imports.size() > kSynthMaxImports) return fail("too many imports for the fixture layout");
-    if (1 + spec.exports.size() + spec.imports.size() > kSynthMaxSymbols)
+    const size_t nimp = spec.imports.size() + spec.data_imports.size();
+    if (nimp > kSynthMaxImports) return fail("too many imports for the fixture layout");
+    if (1 + spec.exports.size() + nimp > kSynthMaxSymbols)
         return fail("too many symbols for the fixture layout");
 
     std::vector<uint8_t> f(kSynthFileSize, 0);
@@ -169,13 +180,16 @@ inline std::vector<uint8_t> synth_prx_bytes(const SynthModuleSpec& spec, std::st
     };
     for (const auto& nid : spec.exports) if (!add_name(nid)) return fail("strtab overflow");
     for (const auto& nid : spec.imports) if (!add_name(nid)) return fail("strtab overflow");
+    for (const auto& nid : spec.data_imports) if (!add_name(nid)) return fail("strtab overflow");
     const uint64_t strsz = so - kSynthStrtab;
 
     // --- dynamic symbol table. Index 0 is the null symbol and is never an export.
-    auto sym = [&](size_t i, uint64_t off, uint16_t shndx, uint64_t value) {
+    // `info` is st_info: (STB_GLOBAL << 4) | ELF64_ST_TYPE. Callers pass 0x12 (FUNC) or 0x11
+    // (OBJECT); the type is what linker.cpp reads to choose an import's aperture (#3529).
+    auto sym = [&](size_t i, uint64_t off, uint16_t shndx, uint64_t value, uint8_t info = 0x12) {
         const uint64_t p = kSynthSymtab + (uint64_t)i * 24;
         sput32(f, p + 0, (uint32_t)off);
-        f[p + 4] = 0x12;                              // STB_GLOBAL | STT_FUNC
+        f[p + 4] = info;
         sput16(f, p + 6, shndx);
         sput64(f, p + 8, value);
         sput64(f, p + 16, 8);                         // st_size
@@ -190,6 +204,11 @@ inline std::vector<uint8_t> synth_prx_bytes(const SynthModuleSpec& spec, std::st
     const size_t first_import_sym = si;
     for (size_t i = 0; i < spec.imports.size(); i++, si++)
         sym(si, name_off[spec.exports.size() + i], 0, 0);   // undefined + value 0 == a Sony import
+    // Data imports are undefined and valueless in exactly the same way -- st_info is the ONLY field
+    // that differs, which is precisely why the linker had nothing to branch on before #3529. Note
+    // st_size stays 8 here as it does for functions; real dumps carry 0 for both.
+    for (size_t i = 0; i < spec.data_imports.size(); i++, si++)
+        sym(si, name_off[spec.exports.size() + spec.imports.size() + i], 0, 0, 0x11);
     const uint64_t nsym = si;
 
     // --- relocations ---
@@ -207,7 +226,15 @@ inline std::vector<uint8_t> synth_prx_bytes(const SynthModuleSpec& spec, std::st
     for (size_t i = 0; i < spec.imports.size(); i++)
         rela(kSynthJmprel + (uint64_t)i * 24, synth_got_va(i), prosper::R_X86_64_JUMP_SLOT,
              (uint32_t)(first_import_sym + i), 0);
-    const uint64_t jmprel_sz = (uint64_t)spec.imports.size() * 24;
+    // GLOB_DAT, not JUMP_SLOT: a data reference goes through the GOT rather than the PLT. Both land
+    // in the same DT_JMPREL table here, which the loader accepts -- what it reads is the relocation
+    // TYPE, and both are handled identically (module.cpp writes sym_addr into the slot).
+    for (size_t i = 0; i < spec.data_imports.size(); i++) {
+        const size_t k = spec.imports.size() + i;
+        rela(kSynthJmprel + (uint64_t)k * 24, synth_got_va(k), prosper::R_X86_64_GLOB_DAT,
+             (uint32_t)(first_import_sym + k), 0);
+    }
+    const uint64_t jmprel_sz = (uint64_t)nimp * 24;
 
     // --- dynamic tags. DT_SCE_SYMTABSZ goes FIRST so module.cpp's "is this really a PS5 .dynamic"
     // --- run check sees an SCE tag inside its 8-entry window (module.cpp: dyn_run_ok).

--- a/prosper/tests/hle/dispatch/test_import_data_seed.cpp
+++ b/prosper/tests/hle/dispatch/test_import_data_seed.cpp
@@ -1,0 +1,67 @@
+// test_import_data_seed — the initial contents of an unresolved Sony DATA import (#3529).
+//
+// Pure: no dump, no mmap, no guest. It pins the ONE variable prosper answers today
+// (`__stack_chk_guard`) and, just as importantly, that it answers nothing else — a seeder that
+// wrote into every slot would satisfy the first assertion and destroy the honest zero every other
+// unresolved variable depends on.
+#include "hle/dispatch/import_data_seed.hpp"
+#include "hle/dispatch/nid.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    printf("== test_import_data_seed ==\n");
+
+    // The two documented properties of the canary, checked on the constant itself so a future edit
+    // to the value cannot quietly drop either.
+    CHECK(kStackGuardValue != 0, "the seeded stack guard is non-zero");
+    CHECK((kStackGuardValue & 0xffu) == 0,
+          "the seeded stack guard's low byte is the terminator NUL");
+
+    // A slot is a page of zeroes when install_import_data hands it over; the sentinel below stands
+    // in for "not zero", so a seeder that writes nothing is distinguishable from one that writes 0.
+    constexpr uint8_t kSentinel = 0xa5;
+    uint8_t slot[64];
+
+    memset(slot, kSentinel, sizeof slot);
+    const std::string guard = nid_hash("__stack_chk_guard");
+    CHECK(seed_import_data(guard, slot, sizeof slot), "__stack_chk_guard is seeded");
+    uint64_t got = 0; memcpy(&got, slot, sizeof got);
+    CHECK(got == kStackGuardValue, "__stack_chk_guard's slot holds exactly the seeded value");
+    // Only the object itself is written -- the rest of the slot's page belongs to nothing.
+    bool tail_intact = true;
+    for (size_t i = sizeof(uint64_t); i < sizeof slot; i++)
+        if (slot[i] != kSentinel) tail_intact = false;
+    CHECK(tail_intact, "seeding writes 8 bytes and does not clobber the rest of the slot");
+
+    // The negative arm. Without it the case above would pass against a seeder that ignores the NID
+    // entirely and stamps the canary into every data slot in the program.
+    memset(slot, kSentinel, sizeof slot);
+    const std::string other = nid_hash("__progname");
+    CHECK(!seed_import_data(other, slot, sizeof slot), "an unknown DATA import is NOT seeded");
+    bool untouched = true;
+    for (size_t i = 0; i < sizeof slot; i++) if (slot[i] != kSentinel) untouched = false;
+    CHECK(untouched, "an unknown DATA import's slot is left exactly as it was");
+
+    // A slot smaller than the object must be refused outright rather than half-written: a truncated
+    // canary is a value the guest would compare against a full one.
+    memset(slot, kSentinel, sizeof slot);
+    CHECK(!seed_import_data(guard, slot, 4), "a slot too small for the value is refused");
+    untouched = true;
+    for (size_t i = 0; i < sizeof slot; i++) if (slot[i] != kSentinel) untouched = false;
+    CHECK(untouched, "a refused seed writes nothing at all");
+
+    CHECK(!seed_import_data(guard, nullptr, 8), "a null slot is refused rather than dereferenced");
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/misc/test_boot_linux.cpp
+++ b/prosper/tests/misc/test_boot_linux.cpp
@@ -29,12 +29,15 @@ int main(int argc, char** argv) {
         { dump + "/Media/Modules/PS5Util.prx",    0x4c0000000ull },
     };
     const uint64_t STUB_BASE = 0x600000000ull;
+    const uint64_t DATA_BASE = 0x7c0000000ull;   // import-DATA aperture (#3529)
 
     Program prog;
     std::string err;
-    if (!link_program(inputs, STUB_BASE, prog, &err)) { printf("  [FAIL] link: %s\n", err.c_str()); return 1; }
-    printf("  linked %zu modules: %zu imports (%zu cross-module, %zu stubbed / %zu slots)\n",
-           prog.mods.size(), prog.total_imports, prog.resolved_cross_module, prog.stubbed, prog.slots.size());
+    if (!link_program(inputs, STUB_BASE, DATA_BASE, prog, &err)) { printf("  [FAIL] link: %s\n", err.c_str()); return 1; }
+    printf("  linked %zu modules: %zu imports (%zu cross-module, %zu stubbed / %zu slots, "
+           "%zu data / %zu data slots)\n",
+           prog.mods.size(), prog.total_imports, prog.resolved_cross_module, prog.stubbed,
+           prog.slots.size(), prog.bound_data, prog.data_slots.size());
 
     // Register the linked module set so sceKernelLoadStartModule resolves the game's OWN runtime
     // PRX loads to real handles (#146/#147) — the guest LoadStartModule's its preloaded Il2Cpp/
@@ -49,6 +52,8 @@ int main(int argc, char** argv) {
     for (auto& img : prog.imgs)
         if (!map_image(img, &err)) { printf("  [FAIL] map: %s\n", err.c_str()); return 1; }
     if (!install_stubs(prog.slots, prog.stub_base, prog.stub_size, &err)) { printf("  [FAIL] stubs: %s\n", err.c_str()); return 1; }
+    if (!install_import_data(prog.data_slots, prog.data_base, prog.data_stride, &err)) {
+        printf("  [FAIL] import data: %s\n", err.c_str()); return 1; }
     install_trap_handler();
 
     volatile int* p = (volatile int*)mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);

--- a/prosper/tests/misc/test_loader_synth_link.cpp
+++ b/prosper/tests/misc/test_loader_synth_link.cpp
@@ -51,6 +51,7 @@ static constexpr uint64_t kBase0    = 0x400000000ull;
 static constexpr uint64_t kBase1    = 0x500000000ull;
 static constexpr uint64_t kBase2    = 0x600000000ull;
 static constexpr uint64_t kStubBase = 0x700000000ull;
+static constexpr uint64_t kDataBase = 0x7c0000000ull;   // import-DATA aperture (#3529)
 
 // The 8 bytes at `rel_va` inside linked module `mod_index`, or a sentinel the tests cannot mistake
 // for a real address when the read is out of range.
@@ -81,6 +82,9 @@ int main() {
     const std::string kHandA    = nid_hash("prosperHandmadeExportA");
     const std::string kHandB    = nid_hash("prosperHandmadeExportB");
     const std::string kHandImp  = nid_hash("prosperHandmadeImport");
+    // #3529: one NID moved between the FUNC and DATA import lists is the whole discriminator.
+    const std::string kVar      = nid_hash("prosperSynthUnsatisfiedVariable");
+    const std::string kVarDefined = nid_hash("prosperSynthDefinedVariable");
 
     const std::string dir = prosper_test::test_scratch_dir().string();
     auto emit = [&](const char* name, const SynthModuleSpec& spec) {
@@ -136,7 +140,7 @@ int main() {
             { main_path, kBase0 }, { release_path, kBase1 }, { logging_path, kBase2 },
         };
         Program p; std::string err;
-        const bool ok = link_program(inputs, kStubBase, p, &err);
+        const bool ok = link_program(inputs, kStubBase, kDataBase, p, &err);
         CHECK(ok, "control: link_program succeeds on three synthetic modules");
         if (!ok) { printf("  link error: %s\n", err.c_str()); printf("FAILED\n"); return 1; }
 
@@ -219,7 +223,7 @@ int main() {
         };
         inputs[2].skip_on_export_collision = true;
         Program p; std::string err;
-        const bool ok = link_program(inputs, kStubBase, p, &err);
+        const bool ok = link_program(inputs, kStubBase, kDataBase, p, &err);
         CHECK(ok, "duplicate build: link_program succeeds");
         CHECK(p.skipped_modules.size() == 1, "duplicate build: the subsumed module is skipped");
         CHECK(p.mods.size() == 2, "duplicate build: only the two other modules are linked");
@@ -254,7 +258,7 @@ int main() {
         };
         inputs[2].skip_on_export_collision = true;
         Program p; std::string err;
-        const bool ok = link_program(inputs, kStubBase, p, &err);
+        const bool ok = link_program(inputs, kStubBase, kDataBase, p, &err);
         CHECK(ok, "distinct library: link_program succeeds");
         CHECK(p.skipped_modules.empty(), "distinct library: the module is NOT skipped");
         CHECK(p.mods.size() == 3, "distinct library: all three modules are linked");
@@ -276,7 +280,7 @@ int main() {
         };
         inputs[2].skip_on_export_collision = true;
         Program p; std::string err;
-        const bool ok = link_program(inputs, kStubBase, p, &err);
+        const bool ok = link_program(inputs, kStubBase, kDataBase, p, &err);
         CHECK(ok, "mutation: link_program succeeds");
         CHECK(p.skipped_modules.empty(),
               "mutation: a flagged module whose exports are all distinct is NOT skipped");
@@ -292,7 +296,7 @@ int main() {
         };
         inputs[2].skip_on_export_collision = true;
         Program p; std::string err;
-        const bool ok = link_program(inputs, kStubBase, p, &err);
+        const bool ok = link_program(inputs, kStubBase, kDataBase, p, &err);
         CHECK(ok, "valueless: link_program succeeds");
         CHECK(p.skipped_modules.empty(),
               "valueless: a defined symbol with st_value 0 does not collide (it is not an export)");
@@ -309,7 +313,7 @@ int main() {
     {
         const std::vector<LinkInput> inputs = { { main_path, kBase0 }, { alt_path, kBase2 } };
         Program p; std::string err;
-        const bool ok = link_program(inputs, kStubBase, p, &err);
+        const bool ok = link_program(inputs, kStubBase, kDataBase, p, &err);
         CHECK(ok, "no-exporter: link_program succeeds");
         CHECK(p.slots.size() == 3, "no-exporter: all three imports now need stub slots");
         CHECK(p.slots.size() == 3 && p.slots[0].nid == kShared && p.slots[1].nid == kOnlyA &&
@@ -337,7 +341,7 @@ int main() {
 
             const std::vector<LinkInput> inputs = { { importer_path, kBase0 }, { hand_path, kBase1 } };
             Program p;
-            const bool ok = link_program(inputs, kStubBase, p, &err);
+            const bool ok = link_program(inputs, kStubBase, kDataBase, p, &err);
             CHECK(ok, "handmade: link_program accepts a module laid out by hand");
             if (!ok) printf("  link error: %s\n", err.c_str());
 
@@ -362,12 +366,93 @@ int main() {
             std::vector<LinkInput> guarded = { { hand_path, kBase1 }, { clash_path, kBase2 } };
             guarded[1].skip_on_export_collision = true;
             Program g;
-            const bool okg = link_program(guarded, kStubBase, g, &err);
+            const bool okg = link_program(guarded, kStubBase, kDataBase, g, &err);
             CHECK(okg, "handmade: the guarded link succeeds");
             CHECK(g.skipped_modules.size() == 1 && g.skipped_modules[0].owner_path == hand_path &&
                   g.skipped_modules[0].nid == kHandA,
                   "handmade: the collision guard fires with the hand-built module as the owner");
         }
+    }
+
+    // ---- Arm 7: a DATA import must not be bound into the executable stub aperture (#3529) -------
+    //
+    // The two link inputs below differ in how ONE symbol is DECLARED and in nothing else that the
+    // linker reads: `data_arm` declares kVar as STT_OBJECT referenced by an R_X86_64_GLOB_DAT,
+    // `func_arm` declares the SAME NID, at the same symbol index, from the same library, at the same
+    // GOT offset, as STT_FUNC referenced by an R_X86_64_JUMP_SLOT -- the two ways a real module
+    // spells "variable" and "function". Of that pair only `st_info` reaches pass 2 (module.cpp
+    // handles GLOB_DAT and JUMP_SLOT identically), so the arm isolates the type.
+    //
+    // The pair therefore does not merely assert that a data import lands somewhere; it shows that
+    // moving the DECLARATION moves the binding, which is what distinguishes this from a test that
+    // would also pass against the old linker.
+    //
+    // Before #3529, `data_arm` produced exactly what `func_arm` produces: two stub slots and no data
+    // slot. That is the mutation -- delete the STT_OBJECT branch in linker.cpp pass 2 and this arm
+    // fails on its first four assertions.
+    {
+        SynthModuleSpec data_arm;
+        data_arm.imports      = { kMissing };
+        data_arm.data_imports = { kVar };
+        SynthModuleSpec func_arm;
+        func_arm.imports = { kMissing, kVar };     // same two NIDs, both as functions
+
+        const std::string data_path = emit("synth_dataimp.prx", data_arm);
+        const std::string func_path = emit("synth_funcimp.prx", func_arm);
+
+        Program pd; std::string err;
+        CHECK(link_program({ { data_path, kBase0 } }, kStubBase, kDataBase, pd, &err),
+              "data import: link_program succeeds");
+        Program pf;
+        CHECK(link_program({ { func_path, kBase0 } }, kStubBase, kDataBase, pf, &err),
+              "func control: link_program succeeds");
+
+        // The control first: with both imports typed FUNC nothing reaches the data aperture. If this
+        // failed, the assertions below would be measuring something other than the symbol type.
+        CHECK(pf.stubbed == 2 && pf.bound_data == 0 && pf.data_slots.empty(),
+              "func control: two FUNC imports -> two stub slots, no data slot");
+        CHECK(pd.stubbed == 1 && pd.bound_data == 1,
+              "data import: one FUNC + one OBJECT -> one stub slot and one data slot");
+        CHECK(pd.data_slots.size() == 1 && pd.data_slots[0].nid == kVar,
+              "data import: the data slot names the OBJECT symbol's NID");
+        CHECK(pd.total_imports == pd.resolved_cross_module + pd.stubbed + pd.bound_data,
+              "data import: import accounting closes over three buckets");
+
+        // What the guest actually dereferences: the relocated GOT slot, not the linker's bookkeeping.
+        // Import 0 is the FUNC (GOT 0), import 1 is the OBJECT (GOT 1) -- the fixture appends
+        // data_imports after imports.
+        const uint64_t got_func = image_u64(pd, 0, prosper_test::synth_got_va(0));
+        const uint64_t got_data = image_u64(pd, 0, prosper_test::synth_got_va(1));
+        CHECK(got_func == kStubBase, "data import: the FUNC import's GOT slot still points at stub 0");
+        CHECK(got_data == kDataBase,
+              "data import: the OBJECT import's GOT slot points at data slot 0");
+        CHECK(got_data < kStubBase || got_data >= kStubBase + 0x10000000ull,
+              "data import: the OBJECT import's GOT slot is OUTSIDE the executable stub aperture");
+        // And the same NID typed FUNC does land on a stub -- so the NID itself is not what decides.
+        CHECK(image_u64(pf, 0, prosper_test::synth_got_va(1)) == kStubBase + pf.stub_size,
+              "func control: the SAME NID typed FUNC lands on stub 1");
+    }
+
+    // ---- Arm 8: a DATA import a sibling module DEFINES still resolves cross-module ---------------
+    //
+    // The aperture is the fallback, not the rule. If the STT_OBJECT branch were placed before the
+    // export lookup, every title whose own libc.prx defines the variable would silently stop seeing
+    // the real definition and start reading a zero page instead -- a regression invisible to arm 7,
+    // which has no exporter at all. This is the arm that pins the ordering.
+    {
+        SynthModuleSpec provider; provider.exports = { kVarDefined };
+        SynthModuleSpec consumer; consumer.data_imports = { kVarDefined };
+        const std::string prov_path = emit("synth_varprov.prx", provider);
+        const std::string cons_path = emit("synth_varcons.prx", consumer);
+
+        Program p; std::string err;
+        CHECK(link_program({ { cons_path, kBase0 }, { prov_path, kBase1 } },
+                           kStubBase, kDataBase, p, &err),
+              "defined variable: link_program succeeds");
+        CHECK(p.resolved_cross_module == 1 && p.bound_data == 0 && p.data_slots.empty(),
+              "defined variable: an OBJECT import a sibling exports consumes no data slot");
+        CHECK(image_u64(p, 0, prosper_test::synth_got_va(0)) == kBase1 + kExp0,
+              "defined variable: the GOT slot points at the provider's definition");
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);

--- a/prosper/tests/misc/test_loader_synth_reject.cpp
+++ b/prosper/tests/misc/test_loader_synth_reject.cpp
@@ -48,6 +48,7 @@ static int fails = 0;
 static constexpr uint64_t kBase0    = 0x400000000ull;
 static constexpr uint64_t kBase1    = 0x500000000ull;
 static constexpr uint64_t kStubBase = 0x700000000ull;
+static constexpr uint64_t kDataBase = 0x7c0000000ull;   // import-DATA aperture (#3529)
 
 static bool contains(const std::string& hay, const std::string& needle) {
     return hay.find(needle) != std::string::npos;
@@ -81,7 +82,7 @@ int main() {
     auto link_error = [&](const std::string& path) {
         const std::vector<LinkInput> inputs = { { good_path, kBase0 }, { path, kBase1 } };
         Program p; std::string err;
-        return link_program(inputs, kStubBase, p, &err) ? std::string() : err;
+        return link_program(inputs, kStubBase, kDataBase, p, &err) ? std::string() : err;
     };
 
     // ---- module-level rejections. Each spec differs from `good_spec` in exactly one field. -------
@@ -251,7 +252,7 @@ int main() {
         auto init_fns_of = [&](const std::string& path) {
             const std::vector<LinkInput> inputs = { { good_path, kBase0 }, { path, kBase1 } };
             Program p; std::string err;
-            if (!link_program(inputs, kStubBase, p, &err)) return std::vector<uint64_t>{ 0xbad };
+            if (!link_program(inputs, kStubBase, kDataBase, p, &err)) return std::vector<uint64_t>{ 0xbad };
             return p.init_fns;
         };
         const std::vector<uint64_t> ctl_fns = init_fns_of(ctl_path);

--- a/prosper/tests/misc/test_plugin_autolink.cpp
+++ b/prosper/tests/misc/test_plugin_autolink.cpp
@@ -174,8 +174,8 @@ int main(int argc, char** argv) {
 
             prosper::Program pc, pg;
             std::string lerr;
-            const bool okc = prosper::link_program(control, 0x600000000ull, pc, &lerr);
-            const bool okg = prosper::link_program(guarded, 0x600000000ull, pg, &lerr);
+            const bool okc = prosper::link_program(control, 0x600000000ull, 0x7c0000000ull, pc, &lerr);
+            const bool okg = prosper::link_program(guarded, 0x600000000ull, 0x7c0000000ull, pg, &lerr);
             CHECK(okc && okg, "both link runs succeed");
             CHECK(pc.skipped_modules.empty(), "control: an unflagged duplicate is still linked");
             CHECK(pc.mods.size() == 3, "control: three modules linked");

--- a/prosper/tests/misc/test_trap_linux.cpp
+++ b/prosper/tests/misc/test_trap_linux.cpp
@@ -5,6 +5,9 @@
 #include "loader/linker.hpp"
 #include "host/image/exec_image.hpp"
 #include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/import_data_seed.hpp"
+#include "hle/dispatch/nid.hpp"
+#include <cstdint>
 #include <cstdio>
 #include <string>
 
@@ -20,7 +23,8 @@ int main(int argc, char** argv) {
     Program prog;
     std::string err;
     // No HLE registered -> all imports become stub slots we can trap on.
-    if (!link_program({ { dump + "/eboot.bin", 0x400000000ull } }, 0x600000000ull, prog, &err)) {
+    if (!link_program({ { dump + "/eboot.bin", 0x400000000ull } }, 0x600000000ull, 0x7c0000000ull,
+                      prog, &err)) {
         printf("  [FAIL] link: %s\n", err.c_str()); return 1;
     }
     // NOT `> 500` (#2997). That threshold was PPSA24651's slot count, and this test is not about how
@@ -36,25 +40,122 @@ int main(int argc, char** argv) {
     // assertion while carrying no weight. These are the linker's own accounting invariants instead,
     // and they are title-agnostic in the way the count only pretended to be:
     //   * the module imports something at all;
-    //   * every import is accounted for as either cross-module-resolved or stubbed. This cannot fail
-    //     on any input: pass 2's body increments total_imports and then exactly one of the other two
-    //     (linker.cpp:115 / :119 / :131), with no third path. It is an EDIT guard, not a detector --
-    //     it fires if a future filter or early-out counts an import without accounting for it.
+    //   * every import is accounted for as cross-module-resolved, stubbed, or bound to the DATA
+    //     aperture. This cannot fail on any input: pass 2's body increments total_imports and then
+    //     exactly one of the other three, with no fourth path. It is an EDIT guard, not a detector --
+    //     it fires if a future filter or early-out counts an import without accounting for it. The
+    //     third bucket arrived with #3529; before it, a DATA import was counted in `stubbed` and
+    //     bound to an executable trampoline.
     //   * every stubbed import got its OWN slot. This is the one that carries weight: deduplicating
     //     on the wrong key (lib instead of NID) leaves the accounting identity intact -- 612 == 0 +
     //     612 on PPSA24651 -- while collapsing 612 slots to 35, which is what a slot-count floor
     //     could not tell apart from a title that simply imports less. It is an equality only because
     //     no eboot imports the same NID twice: MEASURED at 0 duplicates across all 55 dumps, not
-    //     derived (module.cpp:221 does not dedupe imports, and linker.cpp:122 keys the slot table on
-    //     the NID alone).
+    //     derived (module.cpp does not dedupe imports, and linker.cpp keys the slot table on the
+    //     NID alone).
     CHECK(prog.total_imports > 0, "link produced no imports at all");
-    CHECK(prog.total_imports == prog.resolved_cross_module + prog.stubbed,
-          "import accounting does not close: %zu total != %zu cross-module + %zu stubbed",
-          prog.total_imports, prog.resolved_cross_module, prog.stubbed);
+    CHECK(prog.total_imports == prog.resolved_cross_module + prog.stubbed + prog.bound_data,
+          "import accounting does not close: %zu total != %zu cross-module + %zu stubbed + %zu data",
+          prog.total_imports, prog.resolved_cross_module, prog.stubbed, prog.bound_data);
     CHECK(prog.stubbed == prog.slots.size(),
           "%zu imports stubbed but %zu slots emitted", prog.stubbed, prog.slots.size());
+    CHECK(prog.bound_data == prog.data_slots.size(),
+          "%zu data imports bound but %zu data slots emitted", prog.bound_data,
+          prog.data_slots.size());
+
+    // #3529. A DATA import (ELF STT_OBJECT) names a VARIABLE, so it must NOT be bound into the
+    // executable stub aperture: the guest reads it as a value and may store through it, and a store
+    // into that aperture rewrites a trampoline. Two halves, and the first is what makes the second
+    // mean anything:
+    //
+    //   1. The eboot really imports at least one STT_OBJECT symbol. Without this the case below
+    //      passes vacuously on any dump -- the exact failure mode the charter's positive-control
+    //      rule names. This eboot's data imports are `__stack_chk_guard` plus three C++ ABI objects.
+    //   2. Every data-slot address lies in the data aperture and outside the whole stub aperture.
+    //      Checked against the aperture, not against the slots emitted so far, because the stub
+    //      table can still grow at runtime (append_stubs, #639) and an address that is merely past
+    //      today's last stub is not safe.
+    //
+    // The mutation that fails this: bind data imports at `stub_base` again (delete the STT_OBJECT
+    // branch in linker.cpp pass 2) -- then data_slots is empty and (1) fails; keep the branch but
+    // spell the address `out.stub_base + slot * out.stub_size` and (2) fails.
+    CHECK(!prog.data_slots.empty(),
+          "this eboot imports no STT_OBJECT symbol, so the data-binding case below proves nothing");
+    for (size_t i = 0; i < prog.data_slots.size(); i++) {
+        const uint64_t a = prog.data_base + i * prog.data_stride;
+        CHECK(a >= prog.data_base && a < prog.data_base + kImportDataApertureBytes,
+              "data slot %zu at 0x%llx is outside the import-data aperture", i,
+              (unsigned long long)a);
+        CHECK(a < prog.stub_base || a >= prog.stub_base + kStubApertureBytes,
+              "data slot %zu (%s::%s) at 0x%llx is inside the executable stub aperture", i,
+              prog.data_slots[i].lib.c_str(), prog.data_slots[i].nid.c_str(),
+              (unsigned long long)a);
+    }
+    // ...and the guest image really points at those addresses. The loop above checks the slot table;
+    // this checks what apply_relocations actually baked into an import_addr entry, which is what the
+    // guest dereferences. Find the eboot's own STT_OBJECT imports and read their bound addresses.
+    {
+        size_t checked = 0;
+        for (const auto& imp : prog.mods[0]->imports) {
+            if (imp.elf_type != STT_OBJECT) continue;
+            auto it = prog.imgs[0].import_addr.find(imp.sym_index);
+            CHECK(it != prog.imgs[0].import_addr.end(), "data import %s was never bound",
+                  imp.nid.c_str());
+            CHECK(it->second < prog.stub_base || it->second >= prog.stub_base + kStubApertureBytes,
+                  "data import %s::%s is bound to 0x%llx, inside the executable stub aperture",
+                  imp.lib_name.c_str(), imp.nid.c_str(), (unsigned long long)it->second);
+            checked++;
+        }
+        CHECK(checked > 0, "no STT_OBJECT import found in the eboot's own import table");
+    }
+
     for (auto& img : prog.imgs) CHECK(map_image(img, &err), "map: %s", err.c_str());
     CHECK(install_stubs(prog.slots, prog.stub_base, prog.stub_size, &err), "install_stubs: %s", err.c_str());
+    CHECK(install_import_data(prog.data_slots, prog.data_base, prog.data_stride, &err),
+          "install_import_data: %s", err.c_str());
+    // The aperture is real memory: readable, WRITABLE, and holding what install_import_data put
+    // there. The writability half is the one #3529 is really about -- before it, this same store
+    // landed on prosper's executable stub bytes. Non-executability is a property of the
+    // PROT_READ|PROT_WRITE mapping and is deliberately not asserted by jumping into it here, which
+    // would abort the test binary rather than report.
+    //
+    // Slots are addressed BY NID, never by index: which import gets slot 0 depends on symbol order
+    // in the dump, so an index-keyed assertion would silently start measuring a different variable
+    // on a different title.
+    {
+        const std::string guard_nid = nid_hash("__stack_chk_guard");
+        size_t guard_slot = SIZE_MAX, plain_slot = SIZE_MAX;
+        for (size_t i = 0; i < prog.data_slots.size(); i++) {
+            if (prog.data_slots[i].nid == guard_nid) guard_slot = i;
+            else if (plain_slot == SIZE_MAX)         plain_slot = i;
+        }
+        // Every dump in the local corpus imports __stack_chk_guard (60 of 60), so its absence here
+        // means the symbol type or the NID hash changed, not that this title is unusual.
+        CHECK(guard_slot != SIZE_MAX, "__stack_chk_guard is not among this eboot's data imports");
+        if (guard_slot != SIZE_MAX) {
+            volatile uint64_t* g = (volatile uint64_t*)(uintptr_t)import_data_addr(guard_slot);
+            // The seeded value, not merely "non-zero": a slot that happened to hold anything else
+            // would pass a non-zero test while meaning the seed never ran.
+            CHECK(g && *g == kStackGuardValue,
+                  "__stack_chk_guard slot holds 0x%llx, expected the seeded 0x%llx",
+                  (unsigned long long)(g ? *g : 0), (unsigned long long)kStackGuardValue);
+        }
+        // An UNSEEDED slot must be zero. This is the arm that keeps the one above honest: if
+        // install_import_data wrote the canary into every slot (or the mapping were not zero-filled
+        // at all), this fails while the seed assertion still passes.
+        if (plain_slot != SIZE_MAX) {
+            volatile uint64_t* q = (volatile uint64_t*)(uintptr_t)import_data_addr(plain_slot);
+            CHECK(q != nullptr, "import_data_addr(%zu) is 0 after install_import_data", plain_slot);
+            if (q) {
+                CHECK(*q == 0, "unseeded import-data slot %zu is not zero (0x%llx)", plain_slot,
+                      (unsigned long long)*q);
+                *q = 0xfeedfacecafebeefull;
+                CHECK(*q == 0xfeedfacecafebeefull,
+                      "import-data slot %zu did not retain a guest store", plain_slot);
+                *q = 0;
+            }
+        }
+    }
     install_trap_handler();
 
     // These four are the real coverage, and the four names are MEASURED rather than assumed: all 55

--- a/prosper/tests/misc/test_trap_linux.cpp
+++ b/prosper/tests/misc/test_trap_linux.cpp
@@ -70,7 +70,8 @@ int main(int argc, char** argv) {
     //
     //   1. The eboot really imports at least one STT_OBJECT symbol. Without this the case below
     //      passes vacuously on any dump -- the exact failure mode the charter's positive-control
-    //      rule names. This eboot's data imports are `__stack_chk_guard` plus three C++ ABI objects.
+    //      rule names. PPSA24651's eboot declares four STT_OBJECT imports, one of which is
+    //      `__stack_chk_guard`; the NID-keyed case further down names that one explicitly.
     //   2. Every data-slot address lies in the data aperture and outside the whole stub aperture.
     //      Checked against the aperture, not against the slots emitted so far, because the stub
     //      table can still grow at runtime (append_stubs, #639) and an address that is merely past

--- a/prosper/tools/nid_census/nid_census.cpp
+++ b/prosper/tools/nid_census/nid_census.cpp
@@ -30,9 +30,16 @@
 // any module shipped with this title", per title, which is exactly the condition under which
 // `prosper_on_unimpl` runs.
 //
+// --data-only answers a different question with the same machinery (#3529): which imports are
+// DATA (ELF STT_OBJECT) rather than functions, and how many of those no sibling module defines.
+// Those are exactly the bindings the linker sends to the writable import-data aperture, where the
+// guest reads a zero it was never promised. It is the static counterpart of the runtime
+// `[import-data]` listing PROSPER_STUBDUMP prints. Registration is meaningless for a variable, so
+// that column is not a filter in this mode.
+//
 // Usage:
 //   nid_census <app0-dir|module> [more...] [--names <PS5-3.20_Libs-dir>]
-//              [--registered] [--tsv] [--lib <substr>] [--self-check]
+//              [--registered] [--tsv] [--lib <substr>] [--self-check] [--data-only]
 //
 // `<app0-dir>` is scanned recursively for eboot.bin and *.prx/*.sprx. Passing several titles ranks
 // each NID by how many of them import it, which is the reachability signal #2081 asks for: a NID
@@ -70,7 +77,31 @@ struct Row {
     std::set<std::string> libs;       // import library names as the module declares them
     std::set<std::string> titles;     // which inputs import it
     size_t modules = 0;               // how many modules import it
+    // ELF64_ST_TYPE values this NID was imported with. A set, not a scalar: nothing stops two
+    // modules from declaring the same NID with different types, and collapsing that to one value
+    // would hide it. STT_OBJECT here means the linker binds it to the import-data aperture (#3529).
+    std::set<unsigned> elf_types;
+    bool object() const { return elf_types.count(STT_OBJECT) != 0; }
 };
+
+// The ELF symbol types this corpus actually carries, spelled for a report.
+const char* sym_type_name(unsigned t) {
+    switch (t) {
+        case STT_NOTYPE:  return "NOTYPE";
+        case STT_OBJECT:  return "OBJECT";
+        case STT_FUNC:    return "FUNC";
+        case STT_SECTION: return "SECTION";
+        case STT_FILE:    return "FILE";
+        case STT_COMMON:  return "COMMON";
+        case STT_TLS:     return "TLS";
+        default:          return "?";
+    }
+}
+std::string sym_types_of(const Row& r) {
+    std::string out;
+    for (unsigned t : r.elf_types) { if (!out.empty()) out += "+"; out += sym_type_name(t); }
+    return out.empty() ? "-" : out;
+}
 
 // ---- the PS5 3.20 stub dump: authoritative <NID> <-> <funcName> pairs --------------------------
 // Each generated library has one loader line per export:
@@ -150,7 +181,10 @@ std::vector<fs::path> collect_modules(const std::string& input) {
 void print_scope(const char* prefix, size_t total, size_t modules_read, size_t modules_failed,
                  size_t unregistered, size_t shown, size_t shown_unregistered,
                  size_t satisfied_cross_module,
-                 size_t mismatches, const std::string& lib_filter, bool self_check) {
+                 const std::map<std::string, size_t>& data_bindings_by_title,
+                 size_t data_satisfied_cross_module,
+                 size_t mismatches, const std::string& lib_filter, bool self_check,
+                 bool data_only) {
     printf("%sscope: %zu distinct imported NIDs over %zu module(s) read, %zu unreadable\n",
            prefix, total, modules_read, modules_failed);
     printf("%sscope: %zu unregistered before filtering, %zu shown (%zu unregistered)%s%s\n",
@@ -158,6 +192,22 @@ void print_scope(const char* prefix, size_t total, size_t modules_read, size_t m
            lib_filter.empty() ? "" : ", --lib filter=", lib_filter.c_str());
     printf("%sscope: %zu binding(s) excluded as satisfied by a sibling module's export\n",
            prefix, satisfied_cross_module);
+    {
+        // #3529: what reaches the writable import-data aperture. A data import a sibling module
+        // DEFINES is bound to that definition and never comes here, which is why the exclusion
+        // count is reported beside it rather than left implicit.
+        size_t data_total = 0, titles_with_data = 0;
+        for (const auto& [t, n] : data_bindings_by_title) { data_total += n; if (n) titles_with_data++; }
+        printf("%sscope: %zu DATA binding(s) (ELF STT_OBJECT) unresolved by any sibling module, "
+               "over %zu of %zu input(s); a further %zu were satisfied cross-module\n",
+               prefix, data_total, titles_with_data, data_bindings_by_title.size(),
+               data_satisfied_cross_module);
+        // The per-title breakdown only in --data-only: over a whole-corpus run it is one line per
+        // dump, which would bury the default report's own scope block.
+        if (data_only)
+            for (const auto& [t, n] : data_bindings_by_title)
+                printf("%sdata: %-20s %zu\n", prefix, t.c_str(), n);
+    }
     if (self_check)
         printf("%sscope: name-table self-check %zu mismatch(es)\n", prefix, mismatches);
     if (modules_failed)
@@ -187,7 +237,9 @@ void usage(const char* argv0) {
             "  --registered   also list imports that DO have a handler (default: only unregistered)\n"
             "  --tsv          machine-readable output\n"
             "  --lib SUBSTR   only report NIDs whose import library contains SUBSTR\n"
-            "  --self-check   verify every dump NID against prosper's nid_hash()\n",
+            "  --self-check   verify every dump NID against prosper's nid_hash()\n"
+            "  --data-only    only DATA imports (ELF STT_OBJECT) -- what the linker binds to the\n"
+            "                 writable import-data aperture rather than to a code stub (#3529)\n",
             argv0);
 }
 
@@ -196,7 +248,7 @@ void usage(const char* argv0) {
 int main(int argc, char** argv) {
     std::vector<std::string> inputs;
     std::string names_dir, lib_filter;
-    bool show_registered = false, tsv = false, self_check = false;
+    bool show_registered = false, tsv = false, self_check = false, data_only = false;
 
     for (int i = 1; i < argc; ++i) {
         const std::string a = argv[i];
@@ -205,6 +257,7 @@ int main(int argc, char** argv) {
         else if (a == "--registered") show_registered = true;
         else if (a == "--tsv") tsv = true;
         else if (a == "--self-check") self_check = true;
+        else if (a == "--data-only") data_only = true;
         else if (a == "-h" || a == "--help") { usage(argv[0]); return 0; }
         else if (!a.empty() && a[0] == '-') { usage(argv[0]); return 2; }
         else inputs.push_back(a);
@@ -227,6 +280,10 @@ int main(int argc, char** argv) {
 
     std::map<std::string, Row> rows;
     size_t modules_read = 0, modules_failed = 0, satisfied_cross_module = 0;
+    // Per-title DATA accounting (#3529), kept even when --data-only is off so the scope block can
+    // report it unconditionally: it costs two counters and it is the number the issue asked for.
+    std::map<std::string, size_t> data_bindings_by_title;   // unresolved STT_OBJECT bindings
+    size_t data_satisfied_cross_module = 0;
 
     for (const auto& input : inputs) {
         const std::string title = fs::path(input).filename().string();
@@ -254,14 +311,25 @@ int main(int argc, char** argv) {
 
         for (const auto& m : loaded) {
             for (const auto& im : m.imports) {
-                if (title_exports.count(im.nid)) { satisfied_cross_module++; continue; }
+                if (title_exports.count(im.nid)) {
+                    satisfied_cross_module++;
+                    if (im.elf_type == STT_OBJECT) data_satisfied_cross_module++;
+                    continue;
+                }
                 Row& r = rows[im.nid];
                 r.nid = im.nid;
                 if (!im.lib_name.empty()) r.libs.insert(im.lib_name);
                 r.titles.insert(title);
                 r.modules++;
+                r.elf_types.insert(im.elf_type);
+                // One binding per IMPORT, not per NID: two modules importing the same variable are
+                // two bindings that both land on the (one, deduped) data slot.
+                if (im.elf_type == STT_OBJECT) data_bindings_by_title[title]++;
             }
         }
+        // A title with zero unresolved data imports must still appear, or "how many titles are
+        // affected" would be read off a map that silently omits the answer "none".
+        data_bindings_by_title.emplace(title, 0);
     }
 
     // Classify against the live registry.
@@ -271,7 +339,10 @@ int main(int argc, char** argv) {
         total++;
         const bool registered = Hle::registered(nid);
         if (!registered) unregistered++;
-        if (registered && !show_registered) continue;
+        // A variable has no handler to register, so the registration filter would silently drop
+        // every row in this mode. --data-only selects on the symbol type instead.
+        if (data_only) { if (!r.object()) continue; }
+        else if (registered && !show_registered) continue;
         if (auto it = names.by_nid.find(nid); it != names.by_nid.end()) r.name = it->second;
         if (!lib_filter.empty()) {
             bool hit = false;
@@ -292,37 +363,41 @@ int main(int argc, char** argv) {
     });
 
     if (tsv) {
-        printf("nid\tname\tregistered\ttitles\tmodules\tlibs\ttitle_list\n");
+        printf("nid\tname\tsym_type\tregistered\ttitles\tmodules\tlibs\ttitle_list\n");
         for (const Row* r : selected) {
             std::string libs, tl;
             for (const auto& l : r->libs) { if (!libs.empty()) libs += ","; libs += l; }
             for (const auto& t : r->titles) { if (!tl.empty()) tl += ","; tl += t; }
-            printf("%s\t%s\t%d\t%zu\t%zu\t%s\t%s\n", r->nid.c_str(),
-                   r->name.empty() ? "?" : r->name.c_str(),
+            printf("%s\t%s\t%s\t%d\t%zu\t%zu\t%s\t%s\n", r->nid.c_str(),
+                   r->name.empty() ? "?" : r->name.c_str(), sym_types_of(*r).c_str(),
                    Hle::registered(r->nid) ? 1 : 0,
                    r->titles.size(), r->modules, libs.c_str(), tl.c_str());
         }
         print_scope("# ", total, modules_read, modules_failed, unregistered, selected.size(),
-                    shown_unregistered, satisfied_cross_module, names.mismatches,
-                    lib_filter, self_check);
+                    shown_unregistered, satisfied_cross_module, data_bindings_by_title,
+                    data_satisfied_cross_module, names.mismatches, lib_filter, self_check,
+                    data_only);
         return 0;
     }
 
-    printf("%s", show_registered
+    printf("%s", data_only
+        ? "\n== DATA imports (STT_OBJECT) no sibling module defines -> import-data aperture ==\n"
+        : show_registered
         ? "\n== imports (registered and unregistered) ==\n"
         : "\n== imports with NO registered handler -> dispatcher returns 0 ==\n");
-    printf("%-13s %-52s %10s %5s  %s\n",
-           "NID", "name", "registered", "#ttl", "import library");
+    printf("%-13s %-52s %-8s %10s %5s  %s\n",
+           "NID", "name", "sym type", "registered", "#ttl", "import library");
     for (const Row* r : selected) {
         std::string libs;
         for (const auto& l : r->libs) { if (!libs.empty()) libs += ","; libs += l; }
-        printf("%-13s %-52s %10s %5zu  %s\n", r->nid.c_str(),
-               r->name.empty() ? "?" : r->name.c_str(),
+        printf("%-13s %-52s %-8s %10s %5zu  %s\n", r->nid.c_str(),
+               r->name.empty() ? "?" : r->name.c_str(), sym_types_of(*r).c_str(),
                Hle::registered(r->nid) ? "yes" : "no", r->titles.size(), libs.c_str());
     }
     printf("\n");
     print_scope("", total, modules_read, modules_failed, unregistered, selected.size(),
-                shown_unregistered, satisfied_cross_module, names.mismatches,
-                lib_filter, self_check);
+                shown_unregistered, satisfied_cross_module, data_bindings_by_title,
+                data_satisfied_cross_module, names.mismatches, lib_filter, self_check,
+                data_only);
     return 0;
 }


### PR DESCRIPTION
## Two defects on NINJA GAIDEN 4's path, one of them corpus-wide

### 1. Unresolved DATA imports were bound to a CODE stub (#3529)

`linker.cpp` pass 2 bound **every** unresolved import to a slot in the executable import-stub
aperture, with no distinction between a function and a variable — `Symbol` carried no ELF symbol
type, so the linker had nothing to branch on. A data import therefore made the guest read prosper's
own machine code as the variable's value, and — the serious half — made a guest **store** through
that import rewrite an emitted trampoline, silently and with arbitrary delay.

Measured on `PPSA25258` with a hardware execute breakpoint on the guest's own load of its stack
canary:

```text
[hwbp] #1 rip=eboot+0x28c3978 rax=0x600000000 [rax]=0x000000bf ... tid=2535326
```

`0x600000000` is `BOOT_STUB`; `0x000000bf` is stub 0's `mov edi, 0`. The title's stack canary was
prosper's machine code, and it died in `__stack_chk_fail` on its Wwise I/O thread.

**The population is not exotic.** Over the 60 local dumps, three near-universal libc/libkernel
variables reach an aperture: `__stack_chk_guard` (728 bindings, **60 of 60 titles**), one unnamed
`libSceLibcInternal` object (182 bindings, 53 titles) and `__progname` (96 bindings, 60 titles).
Every title in the corpus has been reading stub bytes for at least one of them.

`Symbol`/`Import` now carry `ELF64_ST_TYPE(st_info)` — the only field in an undefined symbol entry
that separates the two cases, since `shndx`, `value` and `size` are identical for both. An
`STT_OBJECT` import goes to a separate writable, never-executable, zero-filled aperture at
`BOOT_IMPORT_DATA`. NOTYPE, FUNC and TLS keep the stub they have always had, and cross-module
resolution still wins over both.

`__stack_chk_guard` is seeded with a fixed non-zero process-lifetime value. Non-zero is what
libkernel supplies, and it is also what preserves measured behaviour: the stub bytes every title has
been reading are non-zero and stable, which is exactly why a defect this universal stayed invisible.
A zero canary would additionally disable `-fstack-protector` in every guest.

`nid_census --data-only` reports the same census over any set of dumps.

### 2. `sceKernelAddAmprEvent` logged the guest's `udata` and threw it away (#3500)

`k_add_ampr_event(eq, id, udata)` named the argument in its own signature comment, printed it under
`PROSPER_EVLOG`, and dropped it — `prosper_eq_add_apr` took only `(eq, id)`. Every APR completion
event therefore carried `udata = 0`, and `sceKernelGetEventUserData` honestly returned 0.

NINJA GAIDEN 4 dereferences that value directly (eboot+0x28c3196):

```asm
call sceKernelGetEventUserData
mov  edi, DWORD PTR [rax]      ; <- rax == 0
```

Measured with `PROSPER_EVLOG=1`, the guest registers four handlers with four distinct live pointers
0x20 apart — an array of per-request contexts, all four discarded:

```text
[ev] AddAmprEvent eq=0x7f22f400fc90 id=0 udata=0x224a280780
[ev] AddAmprEvent eq=0x7f22f400fc90 id=1 udata=0x224a2807a0
[ev] AddAmprEvent eq=0x7f22f400fc90 id=2 udata=0x224a2807c0
[ev] AddAmprEvent eq=0x7f22f400fc90 id=3 udata=0x224a2807e0
```

This file's own USER-event path already did the right thing and is the model followed here:
`k_add_user_event` stores it and `k_trigger_user_event` posts it back. The AMPR sibling simply did
not — the same question answered two ways depending on which registration call the guest used.

Both delivery dialects now carry it. The lookup is a separate function because the post path
deliberately runs with no APR lock held, so the udata is resolved before the post rather than inside
it. Registration stays idempotent but now **upgrades**: three paths register the same `(eq, id)` and
only `AddAmprEvent` carries a udata, so a non-zero value fills an empty slot and nothing ever
overwrites a real one with 0.

## Measured

`tools/screenshot`, Linux/RADV, default launch, no environment variables, `PPSA25258`:

| | before | after |
| --- | --- | --- |
| outcome | `__stack_chk_fail` → `ud2` on `AK::IOThread` | runs its full bound; no canary abort |
| frames | 0 | 0 |

**The rung does NOT move.** Two named causes are removed and the title still presents zero frames; a
further fault in the same Wwise layer remains. Stated plainly because a cleared blocker is not a
milestone.

## Tests

- `loader_synth_link` arms 7 and 8 (no dump, runs in CI): one NID declared `STT_OBJECT` vs
  `STT_FUNC` **at the same symbol index and GOT offset**, and a data import a sibling module defines.
  The pair shows the declaration is what moves the binding; arm 8 pins that the aperture is the
  fallback, not the rule.
- `import_data_seed` (no dump): the canary is written for its own NID and for nothing else, and a
  slot too small is refused rather than half-written.
- `trap_stubs`: the accounting identity closes over three buckets, every data slot is asserted
  outside the whole stub aperture, and the mapped slot is read back, written, and read again.

Local `ctest` is deliberately **not** quoted on this head: a `ctest -j4` run wedged this machine's
amdgpu driver twice today (#3533), so validation is left to CI, which runs the same suite. The
Windows MinGW job matters here — it is the platform arm of a loader change.

Fixes #3529
Refs #3500
Refs #3502
