### PR TITLE
Start the session-start hook with an interpreter that exists on this platform

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,13 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": [
-              "${CLAUDE_PROJECT_DIR}/prosper/tools/session_start.py",
-              "--repo",
-              "${CLAUDE_PROJECT_DIR}",
-              "--hook"
-            ],
+            "command": "python3 \"${CLAUDE_PROJECT_DIR}/prosper/tools/session_start.py\" --repo \"${CLAUDE_PROJECT_DIR}\" --hook || python \"${CLAUDE_PROJECT_DIR}/prosper/tools/session_start.py\" --repo \"${CLAUDE_PROJECT_DIR}\" --hook || py \"${CLAUDE_PROJECT_DIR}/prosper/tools/session_start.py\" --repo \"${CLAUDE_PROJECT_DIR}\" --hook || echo session-start UNVERIFIED: could not start python3, python or py - the checkout and instruction freshness check did not run. See prosper/docs/SESSION_START.md",
             "timeout": 20
           }
         ]

--- a/prosper/docs/SESSION_START.md
+++ b/prosper/docs/SESSION_START.md
@@ -28,9 +28,28 @@ Claude Code invokes the check using the checked-in `.claude/settings.json` Sessi
 Its `--hook` mode returns exit 0 with JSON `additionalContext` for all verdicts, including errors,
 so failures become visible session context instead of disappearing into hook stderr. This follows
 the [SessionStart output contract](https://code.claude.com/docs/en/hooks#sessionstart-decision-control).
-The exec-form hook passes paths as separate arguments, including paths containing spaces. It
-requires Python 3 and Git on the agent host. Root `AGENTS.md` and `CLAUDE.md` instruct other agents
-to run the same command at startup and after moving to another worktree.
+It requires Python 3 and Git on the agent host. Root `AGENTS.md` and `CLAUDE.md` instruct other
+agents to run the same command at startup and after moving to another worktree.
+
+No interpreter name exists on every platform, so the hook tries several. `python3` is the usual and
+often the only name on Linux, while a stock python.org install on Windows provides `python.exe`
+only: there the name `python3` resolves to the Microsoft Store App Execution Alias stub, which
+exits 9009 without running anything. The configured command is therefore the chain
+`python3 ... || python ... || py ... || echo`, written in shell form because that is the form both
+platform shells accept -- `||` and double-quoted paths mean the same thing in `sh` and in
+`cmd.exe`, so one committed string runs on both and still keeps a project directory containing
+spaces in a single argument. The order is deliberate: on each platform the attempt that fails
+writes only to stderr, so the hook's stdout stays parseable JSON.
+
+The closing `echo` is the discoverability guarantee, and it matters more than the interpreter
+search. SessionStart adds a hook's stdout to session context, so a host with no usable Python now
+receives a `session-start UNVERIFIED: ...` line saying the check did not run, instead of nothing.
+Measured on Windows 11 with Claude Code 2.1.269 on 2026-09-11: the previous exec-form `python3`
+hook delivered no session-start context and no error of any kind, so the freshness check had been
+silently absent on Windows since it was introduced (#3540). The same session run against the
+chained command carries the real verdict, and a simulated interpreter-less host carries the
+`UNVERIFIED` line. A machine that needs some other interpreter can override the hook in
+`.claude/settings.local.json`, which stays private to that machine.
 
 When a tracking ref is stale, fetch in your own worktree and repeat the check. Compare instruction
 changes against `git show origin/main:CLAUDE.md`; do not replace another lane's work just to clear
@@ -43,9 +62,14 @@ branch and untracked files first. If another worktree owns `main`, a detached ch
 into two worktrees or reset the peer's branch. Future startup checks still detect when that shared
 checkout falls behind again.
 
-`test_session_start.py` uses local Git repositories to exercise the actual configured hook argv
-and verify delivered context. Controls cover current and stale instructions, staged edits,
-divergence, stale/missing remote refs, unreachable remotes, offline checks, linked worktrees,
-detached HEAD, feature branches, Windows line endings and paths containing spaces. It is registered
+`test_session_start.py` uses local Git repositories to exercise the actual configured hook
+command -- in whichever form it is configured, exec or shell -- and verify delivered context. A
+hook that cannot start reports which interpreter names this host resolves and which it does not,
+because `9009 != 0` on its own makes a configuration problem look like a logic failure in the
+probe. One arm empties `PATH` so that no configured name resolves, and asserts the session still
+receives an `UNVERIFIED` line; it detects its own invalidity by failing if a reachable interpreter
+made it answer the real verdict instead. Controls cover current and stale instructions, staged
+edits, divergence, stale/missing remote refs, unreachable remotes, offline checks, linked
+worktrees, detached HEAD, feature branches, Windows line endings and paths containing spaces. It is registered
 as the `session_start` CTest case. The contribution-shape gate allows only `.claude/settings.json`,
 keeping private settings and agent worktree contents outside the exception.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -10,8 +10,10 @@ capture/replay without requiring an importable system Python module.
 
 - **`session_start.py`** — read-only checkout/instruction freshness signal for #2710. See
   [Session startup](../docs/SESSION_START.md). Its hook mode must deliver failures as visible
-  SessionStart context; an unavailable remote must never be reported as current. The regression
-  executes the configured hook argv against both current and stale temporary repositories.
+  SessionStart context; an unavailable remote must never be reported as current, and a host that
+  cannot start any of the interpreters the hook tries must say so rather than exit into silence.
+  The regression executes the hook exactly as configured, in whichever form it is configured,
+  against both current and stale temporary repositories.
 
 - **`evidence/prerender_check.py`** - **run this before publishing a progression screenshot.** It
   answers whether the frame is the game's own PRE-RENDERED picture rather than something prosper

--- a/prosper/tools/test_session_start.py
+++ b/prosper/tools/test_session_start.py
@@ -19,6 +19,49 @@ PROBE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(PROBE)
 
 
+def hook_command(project):
+    """The configured hook, ready to run, with the documented project-dir substitution.
+
+    Both hook forms are accepted so this keeps exercising whatever is configured rather than a
+    remembered shape. Exec form (``command`` plus ``args``) is a real argv and involves no shell.
+    Shell form (``command`` alone) is one string handed to the platform shell -- cmd.exe on
+    Windows, ``sh`` elsewhere -- which is what lets a single committed string try more than one
+    interpreter name, since no name exists on every platform (#3540). Quoted paths keep a project
+    directory containing spaces in one argument under either form.
+    """
+    substitute = lambda text: text.replace("${CLAUDE_PROJECT_DIR}", project)
+    if "args" in HOOK:
+        return [substitute(HOOK["command"])] + [substitute(x) for x in HOOK["args"]], False
+    return substitute(HOOK["command"]), True
+
+
+def interpreters(command):
+    """The interpreter names the configured hook tries, in the order it tries them."""
+    names = []
+    text = command if isinstance(command, str) else " ".join(command)
+    for segment in text.split("||"):
+        head = segment.strip().split(maxsplit=1)
+        if head and head[0] != "echo" and head[0] not in names:
+            names.append(head[0])
+    return names
+
+
+def diagnosis(command, proc):
+    """Say which interpreter could not be started, not merely that a number was not zero."""
+    tried = ", ".join(name + " -> " + (shutil.which(name) or "NOT FOUND")
+                      for name in interpreters(command))
+    return ("The SessionStart hook configured in .claude/settings.json exited "
+            + str(proc.returncode) + " and produced no session context." + chr(10)
+            + "  configured: "
+            + (command if isinstance(command, str) else " ".join(command)) + chr(10)
+            + "  interpreters this host resolves: " + tried + chr(10)
+            + "  hook stderr: " + (proc.stderr.strip() or "(none)") + chr(10)
+            + "A stock python.org install on Windows provides python.exe only, and the name "
+            "python3 there resolves to the Microsoft Store App Execution Alias stub, which exits "
+            "9009 without running anything (#3540). A failure here is a hook configuration "
+            "problem on this host, not a logic failure in session_start.py.")
+
+
 class StartupTest(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory(prefix="session start ")
@@ -56,13 +99,12 @@ class StartupTest(unittest.TestCase):
         return proc.stdout
 
     def hook(self, repo=None):
-        # Execute the actual exec-form hook argv, with the documented project-dir substitution.
-        # No shell is involved: project paths containing spaces stay one argument.
-        project = str(repo or self.repo)
-        argv = [HOOK["command"]] + [x.replace("${CLAUDE_PROJECT_DIR}", project) for x in HOOK["args"]]
-        proc = subprocess.run(argv, input="{}", capture_output=True, text=True,
+        # Execute what Claude Code executes: the command exactly as configured, in the form it is
+        # configured in, with the documented project-dir substitution.
+        command, shell = hook_command(str(repo or self.repo))
+        proc = subprocess.run(command, shell=shell, input="{}", capture_output=True, text=True,
                               timeout=HOOK["timeout"])
-        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.returncode, 0, diagnosis(command, proc))
         output = json.loads(proc.stdout)["hookSpecificOutput"]
         self.assertEqual(output["hookEventName"], "SessionStart")
         return output["additionalContext"]
@@ -180,6 +222,29 @@ class StartupTest(unittest.TestCase):
         self.assertEqual(status, 0, report)
         self.assertIn("OK:", report)
         self.assertEqual(consulted, [], "the worktree root must not come from git path output")
+
+    def test_hook_without_any_interpreter_still_reports_that_it_did_not_run(self):
+        # Discoverability is the point of the hook, not a nicety: its job is to tell a session that
+        # the charter it just loaded may be stale, so a hook that cannot start its interpreter has
+        # to say so in session context. Measured on Windows 2026-09-11 with the previous exec-form
+        # `python3` configuration: the session carried no session-start line and no error of any
+        # kind -- an unarmed instrument reading as a confident silence (#3540).
+        #
+        # PATH is emptied rather than an interpreter renamed. The case under test is a host that
+        # has none of the configured names, and a control built from the interpreters this host
+        # does have could not express it.
+        bare = Path(self.tmp.name) / "no interpreters here"
+        bare.mkdir()
+        command, shell = hook_command(str(self.repo))
+        proc = subprocess.run(command, shell=shell, input="{}", capture_output=True, text=True,
+                              timeout=HOOK["timeout"], env=dict(os.environ, PATH=str(bare)))
+        # Not an assertion about the exit status: the contract is that something reaches stdout,
+        # which is what SessionStart turns into context.
+        self.assertIn("session-start", proc.stdout, proc.stderr)
+        self.assertIn("UNVERIFIED", proc.stdout, proc.stderr)
+        # Self-invalidating control: an interpreter reached despite the emptied PATH would make
+        # this arm vacuous, and reporting the real check's verdict is how that shows up.
+        self.assertNotIn("OK:", proc.stdout)
 
     def test_root_is_found_from_a_subdirectory(self):
         # The relative derivation that replaced --show-toplevel still has to climb: this is the

--- a/prosper/tools/test_session_start.py
+++ b/prosper/tools/test_session_start.py
@@ -50,16 +50,17 @@ def diagnosis(command, proc):
     """Say which interpreter could not be started, not merely that a number was not zero."""
     tried = ", ".join(name + " -> " + (shutil.which(name) or "NOT FOUND")
                       for name in interpreters(command))
-    return ("The SessionStart hook configured in .claude/settings.json exited "
-            + str(proc.returncode) + " and produced no session context." + chr(10)
-            + "  configured: "
-            + (command if isinstance(command, str) else " ".join(command)) + chr(10)
-            + "  interpreters this host resolves: " + tried + chr(10)
-            + "  hook stderr: " + (proc.stderr.strip() or "(none)") + chr(10)
-            + "A stock python.org install on Windows provides python.exe only, and the name "
-            "python3 there resolves to the Microsoft Store App Execution Alias stub, which exits "
-            "9009 without running anything (#3540). A failure here is a hook configuration "
-            "problem on this host, not a logic failure in session_start.py.")
+    return "\n".join([
+        "The SessionStart hook configured in .claude/settings.json exited "
+        + str(proc.returncode) + " and produced no session context.",
+        "  configured: " + (command if isinstance(command, str) else " ".join(command)),
+        "  interpreters this host resolves: " + tried,
+        "  hook stderr: " + (proc.stderr.strip() or "(none)"),
+        "A stock python.org install on Windows provides python.exe only, and the name python3 "
+        "there resolves to the Microsoft Store App Execution Alias stub, which exits 9009 without "
+        "running anything (#3540). A failure here is a hook configuration problem on this host, "
+        "not a logic failure in session_start.py.",
+    ])
 
 
 class StartupTest(unittest.TestCase):


### PR DESCRIPTION
## The defect

`.claude/settings.json` hardcoded the SessionStart hook's interpreter as `"command": "python3"`.
A stock python.org install on Windows provides `python.exe` only, and the name `python3` there
resolves to the Microsoft Store App Execution Alias stub, which exits 9009 without running
anything. So on Windows the hook launched a program that was not Python and produced no
`hookSpecificOutput`.

`CLAUDE.md` opens by telling every agent that this check compares the checkout and its instruction
files against `origin/main`: it is the mechanism by which a session learns that the charter it has
just loaded may be stale. A failing SessionStart hook is quiet, so that check had been absent on
Windows with nothing saying so.

## Measured, not inferred

Windows 11, Claude Code 2.1.269, `origin/main` `31d8ec34`, 2026-09-11. A headless session was
started in a private worktree and asked to quote any context line containing `session-start`:

| hook configuration | what the session received |
| --- | --- |
| old, exec-form `python3` | `NO-SESSION-START-CONTEXT` -- no verdict and no error |
| this PR's chain | `[session-start] Checkout: branch=... OK: checkout includes current origin/main` |
| this PR's chain, every interpreter name made unreachable | `session-start UNVERIFIED: could not start python3, python or py ...` |

The spawn semantics were measured against the real harness rather than assumed, by registering
probe hooks that record how they were started:

| form | Windows result |
| --- | --- |
| exec `python` / `py` + args | runs |
| exec `python3` + args | **does not run** (Store alias stub) |
| exec form pointing at a `.cmd` | does not run |
| shell form `python "..."` | runs |
| shell form, extension-less path relying on PATHEXT | does not run |
| shell form `a \|\| b` short-circuit, after a stub failure and after a missing command | falls through correctly in both cases |

## The change

No interpreter name exists on every platform: `python3` is the usual and often the only name on
Linux, and is the broken one on Windows; `py` exists only on Windows. A straight substitution
therefore cannot work, so the hook now tries several names in one shell-form command:

```
python3 <check> || python <check> || py <check> || echo session-start UNVERIFIED: ...
```

Shell form is what makes one committed string portable: `||` and double-quoted paths mean the same
thing in `sh` and in `cmd.exe`, and the quoting keeps a project directory containing spaces in a
single argument, which is what the previous exec form was protecting. The order is deliberate --
on each platform the attempt that fails writes only to stderr, so the hook's stdout stays parseable
JSON.

**The closing `echo` is the part that matters most.** SessionStart adds a hook's stdout to session
context, so a host with no usable Python now receives a line saying the check did not run, instead
of silence. That is the #2149 shape removed from the one check whose job is to say the instructions
may be wrong.

`test_session_start.py` now runs whichever form is configured, exec or shell, so it keeps
exercising the real configuration rather than a remembered shape. A hook that cannot start reports
the interpreter names this host resolves and those it does not: `9009 != 0` made a configuration
problem look like a logic failure in the probe.

## Verification

```
prosper/tools/test_session_start.py   Windows (python 3.12):   Ran 15 tests   OK
prosper/tools/test_session_start.py   Linux (WSL, python3):    Ran 15 tests   OK
```

Windows `ctest --no-tests=error` on this box:

`340/340 tests passed, 0 failed` (2 skipped: `refactor_survey_measurement`,
`hle_calls_value_capture`), exit 0. The 334/335 figure quoted when this was assigned came from an
older head and build directory; this is a fresh worktree build at `31d8ec34` plus this change, so
quote the 340.

Before and after were measured on the SAME build directory, which is possible because the test
reads `.claude/settings.json` at run time:

```
.claude/settings.json reverted to exec-form python3   ctest -R ^session_start$   exit 8   FAILED
.claude/settings.json as in this PR                   ctest -R ^session_start$   exit 0   1/1 passed
```

Without-fix arms, with `.claude/settings.json` reverted to the exec-form `python3` and the new test
run unchanged:

- Windows: `AssertionError: 'session-start' not found in ''` (hook stderr: the Store stub's
  "Python was not found" advertisement).
- Linux: `FileNotFoundError: [Errno 2] No such file or directory: 'python3'` -- the emptied-`PATH`
  arm, which is the point of the arm.

The six previously failing `hook()` cases on Windows (`9009 != 0`) now pass.

Local gates: `check_contribution_shape.py --selftest` 17 arms / 0 failed; `check_ascii_output.py`
passed; `check_numbered_table.py` over every tracked `.md` passed; `git diff --check` clean.

## What CI can and cannot say here

Linux CI cannot validate this change: on Linux the first element of the chain is the same
`python3` that already worked, so a green Linux run shows only that nothing regressed there. The
Windows MinGW job does exercise the hook, but its runner resolves `python3`, which is why this
defect never appeared in CI and appears on a stock Windows workstation. The evidence that the fix
works on Windows is the measured session table above.

## Relationship to #3426

Not the same defect, and this PR does not touch it. #3426's eight CI failures are all raised from
`check()`, which runs `sys.executable` -- the interpreter started fine there; its cause was the git
path-flavour round trip, fixed separately by #3444. Measurements are in a comment on #3426.

## Commits

1. the hook chain, the test's support for either hook form, the actionable failure message, the
   emptied-`PATH` arm, and `SESSION_START.md`.
2. `prosper/tools/AGENTS.md`: that folder map said the regression "executes the configured hook
   argv", which stopped being true with this change; it now also names the contract the change adds.
3. cosmetic: the diagnosis message joins with a newline literal rather than `chr(10)`, which was an
   authoring workaround for this machine's heredoc escape handling and had no business in the
   committed source.

## Risk

`.claude/settings.json` is live configuration for every agent in this repository. The JSON is
validated, the change is confined to one string, and it degrades safely: a host where the first
name works behaves exactly as before, and a host where none works now says so instead of failing
silently.

Fixes #3540
