### PR TITLE
gpu: refuse a reserved DST_SEL encoding on an image descriptor

### DIFF
--- a/prosper/src/gpu/agc/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.cpp
@@ -476,6 +476,52 @@ const char* image_descriptor_reject_reason(const DecodedImageDescriptor& d) {
     if (d.base_array != 0 && !image_type_has_modeled_layer_stride(d.type))
         return "base-array-on-unmodelled-type";
     if (d.width > 16384 || d.height > 16384) return "extent-too-large";
+    // SQ_SEL 2 and 3 are RESERVED encodings. prosper already asserts this twice in its own source --
+    // the `DecodedBufferDescriptor::dst_sel` comment in this file's header ("4/5/6/7 = the stored
+    // R/G/B/A component (2 and 3 reserved)") and the buffer lowering in `rdna2_emit_alu.cpp`, which
+    // refuses such a selector with `reject-dst-sel-reserved` rather than guessing a meaning for it.
+    // The image path did not, and the asymmetry was not benign: all four T# selectors flow verbatim
+    // into `ShaderResource::swizzle`, and the backend's `vkswz` maps anything outside {0,1,4,5,6,7}
+    // to VK_COMPONENT_SWIZZLE_IDENTITY through a `default:` case. So a reserved selector became the
+    // IDENTITY selector for its own position -- a wrong channel routing with no reject and no
+    // diagnostic, which is exactly the failure the buffer comment warns about ("a plausible wrong
+    // picture"). Reporting it here routes it through the existing drop-reason machinery instead
+    // (PROSPER_SHARPLOG / PROSPER_DYNTRACE_FAIL), so the descriptor is visibly refused (#3587).
+    //
+    // This screens the ENCODING, not the routing. A T# is free to name any permutation of the six
+    // defined selectors, constants included, and a one-component surface declaring identity
+    // (R,G,B,A) is an ordinary descriptor -- `docs/RESOURCE_BINDING.md` § Ruled out records the
+    // falsification of the opposite claim (#2731). Nothing here constrains which defined selector a
+    // channel may carry.
+    //
+    // Placed LAST on purpose. `base-zero` must keep winning for a zero-base descriptor: the
+    // explicit-null-image path in gpu_executor.cpp keys on that exact verdict string (plus an
+    // all-zero eight-dword check) to publish a null binding, and an all-zero T# decodes all four
+    // selectors as 0 (SQ_SEL_0, a DEFINED constant) rather than as reserved, so the two never
+    // collide today -- but only this ordering keeps that true if either predicate moves.
+    //
+    // What a tightening can cost is a draw that renders TODAY, so the local capture corpus was swept
+    // before landing it (`gpu_replay --inspect-only` over every `.prgcap` under ~/, 56 of which carry
+    // resource records; 21 run directories spanning GTA V, Stray, Evergate, Asterix, DQ, Cobra and
+    // others). 137,588 materialized resources, of which **15,370 are image-class** -- 15,041 TEX and
+    // 329 STORAGE, the exact population this screen judges. Every one decodes to a selector word
+    // built only from defined SQ_SELs: TEX shows seven distinct words (4567, 4561, 4001, 4444, 6547,
+    // 4501, 0004), so the field is demonstrably live and routed rather than a constant default --
+    // 1,203 TEX descriptors declare outright BGRA. Zero reserved selectors, in any position, in any
+    // title. Those records all passed the OLD predicate, so they ARE the set this screen could newly
+    // drop. (`.prgbundle` files are not in that count: gpu_replay rejects `--bundle` together with
+    // `--inspect-only`, so the census route does not reach them.) The scan was validated on
+    // hand-built reserved instances constructed outside the corpus, because a clean zero from an
+    // instrument nobody has seen fire is not evidence (#3587).
+    //
+    // CONFIDENCE: HIGH on the encoding being reserved (published SQ_SEL enum, RDNA2 ISA document
+    // 70648, and prosper's own two prior assertions). CONFIDENCE: HIGH that this drops nothing that
+    // renders today, on that census. What the census cannot say is that no title ANYWHERE emits one
+    // -- it covers the titles that already boot far enough to capture -- so the residual risk is a
+    // T# prosper today mis-binds as identity becoming a visible, named drop instead, which is the
+    // direction this project prefers.
+    for (uint32_t k = 0; k < 4u; ++k)
+        if (d.dst_sel[k] == 2u || d.dst_sel[k] == 3u) return "dst-sel-reserved";
     return nullptr;
 }
 

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -8458,6 +8458,28 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     const VkFormat view_format = upload.borrowed_ds
                         ? upload.ds_format
                         : backend_color_format(r.texture_format);
