### PR TITLE
agc: register sceAgcDcbDrawIndirect and build its real packet (#2929)

### DIFF
--- a/prosper/docs/AGC_PACKET_SIZES.md
+++ b/prosper/docs/AGC_PACKET_SIZES.md
@@ -125,6 +125,7 @@ alone** — that is how a working title gets broken to satisfy a table. Only a g
 | `DcbDrawIndexAuto` | 7 | `DRAW_INDEX_AUTO` | 3 | LOW | same modifier; not a bare PM4 draw |
 | `DcbDrawIndexOffset` | 3 | `DRAW_INDEX_OFFSET_2` | 5 | LOW | prosper emits **fewer** — safe direction |
 | `DcbDrawIndexIndirect` | 4 | `DRAW_INDEX_INDIRECT` | 6 | LOW | fewer — safe direction |
+| `DcbDrawIndirect` | 4 | `DRAW_INDIRECT` | 5 | MED | **new (#2929)**, and the count is derived rather than copied from the indexed row. prosper's payload is the API's own operand list — 32-bit byte offset + 64-bit `ShaderDrawModifier` — so it cannot be smaller; the hardware packet spends header + `DATA_OFFSET` + `BASE_VTX_LOC` + `START_INST_LOC` + `DRAW_INITIATOR`, the same field list as the indexed form. No dump was observed inlining the real size, so the equality is inferred, not measured; only the **upper** bound is load-bearing and 4 ≤ 5 settles it. prosper answers `sceAgcDcbDrawIndirectGetSize` (`cxPZ4Wgvdj8`) from the same constant |
 | `CbDispatch` | 6 | `DISPATCH_DIRECT` | 5 | LOW | no title evidence |
 | `DcbDispatchIndirect` | 4 | `DISPATCH_INDIRECT` | 3–4 | LOW | no title evidence |
 | `AcbDispatchIndirect` | **5** | `DISPATCH_INDIRECT` (MEC, address form) | 4 | MED | **one dword LARGER than the Dcb form, deliberately** (#3218). The ACB carries a whole 64-bit argument address, not an offset: libSceAgc 3.20 has 36 `sceAgcAcb*` exports and no SetBase among them, so nothing on that ring defines a base. Astro Bot's async-compute stream is the live half — its packets carried exactly the low 32 bits of the argument allocations its Dcb announces at full width in the same run. prosper answers `sceAgcAcbDispatchIndirectGetSize` too, so the guest reserves 5 |
@@ -397,4 +398,8 @@ happened to ask, and each time fixed for that title's NIDs alone.
   "final buffer" submit variant (#232), derived from live disassembly and load-bearing. `CbBranch`
   also has a `GetSize`, which implies it is a *builder*. Recorded, not changed — a title calling it
   as a branch would currently reach the submit path instead.
+* `DcbDrawIndirect`'s 4 dwords are an inference from the published `DRAW_INDIRECT` field list,
+  not a measurement of a guest reservation (#2929). The direction that matters is proven — 4 is at or
+  below the reference, so it cannot overrun — but a `PROSPER_DCBWIN` window over a live caller
+  (Little Nightmares II `PPSA02154`, Sifu `PPSA03001`) would settle the exact value cheaply.
 * The three excluded size-carrying `GetSize` functions.

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -9926,6 +9926,60 @@ bool resolve_indirect_draw_arguments(const GpuState& submit, const GpuState::Dra
                                      GpuState::Draw& resolved) {
     resolved = source;
     if (!source.indirect) return true;
+    if (!source.indexed) {
+        // sceAgcDcbDrawIndirect (#2929) — the NON-indexed form. Its argument buffer is FOUR dwords,
+        // not five: (vertexCount, instanceCount, startVertex, startInstance). Reading the indexed
+        // five-dword layout here would demand a fifth dword the guest never wrote and then reject
+        // the draw for having no index base, which is the same silent disappearance the missing
+        // registration caused. Resolves to the DrawIndexAuto shape the realizer already renders:
+        // vertex count in index_count with `indexed` false, and startVertex through the same
+        // per-draw vertex-offset override the indexed path uses (the realizer hands it to
+        // vkCmdDraw's firstVertex).
+        constexpr uint32_t kArgumentBytes = 4u * sizeof(uint32_t);
+        if (!source.indirect_args_addr || (source.indirect_args_addr & 3u) ||
+            !guest_readable(source.indirect_args_addr, kArgumentBytes)) {
+            static std::atomic<int> warned{0};
+            if (warned.fetch_add(1) < 24)
+                std::fprintf(stderr,
+                             "[agc] indirect draw skipped: unreadable arguments at 0x%llx\n",
+                             static_cast<unsigned long long>(source.indirect_args_addr));
+            return false;
+        }
+        uint32_t args[4] = {};
+        std::memcpy(args, reinterpret_cast<const void*>(source.indirect_args_addr), sizeof(args));
+        const uint32_t vertex_count = args[0];
+        const uint32_t instance_count = args[1];
+        const uint32_t first_vertex = args[2];
+        const uint32_t first_instance = args[3];
+        constexpr uint32_t kMaxIndirectCount = 1u << 20;
+        if (!vertex_count || !instance_count) return false;  // hardware no-op
+        if (vertex_count > kMaxIndirectCount || instance_count > kMaxIndirectCount ||
+            first_instance != 0) {
+            static std::atomic<int> warned{0};
+            if (warned.fetch_add(1) < 24)
+                std::fprintf(stderr,
+                             "[agc] indirect draw skipped: vertices=%u instances=%u first_vertex=%u "
+                             "first_instance=%u\n",
+                             vertex_count, instance_count, first_vertex, first_instance);
+            return false;
+        }
+        resolved.index_count = vertex_count;
+        resolved.instance_count = instance_count;
+        resolved.indexed = false;
+        resolved.indirect_vertex_offset = static_cast<int32_t>(first_vertex);
+        resolved.has_vertex_offset_override = true;
+        resolved.indirect = false;
+        if (std::getenv("PROSPER_INDIRECTLOG")) {
+            static std::atomic<int> logged{0};
+            if (logged.fetch_add(1) < 256)
+                std::fprintf(stderr,
+                             "[agc-indirect] draw args=0x%llx vertices=%u instances=%u "
+                             "first_vertex=%u\n",
+                             static_cast<unsigned long long>(source.indirect_args_addr),
+                             vertex_count, instance_count, first_vertex);
+        }
+        return true;
+    }
     constexpr uint32_t kArgumentBytes = 5u * sizeof(uint32_t);
     if (!source.indirect_args_addr || (source.indirect_args_addr & 3u) ||
         !guest_readable(source.indirect_args_addr, kArgumentBytes)) {

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -4631,7 +4631,8 @@ void GpuState::apply(const Pm4Command& c) {
             draws.back().command_order = command_order;
             break;
         }
-        case K::DrawIndexIndirect: {
+        case K::DrawIndexIndirect:
+        case K::DrawIndirect: {
             // #305: bind-vs-work sequence in stream order. Cached — this runs per draw/dispatch,
             // and a per-item environ scan is measurable at this title's ~876k items per route.
             // The three graphics arms emit "DRAW"; the two compute arms below emit "DISPATCH", so
@@ -4653,9 +4654,13 @@ void GpuState::apply(const Pm4Command& c) {
             refresh_state_snapshot();
             Draw d;
             d.state = last_snapshot_;
-            d.indexed = true;
+            // sceAgcDcbDrawIndirect (#2929) is the same packet shape with no index buffer. The
+            // `indexed` flag is what tells the executor which argument-buffer layout to read at the
+            // far end of `indirect_args_addr` — five dwords with an index base, or four without —
+            // so it must carry the packet's own identity rather than a constant.
+            d.indexed = (c.kind == K::DrawIndexIndirect);
             d.modifier = c.di_modifier;
-            d.index_base = index_base;
+            if (d.indexed) d.index_base = index_base;
             d.indirect = true;
             if (indirect_graphics_base <= UINT64_MAX - c.indirect_offset)
                 d.indirect_args_addr = indirect_graphics_base + c.indirect_offset;
@@ -5253,7 +5258,8 @@ size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st,
                     c.reg_offset + c.reg_count > prosper::agc::Pm4::SPI_SHADER_PGM_LO_ES)
                     ++pgm_writes;
             } else if (c.kind == K::DrawIndex || c.kind == K::DrawIndexAuto ||
-                       c.kind == K::DrawIndexOffset || c.kind == K::DrawIndexIndirect) {
+                       c.kind == K::DrawIndexOffset || c.kind == K::DrawIndexIndirect ||
+                       c.kind == K::DrawIndirect) {
                 ++draws;
             }
         }

--- a/prosper/src/gpu/pm4/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4/pm4_decode.cpp
@@ -176,6 +176,15 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                     if (npl >= 1) c.indirect_offset = pl[0];
                     if (npl >= 3) c.di_modifier = lo_hi(pl + 1);
                     break;
+                case R_DRAW_INDIRECT:
+                    // sceAgcDcbDrawIndirect (#2929). Same payload shape as the indexed sibling —
+                    // [0] = byte offset into the graphics argument base, [1..2] = the 64-bit
+                    // ShaderDrawModifier — but a distinct kind, because the arguments it points at
+                    // are the four-dword non-indexed form and no index buffer is bound.
+                    c.kind = K::DrawIndirect;
+                    if (npl >= 1) c.indirect_offset = pl[0];
+                    if (npl >= 3) c.di_modifier = lo_hi(pl + 1);
+                    break;
                 case R_DISPATCH_INDIRECT:
                     c.kind = K::DispatchIndirect;
                     if (npl >= 1) c.indirect_offset = pl[0];

--- a/prosper/src/gpu/pm4/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4/pm4_decode.hpp
@@ -55,6 +55,12 @@ enum : uint32_t {
     // different operation from R_DISPATCH_INDIRECT and gets its own encoding rather than sharing
     // one whose payload cannot hold an address.
     R_DISPATCH_INDIRECT_ADDR = 0x24,
+    // sceAgcDcbDrawIndirect (#2929) — the NON-indexed indirect draw. It is a different operation
+    // from R_DRAW_INDEX_INDIRECT, not a flag on it: the argument buffer it points at holds FOUR
+    // dwords (vertexCount, instanceCount, startVertex, startInstance) where the indexed form holds
+    // five, and no index buffer participates. Sharing the indexed sub-op would make the executor
+    // read a fifth dword the guest never wrote and demand an index base that does not exist.
+    R_DRAW_INDIRECT = 0x25,
     R_NUM = 0x40,
 };
 
@@ -70,7 +76,8 @@ struct Pm4Command {
         SetNumInstances,
         DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem,
         DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Jump, SetPredication,
-        SetBaseIndirectArgs, StallCommandBufferParser, DrawIndexIndirect, DispatchIndirect,
+        SetBaseIndirectArgs, StallCommandBufferParser, DrawIndexIndirect, DrawIndirect,
+        DispatchIndirect,
         DmaData, Unknown,
     } kind = Kind::Unknown;
 

--- a/prosper/src/hle/graphics/hle_agc.cpp
+++ b/prosper/src/hle/graphics/hle_agc.cpp
@@ -78,7 +78,7 @@ constexpr uint32_t R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET =
                    R_JUMP = 0x1e, R_SET_PRED = 0x1f,
                    R_SET_BASE_INDIRECT_ARGS = 0x20, R_STALL_COMMAND_BUFFER_PARSER = 0x21,
                    R_DRAW_INDEX_INDIRECT = 0x22, R_DISPATCH_INDIRECT = 0x23,
-                   R_DISPATCH_INDIRECT_ADDR = 0x24;
+                   R_DISPATCH_INDIRECT_ADDR = 0x24, R_DRAW_INDIRECT = 0x25;
 constexpr uint32_t R_NUM = 0x40;
 
 // --- Packet sizes, in DWORDS, shared by each builder and its sceAgc*GetSize (#1143, #1748, #1756) ---
@@ -99,6 +99,24 @@ constexpr uint32_t kDwDrawIndex          = 7;
 constexpr uint32_t kDwDrawIndexAuto      = 7;
 constexpr uint32_t kDwDrawIndexOffset    = 3;
 constexpr uint32_t kDwDrawIndexIndirect  = 4;
+// sceAgcDcbDrawIndirect (#2929) — the non-indexed sibling, and deliberately the SAME 4 dwords as the
+// indexed one rather than a count copied from it by assumption. Two independent arguments, both for
+// the safe direction:
+//   * prosper's payload is its own encoding and carries exactly what the API call carries: the
+//     32-bit byte offset into the graphics argument base plus the 64-bit ShaderDrawModifier. There
+//     is no fourth operand for the non-indexed form to drop, so it cannot be smaller than this.
+//   * The hardware packet this stands for, PM4 `DRAW_INDIRECT`, spends header + DATA_OFFSET +
+//     BASE_VTX_LOC + START_INST_LOC + DRAW_INITIATOR = 5 dwords — the same field list as
+//     `DRAW_INDEX_INDIRECT`. So 4 is at or below the real library's reservation on the published
+//     layout, which is the only direction that matters: emitting FEWER than the real AGC function
+//     wastes reserved space, emitting MORE overruns a reservation the guest made in good faith
+//     (#1748). See docs/AGC_PACKET_SIZES.md.
+// prosper also answers sceAgcDcbDrawIndirectGetSize (cxPZ4Wgvdj8) from this same constant, so a
+// guest that ASKS reserves exactly what is written here and is self-consistent regardless.
+// CONFIDENCE: MED — no local dump was observed inlining the real size, so the equality with the real
+// AGC packet is inferred from the published PM4 layout rather than measured from a guest reservation.
+// CONFIDENCE: HIGH that 4 is not an overrun, which is the property #1748 makes load-bearing.
+constexpr uint32_t kDwDrawIndirect       = 4;
 constexpr uint32_t kDwDispatch           = 6;
 constexpr uint32_t kDwDispatchIndirect   = 4;
 // The ACB form is one dword larger because it carries a whole 64-bit address where the DCB form
@@ -336,6 +354,7 @@ const char* dcb_subop_name(uint32_t r) {
         case R_SET_BASE_INDIRECT_ARGS:     return "SetBaseIndirectArgs";
         case R_STALL_COMMAND_BUFFER_PARSER: return "StallCommandBufferParser";
         case R_DRAW_INDEX_INDIRECT:        return "DrawIndexIndirect";
+        case R_DRAW_INDIRECT:              return "DrawIndirect";
         case R_DISPATCH_INDIRECT:          return "DispatchIndirect";
         case R_DISPATCH_INDIRECT_ADDR:     return "AcbDispatchIndirect";
         // A raw allocate_dw with no sub-op (CbNop's 1-dword form, the type-2 filler). Without its own
@@ -2689,6 +2708,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
                 case K::SetBaseIndirectArgs: return "SetBaseIndirectArgs";
                 case K::StallCommandBufferParser: return "StallCommandBufferParser";
                 case K::DrawIndexIndirect: return "DrawIndexIndirect";
+                case K::DrawIndirect:     return "DrawIndirect";
                 case K::DispatchIndirect: return "DispatchIndirect";
                 case K::DmaData:         return "DmaData";
                 case K::Unknown:         return "Unknown";
@@ -3130,6 +3150,30 @@ HLE(agc_dcb_draw_index_indirect) {
     cmd[3] = static_cast<uint32_t>(a2 >> 32u);
     return reinterpret_cast<uint64_t>(cmd);
 }
+// sceAgcDcbDrawIndirect (NID 1q1titRBL6o) — the NON-indexed indirect draw, and the sibling that had
+// no handler at all until #2929. The dispatcher's default answered 0, which the AGC builders read as
+// "no packet was appended" and which nothing downstream reports: the draw left the command stream
+// with no reject line, no `[compute] skip`, and only a single one-shot `[prosper] unimplemented:`
+// line naming the NID. 49 of the 54 corpus dumps carry the import; Little Nightmares II (PPSA02154)
+// and Sifu (PPSA03001) are confirmed live callers.
+//
+// Same ABI as the indexed sibling — (dcb, byteOffset, shaderDrawModifier), the offset being relative
+// to the graphics argument base a preceding sceAgcDcbSetBaseIndirectArgs(dcb, 0, addr) selected — so
+// the payload is identical. What differs is at the far end of the pointer: the argument buffer holds
+// the four-dword non-indexed form (vertexCount, instanceCount, startVertex, startInstance), not the
+// five-dword indexed one, and no index buffer participates. That is why this gets its own sub-op
+// instead of a flag on R_DRAW_INDEX_INDIRECT: reusing the indexed decode would read a fifth dword
+// the guest never wrote and then reject the draw for having no index base.
+// CONFIDENCE: HIGH on the signature (identical operand list to the indexed sibling, whose ABI Astro
+// Bot's live callsites pin) and on the argument-buffer layout (the published non-indexed indirect
+// argument structure, identical across GCN/RDNA and every graphics API that exposes it).
+HLE(agc_dcb_draw_indirect) {
+    uint32_t* cmd; if (!begin_packet(a0, kDwDrawIndirect, IT_NOP, R_DRAW_INDIRECT, &cmd)) return 0;
+    cmd[1] = static_cast<uint32_t>(a1);
+    cmd[2] = static_cast<uint32_t>(a2);
+    cmd[3] = static_cast<uint32_t>(a2 >> 32u);
+    return reinterpret_cast<uint64_t>(cmd);
+}
 HLE(agc_dcb_dispatch_indirect) {
     uint32_t* cmd; if (!begin_packet(a0, kDwDispatchIndirect, IT_NOP, R_DISPATCH_INDIRECT, &cmd)) return 0;
     cmd[1] = static_cast<uint32_t>(a1);
@@ -3201,6 +3245,7 @@ HLE(agc_draw_index_get_size)          { (void)a0; return kDwDrawIndex * 4u; }
 HLE(agc_draw_index_auto_get_size)     { (void)a0; return kDwDrawIndexAuto * 4u; }
 HLE(agc_draw_index_offset_get_size)   { (void)a0; return kDwDrawIndexOffset * 4u; }
 HLE(agc_draw_index_indirect_get_size) { (void)a0; return kDwDrawIndexIndirect * 4u; }
+HLE(agc_draw_indirect_get_size)       { (void)a0; return kDwDrawIndirect * 4u; }
 HLE(agc_dispatch_get_size)            { (void)a0; return kDwDispatch * 4u; }
 
 // sceAgcQueueEndOfPipeActionPatchData (MlEw1feXcjg) — the DATA half of the ReleaseMem patch pair.
@@ -3425,6 +3470,7 @@ void register_agc_hle() {
     RN("WrdP9Zxx3lQ", agc_draw_index_auto_get_size);     // sceAgcDcbDrawIndexAutoGetSize
     RN("qMlfB1ZhMDc", agc_draw_index_offset_get_size);   // sceAgcDcbDrawIndexOffsetGetSize
     RN("mStuvI0zOtc", agc_draw_index_indirect_get_size); // sceAgcDcbDrawIndexIndirectGetSize
+    RN("cxPZ4Wgvdj8", agc_draw_indirect_get_size);       // sceAgcDcbDrawIndirectGetSize (#2929)
     RN("Abendgtz+3o", agc_dispatch_get_size);            // sceAgcCbDispatchGetSize
     RN("MlEw1feXcjg", agc_patch_release_mem_data);      // ReleaseMem packet: set the data payload
     RN("Ikfdt-rIqCE", agc_jump_patch_target);            // Jump packet: fill in target + dword count (#2711 Q5)
@@ -3538,6 +3584,7 @@ void register_agc_hle() {
     RN("RmaJwLtc8rY", agc_dcb_set_base_indirect_args);       // graphics/compute indirect base
     RN("u2T2DiA5hRI", agc_dcb_stall_command_buffer_parser); // parser visibility barrier
     RN("t1vNu082-jM", agc_dcb_draw_index_indirect);         // indexed indirect draw
+    RN("1q1titRBL6o", agc_dcb_draw_indirect);               // sceAgcDcbDrawIndirect (#2929)
     RN("CtB+A9-VxO0", agc_dcb_dispatch_indirect);           // sceAgcDcbDispatchIndirect (offset)
     RN("j3EtxFkSIhQ", agc_acb_dispatch_indirect);           // sceAgcAcbDispatchIndirect (address)
     RN("WmAc2MEj6Io", agc_dcb_dma_data);        // sceAgcDcbDmaData — append DMA_DATA packet (#117/#312)

--- a/prosper/tests/gpu/execute/test_gpu_execute.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_execute.cpp
@@ -1220,6 +1220,52 @@ int main() {
         std::filesystem::remove(capture_path, capture_filesystem_error);
     }
 
+    // #2929: the NON-indexed indirect draw (sceAgcDcbDrawIndirect) resolves from the FOUR-dword
+    // argument form — (vertexCount, instanceCount, startVertex, startInstance) — and reaches the
+    // backend as a real draw. The indexed path above reads five dwords and requires an index base;
+    // running this draw through it produces no draw at all, which is the silent disappearance the
+    // missing registration caused in the first place.
+    //
+    // The arm that makes this discriminating is the FOURTH dword. It is `startInstance` here and
+    // `baseVertex` in the indexed form, so a five-dword read of this buffer would take args[3] = 0
+    // as the vertex offset and args[4] — past the end of what the guest wrote — as the first
+    // instance. Setting startVertex to 9 and leaving startInstance 0 makes the two readings give
+    // different, checkable answers: vertex_offset 9 (correct) versus 0 (indexed misreading).
+    {
+        alignas(4) uint32_t nonindexed_args[4] = {3, 2, 9, 0};
+        GpuState nonindexed = st;
+        nonindexed.draws.clear();
+        nonindexed.dispatches.clear();
+        nonindexed.dma_copies.clear();
+        nonindexed.ordered_memory_effects.clear();
+        GpuState::Draw draw;
+        draw.indexed = false;
+        draw.indirect = true;
+        draw.indirect_args_addr = reinterpret_cast<uint64_t>(nonindexed_args);
+        draw.command_order = 300;
+        nonindexed.draws.push_back(draw);
+        bool submitted = false;
+        uint32_t submitted_raw_count = 0;
+        uint32_t submitted_instances = 0;
+        int32_t submitted_vertex_offset = 0;
+        bool submitted_indexed = true;
+        set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            if (!items.empty()) {
+                submitted = true;
+                submitted_raw_count = items.front().raw_draw_count;
+                submitted_instances = items.front().instance_count;
+                submitted_vertex_offset = items.front().vertex_offset;
+                submitted_indexed = items.front().raw_indexed;
+            }
+            return RenderedFrame{};
+        });
+        execute_ordered_and_present(nonindexed, W, H, 79, /*publish=*/false);
+        set_submit_renderer({});
+        CHECK(submitted && submitted_raw_count == 3 && submitted_instances == 2 &&
+              submitted_vertex_offset == 9 && !submitted_indexed,
+              "#2929: non-indexed indirect arguments resolve to a real non-indexed draw");
+    }
+
     // A parser stall makes later indirect packets depend on every producer in the preceding epoch.
     // Valid stale argument bytes must never leak through when that producer failed: doing so can
     // turn last frame's plausible counts into a real backend draw.

--- a/prosper/tests/gpu/pm4/test_agc_dcb.cpp
+++ b/prosper/tests/gpu/pm4/test_agc_dcb.cpp
@@ -34,7 +34,8 @@ constexpr uint32_t IT_NOP = 0x10, IT_NUM_INSTANCES = 0x2F, IT_SET_CONTEXT_REG = 
                    IT_SET_SH_REG = 0x76, IT_SET_UCONFIG_REG = 0x79,
                    R_DRAW_RESET = 0x05, R_PUSH_MARKER = 0x0b, R_POP_MARKER = 0x0c,
                    R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12,
-                   R_UC_REGS_INDIRECT = 0x13, R_DMA_DATA = 0x19, R_JUMP = 0x1e;
+                   R_UC_REGS_INDIRECT = 0x13, R_DMA_DATA = 0x19, R_JUMP = 0x1e,
+                   R_DRAW_INDEX_INDIRECT = 0x22, R_DRAW_INDIRECT = 0x25;
 
 struct ShaderRegister { uint32_t offset, value; };
 
@@ -777,6 +778,59 @@ int main() {
             jpatch((uint64_t)(uintptr_t)decoy, 2, 0x0000002040290080ull, 359, 0, 0);
             CHECK(memcmp(decoy, decoy_before, sizeof decoy) == 0,
                   "JumpPatchTarget refuses a non-Jump packet without modifying a single dword");
+        }
+    }
+
+    // ---- #2929: sceAgcDcbDrawIndirect must build a real packet, byte for byte.
+    //
+    // The defect this pins was the quietest possible one: the NID had no handler, so the call fell
+    // to the dispatcher default, returned 0, and appended NOTHING. Every non-indexed indirect draw
+    // left the command stream with no reject line anywhere -- only a one-shot
+    // `[prosper] unimplemented: libSceAgc::1q1titRBL6o`. So the assertion has to be on the EMITTED
+    // DWORDS and on the cursor advance; "the call returned something" is exactly what the broken
+    // version also did.
+    //
+    // The dword count is an ABI contract with the guest's own reservation (docs/AGC_PACKET_SIZES.md):
+    // the packet is 4 dwords, and sceAgcDcbDrawIndirectGetSize must answer 16 bytes for the same
+    // reason -- a guest that asks reserves exactly this.
+    {
+        auto draw_ind = Hle::lookup("1q1titRBL6o");       // sceAgcDcbDrawIndirect
+        auto draw_idx_ind = Hle::lookup("t1vNu082-jM");   // sceAgcDcbDrawIndexIndirect
+        auto draw_ind_size = Hle::lookup("cxPZ4Wgvdj8");  // sceAgcDcbDrawIndirectGetSize
+        CHECK(draw_ind && draw_idx_ind && draw_ind_size,
+              "#2929: sceAgcDcbDrawIndirect + its GetSize are registered beside the indexed sibling");
+        if (draw_ind && draw_idx_ind && draw_ind_size) {
+            uint32_t ring[16];
+            memset(ring, 0xEE, sizeof ring);
+            Dcb rd{};
+            rd.bottom = ring; rd.top = ring + 16; rd.cursor_up = ring; rd.cursor_down = ring + 16;
+            const uint64_t RD = (uint64_t)(uintptr_t)&rd;
+
+            const uint64_t pkt = draw_ind(RD, /*byte offset*/ 0x140,
+                                          /*ShaderDrawModifier*/ 0x0123456789ABCDEFull, 0, 0, 0);
+            CHECK(pkt == (uint64_t)(uintptr_t)ring, "#2929: the builder returned the packet it wrote");
+            CHECK(rd.cursor_up - ring == 4, "#2929: the packet is exactly 4 dwords (the reservation)");
+            CHECK(ring[0] == PM4(4, IT_NOP, R_DRAW_INDIRECT),
+                  "#2929: header is a 4-dword IT_NOP carrying the DrawIndirect sub-op");
+            CHECK(ring[1] == 0x140u, "#2929: cmd[1] = the byte offset into the graphics argument base");
+            CHECK(ring[2] == 0x89ABCDEFu && ring[3] == 0x01234567u,
+                  "#2929: cmd[2..3] = the 64-bit ShaderDrawModifier, low dword first");
+            CHECK(draw_ind_size(0, 0, 0, 0, 0, 0) == 4u * 4u,
+                  "#2929: GetSize answers the 16 bytes the builder writes");
+
+            // The sub-op must DIFFER from the indexed sibling's. They carry identical payloads, so a
+            // shared sub-op would decode and build identically and every assertion above would still
+            // pass -- while the executor read a fifth argument dword the guest never wrote and then
+            // rejected the draw for having no index base. This is the one comparison that sees it.
+            uint32_t iring[16];
+            memset(iring, 0xEE, sizeof iring);
+            Dcb id{};
+            id.bottom = iring; id.top = iring + 16; id.cursor_up = iring; id.cursor_down = iring + 16;
+            draw_idx_ind((uint64_t)(uintptr_t)&id, 0x140, 0x0123456789ABCDEFull, 0, 0, 0);
+            CHECK(iring[0] == PM4(4, IT_NOP, R_DRAW_INDEX_INDIRECT) && iring[0] != ring[0],
+                  "#2929: the indexed and non-indexed indirect draws are distinct sub-ops");
+            CHECK(memcmp(&iring[1], &ring[1], 3 * sizeof(uint32_t)) == 0,
+                  "#2929: ... with identical (offset, modifier) payloads");
         }
     }
 

--- a/prosper/tests/gpu/pm4/test_command_processor.cpp
+++ b/prosper/tests/gpu/pm4/test_command_processor.cpp
@@ -466,6 +466,42 @@ int main() {
         }
     }
 
+    // #2929: the NON-indexed indirect draw must survive the same fold, and must NOT arrive claiming
+    // to be indexed. `indexed` is what selects the argument-buffer layout the executor reads at the
+    // far end of `indirect_args_addr` — five dwords plus an index base, or four without one — so a
+    // shared arm that hard-coded `indexed = true` would send the executor to read a fifth dword the
+    // guest never wrote and then reject the draw for having no index base. An index buffer IS bound
+    // here, deliberately: the draw must still refuse to inherit it.
+    {
+        auto set_index_buffer = Hle::lookup("l4fM9K-Lyks");
+        auto set_indirect_base = Hle::lookup("RmaJwLtc8rY");
+        auto draw_nonindexed_indirect = Hle::lookup("1q1titRBL6o");
+        CHECK(set_index_buffer && set_indirect_base && draw_nonindexed_indirect,
+              "#2929: sceAgcDcbDrawIndirect is registered alongside the indirect base builder");
+        if (set_index_buffer && set_indirect_base && draw_nonindexed_indirect) {
+            alignas(4) uint32_t graphics_args[8] = {};
+            alignas(4) uint16_t indices[16] = {};
+            uint32_t buf[64] = {};
+            Dcb dcb2{};
+            dcb2.bottom = buf; dcb2.top = buf + 64;
+            dcb2.cursor_up = buf; dcb2.cursor_down = buf + 64;
+            const uint64_t D2 = reinterpret_cast<uint64_t>(&dcb2);
+            idx(D2, /*16-bit*/ 0, 0, 0, 0, 0);
+            set_index_buffer(D2, reinterpret_cast<uint64_t>(indices), 0, 0, 0, 0);
+            set_indirect_base(D2, /*graphics*/ 0, reinterpret_cast<uint64_t>(graphics_args), 0, 0, 0);
+            draw_nonindexed_indirect(D2, /*byte offset*/ 16, 0x90000000ull, 0, 0, 0);
+            GpuState st2;
+            run_cb(buf, 64, st2);
+            CHECK(st2.draws.size() == 1 && st2.draws[0].indirect &&
+                  st2.draws[0].indirect_args_addr ==
+                      reinterpret_cast<uint64_t>(graphics_args) + 16 &&
+                  st2.draws[0].modifier == 0x90000000ull,
+                  "#2929: non-indexed indirect draw retains the graphics base + offset and modifier");
+            CHECK(st2.draws.size() == 1 && !st2.draws[0].indexed && st2.draws[0].index_base == 0,
+                  "#2929: ... and is NOT indexed, even with an index buffer bound");
+        }
+    }
+
     // sceAgcAcbDispatchIndirect carries a WHOLE 64-bit argument address, not a byte offset from a
     // base, because the async-compute ring has no base to offset from: libSceAgc 3.20 exports 36
     // sceAgcAcb* entry points and not one of them sets an indirect-argument base. Sharing the DCB

--- a/prosper/tests/gpu/pm4/test_pm4_decode.cpp
+++ b/prosper/tests/gpu/pm4/test_pm4_decode.cpp
@@ -49,14 +49,15 @@ int main() {
     auto set_indirect_base = Hle::lookup("RmaJwLtc8rY"); // SetBaseIndirectArgs
     auto stall_parser = Hle::lookup("u2T2DiA5hRI");      // StallCommandBufferParser
     auto draw_indirect = Hle::lookup("t1vNu082-jM");     // DrawIndexIndirect
+    auto draw_nonindexed_indirect = Hle::lookup("1q1titRBL6o"); // DrawIndirect (#2929)
     auto dispatch_indirect = Hle::lookup("CtB+A9-VxO0"); // DispatchIndirect
     CHECK(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop && instances &&
           setcx_direct && setsh_direct && setuc_direct && set_indirect_base && stall_parser &&
-          draw_indirect && dispatch_indirect,
+          draw_indirect && dispatch_indirect && draw_nonindexed_indirect,
           "AGC Dcb builders registered");
     if (!(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop && instances &&
           setcx_direct && setsh_direct && setuc_direct && set_indirect_base && stall_parser &&
-          draw_indirect && dispatch_indirect)) {
+          draw_indirect && dispatch_indirect && draw_nonindexed_indirect)) {
         printf("== FAIL ==\n"); return 1;
     }
 
@@ -87,6 +88,10 @@ int main() {
     set_indirect_base(D, /*graphics*/ 0, 0x123456789ABC0000ull, 0, 0, 0);
     stall_parser(D, 0, 0, 0, 0, 0);
     draw_indirect(D, /*byte_offset*/ 0x40, /*modifier*/ 0x80000000ull, 0, 0, 0);
+    // #2929: the non-indexed sibling shares the graphics argument base selected above and
+    // carries the same (offset, modifier) operands; only the sub-op and the four-dword argument
+    // layout at the far end differ, so it must decode to its OWN kind.
+    draw_nonindexed_indirect(D, /*byte_offset*/ 0x60, /*modifier*/ 0x90000000ull, 0, 0, 0);
     set_indirect_base(D, /*compute*/ 1, 0xFEDCBA9876540000ull, 0, 0, 0);
     dispatch_indirect(D, /*byte_offset*/ 0x80, /*modifier*/ 1, 0, 0, 0);
     pop(D, 0, 0, 0, 0, 0);
@@ -97,8 +102,8 @@ int main() {
     std::vector<Pm4Command> ops;
     size_t consumed = decode_pm4(buffer, 256, ops);   // pass full buffer; decoder stops at the zero tail
     CHECK(consumed == used_dw, "decoder consumed exactly the built dwords (stops at zero pad)");
-    CHECK(ops.size() == 17, "decoded 17 packets");
-    if (ops.size() != 17) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
+    CHECK(ops.size() == 18, "decoded 18 packets");
+    if (ops.size() != 18) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
 
     using K = Pm4Command::Kind;
     CHECK(ops[0].kind == K::PushMarker && ops[0].marker_label &&
@@ -149,13 +154,19 @@ int main() {
     CHECK(ops[13].kind == K::DrawIndexIndirect && ops[13].indirect_offset == 0x40 &&
           ops[13].di_modifier == 0x80000000ull,
           "op13 = indexed indirect draw offset/modifier");
-    CHECK(ops[14].kind == K::SetBaseIndirectArgs && ops[14].indirect_shader_type == 1 &&
-          ops[14].indirect_base == 0xFEDCBA9876540000ull,
-          "op14 = compute indirect argument base");
-    CHECK(ops[15].kind == K::DispatchIndirect && ops[15].indirect_offset == 0x80 &&
-          ops[15].dispatch_modifier == 1,
-          "op15 = indirect dispatch offset/modifier");
-    CHECK(ops[16].kind == K::PopMarker, "op16 = PopMarker");
+    // #2929: a distinct kind, not DrawIndexIndirect with a flag. Before the fix this packet did
+    // not exist -- sceAgcDcbDrawIndirect had no handler, the builder call returned 0 having
+    // written nothing, and the stream simply had one fewer draw in it.
+    CHECK(ops[14].kind == K::DrawIndirect && ops[14].indirect_offset == 0x60 &&
+          ops[14].di_modifier == 0x90000000ull,
+          "op14 = non-indexed indirect draw offset/modifier");
+    CHECK(ops[15].kind == K::SetBaseIndirectArgs && ops[15].indirect_shader_type == 1 &&
+          ops[15].indirect_base == 0xFEDCBA9876540000ull,
+          "op15 = compute indirect argument base");
+    CHECK(ops[16].kind == K::DispatchIndirect && ops[16].indirect_offset == 0x80 &&
+          ops[16].dispatch_modifier == 1,
+          "op16 = indirect dispatch offset/modifier");
+    CHECK(ops[17].kind == K::PopMarker, "op17 = PopMarker");
 
     // Every decoded packet's len must match its header, and the payload pointer must be in-buffer.
     bool spans_ok = true;

--- a/prosper/tests/hle/test_agc_getsize.cpp
+++ b/prosper/tests/hle/test_agc_getsize.cpp
@@ -77,6 +77,9 @@ int main() {
         { "DrawIndexAuto",      "WrdP9Zxx3lQ", "Yw0jKSqop+E", 7, 0, 0, 0, 0, 0 },
         { "DrawIndexOffset",    "qMlfB1ZhMDc", "B+aG9DUnTKA", 3, 0, 0, 0, 0, 0 },
         { "DrawIndexIndirect",  "mStuvI0zOtc", "t1vNu082-jM", 4, 0, 0, 0, 0, 0 },
+        // #2929: the NON-indexed sibling. Registered late, so this row is also the guard that the
+        // pair exists at all — Hle::lookup of either NID returning null fails the first CHECK.
+        { "DrawIndirect",       "cxPZ4Wgvdj8", "1q1titRBL6o", 4, 0, 0, 0, 0, 0 },
         { "Dispatch",           "Abendgtz+3o", "k3GhuSNmBLU", 6, 0, 0, 0, 0, 0 },
         { "DispatchIndirect/D", "w8HVkEeXPv8", "CtB+A9-VxO0", 4, 0, 0, 0, 0, 0 },
         // The ACB form is 5, not 4: it carries a whole 64-bit argument address where the DCB form


### PR DESCRIPTION
Fixes #2929.

## The failure scenario

`sceAgcDcbDrawIndirect` (NID `1q1titRBL6o`) had **no registered handler**, so every call fell to
`prosper_on_unimpl` and returned 0. The AGC builders read a 0 return as "no packet was appended",
and nothing downstream reports that: the draw left the guest's command stream with no reject line,
no `[compute] skip`, and no decode warning. The only trace anywhere was a single one-shot
`[prosper] unimplemented: libSceAgc::1q1titRBL6o -> returning 0`.

The indexed sibling `sceAgcDcbDrawIndexIndirect` (`t1vNu082-jM`) was registered, so the two forms
diverged silently. 49 of the 54 corpus dumps import the NID (an import is not a call, so that is an
upper bound); Little Nightmares II `PPSA02154` and Sifu `PPSA03001` are confirmed live callers per
the issue.

## The behavioral contract

`sceAgcDcbDrawIndirect(dcb, byteOffset, shaderDrawModifier)` appends a draw whose vertex and
instance counts are read from GPU memory at `graphicsArgumentBase + byteOffset`, where the base was
selected by a preceding `sceAgcDcbSetBaseIndirectArgs(dcb, 0, addr)`. The operand list is identical
to the indexed sibling's. **What differs is at the far end of the pointer**: the argument buffer
holds the four-dword non-indexed form — `vertexCount, instanceCount, startVertex, startInstance` —
where the indexed form holds five (`indexCount, instanceCount, firstIndex, vertexOffset,
firstInstance`) and binds an index buffer.

That is why this is a distinct operation rather than a flag on the existing one. Reusing
`R_DRAW_INDEX_INDIRECT` would have made the executor read a **fifth dword the guest never wrote**
and then reject the draw for having no index base — the same silent disappearance, one layer down.

## Approach and invariants

- **Builder** (`hle_agc.cpp`): `agc_dcb_draw_indirect` emits a 4-dword `IT_NOP` packet under a new
  sub-op `R_DRAW_INDIRECT = 0x25` — `cmd[1]` = byte offset, `cmd[2..3]` = the 64-bit
  `ShaderDrawModifier`, low dword first. `sceAgcDcbDrawIndirectGetSize` (`cxPZ4Wgvdj8`) is
  registered too and answers from the same `kDwDrawIndirect` constant, so builder and reservation
  cannot drift apart.
- **The dword count is derived, not copied from the indexed row.** A builder's count is an ABI
  contract with the guest's own reservation (`docs/AGC_PACKET_SIZES.md`), and the asymmetry is what
  matters: emitting **fewer** dwords than the real AGC function wastes reserved space, emitting
  **more** overruns a reservation the guest made in good faith (#1748). Two independent arguments
  for 4:
  - prosper's payload is the API's own operand list (32-bit offset + 64-bit modifier), so the packet
    cannot be *smaller* than 4.
  - The hardware packet it stands for, PM4 `DRAW_INDIRECT`, spends header + `DATA_OFFSET` +
    `BASE_VTX_LOC` + `START_INST_LOC` + `DRAW_INITIATOR` = 5 — the same field list as
    `DRAW_INDEX_INDIRECT`. So 4 is at or below the reference, and cannot overrun.

  `CONFIDENCE: MED` on exact equality with the real library (no local dump was observed inlining the
  size, so equality is inferred from the published layout rather than measured from a guest
  reservation); `CONFIDENCE: HIGH` on the upper bound, which is the load-bearing half. Recorded as a
  new row in the `docs/AGC_PACKET_SIZES.md` builder table and as an entry under its `## Open`,
  naming `PROSPER_DCBWIN` over a live caller as the cheap way to settle the exact value.
- **Decoder** (`pm4_decode.*`): new `Kind::DrawIndirect`, same payload extraction as the indexed
  form, distinct kind.
- **Command processor**: the two kinds share one arm, and `Draw::indexed` now carries the *packet's
  own identity* (`c.kind == K::DrawIndexIndirect`) rather than a hard-coded `true`. A non-indexed
  indirect draw does not inherit a bound index buffer. The draw census counts the new kind.
- **Executor** (`resolve_indirect_draw_arguments`): a non-indexed source reads **4** dwords (not 5 —
  reading 5 would touch bytes past what the guest wrote) and resolves to the `DrawIndexAuto` shape
  the realizer already renders: vertex count in `index_count` with `indexed` false, and
  `startVertex` carried through the existing per-draw vertex-offset override, which the realizer
  hands to `vkCmdDraw`'s `firstVertex`. Same bounds, zero-count no-op and `firstInstance != 0`
  guards as the indexed path.

## Deliberately unaffected

- The indexed path (`sceAgcDcbDrawIndexIndirect`) is byte-for-byte unchanged: same sub-op, same
  4-dword packet, same five-dword argument read, same index-base requirement. A test asserts its
  payload is identical to the new form's while its sub-op differs.
- `sceAgcDcbDispatchIndirect` / `sceAgcAcbDispatchIndirect` untouched.
- `sceAgcDcbDrawIndirectMulti` (`kUlvghKs-mA`) and its GetSize remain unregistered — a different
  operation with a count/stride, out of scope here.
- No `PROSPER_*` switch added; the new behavior is unconditional, as an unregistered NID being
  registered must be.

## Risks

- **Dword count.** The one way this could hurt a title is by being *larger* than the real AGC
  packet. Argued above to be at or below it; the only unproven part is exact equality, which is
  harmless in the direction it can be wrong.
- **A previously-absent draw now executes.** A title that was silently dropping these draws will
  start submitting them. That is the point, but it is a behavior change on any title that calls the
  NID, and the new draws go through the same realization and validation as every other indirect
  draw.
- **Sub-op value.** `0x25` was free (`R_NUM` is `0x40`; the previous maximum was `0x24`). Both the
  `hle_agc.cpp` mirror and `pm4_decode.hpp` were updated together; the packet-bytes test pins the
  encoding.

## Build and test

Environment note, stated because it bounds every claim below: this WSL cannot build prosper's
Vulkan chain — its `libvulkan-dev` is 1.3.275 and `frontends/shared/device/vulkan_runtime.hpp:11`
needs `VK_API_VERSION_1_4`. 29 targets (`prosper_live_renderer` and the render/storage test
executables) fail to compile with `'VK_API_VERSION_1_4' was not declared in this scope` and friends;
every one of the compile errors in a keep-going full build is a Vulkan 1.4 header symbol, none in
a file this PR touches. The Vulkan *loader* is 1.3.275 as well, so the Vulkan-execution tests cannot
run here either (`[render] Vulkan 1.4 required; loader reports 1.3.275`).

```
cmake -S prosper -B prosper/build-linux -DCMAKE_BUILD_TYPE=Release \
      -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j5 -- -k
ctest --test-dir prosper/build-linux --no-tests=error
```

**`ctest --no-tests=error`: 458 tests discovered, 346 passed, 112 failed, exit code 8.**

That red number is entirely environmental, and it is established by comparison rather than by
assertion: the same configure/build/ctest was run on a detached worktree at **`origin/main`
(3947f269)**, which gives **458 discovered, 112 failed, exit 8** — and `diff` of the two sorted
failing-test lists is **empty**. Identical set, identical statuses. This branch introduces no new
failure. (68 of the 112 are `Not Run` — the unbuilt Vulkan executables; the rest are Vulkan-runtime
tests plus two `/mnt/c` artifacts: a CRLF-vs-LF manifest byte comparison in `snapshot_guard_logic`
and a DrvFs `0777`-vs-`0755` mode check in `profiling_access`.)

The four tests this PR extends, from that same run:

```
219/458 Test #219: pm4_decode_stream ........... Passed
220/458 Test #220: command_processor_apply ..... Passed
328/458 Test #328: agc_dcb_pm4 ................. Passed
329/458 Test #329: agc_getsize_drift ........... Passed
```

### Tests added

- `tests/gpu/pm4/test_agc_dcb.cpp` — **asserts the emitted packet bytes**: return value, a cursor
  advance of exactly 4 dwords, the `PM4(4, IT_NOP, R_DRAW_INDIRECT)` header, `cmd[1]` = offset,
  `cmd[2..3]` = modifier low-then-high, and `GetSize == 16`. Plus the discriminating arm: the
  indexed sibling built with the *same* operands must produce an identical payload and a **different
  header**, which is the only assertion that would catch a shared sub-op.
- `tests/hle/test_agc_getsize.cpp` — a `DrawIndirect` row in the drift table, pinning the absolute
  count at 4 (not merely "GetSize agrees with the builder", which stays green at any value).
- `tests/gpu/pm4/test_pm4_decode.cpp` — the builder is driven through the NID registry into a real
  DCB alongside the indexed form and the stream is decoded: 18 packets, and op14 is
  `K::DrawIndirect` with its own offset and modifier.
- `tests/gpu/pm4/test_command_processor.cpp` — folds a non-indexed indirect draw **with an index
  buffer bound** and asserts it retains base+offset and modifier and is `!indexed` with
  `index_base == 0`.
- `tests/gpu/execute/test_gpu_execute.cpp` — end-to-end: four-dword arguments `{3, 2, 9, 0}` resolve
  to a real non-indexed draw reaching the submit renderer with `raw_draw_count 3`,
  `instance_count 2`, `vertex_offset 9`, `raw_indexed false`. `startVertex = 9` is chosen so a
  five-dword misreading of this buffer gives a different, checkable answer (`vertex_offset 0`).

### Without-fix arm

Ran explicitly, not assumed. With the two `RN(...)` registrations commented out and nothing else
changed, rebuilt and re-run:

| test | with fix | without fix | failing assertion |
| --- | --- | --- | --- |
| `agc_dcb_pm4` | exit 0 | **exit 1** | `#2929: sceAgcDcbDrawIndirect + its GetSize are registered beside the indexed sibling` |
| `pm4_decode_stream` | exit 0 | **exit 1** | `AGC Dcb builders registered` |
| `agc_getsize_drift` | exit 0 | **exit 1** | `DrawIndirect: GetSize + builder registered` |
| `command_processor_apply` | exit 0 | **exit 1** | `#2929: sceAgcDcbDrawIndirect is registered alongside the indirect base builder` |

Each fails on exactly one assertion — the new one — and on nothing else.

## What I could not verify

- **`test_gpu_execute` was compiled but never executed.** It cannot build or run in this
  environment (above). To get *some* evidence rather than none, the translation unit was compiled
  and linked out-of-tree against a Vulkan 1.4 header set with the project's own include set and link
  line — object and link both exit 0, so the added block compiles and its types/APIs resolve — but
  the binary then dies at `[render] Vulkan 1.4 required; loader reports 1.3.275` before reaching any
  of prosper's executor assertions, including the five that already pass on every other machine. So
  the new executor arm is **compile-verified only**; CI and a Vulkan-1.4 host are where it first
  actually runs.
- **No live-title evidence.** No title was booted — the renderer cannot be built here — so there is
  no screenshot and no before/after on Little Nightmares II or Sifu, and consequently no `BLOG.md`
  entry. The issue's own `CONFIDENCE: LOW` temporal correlation (PPSA02154's transition to a
  permanent flat-white clear bracketing the `unimplemented` line) is **not** tested by this PR and
  remains open; the issue notes re-running `--seconds 13 --count 30` on the default route settles it
  in one run.
- **The exact real packet size.** Derived from the published PM4 layout, not measured from a guest
  reservation; recorded under `## Open` in `docs/AGC_PACKET_SIZES.md` with the `PROSPER_DCBWIN`
  recipe that would settle it.

## Review

Worth an independent read: this is reverse-engineered API semantics (argument-buffer layout, the
packet's dword count as an ABI contract) and it touches a shared decoder/executor path. The
argument-count claim and the `Draw::indexed` change in the shared command-processor arm are the two
places a second reader can most usefully challenge the reasoning.
