### PR TITLE
recompiler: a lane-local scalar must not satisfy the wave-uniformity proof (#3596)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2044,6 +2044,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_vertex_fetch_reject_diagnostic PRIVATE prosper_core)
   add_test(NAME vertex_fetch_reject_diagnostic COMMAND test_vertex_fetch_reject_diagnostic)
 
+  # #3596: a lane-local scalar must not satisfy the wave-uniformity proof.
+  add_executable(test_readfirstlane_uniformity
+                 tests/gpu/recompiler/test_readfirstlane_uniformity.cpp)
+  target_link_libraries(test_readfirstlane_uniformity PRIVATE prosper_core)
+  add_test(NAME readfirstlane_uniformity COMMAND test_readfirstlane_uniformity)
+
   # #3573: the CFG dispatcher must lower a fragment exec/vcc branch as a wave vote.
   add_executable(test_dispatcher_wave_vote tests/gpu/recompiler/test_dispatcher_wave_vote.cpp)
   target_link_libraries(test_dispatcher_wave_vote PRIVATE prosper_core)

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -2877,6 +2877,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // integer-divide reciprocal in the game's shaders). Writes an SGPR, not a VGPR.
                 rs.sreg[in.dst.value] = a;
                 rs.sreg_srt.erase(in.dst.value);
+                // #3596: record that this scalar is NOT wave-uniform. The value above is one lane's,
+                // so any later proof that reasons "it is in an SGPR, therefore it broadcasts" is
+                // wrong about it. Tainting the SSA value rather than the register makes the taint
+                // survive scalar copies for free.
+                rs.lane_local_scalars.insert(a);
                 return true;
             }
             if (in.opcode == kVop1OpcodeMovreldB32) { // VGPR[VDST + M0] = SRC0
@@ -3613,11 +3618,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     case OperandKind::Literal:
                         return true;
                     case OperandKind::SGPR:
+                        // #3596: "lives in a scalar register" is not the same as "is wave-uniform".
+                        // A `v_readfirstlane_b32` result is one lane's value in an SGPR, and a VCC
+                        // derived from it must NOT satisfy the wave-uniformity proof -- otherwise a
+                        // fragment vccz branch skips its wave vote and takes the lane's own bit.
+                        if (scalar_is_lane_local(rs, source.value)) return false;
                         return rs.sreg.contains(source.value) ||
                             rs.sreg_input.contains(source.value);
                     case OperandKind::Special:
                         if (source.value == 125) return true; // SGPR_NULL
                         if (source.value == 253) return rs.scc != 0;
+                        if (scalar_is_lane_local(rs, source.value)) return false;   // #3596
                         return source.value >= 106 && source.value <= 124 &&
                             rs.sreg.contains(source.value);
                     default:

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -4712,12 +4712,40 @@ struct SpirvCompute {
 // Machine state during recompilation: the VGPR and SGPR files (VGPR/SGPR number -> current SSA bits
 // id) and VCC (current bool condition). VGPRs and SGPRs are separate register files; VALU/EXP source
 // operands may reference either (SGPR is a valid ALU operand), so both are resolved by operand_bits.
+// True when the scalar register currently holds a value prosper knows is NOT wave-uniform (#3596).
+// Defined beside RegState so every uniformity predicate can ask the same question the same way; the
+// lookup is on the register's CURRENT SSA value, so an overwrite clears it without bookkeeping.
+inline bool scalar_is_lane_local(const struct RegState& rs, int sgpr);
+
 struct RegState {
     std::unordered_map<int, uint32_t> vreg, sreg;
     // The latest VCC SSA value proved identical in every guest lane. A fragment VCCZ branch over
     // that exact value is already scalar and needs no subgroup vote. Tying the proof to the SSA id
     // makes an overwrite or control-flow merge invalidate it automatically.
     uint32_t vcc_wave_uniform = 0;
+    // SSA values that are NOT wave-uniform despite living in a scalar register (#3596).
+    //
+    // prosper models one guest lane per invocation and has no cross-lane reduction, so
+    // `v_readfirstlane_b32` is lowered as THIS lane's source value -- it is annotated
+    // SPECULATIVE(confidence: med) at that site for exactly this reason. The result lands in
+    // `sreg`, and every uniformity predicate downstream treats "it is in a scalar register" as
+    // "it broadcasts one value to the whole wave". For a readfirstlane result that is false.
+    //
+    // It matters because a fragment `s_cbranch_vccz` whose VCC derives from such a value would
+    // otherwise pass the wave-uniformity proof and SKIP its wave vote, branching on the lane's own
+    // bit -- wrong pixels, no reject, no diagnostic.
+    //
+    // Keyed on the SSA VALUE rather than the register number, which makes copy propagation free:
+    // `s_mov_b32` lowers as `d = a`, so a tainted value stays tainted through any number of scalar
+    // moves, and an overwrite installs a fresh id that is naturally clean.
+    //
+    // THE TAINT SURVIVES COPIES AND NOTHING ELSE, and the gap is wider than a round-trip through a
+    // dispatcher variable. Any scalar ALU that COMPUTES from a tainted value produces a fresh id that
+    // is clean: `s_add_u32 s3, s0, s5` launders it, and so does an `s_cselect_b32` on SCC. SCC itself
+    // is a third route -- a compare on tainted operands sets SCC, and SCC read as a VOPC source
+    // returns from `scalar_data_operand` one line BEFORE the lane-local check. So this closes the
+    // direct and copy-laundered shapes, not the class. #3606 carries the propagation work.
+    std::unordered_set<uint32_t> lane_local_scalars;
     // Before the first compact structured construct, map presence means that the scalar value
     // reaches this exact linear path. Branch/loop PHIs can synthesize zero for an absent SGPR and
     // clear this marker. The CFG dispatcher likewise allocates Function variables for every
@@ -4824,6 +4852,12 @@ struct RegState {
     // never-written slot rejects (fail-visible).
     std::unordered_map<uint64_t, uint32_t> lds_addtid;
 };
+
+inline bool scalar_is_lane_local(const RegState& rs, int sgpr) {
+    if (rs.lane_local_scalars.empty()) return false;
+    const auto it = rs.sreg.find(sgpr);
+    return it != rs.sreg.end() && rs.lane_local_scalars.count(it->second) != 0;
+}
 
 inline bool has_wave64_mask_half_pair(const RegState& rs, int base) {
     const auto low = rs.sreg_wave64_mask_half.find(base);

--- a/prosper/tests/gpu/recompiler/test_readfirstlane_uniformity.cpp
+++ b/prosper/tests/gpu/recompiler/test_readfirstlane_uniformity.cpp
@@ -1,0 +1,169 @@
+// test_readfirstlane_uniformity — a value prosper models as LANE-LOCAL must not satisfy the
+// wave-uniformity proof that lets a fragment scalar branch skip its wave vote.
+//
+// Why this exists (#3596). `s_cbranch_vccz` is a SCALAR branch: the condition is whether the whole
+// wave's VCC mask is zero. prosper votes for it with `OpGroupNonUniformAny` unless it can prove VCC is
+// identical in every lane, in which case `any(P)` is `P` and the vote is pure cost.
+//
+// That proof asked "are both compare operands scalar-register sourced?" — and `v_readfirstlane_b32`
+// writes an SGPR while producing THIS lane's value. prosper says so in place: its lowering is annotated
+// SPECULATIVE(confidence: med) precisely because the per-lane scalar model has no cross-lane reduction.
+// So a VCC derived from a readfirstlane result passed the proof, the vote was skipped, and the branch
+// took the invocation's own bit — wrong pixels, no reject, no diagnostic. That is the exact defect the
+// wave-vote work exists to prevent, reappearing through the escape meant to optimise it.
+//
+// The fix taints the SSA VALUE rather than the register, so it survives scalar copies (`s_mov_b32`
+// lowers as `d = a`) and clears itself on overwrite.
+//
+// WHAT THIS TEST DOES NOT CLAIM. It does not establish that the proof is now sound in general — see
+// the residual recorded in #3596. It establishes that the one demonstrated counterexample no longer
+// passes, and it is built as a PAIR so it cannot pass by the escape simply never firing.
+#include "gpu/recompiler/rdna2_to_spirv.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <iterator>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static uint32_t count_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
+    if (spv.size() < 5) return 0;
+    uint32_t n = 0;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t wc = spv[i] >> 16u;
+        if (wc == 0 || i + wc > spv.size()) break;
+        if ((spv[i] & 0xffffu) == opcode) ++n;
+        i += wc;
+    }
+    return n;
+}
+
+constexpr uint32_t kOpSwitch = 251;
+constexpr uint32_t kOpGroupNonUniformAny = 335;
+
+int main() {
+    printf("== test_readfirstlane_uniformity ==\n");
+
+    // An irreducible fragment CFG -- pc1 branches INTO the region the back-edge closes, giving it two
+    // entries -- so the narrow structurizer rejects and the program routes to the CFG dispatcher, which
+    // is where the escape lives. Four branches, because the graphics dispatcher entry requires more
+    // than two.
+    //
+    // EXEC is restored before the compare (`s_mov_b64 exec, -1`), because the live uniformity marker is
+    // only set for a compare that ran with EXEC not narrowed, and a dispatch case always ENTERS
+    // narrowed. Without that instruction neither variant below would fire the escape and the pair would
+    // compare nothing.
+    //
+    // The two programs differ in ONE instruction: how `s0` is produced.
+    auto build = [](uint32_t producer_lo, uint32_t producer_hi, bool two_dword) {
+        std::vector<uint32_t> k;
+        k.push_back(producer_lo);                       // pc0  s0 = <producer>
+        if (two_dword) k.push_back(producer_hi);
+        k.push_back(0xBE810380u);                       //      s_mov_b32 s1, 0
+        k.push_back(0xBEFE04C1u);                       //      s_mov_b64 exec, -1
+        k.push_back(0xD4C2006Au); k.push_back(0x00000200u);  // v_cmp_eq_u32_e64 vcc, s0, s1
+        k.push_back(0xBF860004u);                       //      s_cbranch_vccz -> +4
+        k.push_back(0xBF068004u);                       //      s_cmp_eq_u32 s4, 0
+        k.push_back(0xBF840004u);                       //      s_cbranch_scc0 -> +4
+        k.push_back(0xBE800385u);                       //      s_mov_b32 s0, 5
+        k.push_back(0xBF820002u);                       //      s_branch -> +2
+        k.push_back(0xBE800387u);                       //      s_mov_b32 s0, 7
+        k.push_back(0xBF82FFFAu);                       //      s_branch back-edge
+        k.push_back(0x7E0202F2u); k.push_back(0x7E040280u); k.push_back(0x7E0602F2u);
+        k.push_back(0xF800180Fu); k.push_back(0x03020100u); k.push_back(0xBF810000u);
+        return k;
+    };
+
+    // CONTROL: `s0` is an immediate. Genuinely wave-uniform, so the escape SHOULD fire.
+    const std::vector<uint32_t> imm = build(0xBE800380u, 0u, false);   // s_mov_b32 s0, 0
+    // THE CASE: `s0` comes from v_readfirstlane_b32 s0, v0 -- lane-local under prosper's model.
+    const std::vector<uint32_t> rfl = build(0x7E000501u, 0u, false);   // v_readfirstlane_b32 s0, v0
+
+    const std::vector<uint32_t> spv_imm = recompile_fragment(imm.data(), imm.size());
+    const std::vector<uint32_t> spv_rfl = recompile_fragment(rfl.data(), rfl.size());
+
+    CHECK(!spv_imm.empty() && !spv_rfl.empty(), "both variants recompile");
+    if (spv_imm.empty() || spv_rfl.empty()) { printf("== FAIL: %d ==\n", fails + 1); return 1; }
+
+    // CONTROLS FIRST. If either program failed to reach the dispatcher, the comparison below would be
+    // about routing rather than about the uniformity proof.
+    CHECK(count_opcode(spv_imm, kOpSwitch) >= 1 && count_opcode(spv_rfl, kOpSwitch) >= 1,
+          "CONTROL: both variants lower through the CFG dispatcher");
+    CHECK(count_opcode(spv_imm, kOpGroupNonUniformAny) == 0,
+          "CONTROL: the immediate-sourced compare IS wave-uniform, so the escape fires and no vote "
+          "is emitted -- without this the arm below could pass on a build that never escapes");
+
+    CHECK(count_opcode(spv_rfl, kOpGroupNonUniformAny) >= 1,
+          "#3596: a VCC derived from v_readfirstlane_b32 does NOT satisfy the proof, so the wave vote "
+          "is emitted rather than the branch taking this invocation's own bit");
+    CHECK(fragment_spirv_required_subgroup_size(spv_rfl) == 64u,
+          "#3596: ...and the module declares the exact subgroup that vote needs");
+
+    // The pair is the discriminator: the two programs differ in exactly one instruction, and they
+    // disagree about the vote. Either arm alone could be satisfied by a build that always votes or one
+    // that never does.
+    CHECK(count_opcode(spv_rfl, kOpGroupNonUniformAny) >
+              count_opcode(spv_imm, kOpGroupNonUniformAny),
+          "#3596: the two differ ONLY in how s0 is produced, and they disagree about the vote -- so "
+          "this pair tests the uniformity proof rather than the routing");
+
+    // The taint must survive a scalar COPY, because it is keyed on the SSA value and `s_mov_b32`
+    // lowers as `d = a`. Same program with the readfirstlane result laundered through s2.
+    {
+        std::vector<uint32_t> via_copy;
+        via_copy.push_back(0x7E040501u);            // v_readfirstlane_b32 s2, v0
+        via_copy.push_back(0xBE800302u);            // s_mov_b32 s0, s2      <- launder
+        const std::vector<uint32_t> tail = build(0xBF800000u, 0u, false);  // s_nop as the producer slot
+        via_copy.insert(via_copy.end(), tail.begin() + 1, tail.end());
+        const std::vector<uint32_t> spv_copy = recompile_fragment(via_copy.data(), via_copy.size());
+        CHECK(!spv_copy.empty() && count_opcode(spv_copy, kOpSwitch) >= 1,
+              "CONTROL: the laundered variant also recompiles and reaches the dispatcher");
+        CHECK(count_opcode(spv_copy, kOpGroupNonUniformAny) >= 1,
+              "#3596: laundering the lane-local value through an s_mov_b32 does not clean it -- the "
+              "taint is on the SSA value, and a scalar move copies that value");
+    }
+
+    // Two controls for the laundering arm, because "it voted" is not by itself evidence that the
+    // READFIRSTLANE caused the vote -- a longer program, or an extra scalar move, could in principle
+    // do it. Both of these are the laundering shape MINUS the thing under test, and both must escape.
+    {
+        // (a) the same two-instruction launder with a CLEAN source: no readfirstlane anywhere.
+        std::vector<uint32_t> clean_launder;
+        clean_launder.push_back(0xBE820380u);       // s_mov_b32 s2, 0
+        clean_launder.push_back(0xBE800302u);       // s_mov_b32 s0, s2     <- same launder shape
+        const std::vector<uint32_t> tail_a = build(0xBF800000u, 0u, false);
+        clean_launder.insert(clean_launder.end(), tail_a.begin() + 1, tail_a.end());
+        const std::vector<uint32_t> spv_a =
+            recompile_fragment(clean_launder.data(), clean_launder.size());
+        CHECK(!spv_a.empty() && count_opcode(spv_a, kOpSwitch) >= 1,
+              "CONTROL: the clean two-move launder recompiles and reaches the dispatcher");
+        CHECK(count_opcode(spv_a, kOpGroupNonUniformAny) == 0,
+              "CONTROL: laundering a CLEAN scalar through the same two moves still escapes -- so the "
+              "vote in the arm above is caused by the readfirstlane, not by the launder shape");
+
+        // (b) readfirstlane PRESENT but not feeding the compare. Its result goes to s2 and is never
+        //     read; the compare still sources the immediate-defined s0.
+        std::vector<uint32_t> unused_rfl;
+        unused_rfl.push_back(0x7E040501u);          // v_readfirstlane_b32 s2, v0   (result unused)
+        unused_rfl.push_back(0xBE800380u);          // s_mov_b32 s0, 0
+        const std::vector<uint32_t> tail_b = build(0xBF800000u, 0u, false);
+        unused_rfl.insert(unused_rfl.end(), tail_b.begin() + 1, tail_b.end());
+        const std::vector<uint32_t> spv_b =
+            recompile_fragment(unused_rfl.data(), unused_rfl.size());
+        CHECK(!spv_b.empty() && count_opcode(spv_b, kOpSwitch) >= 1,
+              "CONTROL: the unused-readfirstlane variant recompiles and reaches the dispatcher");
+        CHECK(count_opcode(spv_b, kOpGroupNonUniformAny) == 0,
+              "CONTROL: a readfirstlane whose result never reaches the compare does NOT suppress the "
+              "escape -- the taint follows the VALUE into the compare, it is not a program-wide flag");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## The defect

`s_cbranch_vccz` is a **scalar** branch — the condition is whether the whole wave's VCC mask is zero — so
prosper votes for it with `OpGroupNonUniformAny` unless it can prove VCC is identical in every lane.

That proof asked only *"are both compare operands scalar-register sourced?"*. `v_readfirstlane_b32`
**writes an SGPR while producing this lane's value** — prosper's per-lane model has no cross-lane
reduction and the lowering is annotated `SPECULATIVE(confidence: med)` for exactly that reason. So a VCC
derived from it passed the proof, the vote was skipped, and the fragment branch took the invocation's
own bit: **wrong pixels, no reject, no diagnostic**.

## The fix

Taint the **SSA value**, not the register. Copies stay tainted for free (`s_mov_b32` lowers as `d = a`)
and overwrites clear themselves (a fresh id is naturally clean), so there is no invalidation
bookkeeping.

## ⚠️ Scope — this is `Refs`, not `Fixes`

An independent review measured that **the taint survives copies and nothing else**, so #3596 stays open.
All three of these still skip the vote on this head:

| laundering shape | why |
| --- | --- |
| `s_add_u32 s3, s0, s5` (with `s5 = 0`) | scalar ALU makes a fresh, clean id |
| SCC + `s_cselect_b32` | same |
| SCC read **directly** as the VOPC source | `scalar_data_operand` returns at `rdna2_emit_alu.cpp:3630`, **one line before** the lane-local check |

Filed as **#3606** (propagation through ALU and SCC) and **#3607** (`uniform_operand_at`, the second site
#3596 names, still fooled — harmless at the four fragment sites because each ANDs it with the live
marker, but it stands alone on a non-fragment path).

**A correction to my earlier claim:** I wrote that *"origin/main's dispatcher took the lane bit
unconditionally for graphics"*. That is **false about this base** — #3573 is already on `main`,
`rdna2_emit_cfg.cpp` is byte-identical between base and head, and a VGPR-sourced fragment compare
already votes. The accurate statement is that the escape #3573 added could be fooled, and this narrows
it.

## Verification

**Two mutations**, both load-bearing:

- drop the taint insert → exactly the four `#3596` arms red, every control green;
- key the taint on the **register** instead of the value → the laundering arm reds **and**
  overwrite-clearing breaks. So both design claims are demonstrated, not asserted.

**Four controls**, two of which the reviewer had to write and are now in the test — because "it voted"
is not by itself evidence the readfirstlane caused it:

| control | result |
| --- | --- |
| immediate-sourced compare | escapes (0 votes) — so the pair discriminates |
| the same two moves on a **clean** source | escapes — the launder *shape* is not what votes |
| readfirstlane present but **never reaching** the compare | escapes — the taint follows the value, it is not a program-wide flag |
| both variants reach the CFG dispatcher | asserted, so this is about the proof and not routing |

```
ctest --no-tests=error -j4    473/473, exit 0     (PROSPER_APP=OFF here)
CI                            11 pass / 2 skip / 0 fail
```

## Known cost

Forcing the vote newly pins a 64-lane fragment subgroup where the escape previously fired
(`reqsub` 0 → 64, measured). That grows the population **#3601** says is unmeasured on 32-lane fragment
hardware. Worth knowing: #3596's own suggested alternative (`subgroup_shuffle`) would **not** have
avoided the pin, so that is not an argument against this approach.

Refs #3596 #3606 #3607
