### PR TITLE
Save the compute pipeline cache on the frontend's _Exit path

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2639,6 +2639,22 @@ if(TARGET prosper_core)
       set_tests_properties(game_compute_exec_scratch_poison PROPERTIES
         ENVIRONMENT "PROSPER_DECODE_SCRATCH_POISON=1")
 
+      # #3425: registered on Windows as well as in the UNIX block below, deliberately. This
+      # defect is about the WINDOWS/NVIDIA frontend's _Exit path and the cost it recovers was
+      # measured there (#3450), so a Linux-only guard would test the fix everywhere except
+      # where it was found. Both registrations run the same fixture and driver script.
+      if(Python3_Interpreter_FOUND)
+        add_executable(test_compute_cache_persistence tests/gpu/execute/test_compute_cache_persistence.cpp)
+        target_include_directories(test_compute_cache_persistence PRIVATE tests frontends)
+        target_link_libraries(test_compute_cache_persistence PRIVATE prosper_live_renderer)
+        add_test(NAME compute_cache_persistence
+                 COMMAND "${Python3_EXECUTABLE}"
+                         "${CMAKE_CURRENT_SOURCE_DIR}/tests/gpu/execute/test_compute_cache_persistence.py"
+                         $<TARGET_FILE:test_compute_cache_persistence>
+                         "${CMAKE_CURRENT_SOURCE_DIR}/frontends/prosper-app/main.cpp")
+        set_tests_properties(compute_cache_persistence PROPERTIES TIMEOUT 300)
+      endif()
+
       # Local-only realized-submit replayer (#514), on Windows since #2331. Same target as the UNIX
       # block below, including the -Werror=switch gate: gpu_replay maps LiveTargetPixelFormat itself
       # in inspect_live_target, and an unhandled member there falls through to the seed's Rgba8Unorm
@@ -3390,6 +3406,20 @@ if(TARGET prosper_core)
                          "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_buffer_timing_runtime.py"
                          $<TARGET_FILE:test_compute_buffer_timing>)
         set_tests_properties(compute_buffer_timing_runtime PROPERTIES TIMEOUT 180)