+                    // SQ_SEL: 0/1 are the constants, 4/5/6/7 the stored R/G/B/A component. 2 and 3
+                    // are RESERVED, and everything above 7 is unrepresentable in the three-bit field
+                    // a descriptor decode produces. Both used to fall into a silent `default:`
+                    // returning IDENTITY -- i.e. the selector for whichever position the value sat
+                    // in -- so an undecodable routing became a plausible wrong picture with no
+                    // diagnostic anywhere (#3587).
+                    //
+                    // A reserved selector can no longer reach here FROM A DESCRIPTOR:
+                    // `image_descriptor_reject_reason` now refuses such a T# as `dst-sel-reserved`
+                    // before it becomes a ShaderResource. This warning is therefore not that path's
+                    // backstop, and it is not dead code either -- `FrameResource::swizzle` has two
+                    // other sources that never meet that predicate: a `.prgbundle`/`.prgcap`
+                    // deserialized verbatim by `capture_codecs.hpp` (including one recorded before
+                    // the reject existed), and FrameResources the live renderer and tests construct
+                    // directly.
+                    //
+                    // It warns rather than dropping the view on purpose. Replay's job is to
+                    // reproduce the frame that was captured, so failing a bundle closed here would
+                    // remove the one tool that can show what the descriptor actually said; the
+                    // identity fallback keeps replay byte-identical to its previous behaviour and
+                    // the message is what makes the value visible. Live guest descriptors are
+                    // rejected upstream, which is where a drop belongs.
                     auto vkswz = [](uint32_t s) -> VkComponentSwizzle {
                         switch (s) {
                             case 0:  return VK_COMPONENT_SWIZZLE_ZERO;
@@ -8466,7 +8488,23 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             case 5:  return VK_COMPONENT_SWIZZLE_G;
                             case 6:  return VK_COMPONENT_SWIZZLE_B;
                             case 7:  return VK_COMPONENT_SWIZZLE_A;
-                            default: return VK_COMPONENT_SWIZZLE_IDENTITY;
+                            default: {
+                                static std::once_flag warned;
+                                std::call_once(warned, [s] {
+                                    std::fprintf(stderr,
+                                                 "[render] UNDECODABLE DST_SEL selector %u on a "
+                                                 "sampled view (SQ_SEL 2/3 are reserved; >7 cannot "
+                                                 "come from a descriptor decode). Falling back to "
+                                                 "IDENTITY, so this channel reads its own position "
+                                                 "rather than what the resource asked for. A live "
+                                                 "guest T# carrying this is refused upstream as "
+                                                 "dst-sel-reserved -- reaching here means the "
+                                                 "resource came from a capture or was built "
+                                                 "directly. See #3587.\n",
+                                                 s);
+                                });
+                                return VK_COMPONENT_SWIZZLE_IDENTITY;
+                            }
                         }
                     };
                     VkComponentMapping components{

--- a/prosper/tests/gpu/agc/AGENTS.md
+++ b/prosper/tests/gpu/agc/AGENTS.md
@@ -1,0 +1,37 @@
+# `tests/gpu/agc` — the AGC front half, tested without a device
+
+Everything here asks a question of `src/gpu/agc` and the predicates it feeds, with no Vulkan device
+and no queue: does an eight-dword T# / four-dword V# decode to the fields the rest of the pipeline
+reads, does `build_shader_resources` turn a shader's user-data block into the resource table the
+recompiler and the backend consume, and — at least as often — does a descriptor that must NOT
+materialize get refused, by the right predicate, for a nameable reason. Several files exist because a
+predicate was *extracted* from `execute_item` so it could be reached at all (`test_image_identity`,
+`test_mip_provenance_identity`, `test_spirv_storage_match`, `test_atomic_image_staging`); each one's
+header says which issue moved it and what the unnamed expression used to hide.
+
+**The boundary against its siblings.** `tests/gpu/execute/` puts modules on a real device and asserts
+pixels or buffer contents — anything needing a queue belongs there. `tests/gpu/resources/` guards the
+`ShaderResource` container and its own helpers. This folder stops where the descriptor stops: the
+decoded struct, the predicate that judges it, and the table entry it becomes.
+
+**A reject verdict here is a CONTRACT STRING, not a diagnostic.** `image_descriptor_reject_reason`
+returns a `const char*`, and production code keys on the exact text — `gpu_executor.cpp` publishes an
+explicit null image only when the reason is `"base-zero"` *and* all eight dwords are zero. So renaming
+a verdict, or reordering the predicate so a descriptor reports a different one first, is a behaviour
+change that no compiler will catch. Add a new screen at the END unless you mean to change which
+verdict an already-refused descriptor reports, and pin the ordering with an arm.
+
+**Know what your fixture actually encodes.** `make_tsharp` (in `test_build_shader_resources.cpp`)
+zeroes the whole descriptor and then sets only base/extent/format/tile/type/array, which leaves
+WORD3\[11:0\] at zero — so every T# it builds decodes `DST_SEL` as four SQ_SEL_0 constants, *not* as
+identity `(R,G,B,A)`. Any arm about channel routing has to set those bits itself; one that does not is
+asserting about a constant-zero descriptor while reading as if it tested the ordinary case.
+
+**Two properties make this folder the right place to do mutation work**, and they are worth keeping:
+the tests are pure, so a rebuild is seconds rather than a device round trip, and `test_build_shader_
+resources.cpp`'s `CHECK` counts failures and keeps going instead of returning at the first one. That
+is what lets you disable a predicate, rebuild, and read *which* arms redden — the only way to show a
+reject arm was load-bearing rather than passing beside the thing it claims to test.
+
+Register new cases in `prosper/CMakeLists.txt` under `if(TARGET prosper_core)`; a case registered in a
+platform branch silently never runs while ctest stays green. Verify by name with `ctest -N`.

--- a/prosper/tests/gpu/agc/test_build_shader_resources.cpp
+++ b/prosper/tests/gpu/agc/test_build_shader_resources.cpp
@@ -492,8 +492,15 @@ int main() {
     }
 
     // #3587 end to end: the reject has to remove the descriptor from the table the recompiler and
-    // the backend consume, not merely name a reason. Paired with a routed-but-DEFINED control on the
-    // same fixture, so a table that bound nothing for an unrelated reason cannot pass as the fix.
+    // the backend consume, not merely name a reason. A "binds nothing" arm is worthless on its own --
+    // it passes just as well when the fixture never bound for an unrelated reason -- so it is paired
+    // with a routed-but-DEFINED control on the SAME descriptor, one field apart.
+    //
+    // The fixture is deliberately the one the BASE_ARRAY block above already proves binds: that arm
+    // is green on every CI platform, so the control here cannot be the thing that is fragile. An
+    // earlier draft used a plain 2D SW_64KB_R_X 256x256 RGBA16F T# instead, which binds on Linux and
+    // on MinGW and did NOT bind on macOS/Rosetta -- leaving the reserved arm beside it passing
+    // vacuously on that platform (#3608). Pick a control with cross-platform evidence behind it.
     {
         AgcShaderSharp sharp[1]; sharp[0].bits = 0;
         AgcShaderUserData ud{};
@@ -505,11 +512,30 @@ int main() {
         // Control: BGRA routing (B,G,R,A) -- non-identity, every selector defined. Must still bind,
         // and must carry the descriptor's routing through to ShaderResource::swizzle unchanged.
         uint32_t sg_bgra[8];
-        make_tsharp(sg_bgra, 0x31465d0000ull, 256, 256, /*RGBA16F*/71, /*SW_64KB_R_X*/27, /*2D*/9);
-        sg_bgra[3] |= 6u | (5u << 3) | (4u << 6) | (7u << 9);
-        const ShaderResource* bgra = build_shader_resources(sh, sg_bgra, 8).by_sgpr_base(0);
-        CHECK(bgra && bgra->swizzle[0] == 6 && bgra->swizzle[1] == 5 &&
-                  bgra->swizzle[2] == 4 && bgra->swizzle[3] == 7,
+        make_tsharp(sg_bgra, 0x31465d0000ull, 256, 256, /*RGBA16F*/71,
+                    /*SW_64KB_R_X*/27, /*2D array*/13, /*layers*/6, /*base array*/1);
+        sg_bgra[3] |= (1u << 12) | (1u << 16);
+        sg_bgra[5] |= 8u << 4;
+        sg_bgra[3] |= 6u | (5u << 3) | (4u << 6) | (7u << 9);   // DST_SEL = B,G,R,A
+        const ShaderResourceTable bgra_table = build_shader_resources(sh, sg_bgra, 8);
+        const ShaderResource* bgra = bgra_table.by_sgpr_base(0);
+        const bool control_bound = bgra && bgra->swizzle[0] == 6 && bgra->swizzle[1] == 5 &&
+                                   bgra->swizzle[2] == 4 && bgra->swizzle[3] == 7;
+        // Self-describing on failure: the arm's whole job is to be attributable, and "it did not
+        // bind" says nothing about which of the texture loop's ten `continue`s took it.
+        if (!control_bound) {
+            const DecodedImageDescriptor dc = decode_image_descriptor(sg_bgra);
+            const char* why = image_descriptor_reject_reason(dc);
+            Gen5ImageFormatInfo cfi{};
+            const bool mapped = gen5_image_format(dc.format, &cfi);
+            printf("  [diag] control: reject=%s fmt-mapped=%d view-supported=%d resources=%zu "
+                   "dst_sel=%u,%u,%u,%u bound=%d\n",
+                   why ? why : "none", (int)mapped,
+                   (int)(mapped && image_base_level_view(dc, cfi).supported),
+                   bgra_table.resources.size(),
+                   dc.dst_sel[0], dc.dst_sel[1], dc.dst_sel[2], dc.dst_sel[3], (int)(bgra != nullptr));
+        }
+        CHECK(control_bound,
               "a BGRA-routed T# binds and carries its DST_SEL into the resource table");
 
         // One field changed: DST_SEL_Z becomes the reserved encoding 2. Without the screen this
@@ -519,8 +545,12 @@ int main() {
         sg_reserved[3] = (sg_reserved[3] & ~(0x7u << 6)) | (2u << 6);
         CHECK(decode_image_descriptor(sg_reserved).dst_sel[2] == 2,
               "the reserved-selector fixture really does decode DST_SEL_Z as 2");
-        CHECK(build_shader_resources(sh, sg_reserved, 8).by_sgpr_base(0) == nullptr,
-              "a T# carrying a reserved DST_SEL binds nothing (visibly dropped, not mis-routed)");
+        // Conjoined with the control ON PURPOSE. `== nullptr` alone is satisfied by a platform where
+        // the descriptor never bound at all, which is exactly how the earlier draft passed vacuously
+        // on macOS; requiring the control in the same predicate makes the arm say "this pair differs
+        // by one reserved selector, and only the reserved one was dropped".
+        CHECK(control_bound && build_shader_resources(sh, sg_reserved, 8).by_sgpr_base(0) == nullptr,
+              "the same T# with one reserved DST_SEL binds nothing while the control does");
     }
 
     // The runtime resource preserves the guest sample count, exposes one host mip, and bounds the

--- a/prosper/tests/gpu/agc/test_build_shader_resources.cpp
+++ b/prosper/tests/gpu/agc/test_build_shader_resources.cpp
@@ -417,6 +417,110 @@ int main() {
         CHECK(image_descriptor_reject_reason(dinv) != nullptr &&
                   strcmp(image_descriptor_reject_reason(dinv), "inverted-array-range") == 0,
               "an inverted LAST_ARRAY/BASE_ARRAY range is rejected as inverted-array-range");
+
+        // #3587: SQ_SEL 2 and 3 are RESERVED encodings, and the image path used to let them through.
+        // All four T# selectors flow verbatim into ShaderResource::swizzle, and the backend's `vkswz`
+        // maps anything outside {0,1,4,5,6,7} to VK_COMPONENT_SWIZZLE_IDENTITY -- so a reserved
+        // selector silently became the IDENTITY selector for its own position: a wrong channel
+        // routing with no reject and no diagnostic. The buffer lowering has always refused the same
+        // encoding (`reject-dst-sel-reserved`, rdna2_emit_alu.cpp); this is the image path catching up.
+        //
+        // Swept over all four positions and both reserved values. A screen written for DST_SEL_X
+        // alone -- the shape the first draft of this fix could plausibly have taken -- passes a
+        // single-channel arm and reddens here.
+        for (uint32_t channel = 0; channel < 4u; ++channel) {
+            for (uint32_t reserved = 2u; reserved <= 3u; ++reserved) {
+                uint32_t bad_sel[8]; memcpy(bad_sel, good, sizeof good);
+                bad_sel[3] = (bad_sel[3] & ~(0x7u << (channel * 3u))) | (reserved << (channel * 3u));
+                const DecodedImageDescriptor dbad = decode_image_descriptor(bad_sel);
+                const char* why = image_descriptor_reject_reason(dbad);
+                char msg[160];
+                snprintf(msg, sizeof msg,
+                         "DST_SEL_%c = %u (reserved) is rejected as dst-sel-reserved, not materialized",
+                         "XYZW"[channel], reserved);
+                CHECK(dbad.dst_sel[channel] == reserved && why != nullptr &&
+                          strcmp(why, "dst-sel-reserved") == 0, msg);
+            }
+        }
+
+        // The discriminator, and the arm that says what the screen is actually about. It gates the
+        // ENCODING, never the routing: a T# may name any permutation of the six DEFINED selectors,
+        // constants included, and `docs/RESOURCE_BINDING.md` § Ruled out records the falsification
+        // (#2731) of the opposite claim -- a one-component surface declaring identity (R,G,B,A) is an
+        // ordinary descriptor, and rejecting shapes on semantic grounds broke live video planes.
+        // An implementation that refused "non-identity DST_SEL", or keyed on WORD3's low twelve bits
+        // being non-zero, passes every arm above and reddens here.
+        {
+            static const uint32_t defined_selectors[6] = {0u, 1u, 4u, 5u, 6u, 7u};
+            uint32_t bad_channel = 0xFFFFFFFFu, bad_value = 0;
+            const char* bad_reason = nullptr;
+            for (uint32_t channel = 0; channel < 4u && bad_channel == 0xFFFFFFFFu; ++channel)
+                for (uint32_t i = 0; i < 6u; ++i) {
+                    uint32_t sel[8]; memcpy(sel, good, sizeof good);
+                    sel[3] = (sel[3] & ~(0x7u << (channel * 3u))) |
+                             (defined_selectors[i] << (channel * 3u));
+                    const char* why = image_descriptor_reject_reason(decode_image_descriptor(sel));
+                    if (why) { bad_channel = channel; bad_value = defined_selectors[i];
+                               bad_reason = why; break; }
+                }
+            char msg[192];
+            if (bad_channel == 0xFFFFFFFFu)
+                snprintf(msg, sizeof msg,
+                         "all six DEFINED selectors (0,1,4,5,6,7) still bind in every DST_SEL "
+                         "position (the reserved ENCODING is what was rejected)");
+            else
+                snprintf(msg, sizeof msg,
+                         "defined selector %u in DST_SEL_%c was refused as %s -- the screen has "
+                         "become a routing gate, not an encoding gate",
+                         bad_value, "XYZW"[bad_channel], bad_reason);
+            CHECK(bad_channel == 0xFFFFFFFFu, msg);
+        }
+
+        // Ordering guard. `base-zero` must keep winning over the new verdict, because the
+        // explicit-null-image path (gpu_executor.cpp) publishes a null binding only when the reason
+        // is exactly "base-zero" AND all eight dwords are zero. An all-zero T# decodes every selector
+        // as 0 -- SQ_SEL_0, a DEFINED constant, so the two verdicts do not collide today; this pins
+        // that neither predicate may be reordered into changing the string that path reads.
+        {
+            const uint32_t all_zero[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+            const DecodedImageDescriptor dnull = decode_image_descriptor(all_zero);
+            const char* why = image_descriptor_reject_reason(dnull);
+            CHECK(dnull.dst_sel[0] == 0 && dnull.dst_sel[1] == 0 && dnull.dst_sel[2] == 0 &&
+                      dnull.dst_sel[3] == 0 && why != nullptr && strcmp(why, "base-zero") == 0,
+                  "an exactly all-zero T# still reports base-zero (the explicit-null path keys on it)");
+        }
+    }
+
+    // #3587 end to end: the reject has to remove the descriptor from the table the recompiler and
+    // the backend consume, not merely name a reason. Paired with a routed-but-DEFINED control on the
+    // same fixture, so a table that bound nothing for an unrelated reason cannot pass as the fix.
+    {
+        AgcShaderSharp sharp[1]; sharp[0].bits = 0;
+        AgcShaderUserData ud{};
+        ud.sharp_resource_offset[0] = sharp;
+        ud.sharp_resource_count[0] = 1;
+        AgcShaderHeader sh{};
+        sh.file_header = 0x34333231u; sh.version = 0x18; sh.type = 1; sh.user_data = &ud;
+
+        // Control: BGRA routing (B,G,R,A) -- non-identity, every selector defined. Must still bind,
+        // and must carry the descriptor's routing through to ShaderResource::swizzle unchanged.
+        uint32_t sg_bgra[8];
+        make_tsharp(sg_bgra, 0x31465d0000ull, 256, 256, /*RGBA16F*/71, /*SW_64KB_R_X*/27, /*2D*/9);
+        sg_bgra[3] |= 6u | (5u << 3) | (4u << 6) | (7u << 9);
+        const ShaderResource* bgra = build_shader_resources(sh, sg_bgra, 8).by_sgpr_base(0);
+        CHECK(bgra && bgra->swizzle[0] == 6 && bgra->swizzle[1] == 5 &&
+                  bgra->swizzle[2] == 4 && bgra->swizzle[3] == 7,
+              "a BGRA-routed T# binds and carries its DST_SEL into the resource table");
+
+        // One field changed: DST_SEL_Z becomes the reserved encoding 2. Without the screen this
+        // materializes, and the backend's identity fallback turns that channel into B -- a wrong
+        // picture nothing downstream can detect.
+        uint32_t sg_reserved[8]; memcpy(sg_reserved, sg_bgra, sizeof sg_bgra);
+        sg_reserved[3] = (sg_reserved[3] & ~(0x7u << 6)) | (2u << 6);
+        CHECK(decode_image_descriptor(sg_reserved).dst_sel[2] == 2,
+              "the reserved-selector fixture really does decode DST_SEL_Z as 2");
+        CHECK(build_shader_resources(sh, sg_reserved, 8).by_sgpr_base(0) == nullptr,
+              "a T# carrying a reserved DST_SEL binds nothing (visibly dropped, not mis-routed)");
     }
 
     // The runtime resource preserves the guest sample count, exposes one host mip, and bounds the


### PR DESCRIPTION
## The failure scenario

`prosper/src/gpu/recompiler/rdna2_emit_alu.cpp` states the contract in its own comment: an SQ_SEL
selector is *"the constant 0 (SQ_SEL_0) or the constant 1 (SQ_SEL_1); 2 and 3 are reserved"*, and the
**buffer** lowering refuses one with `reject-dst-sel-reserved` rather than guessing a meaning for it.
`agc_shader_layout.hpp` repeats it on `DecodedBufferDescriptor::dst_sel`.

The **image** path never screened it. `image_descriptor_reject_reason` checked base-zero, low base,
zero extent, inverted array range, image type, BASE_ARRAY and extent — and had no DST_SEL term at all.
`decode_image_descriptor` reads all four T# selectors verbatim (`&7`, so 2 and 3 survive), they flow
into `ShaderResource::swizzle`, and the backend's `vkswz` (`tests/fixtures/render_runner.h`) mapped
anything outside `{0,1,4,5,6,7}` to `VK_COMPONENT_SWIZZLE_IDENTITY` through its `default:` case.

So a reserved selector became **the identity selector for its own position** — DST_SEL_Z = 2 sampled B
— with no reject, no validation failure and no diagnostic anywhere. That is precisely what the buffer
comment warns about: *"a plausible wrong picture, with no reject and no diagnostic."*

## The contract

`image_descriptor_reject_reason` gains a `"dst-sel-reserved"` verdict when **any** of the four
selectors decodes as 2 or 3, so the descriptor is refused through the existing drop-reason machinery
(`PROSPER_SHARPLOG`'s `degenerate T# (…)` line, `PROSPER_DYNTRACE_FAIL`'s `[dynfail]` line) instead of
mis-binding silently.

Two deliberate properties:

- **It screens the ENCODING, never the ROUTING.** A T# may name any permutation of the six defined
  selectors, constants included. `docs/RESOURCE_BINDING.md` § Ruled out already records the
  falsification (#2731) of the opposite idea — GFX10 does not tie `DST_SEL` to a format's component
  count, a one-component surface declaring identity `(R,G,B,A)` is an ordinary descriptor, and
  rejecting shapes on semantic grounds broke live video planes. Nothing here constrains which
  *defined* selector a channel may carry, and there is a dedicated arm that reddens if it ever does.
- **It is placed LAST in the predicate.** `base-zero` must keep winning for a zero-base descriptor,
  because `gpu_executor.cpp`'s explicit-null-image path publishes a null binding only when the reason
  string is exactly `"base-zero"` *and* all eight dwords are zero. An all-zero T# decodes every
  selector as `0` — SQ_SEL_0, a *defined* constant — so the two verdicts do not collide today; this
  ordering, plus an arm, is what keeps that true if either predicate moves.

## `vkswz`'s silent `default:` — judgement call

Made **loud but non-fatal**: a `std::call_once` warning naming the selector, still falling back to
IDENTITY.

It is not the descriptor path's backstop — after the reject above a reserved selector cannot reach it
*from a live T#*. It is also not dead code: `FrameResource::swizzle` has two sources that never meet
that predicate — a `.prgcap`/`.prgbundle` deserialized verbatim by `capture_codecs.hpp` (including one
recorded before this change existed), and FrameResources the live renderer and tests construct
directly.

It warns rather than dropping the view on purpose. Replay's job is to reproduce the frame that was
captured; failing a bundle closed here would remove the one tool that can show what the descriptor
actually said. The identity fallback keeps replay byte-identical to its previous behaviour and the
message is what makes the value visible. Live guest descriptors are rejected upstream, which is where
a drop belongs.

## Is this tightening safe? — corpus sweep

This converts currently-silent mis-bindings into visible rejects, which **can** drop draws, so the
question is whether any descriptor that renders today carries a reserved selector.

`gpu_replay --inspect-only` over every `.prgcap` under `~/` (56 of them carry resource records, in 21
run directories spanning GTA V, Stray, Evergate, Asterix, DQ, Cobra and others):

| class | records | distinct selector words | reserved |
| --- | --- | --- | --- |
| `TEX` | 15,041 | 7 — `4567` `4561` `4001` `4444` `6547` `4501` `0004` | **0** |
| `STORAGE` | 329 | 5 — `4567` `4001` `4561` `4501` `6547` | **0** |
| `CB` | 114,036 | 3 — `4567` `4001` `0000` | **0** |
| `VB` | 8,182 | 1 — `4567` | **0** |
| total | 137,588 | 8 | **0** |

**15,370 image-class resources** — the exact population this screen judges — and not one reserved
selector, in any position, in any title. Those records all passed the *old* predicate, so they are
precisely the set this screen could newly drop.

Instrument validity, per the charter's rule that a clean zero needs a positive instance built outside
whatever produced the null: the scan was checked against hand-built lines (`swz=4267`, `swz=3567`,
`swz=4537`, `swz=4562`) and flagged all four while leaving `swz=4567` alone. Independently, the `TEX`
population shows seven distinct selector words including **1,203 descriptors declaring outright BGRA**
(`6547`) and 1,621 declaring `RRRR` — so the field is demonstrably live and routed rather than a
constant default the census could not have distinguished from a filtered one.

**What the census cannot say:** `.prgbundle` files are not in it — gpu_replay rejects `--bundle`
together with `--inspect-only`, so that route does not reach them — and it covers only titles that
already boot far enough to capture. It is evidence that this drops nothing that renders today, not a
proof that no title anywhere emits a reserved selector. `CONFIDENCE: HIGH` on the encoding being
reserved (published SQ_SEL enum, RDNA2 ISA document 70648, prosper's own two prior assertions);
`CONFIDENCE: HIGH` on the no-regression claim, on that census.

## Verification

All commands run inside the `ps5ys` distrobox, at `-j4`, on the exact head of this branch.

```
cmake -S prosper -B prosper/build-linux -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0   # rc=0
cmake --build prosper/build-linux -j4                                            # rc=0
ctest --no-tests=error -j4                                                       # rc=0
```

**`100% tests passed out of 500`, exit code 0.** No skips (the dump is `PPSA24651`, so the three
Messenger-specific cases execute rather than reporting `(Skipped)`).

### Mutation arm — the reject really is what the new tests measure

The new loop in `image_descriptor_reject_reason` was replaced by `return nullptr;`, the target
**rebuilt**, and `test_build_shader_resources` re-run:

```
== FAIL: 9 ==      (exit 1)
  [FAIL] DST_SEL_X = 2 (reserved) is rejected as dst-sel-reserved, not materialized
  [FAIL] DST_SEL_X = 3 (reserved) is rejected as dst-sel-reserved, not materialized
  [FAIL] DST_SEL_Y = 2 …   [FAIL] DST_SEL_Y = 3 …
  [FAIL] DST_SEL_Z = 2 …   [FAIL] DST_SEL_Z = 3 …
  [FAIL] DST_SEL_W = 2 …   [FAIL] DST_SEL_W = 3 …
  [FAIL] a T# carrying a reserved DST_SEL binds nothing (visibly dropped, not mis-routed)
```

The source was then restored and the full suite re-run green. The **control** arms stayed green in
both directions, which is what makes the eight above attributable:

- *all six DEFINED selectors (0,1,4,5,6,7) are still ACCEPTED in every DST_SEL position* —
  precisely, each asserts `image_descriptor_reject_reason` returns null; the arm does not call
  `build_shader_resources`, so it does not establish that such a descriptor binds. (The
  end-to-end BGRA arm below is the one that binds.) This is the arm
  that reddens if the screen ever becomes a routing gate instead of an encoding gate.
- *a BGRA-routed T# binds and carries its DST_SEL into the resource table* (end-to-end through
  `build_shader_resources`, the same fixture as the reserved arm with one field changed).
- *an exactly all-zero T# still reports base-zero* — the common case the explicit-null path
  actually sees, kept as its own arm. **This is not the ordering guard**, and an earlier
  revision of this body claimed it was. An all-zero T# decodes every selector as SQ_SEL_0, a
  *defined* encoding, so it trips `base-zero` alone and reports the same string whichever
  predicate runs first — it stays green under a reorder.
- *base-zero still wins over dst-sel-reserved on a descriptor that trips BOTH* — this is the
  ordering guard. Its fixture sets base to zero **and** a reserved `DST_SEL_X`, so only the
  ordering decides the verdict, and it is paired with a control asserting the fixture really
  does trip both. Verified in both directions: hoisting the screen to the first statement of
  `image_descriptor_reject_reason` makes this arm — and only this arm — fail.

Each reserved arm also asserts `dbad.dst_sel[channel] == reserved` first, so a fixture that failed to
encode what it claims cannot pass as the contract being tested.

## Deliberately not changed

- **The buffer path.** `rdna2_emit_alu.cpp` already rejects the same encoding, and its `k < n` /
  `dst_sel_routed` narrowing exists for a documented reason (#3549's store direction, and the
  three-component `X/Y/Z/1` case that would otherwise drop every ordinary
  `buffer_store_format_xyzw`). Untouched.
- **`decode_image_descriptor`.** It keeps reporting the raw decoded selectors; captures and
  diagnostics stay truthful about what the guest actually wrote. The judgement lives in the predicate.
- **`capture_codecs.hpp`.** A reserved selector arriving from a deserialized capture is warned about,
  not refused — see the `vkswz` section.
- **`docs/RESOURCE_BINDING.md`.** Nothing here falsifies a hypothesis, and that file's `## Ruled out`
  table is explicitly scoped to *"how the user-data / SH register block reaches a stage"*. The census
  is recorded in the source comment, on #3587, and here rather than as an off-topic row in a curated
  falsification table.
- **No `BLOG.md` entry.** No screenshot, no rung movement, and no reader-facing picture — per the
  charter's "skip them when there is genuinely nothing a reader would enjoy".

## Risk

A T# that today binds with a reserved selector will now be dropped instead, so a draw could
disappear where one previously rendered. **How bad the pre-change behaviour actually was depends on
the view, and an earlier revision of this body over-stated it.** Both backends apply the swizzle only
to *sampled* views — `render_runner.h` gates on `!r.is_storage_image` and `live_compute.cpp` on
`!bi.storage` — so a reserved selector on a **storage** T# has no observable effect today and the
"wrong-channel picture" claim holds only for the sampled half of the population. The census
above found no such descriptor in 15,370 image-class resources, and the charter's preference is
fail-visible over silently-wrong. The reject reports a named reason through `PROSPER_SHARPLOG`, so
if one ever does appear it says so rather than vanishing.

Fixes #3587

## Follow-up in this PR: a macOS divergence the first draft walked into

The first push's end-to-end control was a plain 2D `SW_64KB_R_X` 256x256 RGBA16F T#. It binds on
Linux and on Windows/MinGW and **does not bind on macOS (x86_64 / Rosetta 2)** — which is not caused
by this change (the predicate arms for that exact shape are green on macOS in the same run) and is
filed as **#3608**.

The consequence is what mattered here: a `== nullptr` arm beside a descriptor that never binds passes
**vacuously**. On macOS the "binds nothing" arm reported green while its own control was red, so on
that platform it proved nothing.

Fixed in `415e24c`, both changes about attributability rather than coverage:

- the pair now uses the 2D-array fixture this file already proves binds on every CI platform, with
  `DST_SEL` ORed into WORD3;
- the negative arm is **conjoined with its control**, so a platform where the control does not bind
  reddens instead of passing quietly. The arm now reads *"the same T# with one reserved DST_SEL binds
  nothing while the control does"*.

The control also prints a `[diag]` line (reject reason, format mapping, view support, table size) if
it ever fails again, so the next occurrence diagnoses itself instead of costing a CI round trip.

**Mutation arm re-run after the rewrite** — reject removed, target rebuilt:
`== FAIL: 9 ==`, exit 1, the eight encoding arms plus this end-to-end arm. Full suite re-run green:
**`100% tests passed out of 500`, exit 0.**

The other red check on the first push was `Windows MinGW`, whose only failing test was `session_start`
— a 20 s `subprocess.TimeoutExpired` in `tools/test_session_start.py` on a runner path containing
spaces. Unrelated to this diff, already tracked as **#3583**, and `Windows MinGW` is green on `main`.


