### PR TITLE
libSceHttp2: stop reporting a request nobody sent as SCE_OK (#2894)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1081,6 +1081,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_http PRIVATE prosper_core)
   add_test(NAME http_hle COMMAND test_http)
 
+  # #2894: libSceHttp2 was unregistered, so a request nobody sent reported SCE_OK and its response
+  # getters handed the guest untouched out-parameters.
+  add_executable(test_http2 tests/hle/net/test_http2.cpp)
+  target_link_libraries(test_http2 PRIVATE prosper_core)
+  add_test(NAME http2_hle COMMAND test_http2)
+
   add_executable(test_guard_recursion tests/hle/test_guard_recursion.cpp)
   target_link_libraries(test_guard_recursion PRIVATE prosper_core Threads::Threads)
   add_test(NAME guard_recursion COMMAND test_guard_recursion)

--- a/prosper/docs/PGA_TOUR_2K25_STATUS.md
+++ b/prosper/docs/PGA_TOUR_2K25_STATUS.md
@@ -84,6 +84,16 @@ modules), so the range selects the real `module_start` and never a C++ static co
 
 ## The current blocker
 
+> **Updated 2026-09-11 (#2894).** The libSceHttp2 false success described below is **fixed**:
+> `src/hle/net/hle_http2.cpp` now implements the library — real ids for the local objects, recorded
+> state for the setters, and a libSceNet `ENETUNREACH` from `sceHttp2SendRequest` with every
+> response getter failing and leaving its out-parameters untouched. **What that does NOT establish
+> is where this title now stops.** The change was written and tested on a machine with no
+> `PPSA17952` dump and no PS5, so no boot was run for it and the fault at `eboot+0x142d5e0` is
+> *predicted* to be gone rather than *observed* to be gone. The rung stays 0 until somebody with
+> the dump re-runs the route in `## Reproduction route` and records what they see. Everything below
+> is the pre-fix record of how the fault was reached, and is left as written.
+
 With the handshake fixed the title runs ~6x longer and reaches GPU submission, then dies on a
 **worker thread named `Background Job.`**:
 

--- a/prosper/src/hle/dispatch/dispatch.hpp
+++ b/prosper/src/hle/dispatch/dispatch.hpp
@@ -259,6 +259,9 @@ size_t savedata_tx_resource_live_count();
 void register_service_hle();
 // libSceHttp local URI helpers; called by register_builtin_hle().
 void register_http_hle();
+// libSceHttp2: local id lifecycle, recorded settings, and an honest offline failure on the
+// request/response path; called by register_builtin_hle().
+void register_http2_hle();
 // libSceFont/libSceFontFt opaque lifecycle and deterministic metrics; called by register_builtin_hle().
 void register_font_hle();
 // libSceFiber cooperative guest-stack switching; called by register_builtin_hle().

--- a/prosper/src/hle/libc/hle_libc.cpp
+++ b/prosper/src/hle/libc/hle_libc.cpp
@@ -1070,6 +1070,7 @@ void register_builtin_hle() {
     register_file_hle();     // file I/O (stdio + POSIX, /app0 translation)
     register_service_hle();  // PS5 system services (user/NP/mouse/appcontent/dialog)
     register_http_hle();     // libSceHttp local URI parsing
+    register_http2_hle();    // libSceHttp2 local ids + honest offline request failure
     register_font_hle();     // libSceFont opaque handles + deterministic text/metric fallback
     register_fiber_hle();    // libSceFiber cooperative guest-stack execution
     register_ult_hle();      // libSceUlt: NOT implemented — fail-visible counted stubs (#1603)

--- a/prosper/src/hle/net/AGENTS.md
+++ b/prosper/src/hle/net/AGENTS.md
@@ -1,7 +1,10 @@
 # `src/hle/net` — Sony networking libraries
 
 Reimplementations of the PS5 networking libraries that prosper answers itself. Today that is
-**libSceHttp** (`hle_http.cpp`): the URI helper family and the library/template id lifecycle.
+**libSceHttp** (`hle_http.cpp`): the URI helper family and the library/template id lifecycle; and
+**libSceHttp2** (`hle_http2.cpp`): the whole v2 library, split between a local object graph
+(contexts, templates, requests, cookie boxes, and the settings recorded on them) and an honest
+offline failure on everything from `sceHttp2SendRequest` onwards.
 
 ## The policy this folder exists to hold
 
@@ -41,9 +44,10 @@ library propagates the **raw libSceNet error**, encoded `0x80410100 | BSD errno`
 This folder is smaller than "prosper's networking" — several networking surfaces are answered
 elsewhere, and looking for them here is the mistake to avoid:
 
-- **`sceHttp2Init`, `sceNetCtlGetState` and the NetCtl/NP service surface live in
-  `../service/hle_service.cpp`**, not here. That is why `libSceHttp2` looks absent from this folder
-  while one of its entry points is already registered.
+- **`sceNetCtlGetState`, `sceNetPoolCreate`, `sceSslInit` and the rest of the NetCtl/NP service
+  surface live in `../service/hle_service.cpp`**, not here. `sceHttp2Init` used to be on that list
+  and is not any more (#2894): it moved into `hle_http2.cpp` with the rest of its library, because
+  the context id it returns has to be a slot that `sceHttp2CreateTemplate` can validate against.
 - Answers must not contradict each other across that boundary. prosper already tells the guest it
   is offline there — `sceNetCtlGetState` writes `SCE_NET_CTL_STATE_DISCONNECTED` and
   `sceNetCtlGetInfo` returns `SCE_NET_CTL_ERROR_NOT_CONNECTED` (`hle_service.cpp:4795`, `:4830`) —

--- a/prosper/src/hle/net/hle_http2.cpp
+++ b/prosper/src/hle/net/hle_http2.cpp
@@ -1,0 +1,653 @@
+// libSceHttp2 (#2894). Until now the library was entirely unregistered except sceHttp2Init, so
+// every one of its 55 exports fell to the dispatcher's `return 0` -- and 0 is SCE_OK. A request
+// prosper never sent reported success, and sceHttp2GetAllResponseHeaders reported success while
+// writing nothing to its out-parameters, so the guest parsed the pointer it already had. In
+// PGA TOUR 2K25 that pointer is NULL and its response-header scanner at eboot+0x142d5e0 dies on
+// `movzx edx,BYTE PTR [r11+rcx*1]` with r11 = 0.
+//
+// The rule this file follows is the one src/hle/net/AGENTS.md states, in both directions:
+//
+//   * Anything answerable from LOCAL state is implemented, not stubbed. Creating a template, a
+//     request or a cookie box really does succeed offline -- it allocates a local object -- so it
+//     returns a real id from a real table. Setters really do record local state, so they record it
+//     and then answer SCE_OK. A getter that reads back state prosper itself recorded answers it.
+//   * Anything that needs a NETWORK answer FAILS, and leaves every out-parameter untouched.
+//     There is no PSN behind this, so SCE_OK is not a true answer, and SCE_OK with an unwritten
+//     out-parameter is the exact shape that crashes callers.
+//
+// Nothing here manufactures an HTTP response: there is no synthesised status code, no fabricated
+// header block and no body. The guest's own error path runs instead, which is what it is written
+// to do -- the blocking title classifies the send result and returns cleanly on any non-zero,
+// and it is prosper's SCE_OK that walked it past that check.
+//
+// WHERE THE CONTRACTS COME FROM. The NID<->name map is the PS5 3.20 firmware library dump
+// (libSceHttp2.c, 55 exports + a dummy). Argument shapes for SendRequest, GetAllResponseHeaders
+// and GetStatusCode are read off the shipped libSceHttp2.sprx export thunks and recorded on
+// #2894; the rest follow the v1 libSceHttp family, whose published contract takes the object id
+// as the first argument everywhere. That "id first" property is the only shape assumption any
+// validation below depends on. CONFIDENCE: HIGH on it; the per-call argument meanings are marked
+// individually where they are weaker.
+//
+// WHAT IS DELIBERATELY NOT MODELLED. prosper models cookie boxes as real objects with real ids,
+// but does not model their CONTENTS. So create/delete/bind/flush are implemented, while the calls
+// that must produce or consume cookie DATA (GetCookie, CookieExport, CookieImport, AddCookie,
+// GetCookieStats, GetMemoryPoolStats) fail with out-parameters untouched. Answering SCE_OK there
+// would claim a store that does not exist, and a later read would contradict it.
+#include "hle/net/hle_http2.hpp"
+#include "hle/dispatch/dispatch.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace prosper {
+
+#define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                                        uint64_t a3, uint64_t a4, uint64_t a5)
+
+namespace {
+
+constexpr size_t kMaxUrlBytes = 64 * 1024;
+constexpr size_t kMaxHeaderBytes = 16 * 1024;
+
+// One unified id space for every object the library hands out. Separate per-kind tables would let
+// a template id and a request id collide numerically, and then a validator could not tell a live
+// id of the wrong class from a live id of the right one. Ids start at 1, so 0 -- the value the
+// dispatcher used to answer -- is never a valid id of any kind.
+enum class Kind : uint8_t { None, Ctx, Template, Request, CookieBox };
+
+struct Object {
+    Kind kind = Kind::None;
+    int32_t owner = 0;  // ctx for a template/cookie box, template for a request; 0 for a ctx
+
+    // Recorded request state. Kept so the setters below are honest: SCE_OK from a setter means
+    // the state really is recorded, not that the call was ignored.
+    std::string url;
+    int32_t method = 0;
+    uint64_t content_length = 0;
+    std::vector<std::pair<std::string, std::string>> headers;
+
+    int32_t cookie_box = 0;
+    int32_t auth_enabled = 1;
+    int32_t auto_redirect = 1;
+    int32_t inflate_gzip = 0;
+    uint32_t connect_timeout_us = 0;
+    uint32_t recv_timeout_us = 0;
+    uint32_t send_timeout_us = 0;
+    uint32_t resolve_timeout_us = 0;
+    uint32_t resolve_retry = 0;
+    uint32_t connection_wait_timeout_us = 0;
+    uint32_t ssl_options = 0;       // union of every SslEnableOption bit, minus the disabled ones
+    uint32_t min_ssl_version = 0;
+    uint32_t cookie_max_num = 0;
+    uint32_t cookie_max_num_per_domain = 0;
+    uint32_t cookie_max_size = 0;
+
+    // Callbacks are recorded and never invoked. Nothing calls them because nothing is ever sent,
+    // nothing is redirected and no TLS handshake happens -- invoking one would mean manufacturing
+    // the event it reports.
+    uint64_t cb_redirect = 0, cb_redirect_arg = 0;
+    uint64_t cb_ssl = 0, cb_ssl_arg = 0;
+    uint64_t cb_auth_info = 0, cb_auth_info_arg = 0;
+    uint64_t cb_cookie_recv = 0, cb_cookie_recv_arg = 0;
+    uint64_t cb_cookie_send = 0, cb_cookie_send_arg = 0;
+    uint64_t cb_pre_send = 0, cb_pre_send_arg = 0;
+
+    bool send_attempted = false;
+    uint32_t send_error = 0;
+    bool aborted = false;
+};
+
+constexpr int kMaxObjects = 128;
+
+std::mutex g_mx;              // guards g_objects in its entirety
+Object g_objects[kMaxObjects + 1];  // 1-based; slot 0 is never handed out
+
+// --- id plumbing -------------------------------------------------------------------------
+// Two return conventions, and they differ because the contracts do (src/hle/net/AGENTS.md):
+//   id_err  -- for an id-returning entry point. Sign-extended, so a guest reading the answer as
+//              int32 OR as int64 sees it as negative and never as a handle.
+//   err     -- for an SCE_OK-or-error entry point. The zero-extended 32-bit form the library
+//              itself returns in eax.
+uint64_t err(uint32_t code) { return static_cast<uint64_t>(code); }
+uint64_t id_err(uint32_t code) {
+    return static_cast<uint64_t>(static_cast<int64_t>(static_cast<int32_t>(code)));
+}
+
+int32_t alloc_object(Kind kind, int32_t owner) {  // caller holds g_mx
+    for (int i = 1; i <= kMaxObjects; ++i) {
+        if (g_objects[i].kind != Kind::None) continue;
+        g_objects[i] = Object{};
+        g_objects[i].kind = kind;
+        g_objects[i].owner = owner;
+        return i;
+    }
+    return 0;
+}
+
+Object* live(uint64_t raw, Kind kind) {  // caller holds g_mx
+    const int32_t id = static_cast<int32_t>(raw);
+    if (id < 1 || id > kMaxObjects) return nullptr;
+    Object& obj = g_objects[id];
+    return obj.kind == kind ? &obj : nullptr;
+}
+
+// Every live object, whatever its class. Used by the setters, deliberately.
+//
+// The v1 family lets one setter take a template, connection or request id, and which classes each
+// v2 setter accepts is not something this machine can check -- so policing the class here would
+// risk REJECTING a call hardware accepts, which is the under-report half of the same defect. What
+// matters, and what this does enforce, is that the id was actually allocated: 0 and every
+// never-created id are rejected. CONFIDENCE: HIGH that id-was-allocated is the right check;
+// LOW on any per-class restriction, which is why none is imposed.
+Object* live_any(uint64_t raw) {  // caller holds g_mx
+    const int32_t id = static_cast<int32_t>(raw);
+    if (id < 1 || id > kMaxObjects) return nullptr;
+    Object& obj = g_objects[id];
+    return obj.kind == Kind::None ? nullptr : &obj;
+}
+
+// Release everything owned by `owner`, transitively: a context owns its templates and cookie
+// boxes, and each template owns its requests. Releasing only the named slot would leak the tree
+// under it, and a title that inits/creates/terms in a loop would then exhaust a table that is
+// really empty -- the failure #3295 had to fix in the v1 sibling.
+void release_owned(int32_t owner) {  // caller holds g_mx
+    for (int i = 1; i <= kMaxObjects; ++i) {
+        if (g_objects[i].kind == Kind::None || g_objects[i].owner != owner) continue;
+        release_owned(i);
+        g_objects[i] = Object{};
+    }
+}
+
+std::string capture(uint64_t ptr, size_t cap) {
+    const char* text = reinterpret_cast<const char*>(ptr);
+    if (!text) return {};
+    return std::string(text, strnlen(text, cap));
+}
+
+// The answer for a response getter. Nothing was received, because nothing was sent: report the
+// failure the send reported, or -- if the guest is reading a response before sending at all --
+// that it called out of order. Out-parameters are not touched on either path, which is the whole
+// point of the issue: a getter that answers SCE_OK while writing nothing hands the caller
+// whatever was already in its buffer.
+uint64_t response_unavailable(const Object& req) {
+    return err(req.send_attempted ? req.send_error : http2::kErrorBeforeInit);
+}
+
+// --- library context ------------------------------------------------------------------------
+
+// sceHttp2Init(libnetMemId, libsslCtxId, poolSize, ...) -> library context id (> 0)
+//
+// Moved here from hle_service.cpp, where it was the library's only registered entry point and
+// answered from a free-running counter. It needs a real slot now, because sceHttp2CreateTemplate
+// validates the id it is handed against this table.
+HLE(h_http2_init) {
+    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    const int32_t id = alloc_object(Kind::Ctx, 0);
+    if (!id) return id_err(http2::kErrorOutOfMemory);
+    return static_cast<uint64_t>(id);
+}
+
+// sceHttp2Term(libCtxId) -> SCE_OK, releasing the context and everything created under it.
+HLE(h_http2_term) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live(a0, Kind::Ctx)) return err(http2::kErrorInvalidId);
+    const int32_t id = static_cast<int32_t>(a0);
+    release_owned(id);
+    g_objects[id] = Object{};
+    return 0;
+}
+
+// --- template -------------------------------------------------------------------------------
+
+// sceHttp2CreateTemplate(libCtxId, userAgent, httpVer, isAutoProxyConf) -> template id (> 0)
+HLE(h_http2_create_template) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live(a0, Kind::Ctx)) return id_err(http2::kErrorInvalidId);
+    const int32_t id = alloc_object(Kind::Template, static_cast<int32_t>(a0));
+    if (!id) return id_err(http2::kErrorOutOfMemory);
+    g_objects[id].url = capture(a1, 256);  // user agent, recorded so the object is not empty
+    return static_cast<uint64_t>(id);
+}
+
+// sceHttp2DeleteTemplate(templateId) -> SCE_OK, taking its requests with it.
+HLE(h_http2_delete_template) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live(a0, Kind::Template)) return err(http2::kErrorInvalidId);
+    const int32_t id = static_cast<int32_t>(a0);
+    release_owned(id);
+    g_objects[id] = Object{};
+    return 0;
+}
+
+// --- request --------------------------------------------------------------------------------
+
+// sceHttp2CreateRequestWithURL(templateId, method, url, contentLength) -> request id (> 0)
+//
+// The parent is the TEMPLATE, not a connection object: libSceHttp2 exports no CreateConnection of
+// any spelling (the v1 library exports three), so the template is the only thing a request can be
+// created from. CONFIDENCE: HIGH on the parent class, MED on the trailing argument meanings.
+HLE(h_http2_create_request_with_url) {
+    (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* tmpl = live(a0, Kind::Template);
+    if (!tmpl) return id_err(http2::kErrorInvalidId);
+    if (!a2) return id_err(http2::kErrorInvalidValue);
+    const Object parent = *tmpl;  // copied before alloc_object can move the table under us
+    const int32_t id = alloc_object(Kind::Request, static_cast<int32_t>(a0));
+    if (!id) return id_err(http2::kErrorOutOfMemory);
+    Object& req = g_objects[id];
+    // A request inherits its template's recorded settings, the way the library's own do.
+    req.cookie_box = parent.cookie_box;
+    req.auth_enabled = parent.auth_enabled;
+    req.auto_redirect = parent.auto_redirect;
+    req.inflate_gzip = parent.inflate_gzip;
+    req.connect_timeout_us = parent.connect_timeout_us;
+    req.recv_timeout_us = parent.recv_timeout_us;
+    req.send_timeout_us = parent.send_timeout_us;
+    req.resolve_timeout_us = parent.resolve_timeout_us;
+    req.resolve_retry = parent.resolve_retry;
+    req.connection_wait_timeout_us = parent.connection_wait_timeout_us;
+    req.ssl_options = parent.ssl_options;
+    req.min_ssl_version = parent.min_ssl_version;
+    req.method = static_cast<int32_t>(a1);
+    req.url = capture(a2, kMaxUrlBytes);
+    req.content_length = a3;
+    return static_cast<uint64_t>(id);
+}
+
+// sceHttp2DeleteRequest(requestId) -> SCE_OK
+HLE(h_http2_delete_request) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live(a0, Kind::Request)) return err(http2::kErrorInvalidId);
+    g_objects[static_cast<int32_t>(a0)] = Object{};
+    return 0;
+}
+
+// sceHttp2AbortRequest(requestId) -> SCE_OK. Aborting a request that was never in flight is a
+// purely local state change, so it genuinely succeeds. CONFIDENCE: MED -- hardware may answer an
+// error for a request with nothing to abort, but it has no out-parameter, so a wrong answer here
+// cannot hand the guest unwritten memory.
+HLE(h_http2_abort_request) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* req = live(a0, Kind::Request);
+    if (!req) return err(http2::kErrorInvalidId);
+    req->aborted = true;
+    return 0;
+}
+
+// --- request headers and body length ---------------------------------------------------------
+
+// sceHttp2AddRequestHeader(id, name, value, mode) -> SCE_OK once the header is recorded.
+HLE(h_http2_add_request_header) {
+    (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    if (!a1) return err(http2::kErrorInvalidValue);
+    obj->headers.emplace_back(capture(a1, kMaxHeaderBytes), capture(a2, kMaxHeaderBytes));
+    return 0;
+}
+
+// sceHttp2RemoveRequestHeader(id, name) -> SCE_OK. Removes every header recorded under that name.
+HLE(h_http2_remove_request_header) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    if (!a1) return err(http2::kErrorInvalidValue);
+    const std::string name = capture(a1, kMaxHeaderBytes);
+    for (size_t i = obj->headers.size(); i-- > 0;)
+        if (obj->headers[i].first == name) obj->headers.erase(obj->headers.begin() + static_cast<std::ptrdiff_t>(i));
+    return 0;
+}
+
+// sceHttp2SetRequestContentLength(id, length) -> SCE_OK
+HLE(h_http2_set_request_content_length) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    obj->content_length = a1;
+    return 0;
+}
+
+// --- the network boundary ---------------------------------------------------------------------
+
+// sceHttp2SendRequest(requestId, body, bodySize) -> the libSceNet error an unreachable network
+// produces. NOT SCE_OK: prosper has no network, so there is no request to report as sent, and
+// this return is what the blocking title's classifier consumes before it decides whether to read
+// a response at all.
+HLE(h_http2_send_request) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* req = live(a0, Kind::Request);
+    if (!req) return err(http2::kErrorInvalidId);
+    req->send_attempted = true;
+    req->send_error = http2::kNetErrorNetUnreach;
+    return err(req->send_error);
+}
+
+// sceHttp2SendRequestAsync(requestId, body, bodySize) -> the same failure, synchronously.
+// An async send that is going to fail at connect can fail at submission; what it must not do is
+// report acceptance and then never complete, because the guest would wait forever on a request
+// that does not exist. sceHttp2WaitAsync below answers the same way for the same reason.
+HLE(h_http2_send_request_async) { return h_http2_send_request(a0, a1, a2, a3, a4, a5); }
+
+// Every response getter. There is no response, so each reports the failure and writes NOTHING to
+// its out-parameters. sceHttp2GetAllResponseHeaders(requestId, char** out, size_t* len) is the
+// one that crashed PGA TOUR 2K25: it used to answer SCE_OK with **out left as it was.
+HLE(h_http2_get_all_response_headers) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* req = live(a0, Kind::Request);
+    if (!req) return err(http2::kErrorInvalidId);
+    return response_unavailable(*req);
+}
+HLE(h_http2_get_status_code) {  // (requestId, int32* out)
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* req = live(a0, Kind::Request);
+    if (!req) return err(http2::kErrorInvalidId);
+    return response_unavailable(*req);
+}
+HLE(h_http2_get_response_content_length) {  // (requestId, int* result, uint64* length)
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* req = live(a0, Kind::Request);
+    if (!req) return err(http2::kErrorInvalidId);
+    return response_unavailable(*req);
+}
+HLE(h_http2_read_data) {  // (requestId, void* buf, size_t size)
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* req = live(a0, Kind::Request);
+    if (!req) return err(http2::kErrorInvalidId);
+    return response_unavailable(*req);
+}
+HLE(h_http2_read_data_async) { return h_http2_read_data(a0, a1, a2, a3, a4, a5); }
+HLE(h_http2_wait_async) {  // (requestId, ...)
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* req = live(a0, Kind::Request);
+    if (!req) return err(http2::kErrorInvalidId);
+    return response_unavailable(*req);
+}
+
+// --- setters that record local state ----------------------------------------------------------
+// Each validates that the id was really allocated, records the value, and only then answers
+// SCE_OK -- "success once the state is actually recorded", not success because there is nothing
+// to do. The timeouts are microseconds in the v1 family. CONFIDENCE: MED on the units, HIGH that
+// the value is argument 1.
+#define HTTP2_SET_U32(fn, field)                                                        \
+    HLE(fn) {                                                                           \
+        (void)a2; (void)a3; (void)a4; (void)a5;                                         \
+        std::lock_guard<std::mutex> lk(g_mx);                                           \
+        Object* obj = live_any(a0);                                                     \
+        if (!obj) return err(http2::kErrorInvalidId);                                   \
+        obj->field = static_cast<uint32_t>(a1);                                         \
+        return 0;                                                                       \
+    }
+
+HTTP2_SET_U32(h_http2_set_connect_timeout, connect_timeout_us)
+HTTP2_SET_U32(h_http2_set_recv_timeout, recv_timeout_us)
+HTTP2_SET_U32(h_http2_set_send_timeout, send_timeout_us)
+HTTP2_SET_U32(h_http2_set_resolve_timeout, resolve_timeout_us)
+HTTP2_SET_U32(h_http2_set_resolve_retry, resolve_retry)
+HTTP2_SET_U32(h_http2_set_connection_wait_timeout, connection_wait_timeout_us)
+HTTP2_SET_U32(h_http2_set_min_ssl_version, min_ssl_version)
+HTTP2_SET_U32(h_http2_set_cookie_max_num, cookie_max_num)
+HTTP2_SET_U32(h_http2_set_cookie_max_num_per_domain, cookie_max_num_per_domain)
+HTTP2_SET_U32(h_http2_set_cookie_max_size, cookie_max_size)
+#undef HTTP2_SET_U32
+
+// sceHttp2SetTimeOut(id, resolveTimeout, connectTimeout, sendTimeout) -- the one call that sets
+// several at once. CONFIDENCE: MED on which slot is which; all three are recorded either way.
+HLE(h_http2_set_timeout) {
+    (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    obj->resolve_timeout_us = static_cast<uint32_t>(a1);
+    obj->connect_timeout_us = static_cast<uint32_t>(a2);
+    obj->send_timeout_us = static_cast<uint32_t>(a3);
+    return 0;
+}
+
+#define HTTP2_SET_FLAG(fn, field)                                                       \
+    HLE(fn) {                                                                           \
+        (void)a2; (void)a3; (void)a4; (void)a5;                                         \
+        std::lock_guard<std::mutex> lk(g_mx);                                           \
+        Object* obj = live_any(a0);                                                     \
+        if (!obj) return err(http2::kErrorInvalidId);                                   \
+        obj->field = static_cast<int32_t>(a1) ? 1 : 0;                                  \
+        return 0;                                                                       \
+    }
+HTTP2_SET_FLAG(h_http2_set_auth_enabled, auth_enabled)
+HTTP2_SET_FLAG(h_http2_set_auto_redirect, auto_redirect)
+HTTP2_SET_FLAG(h_http2_set_inflate_gzip_enabled, inflate_gzip)
+#undef HTTP2_SET_FLAG
+
+// The two flag getters read back exactly what the setter above recorded, so they are answered
+// locally rather than failed -- refusing state prosper holds would be the under-report half of
+// this issue. The out-parameter is written as an int32: the v1 family declares these `SceBool*`,
+// which is a 32-bit int, not a byte. CONFIDENCE: MED on the width; it is the one place in this
+// file where being wrong writes memory rather than merely returning a wrong value.
+#define HTTP2_GET_FLAG(fn, field)                                                       \
+    HLE(fn) {                                                                           \
+        (void)a2; (void)a3; (void)a4; (void)a5;                                         \
+        std::lock_guard<std::mutex> lk(g_mx);                                           \
+        Object* obj = live_any(a0);                                                     \
+        if (!obj) return err(http2::kErrorInvalidId);                                   \
+        if (!a1) return err(http2::kErrorInvalidValue);                                 \
+        *reinterpret_cast<int32_t*>(a1) = obj->field;                                   \
+        return 0;                                                                       \
+    }
+HTTP2_GET_FLAG(h_http2_get_auth_enabled, auth_enabled)
+HTTP2_GET_FLAG(h_http2_get_auto_redirect, auto_redirect)
+#undef HTTP2_GET_FLAG
+
+// sceHttp2SslEnableOption / sceHttp2SslDisableOption(id, optionFlag) -> SCE_OK. The recorded set
+// is the union of the enables minus the disables, so the two calls really do compose.
+HLE(h_http2_ssl_enable_option) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    obj->ssl_options |= static_cast<uint32_t>(a1);
+    return 0;
+}
+HLE(h_http2_ssl_disable_option) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    obj->ssl_options &= ~static_cast<uint32_t>(a1);
+    return 0;
+}
+
+// Callback registration: (id, callback, userArg). Both halves are recorded; neither is ever
+// called, because nothing happens offline that any of them reports.
+#define HTTP2_SET_CB(fn, field)                                                         \
+    HLE(fn) {                                                                           \
+        (void)a3; (void)a4; (void)a5;                                                   \
+        std::lock_guard<std::mutex> lk(g_mx);                                           \
+        Object* obj = live_any(a0);                                                     \
+        if (!obj) return err(http2::kErrorInvalidId);                                   \
+        obj->field = a1;                                                                \
+        obj->field##_arg = a2;                                                          \
+        return 0;                                                                       \
+    }
+HTTP2_SET_CB(h_http2_set_redirect_callback, cb_redirect)
+HTTP2_SET_CB(h_http2_set_ssl_callback, cb_ssl)
+HTTP2_SET_CB(h_http2_set_auth_info_callback, cb_auth_info)
+HTTP2_SET_CB(h_http2_set_cookie_recv_callback, cb_cookie_recv)
+HTTP2_SET_CB(h_http2_set_cookie_send_callback, cb_cookie_send)
+HTTP2_SET_CB(h_http2_set_pre_send_callback, cb_pre_send)
+#undef HTTP2_SET_CB
+
+// --- cookie boxes ------------------------------------------------------------------------------
+
+// sceHttp2CreateCookieBox(libCtxId, ...) -> cookie box id (> 0)
+HLE(h_http2_create_cookie_box) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live(a0, Kind::Ctx)) return id_err(http2::kErrorInvalidId);
+    const int32_t id = alloc_object(Kind::CookieBox, static_cast<int32_t>(a0));
+    if (!id) return id_err(http2::kErrorOutOfMemory);
+    return static_cast<uint64_t>(id);
+}
+
+HLE(h_http2_delete_cookie_box) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live(a0, Kind::CookieBox)) return err(http2::kErrorInvalidId);
+    const int32_t id = static_cast<int32_t>(a0);
+    // Anything still pointing at this box loses the binding rather than keeping a dangling id.
+    for (int i = 1; i <= kMaxObjects; ++i)
+        if (g_objects[i].cookie_box == id) g_objects[i].cookie_box = 0;
+    g_objects[id] = Object{};
+    return 0;
+}
+
+// sceHttp2SetCookieBox(id, cookieBoxId) -> SCE_OK once the binding is recorded.
+HLE(h_http2_set_cookie_box) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    if (a1 != 0 && !live(a1, Kind::CookieBox)) return err(http2::kErrorInvalidId);
+    obj->cookie_box = static_cast<int32_t>(a1);
+    return 0;
+}
+
+// sceHttp2GetCookieBox(id, int32* out) -> the binding prosper recorded. Local state, so it is
+// answered rather than failed. CONFIDENCE: MED on the out-parameter width (int, per the v1 ids).
+HLE(h_http2_get_cookie_box) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    Object* obj = live_any(a0);
+    if (!obj) return err(http2::kErrorInvalidId);
+    if (!a1) return err(http2::kErrorInvalidValue);
+    *reinterpret_cast<int32_t*>(a1) = obj->cookie_box;
+    return 0;
+}
+
+// Flushes. The jar, the auth cache and the redirect cache are all empty and stay empty offline,
+// so discarding their contents is a no-op that genuinely succeeded. None has an out-parameter.
+HLE(h_http2_flush) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live_any(a0)) return err(http2::kErrorInvalidId);
+    return 0;
+}
+
+// The cookie/statistics calls prosper cannot answer without inventing data. Each fails with its
+// out-parameters untouched: AddCookie and CookieImport would have to claim a store that does not
+// exist, and GetCookie, CookieExport, GetCookieStats and GetMemoryPoolStats would have to fill a
+// structure out of nothing. Reporting SCE_OK for any of them is the defect this file removes, not
+// a smaller version of it. CONFIDENCE: HIGH that failing is right; the constant is the facility's
+// invalid-value code because no "unsupported" code is attested in the module.
+HLE(h_http2_not_modelled) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!live_any(a0)) return err(http2::kErrorInvalidId);
+    return err(http2::kErrorInvalidValue);
+}
+
+} // namespace
+
+void register_http2_hle() {
+    // Context lifecycle. sceHttp2Init used to live in hle_service.cpp as the library's only
+    // registration; it is here now because CreateTemplate validates against the same table.
+    Hle::register_fn("3JCe3lCbQ8A", (HleFn)h_http2_init, "sceHttp2Init");
+    Hle::register_fn("YiBUtz-pGkc", (HleFn)h_http2_term, "sceHttp2Term");
+
+    // Local objects: real ids from a real table, never the dispatcher's 0.
+    Hle::register_fn("+wCt7fCijgk", (HleFn)h_http2_create_template, "sceHttp2CreateTemplate");
+    Hle::register_fn("pDom5-078DA", (HleFn)h_http2_delete_template, "sceHttp2DeleteTemplate");
+    Hle::register_fn("mmyOCxQMVYQ", (HleFn)h_http2_create_request_with_url,
+                     "sceHttp2CreateRequestWithURL");
+    Hle::register_fn("c8D9qIjo8EY", (HleFn)h_http2_delete_request, "sceHttp2DeleteRequest");
+    Hle::register_fn("IZ-qjhRqvjk", (HleFn)h_http2_abort_request, "sceHttp2AbortRequest");
+    Hle::register_fn("N4UfjvWJsMw", (HleFn)h_http2_create_cookie_box, "sceHttp2CreateCookieBox");
+    Hle::register_fn("O9ync3F-JVI", (HleFn)h_http2_delete_cookie_box, "sceHttp2DeleteCookieBox");
+
+    // Setters: record, then answer SCE_OK.
+    Hle::register_fn("nrPfOE8TQu0", (HleFn)h_http2_add_request_header, "sceHttp2AddRequestHeader");
+    Hle::register_fn("jHdP0CS4ZlA", (HleFn)h_http2_remove_request_header,
+                     "sceHttp2RemoveRequestHeader");
+    Hle::register_fn("FSAFOzi0FpM", (HleFn)h_http2_set_request_content_length,
+                     "sceHttp2SetRequestContentLength");
+    Hle::register_fn("-HIO4VT87v8", (HleFn)h_http2_set_connect_timeout, "sceHttp2SetConnectTimeOut");
+    Hle::register_fn("izvHhqgDt44", (HleFn)h_http2_set_recv_timeout, "sceHttp2SetRecvTimeOut");
+    Hle::register_fn("XPtW45xiLHk", (HleFn)h_http2_set_send_timeout, "sceHttp2SetSendTimeOut");
+    Hle::register_fn("ACjtE27aErY", (HleFn)h_http2_set_resolve_timeout, "sceHttp2SetResolveTimeOut");
+    Hle::register_fn("Gcjh+CisAZM", (HleFn)h_http2_set_resolve_retry, "sceHttp2SetResolveRetry");
+    Hle::register_fn("n8hMLe31OPA", (HleFn)h_http2_set_connection_wait_timeout,
+                     "sceHttp2SetConnectionWaitTimeOut");
+    Hle::register_fn("VYMxTcBqSE0", (HleFn)h_http2_set_timeout, "sceHttp2SetTimeOut");
+    Hle::register_fn("jjFahkBPCYs", (HleFn)h_http2_set_auth_enabled, "sceHttp2SetAuthEnabled");
+    Hle::register_fn("m-OL13q8AI8", (HleFn)h_http2_get_auth_enabled, "sceHttp2GetAuthEnabled");
+    Hle::register_fn("b9AvoIaOuHI", (HleFn)h_http2_set_auto_redirect, "sceHttp2SetAutoRedirect");
+    Hle::register_fn("od5QCZhZSfw", (HleFn)h_http2_get_auto_redirect, "sceHttp2GetAutoRedirect");
+    Hle::register_fn("uRosf8GQbHQ", (HleFn)h_http2_set_inflate_gzip_enabled,
+                     "sceHttp2SetInflateGZIPEnabled");
+    Hle::register_fn("09tk+kIA1Ns", (HleFn)h_http2_set_min_ssl_version, "sceHttp2SetMinSslVersion");
+    Hle::register_fn("mPKVhQqh2Es", (HleFn)h_http2_set_cookie_max_num, "sceHttp2SetCookieMaxNum");
+    Hle::register_fn("o7+WXe4WadE", (HleFn)h_http2_set_cookie_max_num_per_domain,
+                     "sceHttp2SetCookieMaxNumPerDomain");
+    Hle::register_fn("6a0N6GPD7RM", (HleFn)h_http2_set_cookie_max_size, "sceHttp2SetCookieMaxSize");
+    Hle::register_fn("EWcwMpbr5F8", (HleFn)h_http2_ssl_enable_option, "sceHttp2SslEnableOption");
+    Hle::register_fn("B37SruheQ5Y", (HleFn)h_http2_ssl_disable_option, "sceHttp2SslDisableOption");
+    Hle::register_fn("BJgi0CH7al4", (HleFn)h_http2_set_redirect_callback,
+                     "sceHttp2SetRedirectCallback");
+    Hle::register_fn("YrWX+DhPHQY", (HleFn)h_http2_set_ssl_callback, "sceHttp2SetSslCallback");
+    Hle::register_fn("Wwj6HbB2mOo", (HleFn)h_http2_set_auth_info_callback,
+                     "sceHttp2SetAuthInfoCallback");
+    Hle::register_fn("zdtXKn9X7no", (HleFn)h_http2_set_cookie_recv_callback,
+                     "sceHttp2SetCookieRecvCallback");
+    Hle::register_fn("McYmUpQ3-DY", (HleFn)h_http2_set_cookie_send_callback,
+                     "sceHttp2SetCookieSendCallback");
+    Hle::register_fn("UL4Fviw+IAM", (HleFn)h_http2_set_pre_send_callback,
+                     "sceHttp2SetPreSendCallback");
+    Hle::register_fn("jrVHsKCXA0g", (HleFn)h_http2_set_cookie_box, "sceHttp2SetCookieBox");
+    Hle::register_fn("IX23slKvtQI", (HleFn)h_http2_get_cookie_box, "sceHttp2GetCookieBox");
+
+    // Empty caches: flushing them really does succeed, and none writes an out-parameter.
+    Hle::register_fn("5VlQSzXW-SQ", (HleFn)h_http2_flush, "sceHttp2CookieFlush");
+    Hle::register_fn("WeuDjj5m4YU", (HleFn)h_http2_flush, "sceHttp2AuthCacheFlush");
+    Hle::register_fn("klwUy2Wg+q8", (HleFn)h_http2_flush, "sceHttp2RedirectCacheFlush");
+
+    // The network boundary: fail, and leave every out-parameter untouched.
+    Hle::register_fn("rbqZig38AT8", (HleFn)h_http2_send_request, "sceHttp2SendRequest");
+    Hle::register_fn("A+NVAFu4eCg", (HleFn)h_http2_send_request_async, "sceHttp2SendRequestAsync");
+    Hle::register_fn("-rdXUi2XW90", (HleFn)h_http2_get_all_response_headers,
+                     "sceHttp2GetAllResponseHeaders");
+    Hle::register_fn("9XYJwCf3lEA", (HleFn)h_http2_get_status_code, "sceHttp2GetStatusCode");
+    Hle::register_fn("o0DBQpFE13o", (HleFn)h_http2_get_response_content_length,
+                     "sceHttp2GetResponseContentLength");
+    Hle::register_fn("QygCNNmbGss", (HleFn)h_http2_read_data, "sceHttp2ReadData");
+    Hle::register_fn("bGN-6zbo7ms", (HleFn)h_http2_read_data_async, "sceHttp2ReadDataAsync");
+    Hle::register_fn("MOp-AUhdfi8", (HleFn)h_http2_wait_async, "sceHttp2WaitAsync");
+
+    // Cookie data and statistics prosper does not model: fail rather than fabricate.
+    Hle::register_fn("flPxnowtvWY", (HleFn)h_http2_not_modelled, "sceHttp2AddCookie");
+    Hle::register_fn("GQFGj0rYX+A", (HleFn)h_http2_not_modelled, "sceHttp2GetCookie");
+    Hle::register_fn("JlFGR4v50Kw", (HleFn)h_http2_not_modelled, "sceHttp2CookieExport");
+    Hle::register_fn("B5ibZI5UlzU", (HleFn)h_http2_not_modelled, "sceHttp2CookieImport");
+    Hle::register_fn("eij7UzkUqK8", (HleFn)h_http2_not_modelled, "sceHttp2GetCookieStats");
+    Hle::register_fn("otUQuZa-mv0", (HleFn)h_http2_not_modelled, "sceHttp2GetMemoryPoolStats");
+}
+
+} // namespace prosper