+        # #3425: the compute driver pipeline cache is written on the frontend's _Exit path, not by a
+        # destructor. Separate processes are required -- a single process could pass while writing
+        # nothing -- and the driver also asserts prosper-app still names the flush.
+        add_executable(test_compute_cache_persistence tests/gpu/execute/test_compute_cache_persistence.cpp)
+        target_include_directories(test_compute_cache_persistence PRIVATE tests frontends)
+        target_link_libraries(test_compute_cache_persistence PRIVATE
+                             prosper_live_renderer prosper_core Vulkan::Vulkan)
+        add_test(NAME compute_cache_persistence
+                 COMMAND "${Python3_EXECUTABLE}"
+                         "${CMAKE_CURRENT_SOURCE_DIR}/tests/gpu/execute/test_compute_cache_persistence.py"
+                         $<TARGET_FILE:test_compute_cache_persistence>
+                         "${CMAKE_CURRENT_SOURCE_DIR}/frontends/prosper-app/main.cpp")
+        set_tests_properties(compute_cache_persistence PROPERTIES TIMEOUT 300)
+
         add_executable(test_compute_buffer_residency tests/gpu/execute/test_compute_buffer_residency.cpp)
         target_include_directories(test_compute_buffer_residency PRIVATE tests frontends)
         target_link_libraries(test_compute_buffer_residency PRIVATE

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -3251,7 +3251,19 @@ int main(int argc, char** argv) {
         // _Exit skips RuntimeComputeTimingSelector's destructor. Publish its validity verdict here;
         // the report is idempotent so a future cooperative teardown cannot duplicate it.
         prosper::frontend::report_live_compute_timing_selector_summary();
+        // Both driver pipeline caches, for the same reason: _Exit runs no destructor, so the
+        // compute context's own teardown save never happens on this path (#3425). Compute is the
+        // one that had no caller at all -- every run paid first-use shader compilation forever,
+        // measured at 821 ms across 14 compilations in one 5 s GTA V world window (#3450).
+        //
+        // Placed AFTER the drain and vkDeviceWaitIdle above: those are what make it safe to read a
+        // cache the guest thread was still mutating. Both calls are bounded and both decline
+        // loudly rather than blocking the close.
+        //
+        // This covers the frontend's own exit only. A guest-thread _Exit (#3324) is exit_group()
+        // from a thread this code never reaches, so neither cache is saved on that path.
         prosper::frontend::flush_live_graphics_pipeline_cache();
+        prosper::frontend::flush_live_compute_pipeline_cache();
 #endif
         // The bounded dmem writer trace also has a destructor/atexit fallback, which _Exit skips.
         prosper::host::guest_dmem_write_trace_report();

--- a/prosper/frontends/shared/device/AGENTS.md
+++ b/prosper/frontends/shared/device/AGENTS.md
@@ -4,6 +4,11 @@ Loader/device requirements and selection shared by live frontends and execution 
 Pipeline-cache files belong here: they store opaque driver data, not guest shaders or game assets.
 Cache compatibility checks reject damaged or mismatched files; they cannot guarantee a driver
 accepts its own data safely. Keep disk loading opt-in while the recorded NVIDIA failure remains.
+`PipelineCacheFile` serves BOTH stages -- `graphics()` and `compute()` differ only in the
+filename and the explicit-path variable -- so a policy change cannot land on one and miss the other,
+which is how the compute path ended up writing a bare driver blob with no truncation guard (#3425).
+Note where the file is written from: a frontend that leaves through `_Exit` runs no destructor, so
+persistence is an explicit call on the shutdown path, not a teardown side effect.
 
 Feature acquisition that more than one device path needs belongs here rather than beside whichever
 device was written first: the renderer's device, the compute backend's own device and the adopt path

--- a/prosper/frontends/shared/device/pipeline_cache_file.hpp
+++ b/prosper/frontends/shared/device/pipeline_cache_file.hpp
@@ -47,13 +47,17 @@ struct PipelineCacheFile {
             read_le(blob.data() + 12, 4) == device.deviceID &&
             std::memcmp(blob.data() + 16, device.pipelineCacheUUID, VK_UUID_SIZE) == 0;
     }
-    static PipelineCacheFile graphics(const VkPhysicalDeviceProperties& properties) {
+    // `stage_prefix` separates the graphics and compute blobs: a VkPipelineCache is per-device, not
+    // per-stage, but the two live on different VkDevices whenever compute runs on its own device,
+    // and mixing them would make one context's save clobber the other's.
+    static PipelineCacheFile for_stage(const VkPhysicalDeviceProperties& properties,
+                                       const char* stage_prefix, const char* explicit_path_env) {
         PipelineCacheFile file;
         file.device = properties;
         if (std::getenv("PROSPER_NO_DISK_PIPELINE_CACHE")) return file;
         // Explicit paths also count as opt-in, matching the existing compute policy. This is
         // deliberately not default-on: identity checks do not cure the NVIDIA blob-load crash.
-        if (const char* p = std::getenv("PROSPER_GRAPHICS_PIPELINE_CACHE_PATH")) {
+        if (const char* p = std::getenv(explicit_path_env)) {
             file.path = p;
             return file;
         }
@@ -72,15 +76,28 @@ struct PipelineCacheFile {
             directory = std::filesystem::path(base) / ".cache";
         }
 #endif
-        char name[160];
-        std::snprintf(name, sizeof(name), "graphics-vkcache-v1-%08x-%08x-%08x-",
-                      properties.vendorID, properties.deviceID, properties.driverVersion);
+        char name[192];
+        if (std::snprintf(name, sizeof(name), "%s-%08x-%08x-%08x-", stage_prefix,
+                          properties.vendorID, properties.deviceID,
+                          properties.driverVersion) >= int(sizeof(name)))
+            return file;
         std::string identity(name);
         for (uint8_t b : properties.pipelineCacheUUID) {
             char hex[3]; std::snprintf(hex, sizeof(hex), "%02x", b); identity += hex;
         }
         file.path = directory / "prosper" / identity;
         return file;
+    }
+    static PipelineCacheFile graphics(const VkPhysicalDeviceProperties& properties) {
+        return for_stage(properties, "graphics-vkcache-v1",
+                         "PROSPER_GRAPHICS_PIPELINE_CACHE_PATH");
+    }
+    // v2, not v1: the compute backend used to write the driver blob to this directory RAW, with no
+    // envelope, so a header check alone could not tell a truncated file from a good one (#3425). A
+    // separate identity means an older build's v1 file and this one never overwrite each other.
+    static PipelineCacheFile compute(const VkPhysicalDeviceProperties& properties) {
+        return for_stage(properties, "compute-vkcache-v2",
+                         "PROSPER_COMPUTE_PIPELINE_CACHE_PATH");
     }
     std::vector<uint8_t> load() const {
         if (path.empty()) return {};

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -13,6 +13,7 @@
 #include "shared/live/gpu_retile.hpp"
 #include "shared/rtt/rtt_scale.hpp"
 #include "shared/rtt/rtt_authority.hpp"
+#include "shared/device/pipeline_cache_file.hpp"  // #3425: one checked envelope for both stages
 #include "shared/device/vulkan_device_select.hpp"
 #include "shared/device/image_robustness.hpp"  // #3531: the recompiler's OOB image-read contract
 #include "shared/texture/write_watch_census.hpp"
@@ -80,20 +81,14 @@ bool compute_pipeline_cache_blob_compatible(
     const uint8_t* pipeline_cache_uuid, size_t uuid_bytes) {
     // VkPipelineCacheHeaderVersionOne is a serialized five-field prefix. Avoid casting untrusted
     // file bytes to the structure so short and unaligned files are rejected before any read.
-    constexpr size_t scalar_bytes = 4u * sizeof(uint32_t);
-    constexpr size_t prefix_bytes = scalar_bytes + VK_UUID_SIZE;
-    if (!blob || !pipeline_cache_uuid || uuid_bytes != VK_UUID_SIZE ||
-        blob_bytes < prefix_bytes)
-        return false;
-    uint32_t header_size = 0, header_version = 0, cached_vendor = 0, cached_device = 0;
-    std::memcpy(&header_size, blob + 0u * sizeof(uint32_t), sizeof(uint32_t));
-    std::memcpy(&header_version, blob + 1u * sizeof(uint32_t), sizeof(uint32_t));
-    std::memcpy(&cached_vendor, blob + 2u * sizeof(uint32_t), sizeof(uint32_t));
-    std::memcpy(&cached_device, blob + 3u * sizeof(uint32_t), sizeof(uint32_t));
-    return header_size >= prefix_bytes && header_size <= blob_bytes &&
-           header_version == VK_PIPELINE_CACHE_HEADER_VERSION_ONE &&
-           cached_vendor == vendor_id && cached_device == device_id &&
-           std::memcmp(blob + scalar_bytes, pipeline_cache_uuid, VK_UUID_SIZE) == 0;
+    // The decode itself lives in PipelineCacheFile so the graphics and compute paths cannot drift
+    // apart; this wrapper keeps the exported name and its own regression coverage.
+    if (!blob || !pipeline_cache_uuid || uuid_bytes != VK_UUID_SIZE) return false;
+    PipelineCacheFile identity;
+    identity.device.vendorID = vendor_id;
+    identity.device.deviceID = device_id;
+    std::memcpy(identity.device.pipelineCacheUUID, pipeline_cache_uuid, VK_UUID_SIZE);
+    return identity.compatible(std::span<const uint8_t>(blob, blob_bytes));
 }
 
 LiveComputeBufferDescriptorPlan plan_live_compute_buffer_descriptors(
@@ -1437,8 +1432,14 @@ struct VulkanComputeContext {
     VkDevice device = VK_NULL_HANDLE;
     VkQueue queue = VK_NULL_HANDLE;
     VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
-    std::filesystem::path pipeline_cache_path;
-    std::mutex pipeline_cache_mutex;
+    PipelineCacheFile pipeline_cache_file;
+    // Bytes the driver ACCEPTED from disk when this device's cache was created; 0 means the run
+    // started cold. Written once during init, before any other thread can observe the context.
+    uint64_t pipeline_cache_loaded_bytes = 0;
+    // Timed, not plain: the shutdown snapshot runs on the main thread while a detached guest thread
+    // may still be inside vkCreateComputePipelines, and a driver compile that never returns must
+    // cost a missed save rather than an app that will not close (#3425).
+    std::timed_mutex pipeline_cache_mutex;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
     // #3157: the GPU result-comparison pool, owned by the context so it is reset rather than
     // recreated per dispatch. It contributed about 144 vkCreateDescriptorPool + 144 vkDestroy per
@@ -1537,77 +1538,27 @@ struct VulkanComputeContext {
     // VK_ERROR_DEVICE_LOST is permanent for a VkDevice. Keep the first failure latched so later
     // PM4 dispatches cannot spend minutes rebuilding resources and submitting work that Vulkan is
     // required to reject. AGC submit execution serializes access to this context.
-    bool device_lost = false;
+    std::atomic<bool> device_lost{false};
     // A queue API was entered and no fence or queue-idle result proved completion. The current item
     // and this context then retain objects that Vulkan may still own; neither may be destroyed.
-    bool completion_unproven = false;
+    std::atomic<bool> completion_unproven{false};
 
-    std::filesystem::path persistent_pipeline_cache_path() const {
-        if (std::getenv("PROSPER_NO_DISK_PIPELINE_CACHE")) return {};
-        if (const char* explicit_path = std::getenv("PROSPER_COMPUTE_PIPELINE_CACHE_PATH")) {
-            if (*explicit_path) return std::filesystem::path(explicit_path);
-            return {};
-        }
+    bool create_pipeline_cache() {
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(physical, &properties);
         // Loading a driver-produced cache blob is not yet a safe default. Repeated GTA V runs on
         // NVIDIA reproduced an nvoglv64.dll crash only on the cache-load route; UUID/header
         // validation proves device compatibility, not that the vendor blob itself is robust. Keep
         // persistence available for controlled measurements, but require an explicit opt-in until
-        // that driver failure has a guarded reproducer.
-        if (!std::getenv("PROSPER_DISK_PIPELINE_CACHE")) return {};
-        const char* base = nullptr;
-        [[maybe_unused]] bool base_is_home = false;
-#ifdef _WIN32
-        base = std::getenv("LOCALAPPDATA");
-#else
-        base = std::getenv("XDG_CACHE_HOME");
-        if (!base || !*base) {
-            base = std::getenv("HOME");
-            base_is_home = true;
-        }
-#endif
-        if (!base || !*base) return {};
-        VkPhysicalDeviceProperties properties{};
-        vkGetPhysicalDeviceProperties(physical, &properties);
-        char identity[160]{};
-        char* out = identity;
-        const size_t remaining = sizeof(identity);
-        const int prefix = std::snprintf(
-            out, remaining, "compute-vkcache-v1-%08x-%08x-",
-            properties.vendorID, properties.deviceID);
-        if (prefix < 0 || static_cast<size_t>(prefix) >= remaining) return {};
-        out += prefix;
-        for (uint8_t byte : properties.pipelineCacheUUID) {
-            const int written = std::snprintf(out,
-                static_cast<size_t>(identity + sizeof(identity) - out), "%02x", byte);
-            if (written != 2) return {};
-            out += 2;
-        }
-        std::filesystem::path directory(base);
-#ifndef _WIN32
-        if (base_is_home) directory /= ".cache";
-#endif
-        return directory / "prosper" / identity;
-    }
-
-    bool create_pipeline_cache() {
-        pipeline_cache_path = persistent_pipeline_cache_path();
+        // that driver failure has a guarded reproducer. PipelineCacheFile owns that policy for
+        // both stages, so graphics and compute cannot drift apart on it.
         std::vector<uint8_t> initial;
-        VkPhysicalDeviceProperties properties{};
-        vkGetPhysicalDeviceProperties(physical, &properties);
-        if (!pipeline_cache_path.empty()) {
-            std::error_code ec;
-            const uintmax_t bytes = std::filesystem::file_size(pipeline_cache_path, ec);
-            constexpr uintmax_t max_cache_bytes = 256ull * 1024ull * 1024ull;
-            if (!ec && bytes && bytes <= max_cache_bytes) {
-                initial.resize(static_cast<size_t>(bytes));
-                std::ifstream input(pipeline_cache_path, std::ios::binary);
-                input.read(reinterpret_cast<char*>(initial.data()),
-                           static_cast<std::streamsize>(initial.size()));
-                if (!input || !compute_pipeline_cache_blob_compatible(
-                        initial.data(), initial.size(), properties.vendorID,
-                        properties.deviceID, properties.pipelineCacheUUID, VK_UUID_SIZE))
-                    initial.clear();
-            }
+        try {
+            pipeline_cache_file = PipelineCacheFile::compute(properties);
+            initial = pipeline_cache_file.load();
+        } catch (const std::exception&) {
+            std::fprintf(stderr, "[compute] disk pipeline cache unavailable; starting empty\n");
+            initial.clear();
         }
         VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
         pcci.initialDataSize = initial.size();
@@ -1622,66 +1573,61 @@ struct VulkanComputeContext {
             initial.clear();
         }
         if (result != VK_SUCCESS) return false;
-        if (!pipeline_cache_path.empty())
+        pipeline_cache_loaded_bytes = initial.size();
+        if (!pipeline_cache_file.path.empty())
             std::fprintf(stderr, "[compute] disk pipeline cache %s: %s (%zu bytes)\n",
                          initial.empty() ? "cold" : "loaded",
-                         pipeline_cache_path.string().c_str(), initial.size());
+                         pipeline_cache_file.path.string().c_str(), initial.size());
         return true;
     }
 
-    void persist_pipeline_cache() {
-        if (!pipeline_cache || pipeline_cache_path.empty() || device_lost ||
-            completion_unproven)
-            return;
-        // VkPipelineCache is externally synchronized. The frontend's _Exit flush can overlap the
-        // last guest dispatch even after a cooperative-stop request, so serialize it against every
-        // vkCreateComputePipelines call that mutates the cache.
-        std::lock_guard<std::mutex> cache_lock(pipeline_cache_mutex);
-        size_t bytes = 0;
-        if (vkGetPipelineCacheData(device, pipeline_cache, &bytes, nullptr) != VK_SUCCESS ||
-            !bytes || bytes > 256ull * 1024ull * 1024ull)
-            return;
-        std::vector<uint8_t> blob(bytes);
-        if (vkGetPipelineCacheData(device, pipeline_cache, &bytes, blob.data()) != VK_SUCCESS)
-            return;
-        blob.resize(bytes);
-        VkPhysicalDeviceProperties properties{};
-        vkGetPhysicalDeviceProperties(physical, &properties);
-        if (!compute_pipeline_cache_blob_compatible(
-                blob.data(), blob.size(), properties.vendorID, properties.deviceID,
-                properties.pipelineCacheUUID, VK_UUID_SIZE))
-            return;
-        std::error_code ec;
-        std::filesystem::create_directories(pipeline_cache_path.parent_path(), ec);
-        if (ec) return;
-        const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-        std::filesystem::path temporary = pipeline_cache_path;
-        temporary += ".tmp-" + std::to_string(nonce);
-        {
-            std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
-            output.write(reinterpret_cast<const char*>(blob.data()),
-                         static_cast<std::streamsize>(blob.size()));
-            output.flush();
-            if (!output) {
-                output.close();
-                std::filesystem::remove(temporary, ec);
-                return;
+    // Snapshot the driver cache WITHOUT tearing the context down, so a frontend that leaves through
+    // _Exit still persists what this run compiled (#3425). Returns whether the file was written, so
+    // a caller and a test can tell "nothing to save" from "the save was declined".
+    //
+    // `lock_budget` bounds the wait deliberately: on the shutdown path a detached guest thread may
+    // still be inside vkCreateComputePipelines, and a compile that never returns must cost a missed
+    // cache rather than an app that cannot close.
+    bool persist_pipeline_cache(
+            std::chrono::milliseconds lock_budget = std::chrono::milliseconds(1000)) {
+        if (!pipeline_cache || pipeline_cache_file.path.empty()) return false;
+        // Read once, and read the atomics: this runs on the main thread while the guest thread may
+        // still be writing them. A lost device or an unproven completion means Vulkan may still own
+        // objects here, so touching the cache handle at all is unsafe.
+        if (device_lost.load(std::memory_order_acquire) ||
+            completion_unproven.load(std::memory_order_acquire)) {
+            std::fprintf(stderr, "[compute] disk pipeline cache save skipped: device state unproven\n");
+            return false;
+        }
+        try {
+            std::vector<uint8_t> blob;
+            {
+                // VkPipelineCache is externally synchronized: serialize against every
+                // vkCreateComputePipelines call that mutates it.
+                std::unique_lock<std::timed_mutex> lock(pipeline_cache_mutex, std::defer_lock);
+                if (!lock.try_lock_for(lock_budget)) {
+                    std::fprintf(stderr,
+                                 "[compute] disk pipeline cache save skipped: compilation busy\n");
+                    return false;
+                }
+                size_t bytes = 0;
+                if (vkGetPipelineCacheData(device, pipeline_cache, &bytes, nullptr) != VK_SUCCESS ||
+                    !bytes || bytes > PipelineCacheFile::max_bytes)
+                    return false;
+                blob.resize(bytes);
+                if (vkGetPipelineCacheData(device, pipeline_cache, &bytes, blob.data()) != VK_SUCCESS)
+                    return false;
+                blob.resize(bytes);
             }
+            const bool saved = pipeline_cache_file.save(blob);
+            std::fprintf(stderr, "[compute] disk pipeline cache %s: %s (%zu bytes)\n",
+                         saved ? "saved" : "save failed",
+                         pipeline_cache_file.path.string().c_str(), blob.size());
+            return saved;
+        } catch (const std::exception&) {
+            std::fprintf(stderr, "[compute] disk pipeline cache save failed\n");
+            return false;
         }
-        std::filesystem::rename(temporary, pipeline_cache_path, ec);
-        if (ec) {
-            ec.clear();
-            std::filesystem::remove(pipeline_cache_path, ec);
-            ec.clear();
-            std::filesystem::rename(temporary, pipeline_cache_path, ec);
-        }
-        if (ec) {
-            ec.clear();
-            std::filesystem::remove(temporary, ec);
-            return;
-        }
-        std::fprintf(stderr, "[compute] disk pipeline cache saved: %s (%zu bytes)\n",
-                     pipeline_cache_path.string().c_str(), blob.size());
     }
 
     ~VulkanComputeContext() {
@@ -3255,7 +3201,7 @@ struct VulkanComputeContext {
         cpci.stage.module = compare_shader;
         cpci.stage.pName = "main";
         cpci.layout = compare_pipeline_layout;
-        std::lock_guard<std::mutex> cache_lock(pipeline_cache_mutex);
+        std::lock_guard<std::timed_mutex> cache_lock(pipeline_cache_mutex);
         return vkCreateComputePipelines(device, pipeline_cache, 1, &cpci, nullptr,
                                         &compare_pipeline) == VK_SUCCESS;
     }
@@ -3530,7 +3476,9 @@ struct VulkanComputeContext {
 
 };
 
-VulkanComputeContext* g_live_compute_context = nullptr;
+// Published with release / read with acquire: prosper-app's shutdown snapshot reads this from
+// the MAIN thread while the guest thread is still dispatching (#3425).
+std::atomic<VulkanComputeContext*> g_live_compute_context{nullptr};
 std::atomic<uint64_t> g_sampled_image_upload_skips{0};
 std::atomic<uint64_t> g_cpu_fill_dispatches{0};
 
@@ -7464,7 +7412,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         image_descriptors[i].sampled_float &&
                         std::getenv("PROSPER_NO_GPU_PACKED_RTT") == nullptr;
                     if (packed10_copy) {
-                        std::lock_guard<std::mutex> cache_lock(ctx.pipeline_cache_mutex);
+                        std::lock_guard<std::timed_mutex> cache_lock(ctx.pipeline_cache_mutex);
                         auto& conversion = ctx.packed_rtt_conversion;
                         const VkResult injected = g_next_packed_rtt_setup_result_for_test.exchange(
                             VK_SUCCESS, std::memory_order_acq_rel);
@@ -9700,8 +9648,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 auto& retile = array ? ctx.paired16_retile_pipeline :
                     volume ? ctx.volume_retile_pipeline : ctx.retile_pipeline;
                 auto prepare = [&] {
-                    if (!vk_soft_ok(retile.initialize(ctx.device, ctx.pipeline_cache, bi.retile_parameters.kind),
-                                    "retile-pipeline")) return false;
+                    // #3425: this creates a compute pipeline INTO the shared VkPipelineCache, which
+                    // Vulkan externally synchronizes. Every other creator here already takes this
+                    // lock (the packed-RTT conversion above, and the two dispatch pipelines); this
+                    // one did not, and the shutdown snapshot is now a real concurrent reader of the
+                    // same handle rather than only a destructor that runs when nothing else can.
+                    bool retile_ready = false;
+                    {
+                        std::lock_guard<std::timed_mutex> cache_lock(ctx.pipeline_cache_mutex);
+                        retile_ready = vk_soft_ok(
+                            retile.initialize(ctx.device, ctx.pipeline_cache,
+                                              bi.retile_parameters.kind), "retile-pipeline");
+                    }
+                    if (!retile_ready) return false;
                     VkBufferCreateInfo ci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                     ci.size = bi.retile_parameters.tiled_bytes;
                     ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -9961,7 +9920,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                               low_latency_compile ? "disabled-for-cold-latency" : "driver-default");
             VkResult pipeline_result = VK_SUCCESS;
             {
-                std::lock_guard<std::mutex> cache_lock(ctx.pipeline_cache_mutex);
+                std::lock_guard<std::timed_mutex> cache_lock(ctx.pipeline_cache_mutex);
                 pipeline_result = vkCreateComputePipelines(
                     ctx.device, ctx.pipeline_cache, 1, &cpci, nullptr, &pipeline);
             }
@@ -12237,16 +12196,27 @@ void report_live_compute_timing_selector_summary() {
     runtime_compute_authority_census().report_summary();
 }
 
-void flush_live_compute_pipeline_cache() {
-    VulkanComputeContext* context = g_live_compute_context;
-    if (context) context->persist_pipeline_cache();
+bool flush_live_compute_pipeline_cache(std::chrono::milliseconds lock_budget) {
+    VulkanComputeContext* context = g_live_compute_context.load(std::memory_order_acquire);
+    return context && context->persist_pipeline_cache(lock_budget);
+}
+
+LiveComputePipelineCacheStatus live_compute_pipeline_cache_status() {
+    LiveComputePipelineCacheStatus status;
+    const VulkanComputeContext* context =
+        g_live_compute_context.load(std::memory_order_acquire);
+    if (!context) return status;
+    status.context_live = true;
+    status.persistence_configured = !context->pipeline_cache_file.path.empty();
+    status.loaded_bytes = context->pipeline_cache_loaded_bytes;
+    return status;
 }
 
 bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampled_resource,
                                        uint64_t guest_bytes,
                                        LiveComputeImageImport& import) {
     import = {};
-    VulkanComputeContext* context = g_live_compute_context;
+    VulkanComputeContext* context = g_live_compute_context.load(std::memory_order_acquire);
     const bool ordinary_shape =
         ((sampled_resource.img_dim == 1 || sampled_resource.img_dim == 5) &&
          sampled_resource.depth == 1) ||
@@ -12437,7 +12407,7 @@ bool live_compute_native_storage_3d_supported(prosper::gpu::DataFormat format,
                                               uint32_t components,
                                               uint32_t width, uint32_t height,
                                               uint32_t depth) {
-    VulkanComputeContext* context = g_live_compute_context;
+    VulkanComputeContext* context = g_live_compute_context.load(std::memory_order_acquire);
     if (!context || !context->physical) return false;
     const VkFormat native_format = native_storage_vk_format(format, components);
     return native_storage_image_create_supported(
@@ -12450,11 +12420,13 @@ uint64_t live_compute_cpu_fill_dispatches() {
 }
 
 uint64_t live_compute_storage_result_snapshot_bytes() {
-    return g_live_compute_context ? g_live_compute_context->storage_result_snapshot_bytes : 0;
+    const VulkanComputeContext* context = g_live_compute_context.load(std::memory_order_acquire);
+    return context ? context->storage_result_snapshot_bytes : 0;
 }
 
 uint64_t live_compute_image_result_snapshot_bytes() {
-    return g_live_compute_context ? g_live_compute_context->image_result_snapshot_bytes : 0;
+    const VulkanComputeContext* context = g_live_compute_context.load(std::memory_order_acquire);
+    return context ? context->image_result_snapshot_bytes : 0;
 }
 
 bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
@@ -12718,7 +12690,7 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
         if (std::atexit([] {
                 VulkanComputeContext* doomed = context_ptr;
                 context_ptr = nullptr;
-                g_live_compute_context = nullptr;
+                g_live_compute_context.store(nullptr, std::memory_order_release);
                 // Returning early from ~VulkanComputeContext would still destroy all of its member
                 // caches after the destructor body. When a lost-device submission has no completion
                 // proof, retain the object itself so no GPU-facing member ownership is released.
@@ -12748,7 +12720,7 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
         return fail_closed_items();
     }
     VulkanComputeContext& context = *live_context;
-    g_live_compute_context = &context;
+    g_live_compute_context.store(&context, std::memory_order_release);
     if (context.device_lost) return fail_closed_items();
     const bool perf_capture_timing =
         prosper::perf::interactive_performance_capture().detailed_timing_active();

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -4,6 +4,7 @@
 #include "shared/device/storage_image_contract.hpp"  // #3531: the OOB image-read contract
 #include "shared/texture/write_watch_census.hpp"
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -421,7 +422,23 @@ void report_live_compute_timing_selector_summary();
 
 // Persist the driver pipeline cache without tearing the compute context down. prosper-app cannot
 // run C++/Vulkan destructors while its guest thread is detached, so its deliberate _Exit path calls
-// this explicitly after requesting the guest stop.
-void flush_live_compute_pipeline_cache();
+// this explicitly after requesting the guest stop (frontends/prosper-app/main.cpp). Returns whether
+// a file was actually written, so "nothing to save" is distinguishable from "the save declined".
+//
+// It is idempotent and safe to call with no compute context, a lost device, or persistence disabled.
+// `lock_budget` bounds the wait for an in-flight driver compilation: exceeding it costs this run's
+// cache, never the ability to exit. What it does NOT cover is a guest-thread _Exit (#3324) -- that
+// is exit_group() from another thread and no frontend finalize step runs at all.
+bool flush_live_compute_pipeline_cache(
+    std::chrono::milliseconds lock_budget = std::chrono::milliseconds(1000));
+
+// What the disk compute pipeline cache actually did on this launch. Reported as state rather than
+// as a log line so a separate-launch regression test can assert it (#3425).
+struct LiveComputePipelineCacheStatus {
+    bool context_live = false;           // a compute context exists at all
+    bool persistence_configured = false; // a cache path is set, i.e. the opt-in was satisfied
+    uint64_t loaded_bytes = 0;           // bytes the driver ACCEPTED from disk; 0 means cold
+};
+LiveComputePipelineCacheStatus live_compute_pipeline_cache_status();
 
 } // namespace prosper::frontend

--- a/prosper/tests/gpu/execute/test_compute_cache_persistence.cpp
+++ b/prosper/tests/gpu/execute/test_compute_cache_persistence.cpp
@@ -1,0 +1,132 @@
+// #3425: the compute driver pipeline cache LOADED on launch and was never SAVED, because the only
+// writer was ~VulkanComputeContext and prosper-app leaves through std::_Exit. Every launch then
+// recompiled every pipeline from scratch forever (#3450 measured 821 ms of first-use compilation in
+// one 5 s GTA V world window).
+//
+// Each mode below runs one real compute dispatch and then leaves through _Exit itself, so a
+// destructor-only persistence path cannot make this test pass. The driver script chains the modes
+// across SEPARATE PROCESSES, which is the only way to observe that bytes actually survived.
+#include "gpu/capture/gpu_capture.hpp"
+#include "gpu/execute/gpu_execute.hpp"
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+#include "gpu/resources/shader_resources.hpp"
+#include "shared/live/live_compute.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+
+namespace {
+constexpr uint32_t kBytes = 4096;
+constexpr uint32_t kTail = 0x5a5a5a5au;
+constexpr uint32_t kFill = 0x34250000u;
+constexpr uint64_t kCodeAddress = 0x3425b00200ull;
+
+// One invocation stores the four user-SGPR words through binding 0, which is enough to require a
+// real VkPipeline and therefore a real driver compilation.
+constexpr uint32_t kShader[] = {
+    0x7e080280u,                                          // v4 = 0
+    0x7e000204u, 0x7e020205u, 0x7e040206u, 0x7e060207u,   // v0..v3 = s4..s7
+    0xe01c2000u, 0x80000004u,                             // buffer_store_dwordx4 v[0:3], v4, s[0:3]
+    0xbf810000u,                                          // endpgm
+};
+
+int fail(const char* message) {
+    std::fprintf(stderr, "[compute-cache-fixture] FAIL: %s\n", message);
+    return 1;
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::fprintf(stderr, "usage: fixture save|load|cold|disabled\n");
+        return 2;
+    }
+    const std::string mode = argv[1];
+    if (mode != "save" && mode != "resave" && mode != "load" && mode != "cold" &&
+        mode != "disabled")
+        return 2;
+
+    std::vector<uint32_t> guest(kBytes / sizeof(uint32_t), kTail);
+
+    ShaderResourceTable resources;
+    ShaderResource resource{};
+    resource.cls = ResourceClass::ConstantBuffer;
+    resource.format = DataFormat::Uint32;
+    resource.num_components = 4;
+    resource.binding = 0;
+    resource.sgpr_base = 0;
+    resource.stride = 16;
+    resource.gpu_addr = reinterpret_cast<uint64_t>(guest.data());
+    resource.size = kBytes;
+    resources.resources.push_back(resource);
+
+    ComputeShaderConfig config;
+    config.local_x = 1;
+    config.user_sgprs.resize(8);
+    for (unsigned lane = 0; lane < 4; ++lane) config.user_sgprs[4 + lane] = kFill + lane;
+
+    ComputeItem item;
+    item.spirv = recompile_compute(kShader, std::size(kShader), &resources, config);
+    if (item.spirv.empty()) return fail("the fixture kernel must recompile");
+    item.user_sgprs = config.user_sgprs;
+    item.code_addr = kCodeAddress;
+    item.resources = std::make_shared<ShaderResourceTable>(resources);
+    item.launch.threads_x = item.launch.threads_y = item.launch.threads_z = 1;
+    item.launch.local_x = item.launch.local_y = item.launch.local_z = 1;
+    item.launch.groups_x = item.launch.groups_y = item.launch.groups_z = 1;
+    item.submit_no = 3425;
+
+    if (!prosper::frontend::execute_live_compute_items({item}))
+        return fail("the fixture dispatch must execute");
+    for (unsigned lane = 0; lane < 4; ++lane)
+        if (guest[lane] != kFill + lane)
+            return fail("the fixture dispatch must really have run on the GPU");
+
+    const auto status = prosper::frontend::live_compute_pipeline_cache_status();
+    if (!status.context_live) return fail("a compute context must exist after a dispatch");
+
+    if (mode == "disabled") {
+        // The opt-out must not silently look like a successful save. A flush that returns true here
+        // would mean the caller cannot distinguish "persistence off" from "persisted".
+        if (status.persistence_configured) return fail("persistence must be off in this mode");
+        if (prosper::frontend::flush_live_compute_pipeline_cache())
+            return fail("a disabled cache must decline the flush rather than report a save");
+        std::fflush(nullptr);
+        std::_Exit(0);
+    }
+
+    if (!status.persistence_configured)
+        return fail("an explicit cache path must configure persistence");
+
+    if (mode == "save" || mode == "resave") {
+        // "resave" is the concurrent arm: a peer process may already have written the file, so a
+        // warm start is legal there. Only the serial first launch is required to be cold.
+        if (mode == "save" && status.loaded_bytes)
+            return fail("the save run must start from a cold cache");
+        if (!prosper::frontend::flush_live_compute_pipeline_cache())
+            return fail("the explicit shutdown snapshot must write the cache");
+        // Idempotent: prosper-app may reach this path more than once across future teardown work,
+        // and the destructor still calls it on the non-_Exit route.
+        if (!prosper::frontend::flush_live_compute_pipeline_cache())
+            return fail("a second snapshot must also succeed");
+    } else if (mode == "load") {
+        if (!status.loaded_bytes)
+            return fail("the driver must have accepted bytes written by the previous process");
+    } else if (mode == "cold") {
+        if (status.loaded_bytes)
+            return fail("a rejected cache file must leave the run cold rather than feed the driver");
+    }
+
+    std::fprintf(stderr, "[compute-cache-fixture] success mode=%s loaded=%llu\n", mode.c_str(),
+                 static_cast<unsigned long long>(status.loaded_bytes));
+    std::fflush(nullptr);
+    // _Exit, exactly like prosper-app: destructor-only persistence must not be able to pass.
+    std::_Exit(0);
+}

--- a/prosper/tests/gpu/execute/test_compute_cache_persistence.py
+++ b/prosper/tests/gpu/execute/test_compute_cache_persistence.py
@@ -1,0 +1,76 @@
+"""#3425: the compute pipeline cache must survive a process that leaves through std::_Exit.
+
+Separate processes are the whole point: a single process could pass by holding the blob in memory.
+Each fixture run ends in _Exit, so only an explicit shutdown snapshot can produce the file.
+
+The last check is the one that would have caught the original defect, which was not a broken save
+but an UNCALLED one: the frontend that exits through _Exit must actually name the flush.
+"""
+import concurrent.futures
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+fixture = sys.argv[1]
+app_main = Path(sys.argv[2])
+
+env = os.environ.copy()
+env.pop("PROSPER_NO_DISK_PIPELINE_CACHE", None)
+env.pop("PROSPER_DISK_PIPELINE_CACHE", None)
+
+
+def run(mode, path, extra=None):
+    run_env = env | {"PROSPER_COMPUTE_PIPELINE_CACHE_PATH": str(path)} | (extra or {})
+    return subprocess.run([fixture, mode], env=run_env, check=True, timeout=180)
+
+
+with tempfile.TemporaryDirectory(prefix="compute-cache-") as directory:
+    path = Path(directory) / "cache"
+
+    # A cold launch saves; a following launch loads what it wrote.
+    run("save", path)
+    original = path.read_bytes()
+    assert len(original) > 32, f"the envelope must carry a real blob, got {len(original)} bytes"
+    run("load", path)
+
+    # The opt-out wins over an explicit path, and must not write or report a save.
+    run("disabled", path, {"PROSPER_NO_DISK_PIPELINE_CACHE": "1"})
+    assert path.read_bytes() == original, "a disabled run must not touch the existing cache"
+
+    # A damaged body is rejected by the checksum even though its Vulkan header still matches, and a
+    # truncated file is rejected by the recorded length. Neither may reach vkCreatePipelineCache.
+    damaged = bytearray(original)
+    damaged[-1] ^= 0xFF
+    path.write_bytes(damaged)
+    run("cold", path)
+    path.write_bytes(original[:-1])
+    run("cold", path)
+    path.write_bytes(b"")
+    run("cold", path)
+
+    # A good file still loads after all of that, so rejection is about the bytes, not the path.
+    path.write_bytes(original)
+    run("load", path)
+
+    # Several prosper processes run on one box routinely. Concurrent savers must leave a file that
+    # still loads, never a half-written one.
+    concurrent_path = Path(directory) / "concurrent"
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+        for future in [pool.submit(run, "resave", concurrent_path) for _ in range(3)]:
+            future.result()
+    assert concurrent_path.is_file(), "concurrent savers must leave exactly one cache file"
+    leftovers = [p.name for p in Path(directory).iterdir() if ".tmp-" in p.name]
+    assert not leftovers, f"concurrent savers must clean up their temporaries: {leftovers}"
+    run("load", concurrent_path)
+
+# The defect in #3425 was that flush_live_compute_pipeline_cache() had no caller at all, while its
+# own header comment claimed prosper-app called it. Nothing above can see that, because the fixture
+# calls the function directly. Assert the wiring separately.
+source = app_main.read_text(encoding="utf-8", errors="replace")
+assert "flush_live_compute_pipeline_cache" in source, (
+    f"{app_main.name} exits through std::_Exit and must flush the compute pipeline cache there; "
+    "without that call the cache loads on every launch and is never written"
+)
+print("compute pipeline cache persists across processes and prosper-app calls the flush")


### PR DESCRIPTION
Fixes #3425

## What was actually true before this change

I verified both halves rather than taking the issue's word for it:

- **Load worked.** `create_pipeline_cache()` read the file and passed it to `vkCreatePipelineCache`, with a retry-empty fallback if the driver rejected an identity-compatible blob.
- **Save had no caller.** `flush_live_compute_pipeline_cache()` was declared in `live_compute.hpp` and defined in `live_compute.cpp`, and a repo-wide search finds no third occurrence. Its own header comment claimed *"prosper-app calls this explicitly"*. The only other writer was `~VulkanComputeContext`, and `prosper-app` leaves through `std::_Exit`, which runs no destructor. The graphics sibling `flush_live_graphics_pipeline_cache()` **was** called two lines above, which is exactly why the gap read as handled.

So the cache loaded on every launch and was written on none. **Every run paid first-use pipeline compilation forever.**

## Framing: this is a cold-start cost, not a steady-state one

#3450 measured 14 first-use compilations costing 821 ms — 66% of compute time — in one 5 s GTA V world window, and it amortises to ~1.0% over a 929-dispatch window. So a warm cache does not make the steady state faster. What it removes is a cost that, without a save, is paid again on every single launch.

## The synchronization contract the issue asked for

The issue explicitly said *"do not simply add a main-thread call"*. It named two hazards; I found a third.

1. **The context pointer was published non-atomically.** `g_live_compute_context` is now `std::atomic<VulkanComputeContext*>`, stored with release at the publication point and in the teardown handler, loaded with acquire by every reader.
2. **The persistence method read mutable failure flags before taking its mutex.** `device_lost` and `completion_unproven` are now `std::atomic<bool>`; the snapshot reads both with acquire and declines *loudly* when either is set — a lost device or an unproven completion means Vulkan may still own objects here.
3. **`GpuRetilePipeline::initialize` creates a compute pipeline into the shared `VkPipelineCache` without holding the cache lock.** Every other creator already did (`packed_rtt_conversion`, and both dispatch-pipeline sites). `VkPipelineCache` is externally synchronized, and this change turns the snapshot into a genuine concurrent reader rather than a destructor that runs when nothing else can, so that site is now locked too.

The lock itself becomes a `std::timed_mutex` with a bounded `try_lock_for` (1000 ms, matching the graphics path). A driver compile that never returns must cost this run's cache, never an app that will not close.

## Exit paths, including the one this does not cover

| path | covered? |
| --- | --- |
| normal quit / window close with a booted guest | **yes** — the new call, next to the graphics flush, *after* the submit-gate drain and `vkDeviceWaitIdle` that make the read safe |
| app exit with no guest booted (library UI) | yes — that route returns from `main`, so the `atexit` teardown runs the destructor, which still calls the same method |
| **guest-thread `_Exit`** (`k_exit`, `k_debug_raise_release`) | **no**, and this is stated at the call site. #3324 is exit_group() from a thread the frontend never reaches; no frontend finalize step runs at all. Building the cross-layer finalizer registry #3324 describes is not this PR's job. |
| crash | no |

## Cache validity, location, and concurrency

The compute path wrote the **raw driver blob** with a hand-rolled temp+rename. A truncated file still passed the Vulkan header check (the header carries no length or checksum), and two concurrent writers shared one nonce scheme with a `remove`-then-`rename` fallback that could leave no file at all.

It now uses `PipelineCacheFile` — the checked envelope the graphics cache already used, which records length, an FNV checksum, driver version and pointer size, and reserves a private sibling *directory* atomically so no writer truncates another's temporary or deletes the previous good cache. `PipelineCacheFile::graphics()` and the new `compute()` now differ only in the filename and the explicit-path variable, so a policy change cannot land on one and miss the other.

- **Location** is unchanged in kind: `%LOCALAPPDATA%\prosper\` or `$XDG_CACHE_HOME`/`~/.cache/prosper/`. Not in git, not in `/tmp`.
- **Identity moves to `compute-vkcache-v2-…`.** A v1 file written by an older build is a different format; giving it a different name means the two can never overwrite each other while several builds run on one box. A v1 file is simply not read and the run starts cold.
- **Stale or corrupt is a cache miss, visibly.** A rejected file leaves the run cold and says so on stderr (`cold` vs `loaded`), and the retry-empty fallback on a driver rejection is retained. Loading stays **opt-in** behind `PROSPER_DISK_PIPELINE_CACHE` or an explicit path, because of the recorded NVIDIA blob-load crash.

`compute_pipeline_cache_blob_compatible()` keeps its exported name and its existing coverage in `test_game_compute`, but delegates to `PipelineCacheFile::compatible` so there is one decode rather than two.

## Regression guard — `compute_cache_persistence`

A fixture runs one **real compute dispatch** (a recompiled RDNA2 `buffer_store_dwordx4`, verified by reading the written words back) and then leaves through `std::_Exit` itself, so destructor-only persistence cannot pass it. The Python driver chains **separate processes**:

- `save` → cold start required, flush must return true, flush must be idempotent
- `load` → the next process must have bytes accepted by the driver
- `disabled` (`PROSPER_NO_DISK_PIPELINE_CACHE=1`) → must decline rather than report a save, and must not touch the existing file
- damaged / truncated / empty file → each must leave the run cold, and a good file must still load afterwards
- **three concurrent savers** against one path → the file must still load and no `.tmp-` residue may remain

And the check no in-process test can make: the original defect was an **uncalled** function, so the driver also asserts `prosper-app/main.cpp` still names the flush.

Registered in **both** the Windows and the UNIX CMake blocks, deliberately: this defect is about the Windows/NVIDIA frontend's `_Exit` path and the cost was measured there, so a Linux-only guard would test the fix everywhere except where it was found.

### The without-fix arms both go red

| arm | result |
| --- | --- |
| remove the `flush_live_compute_pipeline_cache()` call from `main.cpp` | **FAILED** — `AssertionError: main.cpp exits through std::_Exit and must flush the compute pipeline cache there` |
| make the flush a no-op returning false (i.e. destructor-only, the #3425 state) | **FAILED** — `[compute-cache-fixture] FAIL: the explicit shutdown snapshot must write the cache` |

Both restored afterwards and the full suite re-run.

## Verification

Windows / MinGW (Vulkan SDK 1.4.350.0, RTX 4090), configured with `-DPROSPER_APP=ON` and `-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0`:

```
cmake --build <WT>/prosper/build-win -j 12       -> exit 0
ctest --no-tests=error -j 4                      -> 348/349 passed, exit 8
```

The single failure is `session_start`, pre-existing on this machine and unrelated (#3540); 2 skips are the usual dump-parameterized ones. Test count is 349 (was 348 — this PR adds one).

`compute_cache_persistence` on its own: **1/1 passed, exit 0.**

Only Linux CI is blocking, and the same test is registered there.

## Measured effect

**Qualitative (contention-invariant), in the real frontend, not the test harness** — `prosper-app`, `PROSPER_RENDER=1`, `--frames`, cache path under `~/`:

| title | compute blob written on `_Exit` | reloaded by the next launch |
| --- | --- | --- |
| GTA V `PPSA04263` | **27,755 bytes** | yes — `disk pipeline cache loaded: … (27755 bytes)` |
| The Messenger `PPSA24651` | 36 bytes (an empty payload — this title compiles nothing the driver retains) | yes |

Before this change all of that was discarded at exit, on every run.

**Timing, GTA V boot-to-menu route, 120 frames, `PROSPER_COMPUTE_PHASE_TIMING=1`**, summing the `pipeline_ms` leaf over all 122 dispatches. The graphics cache was held warm in every arm so the delta is compute-only, and arms were alternated:

| arm | total `pipeline_ms` | slowest single dispatch | dispatches over 1 ms |
| --- | --- | --- | --- |
| cold #1 | 7.2 | 5.1 | 1 |
| cold #2 | 6.5 | 4.2 | 1 |
| warm #1 | **2.0** | 0.3 | **0** |
| warm #2 | **2.7** | 0.7 | **0** |

**Contention disclosure:** one foreign `prosper-app` (another lane's worktree) was running before and after all four arms, so under this project's discipline this is a *contended* timing pair — indicative, not admissible. It is reported because all four arms were equally contended, the arms alternated, and the discriminator is near-categorical (1 vs 0 dispatches above 1 ms). An earlier wall-clock A/B produced one clean 0-peer cold sample and no clean warm sample, so no wall-clock claim is made.

**Do not read the 4.5 ms above as #3450's 821 ms.** This is a boot-to-menu route with 122 dispatches and one first-use compile; #3450's figure is a world window with 929 dispatches and 14 compilations. Mine is a small lower bound from a cheaper route, not a reproduction.

## Deliberately unaffected

- Default behaviour with persistence off (the default) — the flush returns false and writes nothing.
- The graphics cache path, other than being reached through the shared `for_stage` factory with an unchanged `graphics-vkcache-v1` identity.
- Steady-state frame rate. This is cold start only.

## Risks

- The `compute-vkcache-v2` rename orphans any existing v1 file on disk. It is a cache under the user's cache directory, it is opt-in, and it self-heals on the next run; nothing reads it.
- `device_lost` / `completion_unproven` becoming atomic changes their access at ~12 sites. All are plain reads and plain stores, so the semantics are unchanged; the full suite passes.
- Locking `GpuRetilePipeline::initialize` adds one uncontended mutex acquire on a dispatch path that was already doing pipeline creation and buffer allocation there.
