### PR TITLE
Record which Windows session-start failure is which (#3426 verified fixed by #3444)

### DIFF
--- a/prosper/docs/SESSION_START.md
+++ b/prosper/docs/SESSION_START.md
@@ -49,3 +49,30 @@ divergence, stale/missing remote refs, unreachable remotes, offline checks, link
 detached HEAD, feature branches, Windows line endings and paths containing spaces. It is registered
 as the `session_start` CTest case. The contribution-shape gate allows only `.claude/settings.json`,
 keeping private settings and agent worktree contents outside the exception.
+
+## Two ways this check has failed on Windows
+
+Both were quiet, and they are told apart by where the failure is raised. Read the symptom before
+reaching for either explanation: they share a platform and nothing else.
+
+The **interpreter never starts**. On a stock Windows install the name `python3` is the Microsoft
+Store App Execution Alias stub, so the hook exits 9009 having run nothing, stdout is empty, and the
+session receives no session-start context of any kind (#3540). The interpreter chain described
+above, and its closing `echo`, are what keep that visible.
+
+**Git answers a path query in a flavour the caller cannot read.** The Windows MinGW CI job pairs an
+MSYS2 git with a native Windows Python, and `rev-parse --show-toplevel` there replies in POSIX form
+(`/c/Users/...`), which native Python reads back as the drive-relative `\c\Users\...`. Every later
+`-C` then missed the repository, so eight cases reported `[session-start] UNVERIFIED: Git could not
+verify rev-parse` and exit 2 where 0 or 1 was expected (#3426, diagnosed in #3443, fixed in #3444 by
+deriving the root from the relative `--show-cdup`, which never changes flavour). Linux never saw it
+because POSIX Python and POSIX git agree, and a local Windows checkout never saw it because
+Git-for-Windows answers `C:/...`, which round-trips.
+
+So: empty stdout and no report means the interpreter; a `[session-start] UNVERIFIED:` report means
+the check ran and git could not be trusted. Verified 2026-09-11 on `main` at `31d8ec34`: the Windows
+MinGW job runs `session_start` and passes (304 of 304 tests), and the pre-fix module reproduces
+#3426's exact string against a hand-built POSIX answer while the current one returns 0. The standing
+guard is `test_git_path_output_is_never_used_as_a_filesystem_path`, whose poisoned answer is built by
+hand rather than taken from the git on the host running it -- a control drawn from that git would
+inherit the flavour that host already survives, and so could not express the case at all.


### PR DESCRIPTION
## What this is

`#3426` reported `session_start` failing on the Windows MinGW job with
`[session-start] UNVERIFIED: Git could not verify rev-parse`, eight cases returning 2 where 0 or 1
was expected, and recorded that the root cause was never established. **It has since been fixed, by
#3444.** This PR contains no code change: it records the verification and, more usefully, the
symptom that separates this failure from #3540's, because two different defects produced a red
`session_start` on Windows within days of each other.

## Measured, not assumed

The assignment was explicitly not to assume #3426 and #3540 share a cause. They do not, and the
evidence is in the failures themselves.

**1. The interpreter started in CI.** All eight failures in the run cited by #3426
(`actions/runs/34095327529`) are raised at `test_session_start.py:53`, inside `check()`, which
launches `sys.executable`. #3540's failures are raised at `:65`, inside `hook()`, which launches the
configured hook argv, and they carry exit 9009 from a program that is not Python. A `check()`
failure is proof that Python ran.

**2. The mechanism reproduces locally with no interpreter involved.** The pre-fix module
(`883dbc8b:prosper/tools/session_start.py`) and the current one (`31d8ec34`) were each run against a
**hand-built** POSIX answer to `rev-parse --show-toplevel`, rather than against the git on this host,
whose mingw flavour answers `C:/...` and survives the round trip:

```
pre-fix  883dbc8b -> exit 2 | UNVERIFIED: Git could not verify rev-parse
main     31d8ec34 -> exit 0 | Checkout: branch=... HEAD=...
```

The first line is #3426's exact reported string.

**3. The job that reported it is green.** On `main` at `31d8ec34`, the Windows MinGW job runs
`session_start` and passes: `37/304 Test #37: session_start ... Passed 20.31 sec`, `100% tests
passed out of 304`. The test is present and passing, not absent.

That also explains why #3540 never showed up in CI: the Windows MinGW runner resolves `python3`, so
`hook()` passes there. The defect needs a stock Windows workstation.

## The change

One section appended to `prosper/docs/SESSION_START.md` naming both Windows failure modes and how to
tell them apart: empty stdout with no report means the interpreter never started; a
`[session-start] UNVERIFIED:` report means the check ran and could not trust git. It also records why
the guard for the second one (`test_git_path_output_is_never_used_as_a_filesystem_path`) builds its
poisoned answer by hand -- a control drawn from the host's own git would inherit the flavour that
host already survives, so it could not express the case.

## Verification

Documentation-only: `git diff --name-only origin/main...HEAD` is one `.md` file.
`check_numbered_table.py` passes on the file (it has no tables) and over every tracked `.md`;
`git diff --check` is clean. Linux CI has nothing to compile or run for this diff.

## Note for the merger

This PR and #3540's touch different parts of `prosper/docs/SESSION_START.md`; both branch from
`31d8ec34`. Merging either first leaves the other a clean, non-overlapping hunk, but the second one
merged should be checked against the merge result rather than its own base.

Closes #3426
