### PR TITLE
Enable image robustness on the compute backend's own Vulkan device (#3531)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -4001,6 +4001,20 @@ if(TARGET prosper-app AND TARGET prosper_video_vaapi)
   message(STATUS "prosper-app: FFmpeg/VA-API video enabled")
 endif()
 
+# Image robustness (#3531): the device-side half of the recompiler's out-of-bounds image-read
+# contract, and the refusal that replaces executing it undefined. Registered OUTSIDE the per-platform
+# blocks because the contract is not platform-specific and the bug it guards was a divergence between
+# two device paths -- a guard built on only one host would have the same blind spot. Queries a
+# physical device but creates none, so it runs wherever an ICD exists and reports a skip (never a
+# silent pass) where one does not.
+if(TARGET Vulkan::Vulkan AND TARGET prosper_core)
+  add_executable(test_image_robustness tests/shared/device/test_image_robustness.cpp)
+  # Spells `shared/...` and `gpu/...` includes, which resolve from `frontends` and `src`.
+  target_include_directories(test_image_robustness PRIVATE frontends src)
+  target_link_libraries(test_image_robustness PRIVATE prosper_core Vulkan::Vulkan)
+  add_test(NAME image_robustness COMMAND test_image_robustness)
+endif()
+
 # Shared-device adoption guard (#1091). prosper_live_renderer only exists in frontend-enabled
 # configurations and is defined later in this file than the core test block, so register this
 # after the fact and only when the target is actually present.

--- a/prosper/frontends/shared/device/AGENTS.md
+++ b/prosper/frontends/shared/device/AGENTS.md
@@ -4,3 +4,10 @@ Loader/device requirements and selection shared by live frontends and execution 
 Pipeline-cache files belong here: they store opaque driver data, not guest shaders or game assets.
 Cache compatibility checks reject damaged or mismatched files; they cannot guarantee a driver
 accepts its own data safely. Keep disk loading opt-in while the recorded NVIDIA failure remains.
+
+Feature acquisition that more than one device path needs belongs here rather than beside whichever
+device was written first: the renderer's device, the compute backend's own device and the adopt path
+must answer the same question the same way. `image_robustness.hpp` is that for the recompiler's
+out-of-bounds image-read contract, and `storage_image_contract.hpp` holds the Vulkan-free decision so
+the refusing branch is testable without a driver -- no device here lacks the feature, so a test drawn
+from a real device can only exercise the accepting one.