--- a/prosper/src/hle/net/hle_http2.hpp
+++ b/prosper/src/hle/net/hle_http2.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+// libSceHttp2 error constants (#2894).
+//
+// The v2 facility is 0x817b____, NOT v1's 0x8043____. The low code words are shared between the
+// two libraries, so the libSceHttp constants in hle_http.hpp are *not* reusable here -- reusing
+// them would hand the guest an error from the wrong facility, which its own classifier buckets
+// differently. Derivation recorded on #2894: every error-shaped immediate in the shipped
+// libSceHttp2.sprx carries 0x817b, and the blocking title's classifier compares against
+// 0x817b1220 and dispatches 0x817b1064..0x817b1084 through a 33-entry jump table.
+//
+// Two of the code words are pinned to a meaning by code rather than by a name table:
+//   0x_1076  insufficient stack -- every libSceHttp2 export shares a prologue that returns it
+//   0x_1100  invalid id         -- v1's context-id validator (+0xb070) answers 0x80431100 after
+//                                  range-checking the id and cross-checking the table slot
+// The rest are named from their v1 siblings, whose code words match.
+namespace prosper::http2 {
+
+// Called before the library was initialised / out of order. v1's 0x80431001 is the most common
+// error immediate in libSceHttp and is documented in hle_http.cpp as BEFORE_INIT.
+// CONFIDENCE: MED (code word attested in the v2 module; the exact name is read across from v1).
+constexpr uint32_t kErrorBeforeInit = 0x817b1001u;
+
+// No free slot in one of prosper's object tables. CONFIDENCE: MED (v1 sibling 0x80431022 is
+// SCE_HTTP_ERROR_OUT_OF_MEMORY, and 0x817b1022 is the most frequent immediate in libSceHttp2).
+constexpr uint32_t kErrorOutOfMemory = 0x817b1022u;
+
+// An id that was never allocated, or 0. CONFIDENCE: HIGH on the semantic (read off v1's validator
+// on the create path), MED on the facility carry-across.
+constexpr uint32_t kErrorInvalidId = 0x817b1100u;
+
+// A malformed argument, and also prosper's answer for a call whose result it cannot model without
+// fabricating data (see hle_http2.cpp's "not modelled" note). CONFIDENCE: MED.
+constexpr uint32_t kErrorInvalidValue = 0x817b11feu;
+
+// What the send path answers offline. libSceHttp2 does NOT wrap a connect failure in an HTTP
+// error: it propagates the raw libSceNet error, encoded 0x80410100 | <FreeBSD errno>. That
+// encoding is pinned by the library special-casing 0x80410124 (errno 36, EINPROGRESS) as *not* a
+// failure at its connect site, and corroborated by the blocking title's own classifier naming
+// 0x8041013d (61, ECONNREFUSED) and 0x80410140 (64, EHOSTDOWN).
+//
+// prosper has no network, so the honest answer is the one a machine with no route produces:
+// ENETUNREACH (FreeBSD errno 51 = 0x33). This agrees with what prosper already tells the same
+// guest through NetCtl, which reports the link DISCONNECTED / NOT_CONNECTED.
+// CONFIDENCE: HIGH that a libSceNet-facility error is the right family; MED on this exact errno.
+constexpr uint32_t kNetErrorNetUnreach = 0x80410133u;
+
+} // namespace prosper::http2

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -2944,7 +2944,6 @@ HLE(s_np_check_avail) { svc_log("sceNpCheckNpAvailability", a0,a1,a2,a3,a4,a5); 
 namespace {
 std::atomic<int32_t> g_net_pool_id{1};
 std::atomic<int32_t> g_ssl_context_id{1};
-std::atomic<int32_t> g_http2_context_id{1};
 std::atomic<int32_t> g_npweb_context_id{1};
 std::atomic<int32_t> g_npweb_user_context_id{1001};
 }
@@ -2957,10 +2956,6 @@ HLE(s_ssl_init) {
     svc_log("sceSslInit", a0,a1,a2,a3,a4,a5);
     if (!a0) return 0x8094000cull; // SCE_SSL_ERROR_OUT_OF_SIZE
     return (uint64_t)(uint32_t)g_ssl_context_id.fetch_add(1);
-}
-HLE(s_http2_init) {
-    svc_log("sceHttp2Init", a0,a1,a2,a3,a4,a5);
-    return (uint64_t)(uint32_t)g_http2_context_id.fetch_add(1);
 }
 HLE(s_npweb_init) {
     svc_log("sceNpWebApi2Initialize", a0,a1,a2,a3,a4,a5);
@@ -5446,7 +5441,8 @@ void register_service_hle() {
     Hle::register_fn("0cBgduPRR+M", (HleFn)s_netctl_getresult, "sceNetCtlGetResult");
     Hle::register_fn("dgJBaeJnGpo", (HleFn)s_net_pool_create, "sceNetPoolCreate");
     Hle::register_fn("hdpVEUDFW3s", (HleFn)s_ssl_init, "sceSslInit");
-    Hle::register_fn("3JCe3lCbQ8A", (HleFn)s_http2_init, "sceHttp2Init");
+    // libSceHttp2 lives in src/hle/net/hle_http2.cpp now, sceHttp2Init with it (#2894): the
+    // context it returns is a slot that library's own create path validates against.
     Hle::register_fn("+o9816YQhqQ", (HleFn)s_npweb_init, "sceNpWebApi2Initialize");
     Hle::register_fn("sk54bi6FtYM", (HleFn)s_npweb_create_user_context,
                      "sceNpWebApi2CreateUserContext");

--- a/prosper/tests/hle/net/test_http2.cpp
+++ b/prosper/tests/hle/net/test_http2.cpp
@@ -1,0 +1,296 @@
+// test_http2 — libSceHttp2 (#2894), the FALSE SUCCESS class of #2081.
+//
+// The library was entirely unregistered except sceHttp2Init, so every call answered the
+// dispatcher's 0 — which is SCE_OK. Two distinct wrongs follow from that single default, and this
+// file asserts against BOTH, because an arm that only checks "the NID is registered" or only
+// checks "the call returns non-zero" can pass against an implementation that still has the bug:
+//
+//   * an ID-returning entry point answering 0 hands the guest a valid-looking handle it will
+//     carry into later calls, so every id arm below demands a POSITIVE id for a good call and a
+//     NEGATIVE (sign-extended) error for a bad one — 0 satisfies neither;
+//   * a response getter answering SCE_OK while writing nothing to its out-parameters hands the
+//     guest whatever was already in its buffer, which is the NULL that crashed PGA TOUR 2K25's
+//     header scanner. Every such arm pre-fills the out-parameters with a sentinel and requires
+//     the sentinel to SURVIVE alongside a non-zero return.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/net/hle_http2.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+namespace {
+
+// Every NID this library registers, with the name the PS5 3.20 firmware dump gives it. A typo in
+// a NID is indistinguishable at run time from leaving the function unregistered -- the guest's
+// import simply does not resolve -- so the whole set is checked by name rather than spot-checked.
+struct Export { const char* nid; const char* name; };
+const Export kExports[] = {
+    {"3JCe3lCbQ8A", "sceHttp2Init"},
+    {"YiBUtz-pGkc", "sceHttp2Term"},
+    {"+wCt7fCijgk", "sceHttp2CreateTemplate"},
+    {"pDom5-078DA", "sceHttp2DeleteTemplate"},
+    {"mmyOCxQMVYQ", "sceHttp2CreateRequestWithURL"},
+    {"c8D9qIjo8EY", "sceHttp2DeleteRequest"},
+    {"IZ-qjhRqvjk", "sceHttp2AbortRequest"},
+    {"N4UfjvWJsMw", "sceHttp2CreateCookieBox"},
+    {"O9ync3F-JVI", "sceHttp2DeleteCookieBox"},
+    {"nrPfOE8TQu0", "sceHttp2AddRequestHeader"},
+    {"jHdP0CS4ZlA", "sceHttp2RemoveRequestHeader"},
+    {"FSAFOzi0FpM", "sceHttp2SetRequestContentLength"},
+    {"-HIO4VT87v8", "sceHttp2SetConnectTimeOut"},
+    {"izvHhqgDt44", "sceHttp2SetRecvTimeOut"},
+    {"XPtW45xiLHk", "sceHttp2SetSendTimeOut"},
+    {"ACjtE27aErY", "sceHttp2SetResolveTimeOut"},
+    {"Gcjh+CisAZM", "sceHttp2SetResolveRetry"},
+    {"n8hMLe31OPA", "sceHttp2SetConnectionWaitTimeOut"},
+    {"VYMxTcBqSE0", "sceHttp2SetTimeOut"},
+    {"jjFahkBPCYs", "sceHttp2SetAuthEnabled"},
+    {"m-OL13q8AI8", "sceHttp2GetAuthEnabled"},
+    {"b9AvoIaOuHI", "sceHttp2SetAutoRedirect"},
+    {"od5QCZhZSfw", "sceHttp2GetAutoRedirect"},
+    {"uRosf8GQbHQ", "sceHttp2SetInflateGZIPEnabled"},
+    {"09tk+kIA1Ns", "sceHttp2SetMinSslVersion"},
+    {"mPKVhQqh2Es", "sceHttp2SetCookieMaxNum"},
+    {"o7+WXe4WadE", "sceHttp2SetCookieMaxNumPerDomain"},
+    {"6a0N6GPD7RM", "sceHttp2SetCookieMaxSize"},
+    {"EWcwMpbr5F8", "sceHttp2SslEnableOption"},
+    {"B37SruheQ5Y", "sceHttp2SslDisableOption"},
+    {"BJgi0CH7al4", "sceHttp2SetRedirectCallback"},
+    {"YrWX+DhPHQY", "sceHttp2SetSslCallback"},
+    {"Wwj6HbB2mOo", "sceHttp2SetAuthInfoCallback"},
+    {"zdtXKn9X7no", "sceHttp2SetCookieRecvCallback"},
+    {"McYmUpQ3-DY", "sceHttp2SetCookieSendCallback"},
+    {"UL4Fviw+IAM", "sceHttp2SetPreSendCallback"},
+    {"jrVHsKCXA0g", "sceHttp2SetCookieBox"},
+    {"IX23slKvtQI", "sceHttp2GetCookieBox"},
+    {"5VlQSzXW-SQ", "sceHttp2CookieFlush"},
+    {"WeuDjj5m4YU", "sceHttp2AuthCacheFlush"},
+    {"klwUy2Wg+q8", "sceHttp2RedirectCacheFlush"},
+    {"rbqZig38AT8", "sceHttp2SendRequest"},
+    {"A+NVAFu4eCg", "sceHttp2SendRequestAsync"},
+    {"-rdXUi2XW90", "sceHttp2GetAllResponseHeaders"},
+    {"9XYJwCf3lEA", "sceHttp2GetStatusCode"},
+    {"o0DBQpFE13o", "sceHttp2GetResponseContentLength"},
+    {"QygCNNmbGss", "sceHttp2ReadData"},
+    {"bGN-6zbo7ms", "sceHttp2ReadDataAsync"},
+    {"MOp-AUhdfi8", "sceHttp2WaitAsync"},
+    {"flPxnowtvWY", "sceHttp2AddCookie"},
+    {"GQFGj0rYX+A", "sceHttp2GetCookie"},
+    {"JlFGR4v50Kw", "sceHttp2CookieExport"},
+    {"B5ibZI5UlzU", "sceHttp2CookieImport"},
+    {"eij7UzkUqK8", "sceHttp2GetCookieStats"},
+    {"otUQuZa-mv0", "sceHttp2GetMemoryPoolStats"},
+};
+
+HleFn fn(const char* nid) { return Hle::lookup(nid); }
+
+// An id-returning entry point's error must be negative read as int32 AND as int64 -- the guest may
+// take either width, and a zero-extended 0x817b1100 is a positive 64-bit number that looks like a
+// (very large) handle. This is also the arm that fails against a plain `return 0`.
+bool is_id_error(uint64_t ret) {
+    return static_cast<int32_t>(ret) < 0 && static_cast<int64_t>(ret) < 0;
+}
+bool is_positive_id(uint64_t ret) {
+    return static_cast<int64_t>(ret) > 0 && static_cast<int64_t>(ret) < 0x10000;
+}
+
+} // namespace
+
+int main() {
+    std::printf("== test_http2 ==\n");
+    register_builtin_hle();
+
+    // ---- registration ---------------------------------------------------------------------
+    // Kills: the whole bug. Every one of these answered the dispatcher's 0 before.
+    std::printf("-- registration --\n");
+    int missing = 0, misnamed = 0;
+    for (const auto& e : kExports) {
+        if (!fn(e.nid)) { std::printf("  [FAIL] %s (%s) unregistered\n", e.name, e.nid); ++missing; continue; }
+        const char* name = Hle::name_of(e.nid);
+        if (!name || std::strcmp(name, e.name) != 0) {
+            std::printf("  [FAIL] %s registered under the wrong name (%s)\n", e.nid, name ? name : "(null)");
+            ++misnamed;
+        }
+    }
+    CHECK(missing == 0, "every libSceHttp2 export this file implements is registered");
+    CHECK(misnamed == 0, "every registration carries its PS5 3.20 name");
+    if (missing) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+
+    HleFn init = fn("3JCe3lCbQ8A"), term = fn("YiBUtz-pGkc");
+    HleFn create_tmpl = fn("+wCt7fCijgk"), del_tmpl = fn("pDom5-078DA");
+    HleFn create_req = fn("mmyOCxQMVYQ"), del_req = fn("c8D9qIjo8EY");
+    HleFn create_box = fn("N4UfjvWJsMw");
+    HleFn add_header = fn("nrPfOE8TQu0");
+    HleFn send = fn("rbqZig38AT8");
+    HleFn get_headers = fn("-rdXUi2XW90"), get_status = fn("9XYJwCf3lEA");
+    HleFn get_length = fn("o0DBQpFE13o"), read_data = fn("QygCNNmbGss");
+    HleFn set_auth = fn("jjFahkBPCYs"), get_auth = fn("m-OL13q8AI8");
+    HleFn set_box = fn("jrVHsKCXA0g"), get_box = fn("IX23slKvtQI");
+    HleFn add_cookie = fn("flPxnowtvWY"), cookie_flush = fn("5VlQSzXW-SQ");
+
+    // ---- ids ------------------------------------------------------------------------------
+    std::printf("-- id lifecycle --\n");
+    const uint64_t ctx = init(1, 1, 0x58000, 3, 0, 0);
+    // Kills: THE BUG for this entry point -- 0 is a library context id the guest carries onward.
+    CHECK(is_positive_id(ctx), "sceHttp2Init returns a positive library context id");
+    const uint64_t ctx2 = init(1, 1, 0x58000, 3, 0, 0);
+    CHECK(is_positive_id(ctx2) && ctx2 != ctx, "a second Init returns a different context id");
+
+    // Kills: accepting any id at all, which is what a table-less implementation does. A context
+    // id of 0 is precisely what the OLD dispatcher default handed the guest, so a CreateTemplate
+    // that accepts it would take the bug's own output as valid input.
+    CHECK(is_id_error(create_tmpl(0, 0, 0, 0, 0, 0)),
+          "CreateTemplate on context id 0 answers a negative error, not a template id");
+    CHECK(is_id_error(create_tmpl(0x7fff, 0, 0, 0, 0, 0)),
+          "CreateTemplate on a never-allocated context id answers a negative error");
+
+    const uint64_t tmpl = create_tmpl(ctx, (uint64_t)(uintptr_t)"prosper-test/1.0", 0, 0, 0, 0);
+    CHECK(is_positive_id(tmpl) && tmpl != ctx, "CreateTemplate returns a positive, distinct id");
+
+    const char* url = "https://example.invalid/api/submit?token=abc";
+    CHECK(is_id_error(create_req(0, 0, (uint64_t)(uintptr_t)url, 0, 0, 0)),
+          "CreateRequestWithURL on template id 0 answers a negative error");
+    CHECK(is_id_error(create_req(tmpl, 0, 0, 0, 0, 0)),
+          "CreateRequestWithURL with a null URL answers a negative error");
+    const uint64_t req = create_req(tmpl, 0, (uint64_t)(uintptr_t)url, 0, 0, 0);
+    CHECK(is_positive_id(req) && req != tmpl && req != ctx,
+          "CreateRequestWithURL returns a positive, distinct request id");
+
+    // ---- setters record, and reject an id nobody allocated ---------------------------------
+    std::printf("-- setters --\n");
+    CHECK(add_header(req, (uint64_t)(uintptr_t)"X-Prosper", (uint64_t)(uintptr_t)"1", 0, 0, 0) == 0,
+          "AddRequestHeader on a live request succeeds");
+    // Kills: "return SCE_OK unconditionally", which is what the dispatcher default did. Note this
+    // arm cannot be satisfied by the default, because the default also returns 0 here.
+    CHECK(add_header(0, (uint64_t)(uintptr_t)"X-Prosper", (uint64_t)(uintptr_t)"1", 0, 0, 0)
+              == http2::kErrorInvalidId,
+          "AddRequestHeader on id 0 answers SCE_HTTP2_ERROR_INVALID_ID");
+
+    // A setter/getter pair over the SAME field, both directions. Kills: a getter that writes a
+    // constant, a getter that writes nothing, and a setter that answers SCE_OK without recording.
+    // The out-parameter sits between two sentinels, so a write of the wrong width is visible.
+    int32_t probe[3] = {(int32_t)0xA5A5A5A5, (int32_t)0xA5A5A5A5, (int32_t)0xA5A5A5A5};
+    CHECK(set_auth(req, 0, 0, 0, 0, 0) == 0, "SetAuthEnabled(false) succeeds");
+    CHECK(get_auth(req, (uint64_t)(uintptr_t)&probe[1], 0, 0, 0, 0) == 0 && probe[1] == 0,
+          "GetAuthEnabled reads back the false the setter recorded");
+    CHECK(set_auth(req, 1, 0, 0, 0, 0) == 0 &&
+              get_auth(req, (uint64_t)(uintptr_t)&probe[1], 0, 0, 0, 0) == 0 && probe[1] == 1,
+          "GetAuthEnabled reads back the true the setter recorded");
+    CHECK(probe[0] == (int32_t)0xA5A5A5A5 && probe[2] == (int32_t)0xA5A5A5A5,
+          "GetAuthEnabled writes exactly its own 32-bit slot, not its neighbours");
+
+    const uint64_t box = create_box(ctx, 0, 0, 0, 0, 0);
+    CHECK(is_positive_id(box), "CreateCookieBox returns a positive cookie box id");
+    CHECK(set_box(tmpl, box, 0, 0, 0, 0) == 0, "SetCookieBox binds a live box to a template");
+    CHECK(set_box(tmpl, 0x7fff, 0, 0, 0, 0) == http2::kErrorInvalidId,
+          "SetCookieBox rejects a cookie box id nobody allocated");
+    probe[1] = (int32_t)0xA5A5A5A5;
+    CHECK(get_box(tmpl, (uint64_t)(uintptr_t)&probe[1], 0, 0, 0, 0) == 0 &&
+              probe[1] == (int32_t)box,
+          "GetCookieBox reads back the binding SetCookieBox recorded");
+
+    // ---- the network boundary ---------------------------------------------------------------
+    std::printf("-- send and response --\n");
+    // Before any send there is still no response, and a getter must say so without writing.
+    uint64_t out_ptr = 0xDEADBEEFCAFEF00Dull, out_len = 0xDEADBEEFCAFEF00Dull;
+    CHECK(get_headers(req, (uint64_t)(uintptr_t)&out_ptr, (uint64_t)(uintptr_t)&out_len, 0, 0, 0) != 0,
+          "GetAllResponseHeaders fails before anything was sent");
+    CHECK(out_ptr == 0xDEADBEEFCAFEF00Dull && out_len == 0xDEADBEEFCAFEF00Dull,
+          "...and writes neither out-parameter");
+
+    const uint64_t sent = send(req, 0, 0, 0, 0, 0);
+    // Kills: THE BUG. The dispatcher answered 0 = SCE_OK for a request that was never sent, and
+    // that is exactly what walked PGA TOUR 2K25 past its own error handling.
+    CHECK(sent != 0, "SendRequest does NOT report success for a request prosper never sent");
+    // Kills: an arbitrary non-zero. The offline answer is the libSceNet error an unreachable
+    // network produces, which is the family the library itself propagates from its connect site.
+    CHECK(sent == http2::kNetErrorNetUnreach,
+          "SendRequest reports SCE_NET_ERROR_ENETUNREACH (0x80410133)");
+    CHECK((sent & 0x80000000u) != 0, "...and it is an error-shaped value with the top bit set");
+
+    // The four response getters, each with pre-filled out-parameters. This is the crash the issue
+    // is about: eboot+0x142d5e0 scans the buffer GetAllResponseHeaders was supposed to hand back.
+    out_ptr = out_len = 0xDEADBEEFCAFEF00Dull;
+    CHECK(get_headers(req, (uint64_t)(uintptr_t)&out_ptr, (uint64_t)(uintptr_t)&out_len, 0, 0, 0) == sent,
+          "GetAllResponseHeaders reports the same failure the send did");
+    CHECK(out_ptr == 0xDEADBEEFCAFEF00Dull && out_len == 0xDEADBEEFCAFEF00Dull,
+          "...and leaves the caller's header pointer and length untouched");
+
+    int32_t status = (int32_t)0xA5A5A5A5;
+    CHECK(get_status(req, (uint64_t)(uintptr_t)&status, 0, 0, 0, 0) != 0 &&
+              status == (int32_t)0xA5A5A5A5,
+          "GetStatusCode fails and writes no status code");
+    uint64_t length = 0xDEADBEEFCAFEF00Dull;
+    CHECK(get_length(req, (uint64_t)(uintptr_t)&length, 0, 0, 0, 0) != 0 &&
+              length == 0xDEADBEEFCAFEF00Dull,
+          "GetResponseContentLength fails and writes no length");
+    unsigned char body[16];
+    std::memset(body, 0x5A, sizeof(body));
+    CHECK(read_data(req, (uint64_t)(uintptr_t)body, sizeof(body), 0, 0, 0) != 0,
+          "ReadData fails");
+    bool body_untouched = true;
+    for (unsigned char c : body) body_untouched &= (c == 0x5A);
+    CHECK(body_untouched, "...and writes no body bytes");
+
+    // A send on an id nobody allocated is a different failure from "no response".
+    CHECK(send(0, 0, 0, 0, 0, 0) == http2::kErrorInvalidId,
+          "SendRequest on request id 0 answers INVALID_ID, not the network error");
+
+    // ---- what prosper deliberately does not model ------------------------------------------
+    std::printf("-- not modelled / flushes --\n");
+    CHECK(add_cookie(ctx, 0, 0, 0, 0, 0) != 0,
+          "AddCookie fails rather than claiming a cookie store prosper does not keep");
+    CHECK(cookie_flush(ctx, 0, 0, 0, 0, 0) == 0,
+          "CookieFlush succeeds: an empty jar really is discardable");
+    CHECK(cookie_flush(0, 0, 0, 0, 0, 0) == http2::kErrorInvalidId,
+          "CookieFlush still rejects an id nobody allocated");
+
+    // ---- teardown reclaims the whole tree ---------------------------------------------------
+    std::printf("-- teardown --\n");
+    CHECK(del_req(req, 0, 0, 0, 0, 0) == 0, "DeleteRequest accepts its own request id");
+    CHECK(del_req(req, 0, 0, 0, 0, 0) == http2::kErrorInvalidId,
+          "...and the id is dead afterwards");
+    const uint64_t req2 = create_req(tmpl, 0, (uint64_t)(uintptr_t)url, 0, 0, 0);
+    CHECK(is_positive_id(req2), "a fresh request can be created from the same template");
+    CHECK(del_tmpl(tmpl, 0, 0, 0, 0, 0) == 0, "DeleteTemplate accepts its own template id");
+    CHECK(send(req2, 0, 0, 0, 0, 0) == http2::kErrorInvalidId,
+          "DeleteTemplate took its outstanding request with it");
+
+    // The leak control. A loop that terminates contexts WITHOUT ever creating anything under them
+    // cannot express the leak it is meant to catch (the vacuity #3295 had to fix in the v1
+    // sibling), so this one fills the table from one context first, tears that context down, and
+    // then requires a FRESH context to reach the same depth.
+    CHECK(term(ctx2, 0, 0, 0, 0, 0) == 0, "Term accepts the second context");
+    CHECK(term(ctx, 0, 0, 0, 0, 0) == 0, "Term accepts the first context");
+    CHECK(term(ctx, 0, 0, 0, 0, 0) == http2::kErrorInvalidId, "...and the context id is dead");
+    CHECK(is_id_error(create_tmpl(ctx, 0, 0, 0, 0, 0)),
+          "CreateTemplate on a terminated context answers a negative error");
+
+    int depth[2] = {0, 0};
+    for (int pass = 0; pass < 2; ++pass) {
+        const uint64_t c = init(1, 1, 0x58000, 3, 0, 0);
+        if (!is_positive_id(c)) { std::printf("  [FAIL] Init failed on pass %d\n", pass); ++fails; break; }
+        while (true) {
+            const uint64_t t = create_tmpl(c, 0, 0, 0, 0, 0);
+            if (!is_positive_id(t)) break;
+            ++depth[pass];
+            // Give each template a request, so a Term that frees only templates still leaks.
+            create_req(t, 0, (uint64_t)(uintptr_t)url, 0, 0, 0);
+        }
+        CHECK(term(c, 0, 0, 0, 0, 0) == 0, "the filled context terminates");
+    }
+    CHECK(depth[0] > 0, "the table really was filled (the control can express a leak)");
+    CHECK(depth[1] == depth[0],
+          "a fresh context reaches the same depth: Term reclaimed the whole tree, not just the slot");
+
+    if (fails) std::printf("== FAIL: %d ==\n", fails);
+    else std::printf("== PASS ==\n");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #2894.

## The failure

`libSceHttp2` was registered exactly once — `sceHttp2Init`, and that lived in `hle_service.cpp`.
Every other export of the library fell through to the dispatcher's unregistered default, `return 0`,
and **0 is `SCE_OK`**. Two different wrongs follow from that one default:

* `sceHttp2CreateTemplate` / `CreateRequestWithURL` / `CreateCookieBox` answered **0 as an id**, so
  the guest carried a handle that was never allocated into every later call;
* `sceHttp2SendRequest` reported that a request prosper never sent had been **sent successfully**,
  and `sceHttp2GetAllResponseHeaders` reported success **while writing nothing to its
  out-parameters**, so the guest parsed the pointer it already held.

In *PGA TOUR 2K25* (`PPSA17952`) that pointer is NULL, and the title's HTTP response-header scanner
at `eboot+0x142d5e0` dies on `movzx edx,BYTE PTR [r11+rcx*1]` with `r11 = 0`. It is the blocker
holding the title at rung 0. *Metaphor: ReFantazio* reaches the same library through
`sceHttp2CreateTemplate`.

## Behavioural contract

The rule is the one `src/hle/net/AGENTS.md` already states, applied in **both** directions:

* **Anything answerable from local state is implemented, not stubbed.** Creating a template, a
  request or a cookie box really does succeed offline — it allocates a local object — so it returns
  a real id from a real table. Setters really do record local state, so they record it and *then*
  answer `SCE_OK`. A getter that reads back state prosper itself recorded answers it.
* **Anything that needs a network answer FAILS, and leaves every out-parameter untouched.** There is
  no PSN behind this. `SCE_OK` is not a true answer, and `SCE_OK` with an unwritten out-parameter is
  the specific shape that crashes callers.

**Nothing is manufactured.** There is no synthesised status code, no fabricated header block, no
invented body, and no "pretend it worked" path. The guest's own error handling runs instead — which
is what it is written to do: the blocking title classifies the send result and returns cleanly on any
non-zero, and it was prosper's `SCE_OK` that walked it past that check.

## Approach and invariants

New `src/hle/net/hle_http2.cpp` (+ `hle_http2.hpp` for the error constants), registered from
`register_builtin_hle()` alongside `register_http_hle()`.

* **One unified id space** for contexts, templates, requests and cookie boxes. Separate per-kind
  tables would let a template id and a request id collide numerically, and a validator could then not
  tell a live id of the wrong class from a live id of the right one. Ids start at 1, so **0 — the
  value the dispatcher used to answer — is never a valid id of any kind**.
* **Two return conventions, because the contracts differ.** An id-returning entry point sign-extends
  its error, so a guest reading the answer as `int32` *or* `int64` sees it negative and never as a
  handle; an `SCE_OK`-or-error entry point keeps the zero-extended 32-bit form the library returns in
  `eax`. Both are commented as such, matching `hle_http.cpp`.
* **`sceHttp2Term` reclaims the whole tree** — a context owns its templates and cookie boxes, each
  template owns its requests. Releasing only the named slot would leak everything under it, which is
  the failure #3295 had to fix in the v1 sibling.
* **Setters validate that the id was allocated, then record, then answer `SCE_OK`.** They accept a
  live id of *any* class deliberately: the v1 family lets one setter take a template, connection or
  request id, and policing the class here would risk *rejecting* a call hardware accepts — the
  under-report half of the same defect. What is enforced is that the id exists, which is exactly what
  rejects the old default's 0.
* **`sceHttp2SendRequest` answers a libSceNet `ENETUNREACH` (`0x80410133`).** libSceHttp2 does not
  wrap a connect failure in an HTTP error — it propagates the raw libSceNet error, encoded
  `0x80410100 | <FreeBSD errno>`, pinned by the library special-casing `0x80410124` (errno 36,
  `EINPROGRESS`) as *not* a failure at its connect site, and corroborated by the title's own
  classifier naming `0x8041013d` (61, `ECONNREFUSED`) and `0x80410140` (64, `EHOSTDOWN`). An
  unreachable network is the honest offline condition, and it agrees with what prosper already tells
  the same guest through NetCtl (`SCE_NET_CTL_STATE_DISCONNECTED` / `NOT_CONNECTED`).
* **Every response getter answers that same failure and writes nothing** — `GetAllResponseHeaders`,
  `GetStatusCode`, `GetResponseContentLength`, `ReadData`, `ReadDataAsync`, `WaitAsync`. A getter
  reached before any send answers "out of order" rather than the send error.
* **`sceHttp2Init` moves here from `hle_service.cpp`**, because the context id it returns now has to
  be a slot `sceHttp2CreateTemplate` validates against. Its observable contract is unchanged
  (positive, distinct context ids); `tests/hle/dispatch/test_service_getters.cpp`'s offline-context
  arm still passes unchanged.

Coverage is the library's full export surface (55 functions + the dump's `_Z5dummyv`), so nothing in
`libSceHttp2` still falls to the dispatcher. Cookie *boxes* are modelled as real objects; cookie
*contents* are not, so `AddCookie`, `GetCookie`, `CookieExport`, `CookieImport`, `GetCookieStats` and
`GetMemoryPoolStats` fail rather than claim a store that does not exist — flushing the empty jar,
auth cache and redirect cache genuinely succeeds and is answered `SCE_OK`.

Confidence is marked per call. `CONFIDENCE: HIGH` on "the object id is argument 0" (the only shape
assumption any validation depends on) and on the id/error conventions; `MED` on individual argument
meanings carried across from the v1 family, on the facility carry-across for the `0x817b____`
constants, and on the exact errno; the two flag getters carry an explicit note that their 32-bit
out-parameter width is the one place in the file where being wrong writes memory rather than
returning a wrong value.

## Affected and deliberately unaffected

* **Affected:** any title that calls `libSceHttp2`. It now receives real ids, recorded settings, and
  an honest failure on the request/response path instead of `SCE_OK` everywhere.
* **Deliberately unaffected:** `libSceHttp` (v1) — a different facility with different constants, and
  its remaining request-path hole is #2930, handled separately. NetCtl/NP, `sceSslInit` and
  `sceNetPoolCreate` keep their existing answers; the only `hle_service.cpp` change is deleting the
  `sceHttp2Init` stub that moved.
* No renderer, loader or GPU path is touched.

## Risks

* **The exact error constants are `CONFIDENCE: MED`.** They are derived (facility from the shipped
  module and from the blocking title's own classifier, semantics for `_1100` from v1's validator),
  not invented, but they are not read from a name table. The behavioural finding on #2894 is that the
  guest classifies *any* non-zero as a failure, so a wrong constant here would be wrong rather than
  dangerous, and revisable without touching the object model.
* **Registering a NID can be worse than leaving it unregistered** if the argument shape is wrong. The
  mitigation is that every call whose shape is not well supported takes the "fail and touch nothing"
  path, which needs no knowledge of the out-parameter layout at all. The only calls that *write* guest
  memory are `GetAuthEnabled`, `GetAutoRedirect` and `GetCookieBox`, all writing a single `int32`.
* A title that previously stumbled forward on false success may now take a different branch. That is
  the intended change, and it is the branch the guest is written for, but it is a behaviour change for
  every `libSceHttp2` caller and not only for the crashing one.

## Verification

Platform: **Linux (WSL Ubuntu-24.04, GCC 13.3, Release)**. All commands from the worktree root.

```
cmake -S prosper -B prosper/build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j12 -- -k
ctest --test-dir prosper/build-linux --no-tests=error -j8
```

* New `test_http2` (`ctest -R http2_hle`): **48 executed assertions from 47 `CHECK` sites** (one site
  is inside the two-pass leak control and runs twice), **rc=0**. The neighbours it could disturb also
  pass: `test_http` rc=0, `test_hle_no_shadow` rc=0 (no shadowed NID — the moved `sceHttp2Init` is
  registered once), `test_service_getters` rc=0.
* `ctest --no-tests=error`: **459 tests discovered**, 347 passed, 112 failed, **rc=8** — and that rc
  is **environmental on this machine, not this branch**: this box has Vulkan **1.3.275** headers while
  `frontends/shared/device/vulkan_runtime.hpp` needs `VK_API_VERSION_1_4`, so the live-renderer chain
  and every Vulkan-execution test cannot build here at all and report `Not Run`. 297 targets built;
  the 9 compile errors are all `VK_API_VERSION_1_4` / `VkPhysicalDeviceHostImageCopyFeatures` in that
  one header. An `origin/main` baseline measured in a second worktree on the same box is posted as a
  comment below, so the claim is checkable rather than asserted.

### Every regression arm was shown to fail without the fix

Six mutations, each rebuilt and re-run; the test must go red for each and green again after restore.

| mutation | `test_http2` |
| --- | --- |
| baseline (unmutated) | rc=0, 0 failing checks |
| `register_http2_hle()` not called (**the pre-fix state**) | rc=1, **56** failing checks |
| `sceHttp2SendRequest` returns `SCE_OK` | rc=1, 4 failing checks |
| response getters return `SCE_OK`, out-parameters untouched | rc=1, 5 failing checks |
| `sceHttp2CreateTemplate` hands out id 0 | rc=1, 13 failing checks |
| `sceHttp2Term` releases only its own slot (leaks the tree) | rc=1, 1 failing check |
| `live_any` accepts any id including 0 | rc=1, 2 failing checks |
| restored | rc=0, 0 failing checks |

The arms are written to die to a *specific* wrong implementation rather than merely to be true of the
right one: every id arm demands a **positive** id for a good call and a **negative** one for a bad
call, so 0 satisfies neither; every response arm pre-fills its out-parameters with a sentinel and
requires the sentinel to **survive** alongside a non-zero return. The `Term` leak control fills the
table from one context *with templates and requests under it* before terminating it, so the leak it
guards is structurally expressible — the vacuity #3295 had to fix in the v1 sibling.

## What I could NOT verify

Said plainly, because it bounds what this PR claims:

* **No boot was run, and no title was observed.** This machine has no `PPSA17952` dump and no PS5
  console, so the fault at `eboot+0x142d5e0` is *predicted* to be gone, not *observed* to be gone, and
  nothing here establishes where PGA TOUR 2K25 now stops. #2895 is upstream of this and the title may
  halt somewhere else. `docs/PGA_TOUR_2K25_STATUS.md` is updated to say exactly that and the rung
  stays 0.
* **The shipped `libSceHttp2.sprx` is not on this machine**, so the offsets, argument shapes and
  facility derivation are taken from the reviewed derivation recorded on #2894 and from
  `src/hle/net/AGENTS.md` on `main` — I did not re-derive them from the module myself.
* **No network service exists to check the failure path against**, by design; "what hardware returns
  when the network *is* reachable" is untested and untestable here.
* No Vulkan-execution or snapshot test ran (they cannot build on this box, see above), and none is
  reachable from an HLE registration change.
* Windows and macOS were not built. The file is plain C++ with no platform surface.
