### PR TITLE
tests: restore stderr, fix an inverted portability guard, and stop two comments over-claiming (#3598 #3600 #3602)

### DIFF
--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -6717,10 +6717,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                 } else if (packed_word) {
                     // #3575: every component shares ONE dword. This is the exact inverse of the
-                    // packed_word LOAD above and deliberately reads its field table rather than
-                    // restating one -- same offsets, same widths, same per-field norms. A store whose
-                    // layout disagreed with the load would round-trip wrongly through prosper's own
-                    // reload, which is the cheapest way for this to be wrong and go unnoticed.
+                    // packed_word LOAD, which lives BELOW in this same function -- search
+                    // `packed_10_11_11 ? (sk == 0 ...` -- and the two field tables are RESTATED
+                    // independently rather than shared (#3600). They must be kept in step by hand:
+                    // a store whose layout disagreed with the load would round-trip wrongly through
+                    // prosper's own reload, which is the cheapest way for this to be wrong and go
+                    // unnoticed. If you edit either table, edit both.
                     //
                     // `comp_bytes` is 0 for these formats (data_format_bytes has no case for them),
                     // so the generic packed loop below would compute dwords=0 and silently write
@@ -6878,6 +6880,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // All requested components share one packed dword. GFX10 names layouts from high
                     // field to low field, so 2_10_10_10 is logical R/G/B in bits 0/10/20 and A in 30;
                     // 10_11_11 is R/G/B in bits 0/11/22 with widths 11/11/10.
+                    //
+                    // This table is RESTATED, not shared, by the packed-word STORE above (#3600) --
+                    // search `packed_word_ncomp`. The two must agree or a store will not round-trip
+                    // through this load. If you edit this table, edit that one.
                     uint32_t dw = load_dword(idx);
                     uint32_t boff = packed_10_11_11 ? (sk == 0 ? 0u : sk == 1 ? 11u : 22u)
                                                     : (sk == 0 ? 0u : sk == 1 ? 10u : sk == 2 ? 20u : 30u);

--- a/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
@@ -5129,11 +5129,18 @@ bool emit_cfg_state_machine(
                 // EXEC keeps voting. That is the conservative direction and it is the common one; the
                 // escape is an optimisation for the restored case, not the default.
                 //
-                // `state.vcc != 0` is an extra term the structured sites do not carry, and it is
-                // load-bearing HERE: `load_state` does not restore `vcc_wave_uniform`, so both sides
-                // would read 0 for a case that never emitted its own compare -- and `0 == 0` would
-                // silently skip the vote on a VCC this block knows nothing about. Requiring a live
-                // VCC makes that miss fail CLOSED.
+                // `state.vcc != 0` is an extra term the structured sites do not carry. It guards a
+                // specific miss: `load_state` does not restore `vcc_wave_uniform`, so a case that
+                // never emitted its own compare would read 0 from BOTH sides, and `0 == 0` would skip
+                // the vote on a VCC the case knows nothing about.
+                //
+                // It is DEFENSIVE rather than demonstrably load-bearing, and the distinction is
+                // recorded because an earlier revision of this comment overstated it (#3595). Deleting
+                // the term leaves the suite green, and I could not construct a program where it
+                // changes the lowering: `load_state` sets `state.vcc = live_vcc ? load(vcc_var) : 0`,
+                // and a VCC branch is itself what makes VCC live -- so at a vccz terminator the value
+                // is a real SSA id and the `== vcc_wave_uniform` term already fails on its own. Keep
+                // the term (it costs nothing and fails closed), but do not describe it as proven.
                 const bool vcc_branch = terminator->opcode <= 0x07;
                 const bool wave_uniform_vcc =
                     vcc_branch && state.vcc != 0 &&

--- a/prosper/tests/gpu/recompiler/test_buf_op_census_disposition.cpp
+++ b/prosper/tests/gpu/recompiler/test_buf_op_census_disposition.cpp
@@ -20,6 +20,17 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstdlib>
+#if defined(_MSC_VER)
+#include <io.h>
+#define PROSPER_DUP   _dup
+#define PROSPER_DUP2  _dup2
+#define PROSPER_CLOSE _close
+#else
+#include <unistd.h>
+#define PROSPER_DUP   dup
+#define PROSPER_DUP2  dup2
+#define PROSPER_CLOSE close
+#endif
 #include <string>
 #include <vector>
 
@@ -37,11 +48,19 @@ static void set_test_env(const char* name, const char* value) {
 #endif
 }
 
+// Captures one recompile's stderr and PUTS STDERR BACK (#3598). Without the restore the file is
+// unlinked below and every later line of the test -- including a crash message -- writes to a
+// descriptor nobody can read, which is a silent loss precisely when something has gone wrong.
 static std::string recompile_capturing_stderr(const uint32_t* code, size_t dwords,
                                               const ShaderResourceTable* rt,
                                               const char* scratch) {
     std::fflush(stderr);
-    if (!std::freopen(scratch, "w+", stderr)) { printf("  [FAIL] cannot redirect stderr\n"); fails++; return {}; }
+    const int saved_stderr = PROSPER_DUP(fileno(stderr));
+    if (!std::freopen(scratch, "w+", stderr)) {
+        printf("  [FAIL] cannot redirect stderr\n"); fails++;
+        if (saved_stderr >= 0) PROSPER_CLOSE(saved_stderr);
+        return {};
+    }
     (void)recompile_compute(code, dwords, rt, ComputeShaderConfig{});
     std::fflush(stderr);
     std::string text;
@@ -52,6 +71,11 @@ static std::string recompile_capturing_stderr(const uint32_t* code, size_t dword
         std::fclose(f);
     }
     std::remove(scratch);
+    if (saved_stderr >= 0) {
+        std::fflush(stderr);
+        PROSPER_DUP2(saved_stderr, fileno(stderr));
+        PROSPER_CLOSE(saved_stderr);
+    }
     return text;
 }
 

--- a/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
+++ b/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
@@ -19,8 +19,19 @@
 #include <array>
 #include <cstdio>
 #include <cstring>
-#ifndef _WIN32
+// `dup`/`dup2`/`close`/`fileno` below are declared in <unistd.h>, and MinGW-w64 ships it -- so
+// guarding the include out on _WIN32 removed the declarations on the one platform that needed them
+// (#3602). MSVC is the case that genuinely lacks it, and there the POSIX names live in <io.h>.
+#if defined(_MSC_VER)
+#include <io.h>
+#define PROSPER_DUP   _dup
+#define PROSPER_DUP2  _dup2
+#define PROSPER_CLOSE _close
+#else
 #include <unistd.h>
+#define PROSPER_DUP   dup
+#define PROSPER_DUP2  dup2
+#define PROSPER_CLOSE close
 #endif
 #include <cstdlib>
 #include <vector>
@@ -2996,7 +3007,7 @@ int main() {
         // of this test run with stderr pointing at a file that is then unlinked, so any later
         // diagnostic -- including a crash message -- goes nowhere.
         std::fflush(stderr);
-        const int saved_stderr = dup(fileno(stderr));
+        const int saved_stderr = PROSPER_DUP(fileno(stderr));
         const char* scratch = "dynfetch_control_bit_diag.log";
         FILE* redirected = std::freopen(scratch, "w+", stderr);
         const ShaderResource* diag_resource = nullptr;
@@ -3015,8 +3026,8 @@ int main() {
         std::remove(scratch);
         if (saved_stderr >= 0) {                      // put stderr back where it was
             std::fflush(stderr);
-            dup2(saved_stderr, fileno(stderr));
-            close(saved_stderr);
+            PROSPER_DUP2(saved_stderr, fileno(stderr));
+            PROSPER_CLOSE(saved_stderr);
         }
 #ifdef _WIN32
         _putenv_s("PROSPER_SRTTABLE_LOG", saved.c_str());


### PR DESCRIPTION
Four small corrections, batched because they land in the same two files and separate PRs would conflict
on every one.

## #3602 — the portability guard was inverted

`test_dynfetch_fold` guarded `#include <unistd.h>` with `#ifndef _WIN32`, then called `dup`, `dup2`,
`close` and `fileno` unconditionally. **MinGW-w64 ships `<unistd.h>` and declares those there**, so the
guard removed the declarations on the one platform that needed them. MSVC is the case that genuinely
lacks it, and there the POSIX names live in `<io.h>` under underscored spellings. The guard now keys on
`_MSC_VER` and maps them.

## #3598 — the census test now restores stderr

It redirected per arm with `freopen`, removed the scratch file, and never put stderr back — so every
later line of the test wrote to an unlinked descriptor. That is a silent loss precisely when something
has gone wrong, and a crash message is the most likely casualty. The sibling test was fixed this way
earlier; this closes the pair.

## #3600 — two comments claimed a shared field table that does not exist

The packed-word store said it *"reads the field table"* of the load, and that the load was *"above"*.
Neither was true: both tables are restated literals, and the load is **below** in the same function.
They agree today, so this was a false claim rather than a defect — but it told a maintainer editing one
that the other would follow. Both sites now say they are restated, name each other, and say to edit
both.

## #3595 — NOT fixed, and this is the interesting one

The issue reports that the escape's `state.vcc != 0` conjunct is *"deletable with the suite green,
including the one the comment calls load-bearing"*.

Deleting it does leave the suite green — **and I could not construct a program where it changes the
lowering.** `load_state` sets `state.vcc = live_vcc ? load(vcc_var) : 0`, and a VCC branch is itself
what makes VCC live, so at a `vccz` terminator the value is a real SSA id and the
`== vcc_wave_uniform` term already fails on its own.

**I wrote an arm for it first, and it passed with the conjunct deleted** — i.e. it pinned nothing, which
would have been the sixth arm on this work that is true for an unrelated reason. Rather than ship it,
the arm is removed and the source comment is downgraded from *"load-bearing HERE"* to
defensive-and-unproven, with the reason recorded in place.

The term stays: it costs nothing and fails closed. #3595 remains open for the other uncovered conjunct
(`vcc_exit_is_wave_uniform`), which I also did not manage to isolate — the two terms move together
under every mutation I tried.

## Verification

```
ctest --no-tests=error -j4    472/472, exit 0
```

No behaviour change in any of the four: three are test/comment-only, and the fourth is a comment
downgrade.

Fixes #3598 #3600 #3602
Refs #3595