--- a/prosper/frontends/shared/device/image_robustness.hpp
+++ b/prosper/frontends/shared/device/image_robustness.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+// Vulkan acquisition of the storage-image device contract (#3531). The contract itself -- what the
+// recompiler needs and why -- is in storage_image_contract.hpp; this header is only the part that
+// must speak Vulkan: query the physical device and chain the feature into VkDeviceCreateInfo.
+
+#include "shared/device/storage_image_contract.hpp"
+
+#include <vulkan/vulkan.h>
+
+#include <cstdio>
+
+namespace prosper::frontend {
+
+// Query `physical` for image robustness, chain VkPhysicalDeviceImageRobustnessFeatures into `dci`
+// when it is advertised, and report what the resulting device will have. `storage` must outlive the
+// vkCreateDevice call -- it becomes part of the pNext chain.
+//
+// The feature is core in Vulkan 1.3 and the runtime floor is 1.4 (kVulkanRuntimeVersion), so the
+// promoted extension name is deliberately NOT requested: a 1.4 device need not still advertise
+// `VK_EXT_image_robustness`, and gating on the string would disable the feature on devices that
+// have it. This matches how the neighbouring descriptor-indexing and int64-atomics features are
+// acquired.
+//
+// Logs in BOTH directions. A line that prints only on success makes the failing case silent, which
+// is precisely how #3531 survived: there was no run anywhere whose log could contradict the
+// assumption that robustness was on.
+inline StorageImageDeviceFeatures acquire_storage_image_device_features(
+    const char* owner, VkPhysicalDevice physical, bool read_without_format,
+    bool write_without_format, VkPhysicalDeviceImageRobustnessFeatures& storage,
+    VkDeviceCreateInfo& dci) {
+    storage = VkPhysicalDeviceImageRobustnessFeatures{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES};
+    VkPhysicalDeviceFeatures2 features2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+    features2.pNext = &storage;
+    vkGetPhysicalDeviceFeatures2(physical, &features2);
+    const StorageImageDeviceFeatures features = storage_image_device_features(
+        storage.robustImageAccess == VK_TRUE, read_without_format, write_without_format);
+    if (features.robust_image_access) {
+        // Request exactly the one bit in use; the query struct carries no others.
+        storage.pNext = const_cast<void*>(dci.pNext);
+        dci.pNext = &storage;
+    }
+    std::fprintf(stderr,
+                 "[%s] image robustness %s (core feature; recompiled storage-image reads are "
+                 "out-of-bounds by design and need it)\n",
+                 owner, features.robust_image_access ? "ENABLED" : "unavailable");
+    if (!features.robust_image_access && read_without_format && write_without_format)
+        std::fprintf(stderr,
+                     "[%s] refusing recompiled storage-image work on this device: without "
+                     "robustImageAccess an inactive lane's out-of-range OpImageRead is undefined\n",
+                     owner);
+    return features;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/device/storage_image_contract.hpp
+++ b/prosper/frontends/shared/device/storage_image_contract.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+// The storage-image device contract -- what a Vulkan device must offer before prosper may execute a
+// recompiled storage-image kernel on it (#3531). Deliberately Vulkan-free so the decision can be
+// unit-tested with no driver, no device and no Vulkan headers, and so the compute backend's public
+// header can report the capability without pulling Vulkan into every consumer.
+//
+// `src/gpu/recompiler/rdna2_to_spirv_internal.hpp` (image_read) issues an OpImageRead for ALL
+// invocations, including EXEC-inactive lanes whose coordinate may be out of range: the loaded value
+// is discarded by write-back predication at the call site. That is defined only when the device
+// enables IMAGE ROBUSTNESS (`robustImageAccess`, core in Vulkan 1.3; `VK_EXT_image_robustness`
+// before that), which makes an out-of-range image read return zero. Without it the kernel is
+// undefined behaviour, and on RADV an out-of-range image read is the shape that raises
+// GCVM_L2_PROTECTION_FAULT (CLIENT_ID: TCP, RW: 0).
+//
+// Every device prosper executes recompiled storage-image work on must therefore acquire the feature,
+// and every device that CANNOT must refuse that work rather than run it. This is the single place
+// that decision is made, so the renderer device, the compute backend's own device and the adopt path
+// cannot diverge -- divergence is what #3531 was: the renderer chained the feature, the compute
+// backend's own device did not, and no test could tell because every harness chained it.
+
+namespace prosper::frontend {
+
+// What a device offers the recompiled storage-image path. Fields describe what is ENABLED on the
+// device (or will be, at creation), never what the physical device merely supports -- the consumer's
+// question is "may this device execute the kernel", and a supported-but-not-requested feature
+// answers it wrongly.
+struct StorageImageDeviceFeatures {
+    // VkPhysicalDeviceImageRobustnessFeatures::robustImageAccess. The OOB contract above.
+    bool robust_image_access = false;
+    bool read_without_format = false;
+    bool write_without_format = false;
+
+    // The only predicate a caller should gate recompiled storage-image dispatches on. All three
+    // terms are required: the format-free capabilities to express the raw uvec4 texel model at all,
+    // and image robustness to make the model's deliberate out-of-range reads defined.
+    bool storage_image_capable() const {
+        return robust_image_access && read_without_format && write_without_format;
+    }
+};
+
+// Pure decision, so the refusal branch is testable without a device. No device available to this
+// project lacks `robustImageAccess`, so a test drawn from a real device can only ever exercise the
+// accepting branch -- it tests the discriminator, not the domain. Build the refusing input by hand.
+constexpr StorageImageDeviceFeatures storage_image_device_features(bool robust_image_access,
+                                                                   bool read_without_format,
+                                                                   bool write_without_format) {
+    StorageImageDeviceFeatures features;
+    features.robust_image_access = robust_image_access;
+    features.read_without_format = read_without_format;
+    features.write_without_format = write_without_format;
+    return features;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -14,6 +14,7 @@
 #include "shared/rtt/rtt_scale.hpp"
 #include "shared/rtt/rtt_authority.hpp"
 #include "shared/device/vulkan_device_select.hpp"
+#include "shared/device/image_robustness.hpp"  // #3531: the recompiler's OOB image-read contract
 #include "shared/texture/write_watch_census.hpp"
 #include "shared/texture/write_watch_policy.hpp"
 #include "diagnostics/env_numeric.hpp"   // #3253: a typo must not select a different setting
@@ -1420,6 +1421,16 @@ VkDeviceSize compute_memory_pool_limit() {
     return limit;
 }
 
+// What the compute device this process runs on offers the recompiled storage-image path (#3531).
+// Written once by VulkanComputeContext::init(), on whichever of the two device paths it took, and
+// read by live_compute_storage_image_device(). A record rather than a member because the context is
+// constructed lazily at the first dispatch: a caller asking "did the shipped init acquire image
+// robustness?" must not be the thing that decides whether init has happened.
+LiveComputeStorageImageDevice& mutable_storage_image_device() {
+    static LiveComputeStorageImageDevice record;
+    return record;
+}
+
 struct VulkanComputeContext {
     VkInstance instance = VK_NULL_HANDLE;
     VkPhysicalDevice physical = VK_NULL_HANDLE;
@@ -1494,7 +1505,18 @@ struct VulkanComputeContext {
     // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
     // tests/fixtures/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
     // the features, image-binding dispatches are skipped loudly instead of creating an invalid device.
+    // Since #3531 it also requires image robustness: the recompiled read is issued for EXEC-inactive
+    // lanes whose coordinate may be out of range, which is defined only when the device enables
+    // robustImageAccess. `image_support` is assigned from `storage_image_features` and from nowhere
+    // else, on BOTH device paths, so the capability and the feature acquisition cannot drift apart.
     bool image_support = false;
+    // What the device this backend runs on actually offers the storage-image path. Written only by
+    // init(), from prosper::frontend::acquire_storage_image_device_features() on the own-device path
+    // and from the adopted device's published capabilities on the shared path. Exposed through
+    // live_compute_storage_image_device_features() so a test can assert the SHIPPED init acquired
+    // the feature, rather than asserting that some copy of the code would have.
+    prosper::frontend::StorageImageDeviceFeatures storage_image_features{};
+    bool storage_image_device_adopted = false;
     // Stage 1 of the descriptor lift (#2412): true when this compute device can express an indexed
     // descriptor array. Assigned on the own-device path below, and inherited from SharedVulkanContext on
     // the adopt path -- both are real assignments. An earlier revision of this comment claimed the
@@ -3292,7 +3314,19 @@ struct VulkanComputeContext {
             queue = static_cast<VkQueue>(shared.queue);
             queue_family = shared.queue_family;
             borrowed = true;
-            image_support = true;
+            // Storage-image capability is INHERITED, never assumed (#3531). The adopt condition above
+            // already required the two format-free features; image robustness is the third term of the
+            // same contract, and the renderer publishes whether it enabled it. Adoption itself still
+            // proceeds — a second private device would be no more robust than the first, and sharing
+            // is what lets a dispatch bind a renderer-owned image at all — but the storage-image path
+            // is declined loudly instead of executing the recompiler's deliberate out-of-range reads
+            // against a device where they are undefined.
+            storage_image_features = prosper::frontend::storage_image_device_features(
+                shared.image_robustness, shared.storage_image_read_without_format,
+                shared.storage_image_write_without_format);
+            storage_image_device_adopted = true;
+            image_support = storage_image_features.storage_image_capable();
+            mutable_storage_image_device() = {storage_image_features, true, true};
             // Inherit the descriptor-indexing capability from the device being adopted. Its absence was
             // the blocking review finding on #2458: the flag stayed false on the shared path -- which is
             // the normal path whenever a renderer exists -- even though the adopted device had the
@@ -3323,6 +3357,14 @@ struct VulkanComputeContext {
                 std::fprintf(stderr, "[compute] storage-buffer int64 atomics %s "
                                      "(inherited from the adopted device)\n",
                              shared.storage_buffer_int64_atomics ? "ENABLED" : "unavailable");
+                // Same both-directions rule for the OOB image contract (#3531). "unavailable" here
+                // means every storage-image dispatch will be declined, which is a large behavioural
+                // difference that must be readable from the log rather than inferred from a black
+                // frame.
+                std::fprintf(stderr, "[compute] image robustness %s -> recompiled storage-image "
+                                     "dispatches %s (inherited from the adopted device)\n",
+                             storage_image_features.robust_image_access ? "ENABLED" : "unavailable",
+                             image_support ? "enabled" : "DECLINED");
                 // Same both-directions rule, one field over -- and this one decides whether a whole
                 // class of kernel can compile at all. A shader that reads VCC or EXEC as scalar DATA
                 // is materialised from subgroupBallot, and only when the native subgroup IS the guest
@@ -3348,6 +3390,7 @@ struct VulkanComputeContext {
             instance = VK_NULL_HANDLE; physical = VK_NULL_HANDLE;
             device = VK_NULL_HANDLE; queue = VK_NULL_HANDLE;
             queue_family = UINT32_MAX; borrowed = false; image_support = false;
+            storage_image_features = {}; storage_image_device_adopted = false;
             native_subgroup_contract = false;
             min_native_subgroup_size = max_native_subgroup_size = 0;
             pipeline_cache = VK_NULL_HANDLE;
@@ -3392,10 +3435,12 @@ struct VulkanComputeContext {
         enabled.shaderInt64 = supported.shaderInt64;
         // The standalone device must enable the same gather capability as the shared renderer.
         enabled.shaderImageGatherExtended = supported.shaderImageGatherExtended;
-        // Image bindings (#590): enable the format-free storage-image features when available.
-        image_support = supported.shaderStorageImageReadWithoutFormat &&
-                        supported.shaderStorageImageWriteWithoutFormat;
-        if (image_support) {
+        // Image bindings (#590): enable the format-free storage-image features when available. The
+        // third term of the contract -- image robustness -- is acquired below, once the
+        // VkDeviceCreateInfo exists to chain it into.
+        const bool format_free_storage_images = supported.shaderStorageImageReadWithoutFormat &&
+                                                supported.shaderStorageImageWriteWithoutFormat;
+        if (format_free_storage_images) {
             enabled.shaderStorageImageReadWithoutFormat = VK_TRUE;
             enabled.shaderStorageImageWriteWithoutFormat = VK_TRUE;
         }
@@ -3437,6 +3482,20 @@ struct VulkanComputeContext {
         // allows replaying modules compiled against a known feature contract.
         std::fprintf(stderr, "[compute] storage-buffer int64 atomics %s (own device, core feature)\n",
                      private_storage_buffer_int64_atomics ? "ENABLED" : "unavailable");
+        // Image robustness (#3531). This device executes the SAME recompiled kernels as the
+        // renderer's, and those kernels read out of range from EXEC-inactive lanes by construction;
+        // the renderer chained this feature and this path did not, so every storage-image dispatch on
+        // a run with no live renderer -- boot_trace registers compute unconditionally, and one such
+        // run executed ~135,000 dispatches -- was undefined behaviour. Chained last so it extends
+        // whatever pNext chain the features above built, and declared here so it outlives
+        // vkCreateDevice.
+        VkPhysicalDeviceImageRobustnessFeatures image_robustness_features{};
+        storage_image_features = prosper::frontend::acquire_storage_image_device_features(
+            "compute", physical, format_free_storage_images, format_free_storage_images,
+            image_robustness_features, dci);
+        storage_image_device_adopted = false;
+        image_support = storage_image_features.storage_image_capable();
+        mutable_storage_image_device() = {storage_image_features, false, true};
 #ifdef __APPLE__
         // Spec-mandated on MoltenVK: enable VK_KHR_portability_subset when advertised (always is).
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
@@ -6384,11 +6443,24 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         return true;
     }
     if (has_storage_images && !ctx.image_support) {
+        // Name which term of the contract is missing. The two causes need different actions -- a
+        // device without the format-free features cannot express the texel model at all, while one
+        // without image robustness could execute the kernel and would be undefined doing it (#3531) --
+        // and a message naming only the first sent a reader looking at the wrong feature.
+        const bool robustness_only = ctx.storage_image_features.read_without_format &&
+                                     ctx.storage_image_features.write_without_format &&
+                                     !ctx.storage_image_features.robust_image_access;
         static bool warned = false;
         if (!warned) { warned = true;
-            std::fprintf(stderr, "[compute] device lacks shaderStorageImageRead/WriteWithoutFormat; "
-                                 "image-binding dispatches are skipped\n"); }
-        return decline("device-lacks-storage-image");
+            if (robustness_only)
+                std::fprintf(stderr, "[compute] device lacks robustImageAccess; image-binding "
+                                     "dispatches are skipped rather than executing the "
+                                     "recompiler's out-of-range reads undefined (#3531)\n");
+            else
+                std::fprintf(stderr, "[compute] device lacks shaderStorageImageRead/WriteWithoutFormat; "
+                                     "image-binding dispatches are skipped\n"); }
+        return decline(robustness_only ? "device-lacks-image-robustness"
+                                       : "device-lacks-storage-image");
     }
     std::sort(descriptors.begin(), descriptors.end(), [](const auto& a, const auto& b) {
         return a.binding < b.binding;
@@ -12335,6 +12407,10 @@ uint64_t live_compute_buffer_gpu_result_skips() {
 
 WriteWatchCensusSnapshot live_compute_write_watch_census() {
     return g_write_watch_census.snapshot();
+}
+
+LiveComputeStorageImageDevice live_compute_storage_image_device() {
+    return mutable_storage_image_device();
 }
 
 uint64_t live_compute_sampled_image_upload_skips() {

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "gpu/execute/gpu_execute.hpp"
 #include "shared/compute/compute_image_borrow_census.hpp"
+#include "shared/device/storage_image_contract.hpp"  // #3531: the OOB image-read contract
 #include "shared/texture/write_watch_census.hpp"
 
 #include <cstddef>
@@ -311,6 +312,22 @@ void live_compute_record_image_borrow_renderer_verdict(bool accepted);
 // Monotonic diagnostic count of retained sampled-image hits whose validated source omitted upload.
 // Capture/replay tests use this to prove residency without relying on timing-sensitive assertions.
 uint64_t live_compute_sampled_image_upload_skips();
+// What the compute backend's Vulkan device actually offers the recompiled storage-image path
+// (#3531), as acquired by its init: `adopted` distinguishes the renderer's shared device from this
+// backend's own. `features.storage_image_capable()` is the exact predicate every storage-image
+// dispatch is gated on, and `robust_image_access` is the term that was silently missing on the
+// own-device path -- the recompiler reads out of range from EXEC-inactive lanes by design, which is
+// defined only when the device enabled robustness.
+//
+// Exposed so a test can assert the SHIPPED init acquired the feature on the device the run really
+// uses, rather than asserting that a harness's copy of the device-creation code would have. Returns
+// a default-constructed (all false) record when the backend has not initialized a device.
+struct LiveComputeStorageImageDevice {
+    StorageImageDeviceFeatures features{};
+    bool adopted = false;
+    bool initialized = false;
+};
+LiveComputeStorageImageDevice live_compute_storage_image_device();
 // True only when an ordinary guest-backed 2D sampled image uses the same native Vulkan texel
 // representation as its typed storage counterpart. This is the format half of the retained-image
 // transfer contract; resource identity and write authority are checked separately at runtime.

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -1160,6 +1160,13 @@ struct SharedVulkanContext {
     // Features the compute backend requires; when false it must decline the shared device.
     bool storage_image_read_without_format = false;
     bool storage_image_write_without_format = false;
+    // VkPhysicalDeviceImageRobustnessFeatures::robustImageAccess, ENABLED on the published device
+    // (#3531). Same contract as every other field here: it reports what device creation requested,
+    // never what the physical device merely supports. A recompiled storage-image kernel reads out of
+    // range from EXEC-inactive lanes on purpose and relies on robustness to make that return zero,
+    // so a consumer that adopts this device must refuse storage-image work when this is false rather
+    // than execute undefined behaviour.
+    bool image_robustness = false;
     // Exact compute-wave acceleration. These describe features ENABLED on the borrowed device, not
     // merely physical support. The recompiler opts in only when the requested guest wave is inside
     // this range, full compute subgroups can be required, and both vote and arithmetic subgroup

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -2368,8 +2368,11 @@ struct SpirvCompute {
     // bounds check narrowed EXEC). The loaded value for such a lane is discarded by write-back predication
     // (predicate_write) at the call site, so it is harmless — PROVIDED the device enables IMAGE ROBUSTNESS
     // (robustImageAccess / VK_EXT_image_robustness: OOB image reads return 0), the image analogue of the
-    // robustBufferAccess this recompiler already depends on for buffer loads. The runtime must enable it
-    // (the test harness does). The store side is instead EXEC-predicated (no robust "harmless" OOB write).
+    // robustBufferAccess this recompiler already depends on for buffer loads. Every device prosper
+    // executes this on acquires it through frontends/shared/device/image_robustness.hpp, and a device
+    // that CANNOT declines the storage-image path rather than running it undefined (#3531 -- until
+    // then the compute backend's own device silently did neither). The store side is instead
+    // EXEC-predicated (no robust "harmless" OOB write).
     void image_read(uint32_t binding, uint32_t dim, bool arrayed, uint32_t ncoord, const uint32_t* coords,
                     uint32_t out[4], bool ms = false, uint32_t sample = 0) {
         if (stg_img_format[binding] == ImgFmt_Unknown && !declared_read_wo_fmt) {

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -22,6 +22,7 @@
 #include "shared/rtt/rtt_scale.hpp"
 #include "shared/device/vulkan_device_select.hpp"
 #include "shared/device/pipeline_cache_file.hpp"
+#include "shared/device/image_robustness.hpp"  // #3531: the recompiler's OOB image-read contract
 #include "shared/perf/performance_timing_gate.hpp"
 #include "shared/perf/performance_timing_policy.hpp"
 #include "shared/present/readback_policy.hpp"
@@ -1192,6 +1193,10 @@ struct RenderVkCtx {
     // wave-uniform, and a driver waterfall over the distinct values present converges in one iteration.
     bool descriptor_indexing = false;
     bool storage_buffer_int64_atomics = false;
+    // What this device offers the recompiled storage-image path (#3531): acquired by the same
+    // shared helper the compute backend's own device uses, and published to SharedVulkanContext so
+    // an adopting consumer inherits the verdict instead of assuming it.
+    prosper::frontend::StorageImageDeviceFeatures storage_image_features{};
     bool compute_full_subgroups = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
     uint32_t max_compute_workgroup_subgroups = 0;
@@ -1486,7 +1491,7 @@ inline const RenderVkCtx& render_vk_ctx() {
         // OpImageRead OOB must return zero (#131); enable robustImageAccess when supported.
         // Only features not promoted to core still require extension names below.
         std::vector<const char*> dev_exts;
-        VkPhysicalDeviceImageRobustnessFeatures irf{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES};
+        VkPhysicalDeviceImageRobustnessFeatures irf{};
         VkPhysicalDeviceSubgroupSizeControlFeatures subgroup_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES};
         VkPhysicalDeviceSubgroupSizeControlProperties subgroup_properties{
@@ -1501,14 +1506,14 @@ inline const RenderVkCtx& render_vk_ctx() {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
         // These features are core in Vulkan 1.2/1.3. Query the feature bits directly;
         // promoted extensions need not still be advertised by a Vulkan 1.4 device.
-        {
-            VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
-            f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
-            if (irf.robustImageAccess) {
-                irf.pNext = const_cast<void*>(dci.pNext);
-                dci.pNext = &irf;
-            }
-        }
+        //
+        // Image robustness goes through the shared helper (#3531) rather than an inline query: this
+        // device and the compute backend's own device execute the SAME recompiled kernels, and the
+        // bug that helper exists to prevent was exactly the two paths diverging -- this one chained
+        // the feature and the other silently did not.
+        r.storage_image_features = prosper::frontend::acquire_storage_image_device_features(
+            "vk", r.phys, feats.shaderStorageImageReadWithoutFormat == VK_TRUE,
+            feats.shaderStorageImageWriteWithoutFormat == VK_TRUE, irf, dci);
 
         // Runtime-selected storage buffers use bounded fixed arrays. Request only the one
         // descriptor-indexing feature their non-uniform access chains require.
@@ -1692,6 +1697,10 @@ inline const RenderVkCtx& render_vk_ctx() {
             // declaring a capability the device never enabled.
             shared.storage_image_read_without_format = feats.shaderStorageImageReadWithoutFormat;
             shared.storage_image_write_without_format = feats.shaderStorageImageWriteWithoutFormat;
+            // Publish the third term of the storage-image contract (#3531). Same rule as the two
+            // above: this is what device creation REQUESTED, so an adopting consumer can refuse the
+            // recompiled storage-image path rather than execute out-of-range reads undefined.
+            shared.image_robustness = r.storage_image_features.robust_image_access;
             shared.compute_subgroup_size_control = r.subgroup_size_control &&
                 (r.required_subgroup_size_stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
                 (r.subgroup_stages & VK_SHADER_STAGE_COMPUTE_BIT);

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -7472,6 +7472,29 @@ int main() {
               "device loss is unconditional and identifies the first observed guest dispatch");
     }
 
+    // #3531: the device THIS suite actually ran on must have acquired image robustness. Every
+    // storage-image kernel above reads out of range from EXEC-inactive lanes by construction, and
+    // that is defined only when the device enabled robustImageAccess -- so this is not a style
+    // assertion about device creation, it is the precondition the dispatches above depend on.
+    //
+    // The record comes from the shipped backend's own init (whichever device path it took), not from
+    // a copy of the device-creation code, which is the gap that let #3531 exist: the renderer's
+    // device chained the feature, this one did not, and every harness in the tree chained it so no
+    // test could see the difference. This suite runs with no live renderer, i.e. on exactly the
+    // path that was wrong.
+    {
+        const auto device = prosper::frontend::live_compute_storage_image_device();
+        CHECK(device.initialized,
+              "the compute backend published the storage-image device it initialized");
+        std::printf("[compute-device] adopted=%d robustImageAccess=%d storage_image_capable=%d\n",
+                    (int)device.adopted, (int)device.features.robust_image_access,
+                    (int)device.features.storage_image_capable());
+        CHECK(device.features.robust_image_access,
+              "the compute device acquired robustImageAccess for the recompiled OOB image reads");
+        CHECK(device.features.storage_image_capable(),
+              "the compute device may execute recompiled storage-image kernels");
+    }
+
     // #3155: report the write-watch census this run produced, and pin the structural identities
     // that make it readable. The numbers themselves are workload-dependent and are deliberately NOT
     // asserted -- this suite is not The Plucky Squire -- but a census whose buckets do not partition

--- a/prosper/tests/shared/device/test_image_robustness.cpp
+++ b/prosper/tests/shared/device/test_image_robustness.cpp
@@ -33,6 +33,7 @@
 #include "gpu/execute/gpu_execute.hpp"
 
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 static int fails = 0;
@@ -43,6 +44,10 @@ static int checks = 0;
 using prosper::frontend::storage_image_device_features;
 
 int main() {
+    // Unbuffered: a crash must not swallow the arms that already reported. Without this a fault
+    // anywhere below turns a run that had printed twelve [ok] lines into a run that printed none,
+    // which reads as "the test never started".
+    std::setvbuf(stdout, nullptr, _IONBF, 0);
     std::printf("== test_image_robustness ==\n");
 
     // --- 1. The pure decision, hand-built ------------------------------------------------------
@@ -137,19 +142,29 @@ int main() {
                 CHECK(acquired.robust_image_access == supported,
                       "the helper reports exactly what the physical device advertises");
 
+                // Walk the chain by COPYING each node's header out rather than reading the node
+                // through a VkBaseInStructure lvalue. Reading one struct type through a pointer to
+                // an unrelated one is a strict-aliasing violation even when the two share an initial
+                // sequence, and it is not theoretical here: the first draft of this arm did the
+                // obvious reinterpret walk and GCC 15 at -O2 turned the without-fix run into a
+                // SIGSEGV instead of the clean failure the arm is supposed to produce -- adding an
+                // unrelated fprintf made the fault vanish. memcpy is always defined, and a regression
+                // arm that can crash instead of failing is not one you can read.
                 bool chained = false, incumbent_survived = false;
-                for (const VkBaseInStructure* s =
-                         static_cast<const VkBaseInStructure*>(dci.pNext);
-                     s; s = s->pNext) {
-                    if (s->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES) {
+                for (const void* node = dci.pNext; node;) {
+                    VkBaseInStructure header{};
+                    std::memcpy(&header, node, sizeof header);
+                    if (header.sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES) {
                         chained = true;
-                        CHECK(reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(s)
-                                      ->robustImageAccess == VK_TRUE,
+                        VkPhysicalDeviceImageRobustnessFeatures requested{};
+                        std::memcpy(&requested, node, sizeof requested);
+                        CHECK(requested.robustImageAccess == VK_TRUE,
                               "the chained struct REQUESTS robustImageAccess (not merely present)");
                     }
-                    if (s->sType ==
+                    if (header.sType ==
                         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES)
                         incumbent_survived = true;
+                    node = header.pNext;
                 }
                 CHECK(chained == supported,
                       supported ? "VkPhysicalDeviceImageRobustnessFeatures reaches the "

--- a/prosper/tests/shared/device/test_image_robustness.cpp
+++ b/prosper/tests/shared/device/test_image_robustness.cpp
@@ -1,0 +1,175 @@
+// test_image_robustness — the device-side half of the recompiler's out-of-bounds image contract
+// (#3531).
+//
+// The recompiled storage-image load issues an OpImageRead for ALL invocations, including
+// EXEC-inactive lanes whose coordinate may be out of range; the value is discarded by write-back
+// predication. That is defined ONLY when the device enabled `robustImageAccess`. The compute
+// backend's own device did not chain the feature while the renderer's did, and no test could see it
+// because every execution harness in this repository chains it too.
+//
+// That last sentence is why this file exists and why it is shaped the way it is. A test that builds
+// its device the way the harnesses do can only ever exercise the ACCEPTING branch: no device
+// available to this project lacks `robustImageAccess`, so the refusing case is not merely rare, it
+// is unreachable from a real device. The positive-control rule in CLAUDE.md names that failure — a
+// control drawn from the same source tests the discriminator, not the domain — so the refusing
+// instance below is constructed BY HAND, outside anything that queries a driver.
+//
+// Three arms, and it is worth being precise about what each does and does not prove:
+//
+//  1. the pure decision, including the hand-built device that lacks robustness -> must refuse;
+//  2. the SHIPPED helper against a real physical device: the feature struct must actually appear in
+//     the VkDeviceCreateInfo pNext chain, and an unrelated struct already on that chain must
+//     survive. This is what pins "chained", rather than a copy of the chaining code asserting about
+//     itself;
+//  3. both device paths' capability is computed by the same function, so a run cannot enable the
+//     feature on one device and silently skip it on the other.
+//
+// What no arm here proves is that the compute backend CALLS the helper — that is asserted on the
+// real backend by test_game_compute (`live_compute_storage_image_device()`), and enforced by
+// construction, since `image_support` is assigned from the helper's verdict and from nowhere else.
+
+#include "shared/device/image_robustness.hpp"
+#include "shared/device/vulkan_runtime.hpp"
+#include "gpu/execute/gpu_execute.hpp"
+
+#include <cstdio>
+#include <vector>
+
+static int fails = 0;
+static int checks = 0;
+#define CHECK(c, m) do { ++checks; if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+using prosper::frontend::storage_image_device_features;
+
+int main() {
+    std::printf("== test_image_robustness ==\n");
+
+    // --- 1. The pure decision, hand-built ------------------------------------------------------
+    // The #3531 device: it can express the raw uvec4 texel model (both format-free features) and
+    // cannot make the recompiler's deliberate out-of-range reads defined. Executing there is UB, so
+    // the only correct verdict is refusal. No driver on this project's machines produces this input,
+    // which is exactly why it is written out literally.
+    const auto no_robustness = storage_image_device_features(false, true, true);
+    CHECK(!no_robustness.storage_image_capable(),
+          "a device with both format-free features but NO robustImageAccess refuses storage images");
+    CHECK(!no_robustness.robust_image_access, "the refusing device reports the missing term");
+
+    const auto complete = storage_image_device_features(true, true, true);
+    CHECK(complete.storage_image_capable(),
+          "a device with all three terms may execute recompiled storage-image kernels");
+
+    // The other two terms still gate independently: robustness alone is not a licence to run a
+    // kernel whose capabilities the device cannot declare.
+    CHECK(!storage_image_device_features(true, false, true).storage_image_capable(),
+          "robustness does not substitute for shaderStorageImageReadWithoutFormat");
+    CHECK(!storage_image_device_features(true, true, false).storage_image_capable(),
+          "robustness does not substitute for shaderStorageImageWriteWithoutFormat");
+    CHECK(!storage_image_device_features(false, false, false).storage_image_capable(),
+          "a device offering none of the three refuses");
+
+    // --- 3. One decision function, both device paths -------------------------------------------
+    // The adopt path feeds the renderer's PUBLISHED capabilities through the same function the
+    // own-device path feeds its physical-device query through. Divergence between those two is the
+    // defect this guards: the renderer chained the feature and the compute device did not.
+    prosper::gpu::SharedVulkanContext published;
+    published.storage_image_read_without_format = true;
+    published.storage_image_write_without_format = true;
+    published.image_robustness = false;
+    CHECK(!storage_image_device_features(published.image_robustness,
+                                         published.storage_image_read_without_format,
+                                         published.storage_image_write_without_format)
+               .storage_image_capable(),
+          "adopting a renderer device that did NOT enable robustness refuses storage images");
+    published.image_robustness = true;
+    CHECK(storage_image_device_features(published.image_robustness,
+                                        published.storage_image_read_without_format,
+                                        published.storage_image_write_without_format)
+               .storage_image_capable(),
+          "adopting a renderer device that DID enable robustness accepts storage images");
+
+    // --- 2. The shipped helper against a real physical device ----------------------------------
+    // Queries only; no device is created and no GPU work is submitted, so this runs anywhere a
+    // Vulkan ICD is installed. When there is none the arm reports that it did not run rather than
+    // passing silently -- an arm that cannot distinguish "verified" from "never executed" is the
+    // instrument trap this project keeps hitting.
+    if (!prosper::frontend::require_vulkan_runtime_loader("test")) {
+        std::printf("  [skip] no Vulkan 1.4 loader: the real-device chain arm did not run\n");
+    } else {
+        VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
+        app.apiVersion = prosper::frontend::kVulkanRuntimeVersion;
+        VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+        ici.pApplicationInfo = &app;
+        VkInstance instance = VK_NULL_HANDLE;
+        if (vkCreateInstance(&ici, nullptr, &instance) != VK_SUCCESS || !instance) {
+            std::printf("  [skip] vkCreateInstance failed: the real-device chain arm did not run\n");
+        } else {
+            uint32_t count = 0;
+            vkEnumeratePhysicalDevices(instance, &count, nullptr);
+            std::vector<VkPhysicalDevice> devices(count);
+            if (count) vkEnumeratePhysicalDevices(instance, &count, devices.data());
+            if (!count) {
+                std::printf("  [skip] no physical device: the real-device chain arm did not run\n");
+            } else {
+                const VkPhysicalDevice physical = devices[0];
+
+                // Ask the driver INDEPENDENTLY of the helper, so the expectation is not derived from
+                // the thing being tested.
+                VkPhysicalDeviceImageRobustnessFeatures advertised{
+                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES};
+                VkPhysicalDeviceFeatures2 query{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+                query.pNext = &advertised;
+                vkGetPhysicalDeviceFeatures2(physical, &query);
+                const bool supported = advertised.robustImageAccess == VK_TRUE;
+
+                // A struct already on the chain. The helper must extend the chain, never replace it:
+                // clobbering it here would silently drop descriptor indexing or int64 atomics at the
+                // one call site that matters.
+                VkPhysicalDeviceDescriptorIndexingFeatures incumbent{
+                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
+                VkDeviceCreateInfo dci{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
+                dci.pNext = &incumbent;
+
+                VkPhysicalDeviceImageRobustnessFeatures storage{};
+                const auto acquired = prosper::frontend::acquire_storage_image_device_features(
+                    "test", physical, true, true, storage, dci);
+
+                CHECK(acquired.robust_image_access == supported,
+                      "the helper reports exactly what the physical device advertises");
+
+                bool chained = false, incumbent_survived = false;
+                for (const VkBaseInStructure* s =
+                         static_cast<const VkBaseInStructure*>(dci.pNext);
+                     s; s = s->pNext) {
+                    if (s->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES) {
+                        chained = true;
+                        CHECK(reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(s)
+                                      ->robustImageAccess == VK_TRUE,
+                              "the chained struct REQUESTS robustImageAccess (not merely present)");
+                    }
+                    if (s->sType ==
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES)
+                        incumbent_survived = true;
+                }
+                CHECK(chained == supported,
+                      supported ? "VkPhysicalDeviceImageRobustnessFeatures reaches the "
+                                  "VkDeviceCreateInfo pNext chain"
+                                : "an unsupporting device is not sent a feature it cannot enable");
+                CHECK(incumbent_survived,
+                      "chaining preserves the structs already on VkDeviceCreateInfo::pNext");
+                CHECK(acquired.storage_image_capable() == supported,
+                      "the storage-image verdict follows the feature actually requested");
+                std::printf("  real device: robustImageAccess advertised=%d chained=%d\n",
+                            (int)supported, (int)chained);
+                if (!supported)
+                    std::printf("  NOTE: this device cannot run recompiled storage-image kernels "
+                                "defined; prosper declines them there (#3531)\n");
+            }
+            vkDestroyInstance(instance, nullptr);
+        }
+    }
+
+    if (fails) { std::printf("== FAIL: %d == (%d assertions executed)\n", fails, checks); return 1; }
+    std::printf("== PASS == (%d assertions executed)\n", checks);
+    return 0;
+}


### PR DESCRIPTION
Fixes #3531.

## Failure scenario

`src/gpu/recompiler/rdna2_to_spirv_internal.hpp` (`image_read`) issues an `OpImageRead` for **all**
invocations, including EXEC-inactive lanes whose coordinate may be out of range; the loaded value is
discarded by write-back predication at the call site. That is defined only when the device enabled
**image robustness** (`robustImageAccess`, core in Vulkan 1.3), which makes an out-of-range image read
return zero.

The live renderer's device chained `VkPhysicalDeviceImageRobustnessFeatures`. The compute backend's
**own** device — the one used by any run with no live renderer, and `boot_trace` registers compute
unconditionally — never did. Every recompiled storage-image dispatch on that path was undefined
behaviour; the issue records a "CPU-only" `boot_trace` of `PPSA19244` executing ~135,000 dispatches
there. No test could see it because every harness in the tree chains the feature, so the contract held
in tests and was violated only on the shipped standalone path.

## Behavioural contract

A device may execute recompiled storage-image kernels only when it has all three of
`shaderStorageImageReadWithoutFormat`, `shaderStorageImageWriteWithoutFormat` and `robustImageAccess`.
A device that has the first two and not the third **declines** the work; it does not run it.

## Approach and invariants

- New `frontends/shared/device/storage_image_contract.hpp` (Vulkan-free) holds
  `StorageImageDeviceFeatures` and the pure decision; `frontends/shared/device/image_robustness.hpp`
  holds the Vulkan half that queries the physical device, chains the feature struct into
  `VkDeviceCreateInfo`, and logs the outcome **in both directions**.
- All three device paths go through it: the renderer's device, the compute backend's own device, and
  the adopt path (via a new `SharedVulkanContext::image_robustness`, published as *enabled*, never as
  *supported*, like every other field there). One decision function, so the paths cannot diverge —
  divergence was the bug.
- `image_support` in `live_compute.cpp` is assigned from that verdict and from nowhere else, on both
  paths. When it is false a storage-image dispatch takes the existing fail-visible `decline(...)` path
  with a **new, distinct reason** — `device-lacks-image-robustness` rather than the old
  `device-lacks-storage-image`, because the two causes need different actions and the old message
  pointed at the wrong feature.
- **Chosen deliberately: refuse, do not proceed, and do not kill the run.** The charter's rule is
  fail-visible; refusing the recompiled-storage-image path loses those dispatches loudly (named
  decline reason plus a one-shot warning), while failing device creation outright would take down
  buffer-only compute that is perfectly well defined on such a device. The feature is requested via
  the **core 1.3 struct with no extension name**, because the runtime floor is 1.4 and a 1.4 device
  need not still advertise `VK_EXT_image_robustness` — the same reasoning the neighbouring
  descriptor-indexing and int64-atomics acquisitions already use.

## The regression arms, and what they do and do not prove

Three arms, because no single one is strong on its own. Both without-fix arms were **actually run**;
results below.

1. **`image_robustness` (new, 13 assertions).** The refusing device — format-free features present,
   robustness absent — is constructed **by hand**, outside anything that queries a driver, because no
   device available to this project lacks the feature: a control drawn from a real device could only
   ever exercise the accepting branch (CLAUDE.md's positive-control rule). The strong part is the
   second arm: it calls the **shipped helper** against a real physical device and then walks the
   resulting `VkDeviceCreateInfo::pNext` chain, asserting the struct is really there, really requests
   `VK_TRUE`, and that a struct already on the chain survived. That pins "chained" rather than letting
   a copy of the chaining code assert about itself. It creates no device and submits no GPU work, so
   it runs anywhere an ICD exists and prints an explicit `[skip]` — never a silent pass — where one
   does not.
2. **`game_compute_exec`** now reads `live_compute_storage_image_device()`, the record the **shipped
   backend's own init** writes. That suite runs with no renderer, i.e. on exactly the device path that
   was wrong (`adopted=0` in its output).
3. Both device paths' capability is computed by the same function, asserted with hand-built inputs.

**What none of them proves:** that a device lacking `robustImageAccess` is actually protected at
runtime — no such device exists here to run it on. That branch is covered by construction and by the
hand-built decision arms only. `CONFIDENCE: HIGH` on the acquisition and the refusal wiring,
`CONFIDENCE: MED` on the untestable refusing-device execution path.

Also note what arm 2 does *not* catch: on a device that supports the feature, deleting only the
chaining line leaves the verdict (and therefore `image_support`) true, so the dispatch assertions stay
green. That is arm 1's job, and it is why arm 1 exists.

## Affected / deliberately unaffected

- Affected: the compute backend's own device (acquires the feature; storage-image capability now gated
  on it), the renderer's device (same acquisition through the shared helper; behaviour unchanged, but
  it now logs the outcome), the adopt path (inherits the verdict instead of assuming `image_support`).
- Deliberately unaffected: `tests/fixtures/image_compute_runner.h` keeps its extension-name-gated
  acquisition — its instance is not guaranteed to be 1.1+, where `vkGetPhysicalDeviceFeatures2` lives.
  `frontends/prosper-app/main.cpp`'s present device is not changed: it blits a swapchain image and
  executes no recompiled kernels.

## Risks

- Enabling image robustness can cost performance on out-of-range accesses. The renderer has shipped
  with it since #131, so this only brings the compute-only path to parity.
- The renderer now prints one unconditional device line (`[vk] image robustness …`). That is the
  point — the issue notes there was previously no run anywhere whose log could contradict the
  assumption that it was on.
- A device that genuinely lacks the feature now loses its storage-image dispatches instead of running
  them undefined. That is the intended trade, and it is loud.

## Verification (all on Windows / MinGW, Vulkan SDK 1.4, real GPU)

```
cmake -S prosper -B prosper/build-win -G Ninja -DCMAKE_BUILD_TYPE=Release \
      -DCMAKE_C_COMPILER=<mingw>/gcc.exe -DCMAKE_CXX_COMPILER=<mingw>/g++.exe \
      -DCMAKE_MAKE_PROGRAM=<mingw>/ninja.exe -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-win            # exit 0
ctest --test-dir prosper/build-win --no-tests=error
```

- `ctest -N` reports **335 registered tests**. Full run: **1 failure — `session_start`** (pre-existing,
  #3540, unrelated to this diff), 2 skipped (`refactor_survey_measurement`, `hle_calls_value_capture`);
  ctest exit **8**.
- `image_robustness`: PASS, **13 assertions**, `real device: robustImageAccess advertised=1 chained=1`.
- `game_compute_exec`: PASS, **627 assertions**, `[compute-device] adopted=0 robustImageAccess=1
  storage_image_capable=1` — i.e. the standalone path, which is the one that was broken.

### Without-fix arms (both run, both red)

- Removed the chaining block from `acquire_storage_image_device_features` → `image_robustness` fails
  `VkPhysicalDeviceImageRobustnessFeatures reaches the VkDeviceCreateInfo pNext chain`, 12/13
  assertions, exit 1, reproduced 3 of 3. Restored → PASS 13/13.
- Reverted `live_compute.cpp`'s own-device path to the pre-fix `image_support = <format-free features>`
  with no acquisition → `game_compute_exec` fails 3 assertions (`published the storage-image device it
  initialized`, `acquired robustImageAccess`, `may execute recompiled storage-image kernels`), exit 1,
  with `[compute-device] adopted=0 robustImageAccess=0 storage_image_capable=0`. Restored → PASS.

Notably, in that second arm **none of the other 624 assertions moved** — the suite's storage-image
dispatches still passed, because this GPU supports the feature whether or not it is requested. That is
issue #3531 in one line, and it is why the arm had to be written against the device record rather than
against dispatch results.

### An instrument note on the arm itself (second commit)

The first draft of the chain walk read each node through a `VkBaseInStructure*`. That is a
strict-aliasing violation even though the structs share an initial sequence, and it was not
theoretical: GCC 15 at `-O2` turned the without-fix run into a **SIGSEGV** instead of the clean failure
the arm exists to produce, and adding an unrelated `fprintf` made the fault vanish. The walk now copies
each header with `memcpy`, and the test runs unbuffered so a fault cannot swallow the arms that already
reported.

Not run: Linux. This machine's WSL has Vulkan 1.3 headers and cannot build the live-renderer chain at
all (`VK_API_VERSION_1_4`), so every Vulkan-linking target here is Windows-verified; CI covers Linux.
No snapshots were run — this diff changes device feature acquisition, not rendering, and the full
Windows suite including the render and GPU-execution tests is green.
